### PR TITLE
docs(figma): establish Figma as the design source of truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,14 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 - Platform-specific code (SecureStore, WebBrowser, expo-auth-session, DOM APIs) lives in `apps/*`.
 - `@glaon/ui` is the only place that imports Untitled UI source.
 
+## Design Source of Truth (MANDATORY)
+
+- Figma is the canonical source for Glaon's design: colors, spacing, typography, shadow, component visuals, and screen mockups all live there. Code **references** this source — it does not invent parallel values.
+- Design tokens are not hand-typed. They are exported from Figma Variables via the Figma Tokens plugin, committed as JSON, and transformed by Style Dictionary into per-platform outputs. Hex codes and raw spacing numbers don't appear in component code; token references do.
+- New primitives are designed in Figma first. A code-only primitive without a Figma counterpart is not mergeable — design review gate applies before the Storybook story is written.
+- Figma component descriptions carry the Storybook component ID in the form `storybook-id: <kebab-case>`. This is the contract that Chromatic's Figma plugin (#53) relies on; don't change the format without coordinating that integration.
+- Setup and workflow details: [docs/figma.md](docs/figma.md).
+
 ## Storybook Rule (MANDATORY)
 
 - Every new UI component (web or mobile) ships in the same PR with at least one Storybook story. No story, no merge.

