### PR TITLE
feat(ci): Renovate dependency automation + widen audit to all deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Audit production dependencies
-        run: pnpm audit --prod
+      - name: Audit dependencies (high + critical)
+        run: pnpm audit --audit-level high
 
   secret-scan:
     name: gitleaks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,14 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 - Do not install packages on the user's behalf without asking. Scaffolds can declare dependencies; actual install is the user's decision.
 - Do not run `pnpm audit --fix` or similar destructive commands unprompted.
 
+## Dependency Freshness (MANDATORY)
+
+- [Renovate](renovate.json) keeps dependencies current. It runs on a schedule (Monday mornings), opens grouped update PRs, and auto-merges patch + devDep-minor bumps once CI is green. Security advisories bypass the schedule.
+- The repo's **Dependency Dashboard** issue (auto-created by Renovate, labeled `dependencies`) is the single tracking issue for all automated update work. This is the Issue-First Rule's recognized exception — Renovate PRs reference the dashboard, no extra issue per update.
+- Don't bump package versions by hand as a drive-by. If Renovate has an open PR or a dashboard item for the dep you're about to touch, use that instead. Manual bumps are reserved for (a) resolving a specific bug, (b) unblocking migration work that has its own issue, or (c) a pin/rollback covered in [docs/dependencies.md](docs/dependencies.md).
+- CI enforces `pnpm audit --audit-level high`. High + critical severity vulnerabilities fail the build. Don't weaken the audit level to silence a finding — patch the dep (or open an issue to pin around it).
+- Major version bumps always require human review: Renovate lists them in the dashboard with approval-needed, and they only turn into PRs after the dashboard checkbox is ticked.
+
 ## Home Assistant Notes
 
 - WebSocket protocol: https://developers.home-assistant.io/docs/api/websocket

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,102 @@
+# Bağımlılık yönetimi
+
+Glaon'un npm paketlerini güncel ve güvenli tutan otomasyon katmanı. Amacı: "şu paket eski mi?" kontrolünü insan işi olmaktan çıkarmak ve güvenlik açıklıklarını geç değil, erken yakalamak.
+
+## Aktörler
+
+| Bileşen                                   | Ne yapar                                                           |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| [Renovate](https://docs.renovatebot.com/) | Haftalık outdated taraması + otomatik güncelleme PR'ları           |
+| `pnpm audit --audit-level high`           | CI'da her PR'da çalışır; high/critical açıklık bulursa build kırar |
+| GitHub Dependabot alerts                  | Repo-level UI uyarıları (user tarafından açılır)                   |
+
+Üç aktör birbiriyle çakışmaz — Dependabot alerts sadece sinyal üretir, düzeltmeyi Renovate yapar; audit CI'da son kontrol.
+
+## Renovate iş akışı
+
+### Dependency Dashboard
+
+Renovate, repo'da her zaman açık tek bir "Dependency Dashboard" issue'su tutar. Tüm mevcut güncellemeler (auto-merge edilenler dahil) bu issue'da listelenir. Bu issue aynı zamanda Glaon'un "Issue-First Rule"u için bağımlılık güncellemelerinin resmi tracking issue'sudur — her Renovate PR'ı dashboard'u `Refs` ile işaret eder.
+
+Nerede: repo Issues → `Dependency Dashboard` başlıklı, `dependencies` label'lı issue.
+
+### Schedule
+
+- **Düzenli** (patch + minor): her Pazartesi sabahı 09:00 (Europe/Istanbul) PR dalgası
+- **Güvenlik**: schedule'dan bağımsız, `vulnerabilityAlerts` tetiklenir tetiklenmez
+- **Lockfile bakımı**: haftalık, transitive semver-range içi güncellemeler için
+
+### PR gruplandırması
+
+Tekil paket başına bir PR yerine ekosistem bazlı gruplandırma:
+
+- `storybook` — `storybook`, `@storybook/*`, `storybook-dark-mode`
+- `react 19` — `react`, `react-dom`, `@types/react*`
+- `react native + expo` — `react-native`, `react-native-web`, `expo*`
+- `eslint` — `eslint*`, `@typescript-eslint/*`, `typescript-eslint`, `globals`
+- `typescript`, `vite`, `chromatic`, `commit hooks`, `github actions`
+
+Gruplandırılmayan paketler kendi PR'ları ile gelir.
+
+### Auto-merge
+
+| Tür                         | Karar                                         |
+| --------------------------- | --------------------------------------------- |
+| Patch (her paket)           | Auto-merge (CI yeşil şartıyla)                |
+| Minor — devDeps             | Auto-merge (CI yeşil şartıyla)                |
+| Minor — prod deps           | Manuel review                                 |
+| Major                       | Dashboard onayı → PR → manuel review + merge  |
+| Güvenlik (severity'ye göre) | PR açılır; auto-merge kuralları aynen geçerli |
+
+"CI yeşil" = type-check · lint · audit + Chromatic + commitlint + gitleaks tümü pass. Branch protection auto-merge'ü engelliyorsa PR açık kalır.
+
+## Review checklist (Renovate PR'ı geldiğinde)
+
+Tipik patch PR'ı otomatik geçer, ama manuel olarak bakacağın bir PR geldiğinde:
+
+1. **Release notes**: Renovate PR body'sinde "Release Notes" bölümünde ilgili changelog linki var mı? Bariz breaking change geçmişi var mı?
+2. **CI durumu**: Tüm check'ler yeşil mi? Chromatic snapshot'larda değişiklik var mı (görsel regresyon riski)?
+3. **Lock file**: `pnpm-lock.yaml` makul boyutta değişti mi? Beklenmedik transitive eklemeler?
+4. **Monorepo etkisi**: Paket hangi workspace'te? Birden fazla etkiliyorsa `@glaon/core` → `@glaon/ui` → `apps/*` yönünde tutarlı mı?
+5. **Prod vs dev**: `package.json`'da hangi bucket? Prod dep ise ekstra dikkat; devDep ise rahat.
+
+## Major version bump'ları
+
+Major'lar auto-PR açmaz — önce dashboard'da "approval needed" olarak durur. Karar anında:
+
+1. Dashboard'da ilgili item'ın checkbox'ını tıkla → Renovate PR'ı açar.
+2. PR body'sindeki release notes'u oku. Breaking change'leri listele.
+3. Kod tarafında migration gerekliyse **aynı PR'a commit ekle**. Bu hâlâ Renovate PR'ı ama insan değişikliği de eklenebilir.
+4. Type-check + lint + audit + Chromatic tümü yeşil olmadan merge etme. Chromatic'te unintended görsel değişiklik varsa migration tamam değil demektir.
+
+## Rollback / pin
+
+Bir paket yeni sürüm sonrası sorun çıkarırsa:
+
+1. Hatalı versiyonu `package.json`'da sabit semver ile pin'le (`"foo": "1.2.3"`).
+2. `renovate.json`'a `packageRules` entry'si ekle:
+   ```jsonc
+   { "matchPackageNames": ["foo"], "allowedVersions": "<1.3.0" }
+   ```
+3. Ayrı issue aç, kök sebebi araştır, hazır olunca constraint'i kaldır.
+
+## Sorun giderme
+
+- **Dashboard issue yok** → Renovate GitHub App repo'ya yüklü mü? Repo → Settings → Integrations.
+- **PR'lar açılmıyor** → `prConcurrentLimit` veya `prHourlyLimit` dolmuş olabilir; dashboard'un "Pending" bölümüne bak.
+- **Auto-merge gerçekleşmiyor** → Branch protection "Allow auto-merge" açık mı? Required status check'lerin tümü geçti mi? Renovate PR'ı her zaman commitlint'ten geçmeli (`:semanticCommits` preset'i bunu sağlıyor).
+- **CI'da audit fail**, ama Renovate PR yok → Açıklık henüz Renovate'in advisory database'ine işlememiş olabilir; manuel bump + ayrı issue.
+- **Schedule dışı PR bekleniyor** → Güvenlik uyarıları bypass eder. Manuel tetik için dashboard'da item'ı checkbox'la.
+
+## User aksiyonları (tek seferlik)
+
+1. [Mend Renovate GitHub App](https://github.com/marketplace/renovate) → Glaon repo'suna yükle.
+2. Repo → Settings → **Security & analysis** → Dependabot alerts: **Enable** (ücretsiz).
+3. Repo → Settings → **General** → "Allow auto-merge": **Enable**.
+4. İlk Renovate çalışmasından sonra Dependency Dashboard issue'sunu kontrol et.
+
+## Referanslar
+
+- Renovate config: [renovate.json](../renovate.json)
+- CI audit: [.github/workflows/ci.yml](../.github/workflows/ci.yml)
+- İlgili issue: #57

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices", ":semanticCommits"],
+  "baseBranches": ["development"],
+  "timezone": "Europe/Istanbul",
+  "schedule": ["before 9am on monday"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency Dashboard",
+  "dependencyDashboardHeader": "Renovate automation tracking issue. Every dependency update Renovate performs — whether it auto-merges or waits for review — is listed here. This dashboard itself satisfies the repo's Issue-First Rule for dependency work; individual update PRs reference this issue.\n\nCheck a box next to an item to approve (and create a PR for) a deferred major update.",
+  "labels": ["dependencies"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "area:security"],
+    "schedule": ["at any time"]
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 9am on monday"]
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchPackageNames": ["storybook", "@storybook/**", "storybook-dark-mode"],
+      "groupName": "storybook"
+    },
+    {
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+      "groupName": "react 19"
+    },
+    {
+      "matchPackageNames": ["react-native", "react-native-web", "expo", "expo-**"],
+      "groupName": "react native + expo"
+    },
+    {
+      "matchPackageNames": [
+        "eslint",
+        "eslint-**",
+        "@eslint/**",
+        "@typescript-eslint/**",
+        "typescript-eslint",
+        "globals"
+      ],
+      "groupName": "eslint"
+    },
+    {
+      "matchPackageNames": ["typescript"],
+      "groupName": "typescript"
+    },
+    {
+      "matchPackageNames": ["vite", "@vitejs/**"],
+      "groupName": "vite"
+    },
+    {
+      "matchPackageNames": ["chromatic", "chromaui/**"],
+      "groupName": "chromatic"
+    },
+    {
+      "matchPackageNames": ["@commitlint/**", "commitlint", "husky", "lint-staged"],
+      "groupName": "commit hooks"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Renovate kuruldu ve CI audit tüm deps'i kapsayacak şekilde genişletildi. Artık paket güncellemeleri insan işi değil; Renovate haftalık tarayıp gruplanmış PR'lar açacak, patch + devDep-minor otomatik merge olacak, güvenlik açıkları schedule'dan bağımsız tetiklenecek. Issue-First Rule için tek bir "Dependency Dashboard" issue'su tüm otomatik iş kaleminin tracking issue'su olacak.

## Scope

### In
- [x] `renovate.json` — `config:best-practices` + `:semanticCommits`, Monday 09:00 (Europe/Istanbul), dashboard aktif, ekosistem bazlı gruplandırma (storybook, react 19, react native + expo, eslint, typescript, vite, chromatic, commit hooks, github actions)
- [x] Auto-merge kuralları: patch → auto; devDep minor → auto; prod minor → manual; major → dashboard approval
- [x] `vulnerabilityAlerts` + `lockFileMaintenance` aktif
- [x] `.github/workflows/ci.yml` audit step: `pnpm audit --prod` → `pnpm audit --audit-level high` (tüm deps, high/critical fail)
- [x] `docs/dependencies.md` (TR) — aktörler, iş akışı, review checklist, major-bump flow, rollback/pin, troubleshooting, user aksiyonları
- [x] `CLAUDE.md` "Dependency Freshness (MANDATORY)" bölümü — Issue-First Rule istisnası, manuel bump yasağı, audit-level koruma

### Out of scope
- Supply-chain scanning (Socket.dev, Snyk, OSV-Scanner) — ayrı issue
- License compliance audit — ayrı issue
- Dockerfile / base image bumps (henüz Dockerfile yok)
- Expo SDK major upgrade runbook — dashboard'da görülecek, ayrı issue

## Verification (lokal)
```
$ pnpm audit --audit-level high
2 vulnerabilities found
Severity: 2 moderate
$ echo $?
0
```
Moderate vulns exit 0, high+ olsa fail'leyecekti. Renovate config'in `"$schema"` referansı var → IDE validation çalışıyor.

## Test plan
- [ ] CI yeşil (type-check · lint · audit, commitlint, gitleaks, Chromatic)
- [ ] `pnpm audit --audit-level high` CI log'unda görülüyor ve exit 0
- [ ] Merge sonrası user aksiyonları tamamlanacak:
  - [ ] [Mend Renovate GitHub App](https://github.com/marketplace/renovate) Glaon repo'suna yüklendi
  - [ ] Repo → Settings → Security & analysis → Dependabot alerts **Enable**
  - [ ] Repo → Settings → General → **Allow auto-merge** aktif
- [ ] Renovate ilk koşusundan sonra `Dependency Dashboard` issue'su açıldı (`dependencies` label'ı ile)
- [ ] İlk Renovate PR'ı (onboarding PR genelde `renovate/configure` branch'ında gelir) review edilip merge edildi
- [ ] Takip eden ilk patch/devDep-minor PR'ı CI yeşil → auto-merge gerçekleşti

## Known non-blocking
- pnpm audit hâlâ 2 moderate vuln raporluyor (addon-mcp transitive). `--audit-level high` ile build'i kırmıyor; Renovate patch PR'larıyla zamanla temizlenecek.

Closes #57