--- a/docs/figma.md
+++ b/docs/figma.md
@@ -1,0 +1,156 @@
+# Figma — Tasarım Tek Kaynağı
+
+Glaon için tasarım Figma'da yaşar. Renkler, spacing, typography, shadow, component görselleri, ekran mockup'ları hepsi Figma'dadır. Kod bu kaynağa **referans yazar**, alternatif değildir.
+
+Bu sayfa:
+
+- Figma dosya yapısını tanımlar.
+- Design token export stratejisini sabitler.
+- Figma Remote MCP bind adımlarını anlatır.
+- Figma ⇄ Storybook naming eşlemesini koyar.
+- Design → kod review akışını anlatır.
+
+## Dosya yapısı
+
+Üç ayrı Figma dosyası (aynı takım / workspace altında):
+
+| Dosya             | İçerik                                                                               | URL                |
+| ----------------- | ------------------------------------------------------------------------------------ | ------------------ |
+| **Design System** | Primitive'ler, color palette, type scale, spacing, radii, shadow — published library | _TBD (bkz. aşağı)_ |
+| **Components**    | Design System'i tüketen composite component'ler (Card, Dialog, DeviceTile…)          | _TBD_              |
+| **Screens**       | Web + mobile ekran mockup'ları (dashboard, detail, settings…)                        | _TBD_              |
+
+> Dosyalar oluşturulduktan sonra URL'ler bu tabloya işlenir (küçük follow-up commit). Tüm takım üyeleri üçüne de en az "can view" seviyesinde erişime sahip olur.
+
+### Neden üç dosya?
+
+- **Library vs consumer ayrımı**: Design System published library olduğunda, Components ve Screens dosyaları onu tüketir (version pinning, instance override trace'i). Tek dosyada karışık olsa branch publish karmaşık hale gelir.
+- **Scope-based review**: Token değişikliği Design System PR'ında, yeni composite Components dosyasında, ekran mockup'ı Screens dosyasında tartışılır.
+- **Chromatic-Figma uyumu** (#53): Chromatic Figma plugin'i bir Storybook component'ini bir Figma component'ine map ederken, Design System dosyasındaki kanonik olanı işaret eder.
+
+## Design token akışı
+
+### Karar: **Seçenek A** — Figma Tokens plugin → Style Dictionary
+
+Tokens `@glaon/core` (veya `@glaon/design-tokens` — ayrı paket kararı token generator issue'sunda) içinde JSON olarak commit'lenir. Figma'dan export, Style Dictionary üzerinden web/mobile dağılım.
+
+```
+Figma Variables  →  [Figma Tokens plugin]  →  tokens/*.json  →  [Style Dictionary]  →  {web/*.css, rn/*.ts}
+     (kanonik)          export                  (repo)            transform              (tüketici)
+```
+
+Neden A (B ve C'ye karşı):
+
+- **Deterministik build**: Tokens commit'lenir → PR diff'i görülür → "renk mi değişti?" sorusu tek kelimelik review'la cevaplanır.
+- **Offline build**: CI + local build Figma'ya bağlı değil; network outage prod'u etkilemez.
+- **Chromatic-Figma hazır**: Token + component kombinasyonu bire bir izlenebilir (#53).
+- **Rollback kolay**: Yanlış bir token revert = git revert.
+
+Seçilmeyenler:
+
+- **B** (lokal REST script): Aynı JSON'u üretir ama "kim ne zaman koştu" belirsiz. İlerde A'ya CI eklenirse B otomatik devre dışı kalır; şimdi seçmenin kazancı yok.
+- **C** (runtime MCP read): Tasarım verisi kod base'ine işlenmez → PR diff'lenemez, build-time deterministik değil, offline çalışmaz. Keşif/prototip için OK ama prod için değil.
+
+### Token generator implementasyonu (bu issue'da yok)
+
+Figma Tokens plugin'in hangi versiyonu, tokens.json şeması, Style Dictionary config'i, CI'a bağlanması — hepsi **ayrı issue**. Bu baseline issue sadece kararı sabitler; kod üretimi design system dosyası oluşup ilk token set'i çıkınca başlar.
+
+### Token kategorileri (plugin config'i için)
+
+Figma Variables'da en az iki mode tanımlanır:
+
+- **Theme**: `light` / `dark`
+- **Platform**: `web` / `mobile` (spacing scale RN'de 4px multiplier farkı var; typography stack'leri farklı)
+
+Token isimlendirmesi: `color.brand.primary`, `space.4`, `radius.md`, `shadow.card`, `type.body.medium.size`. Dot-notation Style Dictionary default'u ile uyumlu.
+
+## Figma Remote MCP
+
+Claude Code ve diğer agent'lar Figma Remote MCP üzerinden tasarım dosyalarını okur (component listesi, frame'ler, variable'lar). Lokal Figma desktop app'inin MCP server'ı (dev-mode) ayrı bir kanaldır; Glaon için remote MCP kullanılır çünkü takımın tümü aynı endpoint'e bağlanır.
+
+### Kurulum
+
+1. Figma hesabı ile giriş yap → Team'de **Dev mode** ve MCP enabled.
+2. Claude Code → Figma MCP authenticate tool'u tetikle; browser OAuth flow'u açılır.
+3. Onaylanan scope: file read (component, variable, frame metadata). **Write scope istenmez.**
+4. Repo kökündeki [`.mcp.json`](../.mcp.json)'a Figma entry'si eklenir (_yazma sırası: OAuth başarıyla döndükten sonra, ayrı commit_). Beklenen şekil:
+
+   ```jsonc
+   {
+     "mcpServers": {
+       "chromatic": { "...mevcut...": true },
+       "figma": {
+         "type": "http",
+         "url": "https://<figma-remote-endpoint>",
+         "headers": { "...auth metadata...": "" },
+       },
+     },
+   }
+   ```
+
+   > Gerçek URL ve auth header'lar Figma tarafından OAuth callback'inde sağlanır; şu an placeholder. `.mcp.json` güncellemesi OAuth başarıyla tamamlanana kadar ertelenir.
+
+5. `claude mcp list` → `figma` status **connected**.
+
+### Kullanım sınırları
+
+- Read-only. Agent Figma'da değişiklik yapmaz; tasarım değişiklikleri insan aksiyonudur.
+- Büyük dosyalarda frame sayısı MCP response boyutunu şişirir; spesifik component/page sorgula.
+
+## Naming convention (Figma ⇄ kod)
+
+Design System Figma dosyasındaki component hiyerarşisi bire bir Storybook `title` alanına eşlenir:
+
+| Figma path                              | Storybook title                                   |
+| --------------------------------------- | ------------------------------------------------- |
+| `Web Primitives/Button/Primary`         | `Web Primitives/Button` → story `Primary`         |
+| `Web Primitives/Button/Disabled`        | `Web Primitives/Button` → story `Disabled`        |
+| `RN Primitives/PressableButton/Primary` | `RN Primitives/PressableButton` → story `Primary` |
+
+Storybook tarafındaki konvansiyon [docs/storybook.md](storybook.md)'de tanımlı.
+
+### Component description → Storybook ID
+
+Her Figma component'inin description alanında Storybook component ID'si yazılır:
+
+```
+storybook-id: web-primitives-button
+```
+
+Chromatic Figma plugin (#53) bu etiketi okuyup pixel diff map'ini kurar. Storybook ID formatı: CSF path'inin kebab-case'i (`Web Primitives/Button` → `web-primitives-button`).
+
+## Design review akışı
+
+1. **Figma'da öneri**: Tasarımcı ilgili dosyada branch açar (Figma branching) veya comment'lerle değişikliği iletir.
+2. **Tartışma**: Figma comment thread'i.
+3. **Merge (Figma tarafı)**: Onay sonrası branch main'e merge olur. Design System'de token değişikliyse published library bump'lanır.
+4. **Kod PR'ı**: Token değişikliyse ayrı bir issue + PR açılır, token regenerate edilir, commit'lenir. Component görsel değişikliyse Chromatic'te diff oluşur → #53 üzerinden otomatik mapping.
+
+### Tasarım ↔ kod senkron kuralı
+
+- Figma'da değişen bir component'in kodda karşılığı yoksa, kod PR'ı **zorunlu follow-up** (issue + PR). Design System'de orphan component bırakılmaz.
+- Kodda yeni bir primitive eklenmek isteniyorsa **önce Figma'da** tasarlanır; Figma olmadan eklenen component'in review'ı blocked.
+
+## Follow-up işler (bu issue kapsamı dışı)
+
+| Konu                                             | Durum                                                           |
+| ------------------------------------------------ | --------------------------------------------------------------- |
+| Figma Tokens plugin + Style Dictionary generator | ayrı issue açılacak (dosyalar + ilk token set'i olduktan sonra) |
+| Figma MCP `.mcp.json` entry                      | OAuth başarılı olunca küçük PR                                  |
+| Chromatic ⇄ Figma design-code diff               | #53                                                             |
+| Figma branching + design review Slack bot        | ayrı issue                                                      |
+
+## Sorun giderme
+
+- **MCP OAuth loop** → Figma takım ayarında "Third-party integrations" kapatılmış olabilir; takım admin'i açar.
+- **`claude mcp list` → figma connected yok** → `.mcp.json` entry'si henüz commit'lenmedi; bu dosyanın MCP bölümü OAuth bitince güncellenir.
+- **Storybook ID'leri eşleşmiyor** → Figma component description formatı `storybook-id: <kebab-case>` olmalı; boşluk veya noktalı virgül olursa plugin parse edemez.
+- **Token değişikliği kodda yansımıyor** → Generator script'i henüz yok; şimdilik manuel export → JSON commit; generator ayrı issue ile.
+
+## Referanslar
+
+- Figma Variables: <https://help.figma.com/hc/en-us/articles/15145852043927>
+- Figma Tokens plugin: <https://docs.tokens.studio/>
+- Style Dictionary: <https://amzn.github.io/style-dictionary/>
+- Figma MCP (remote): <https://www.figma.com/developers/mcp>
+- İlgili issue'lar: #52 (bu sayfa), #53 (Chromatic-Figma), #47 (Storybook RN), #48 (Untitled UI wrap)


### PR DESCRIPTION
## Summary

Glaon'un tasarım tek kaynağını Figma olarak sabitler ve bu kararın iş akışlarını yazılı hâle getirir. Dosya yapısı (3 dosya: Design System / Components / Screens), design token export stratejisi (Seçenek A — Figma Tokens plugin + Style Dictionary), Figma Remote MCP bind prosedürü ve Figma ⇄ Storybook naming contract'ı tek yerde. Chromatic-Figma diff (#53) bu baseline üstüne kurulacak.

## Scope

### In
- [x] [docs/figma.md](docs/figma.md) (yeni, TR) — eksiksiz runbook: dosya yapısı (URL placeholder'lı tablo), token akışı + Seçenek A kararı, Figma MCP bind, naming eşleme, design review
- [x] [CLAUDE.md](CLAUDE.md) — "Design Source of Truth (MANDATORY)" bölümü: Figma-first zorunlu, token'lar elle yazılmaz, `storybook-id: <kebab-case>` contract'ı

### Out of scope (follow-up'lar)
- Figma dosyalarının kendisini oluşturmak (kullanıcı aksiyonu)
- Token generator script / Style Dictionary config (ayrı issue — dosyalar + ilk token set'i olduktan sonra)
- Figma MCP `.mcp.json` entry'si (OAuth success sonrası küçük PR)
- Chromatic-Figma design-code diff — #53
- Design review Slack bot

## Merge sonrası user aksiyonları (issue'daki kabul kriterlerinin geri kalanı)

Aşağıdakiler bu PR'ın dışında, Figma tarafında yapılacaklar:

- [ ] Figma'da üç dosya oluşturuldu (Design System / Components / Screens)
- [ ] URL'ler docs/figma.md dosya yapısı tablosuna yazıldı (küçük follow-up commit)
- [ ] Takım üyelerine "can view" erişimi verildi
- [ ] Figma Tokens plugin yüklendi, ilk token set'i (en az color + space + radius) tanımlandı
- [ ] Figma Remote MCP için OAuth flow tamamlandı (`mcp__figma-remote-mcp__authenticate`)
- [ ] Design System'deki Button component'ine `storybook-id: web-primitives-button` description eklendi (Chromatic-Figma #53 için önkoşul)

Bu checkbox'lar issue #52'nin kendi acceptance criteria'sına denk — dosyalar + description eklenince #52 tam kapanır.

## Test plan
- [x] CI yeşil (type-check, lint, audit, gitleaks, commitlint, Chromatic — bu PR kod değiştirmediği için 8 tests unchanged bekleniyor)
- [x] docs/figma.md render edilip başlıklar (Dosya yapısı, Design token akışı, Figma Remote MCP, Naming convention, Design review akışı) doğru linkleniyor
- [x] CLAUDE.md "Design Source of Truth" bölümü "Storybook Rule"'un hemen üstünde okunabilir

Closes #52