### PR TITLE
docs(chromatic): Chromatic ↔ Figma design-code diff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 - `CHROMATIC_PROJECT_TOKEN` secret and branch protection rules are user-managed; see [docs/chromatic.md](docs/chromatic.md).
 - Chromatic MCP: after the first successful publish, the remote endpoint exposes only `docs` tools. Dev/test tools stay on the local Storybook server — don't try to replicate them remotely.
 - The Chromatic MCP entry in `.mcp.json` is part of the repo contract — don't edit or remove it as a drive-by. New MCP servers get their own entry and their own issue; breaking changes to the existing Chromatic URL require a tracked migration PR.
+- Chromatic also runs a Figma design-code diff on each build. Every Storybook story is mapped to its Figma counterpart via the `storybook-id: <kebab-case>` string in the Figma component description (see [docs/figma.md](docs/figma.md#component-description--storybook-id)). When a build shows `Not implemented` or `Design changed`, treat it as a signal to coordinate a follow-up with design, not as a Chromatic config glitch.
 
 ## PR Scope & Test Plan Sync (MANDATORY)
 

--- a/docs/chromatic.md
+++ b/docs/chromatic.md
@@ -133,6 +133,65 @@ Repo-scoped `.mcp.json`'ı kullanmak istemeyen developer'lar aynı config'i `cla
 - `preview-stories` → sadece dev server.
 - `run-story-tests` → Vitest browser + addon-vitest gerekli; ayrı issue.
 
+## Figma entegrasyonu
+
+Chromatic, Figma'daki tasarımı Storybook'taki kod karşılığı ile aynı ekranda gösterir ve drift'i PR review anında yakalar. Bu bağlantı tasarımcı ile developer arasındaki "acaba bu güncel mi?" sorusunu ortadan kaldırır.
+
+### Nasıl çalışır (mapping)
+
+1. Chromatic, her build'de Storybook'un publish ettiği component kataloguna bakar.
+2. Her component için Figma dosyalarında eşleşen ana component'i arar.
+3. Eşleştirmeyi **otomatik** yapar: Figma component'inin `Description` alanındaki `storybook-id: <kebab-case>` satırı Storybook CSF title'ı ile karşılaştırılır (örn. `storybook-id: web-primitives-button` ⟷ Storybook `Web Primitives/Button`).
+4. Manuel override Chromatic UI'dan mümkün ama default strateji otomatik — naming contract'ı [docs/figma.md](figma.md#component-description--storybook-id)'de sabit.
+
+### PR experience
+
+Chromatic build sonrası her PR'ın **Component snapshots** sayfasında her story için üç kolon:
+
+| Kolon     | Ne gösterir                                                       |
+| --------- | ----------------------------------------------------------------- |
+| Figma     | Tasarımdaki son published varyant                                 |
+| Storybook | Bu PR branch'indeki snapshot                                      |
+| Diff      | `In sync` / `Design changed` / `Code changed` / `Not implemented` |
+
+- **In sync** → iş tamam.
+- **Design changed** → tasarımcı Figma'da güncelledi, kodda henüz yansımadı. Takip eden bir issue/PR lazım.
+- **Code changed** → kod tasarımdan farklı yönde saptı. Tasarımcının onayı gerekir.
+- **Not implemented** → Figma'da component var, Storybook'ta karşılığı yok. Storybook Rule'a göre zorunlu follow-up ([CLAUDE.md](../CLAUDE.md#storybook-rule-mandatory)).
+
+### Design review iş akışı
+
+Figma ve kod tarafının senkronu iki yönlü:
+
+**Tasarımcı tarafından başlayan akış:**
+
+1. Tasarımcı Figma Design System'de değişiklik yapar + publish eder.
+2. Chromatic next build'te "Design changed" badge'ini basar.
+3. Developer PR açarak kod tarafını günceller.
+4. Chromatic build yeşil + "In sync" → merge.
+
+**Developer tarafından başlayan akış:**
+
+1. Developer kodda bir variant ekler + Storybook story'si yazar.
+2. Chromatic build "Code changed" (Figma'da karşılığı yoksa) veya "Not implemented" (Figma'da hiç yoksa) basar.
+3. Tasarımcıya Figma tarafında karşılığı çizmesi için issue açılır.
+4. Her iki taraf hazır olunca Chromatic "In sync" → merge.
+
+### Kurulum (one-time, kullanıcı aksiyonu)
+
+1. [chromatic.com](https://www.chromatic.com) → Glaon projesi → **Manage** → **Integrations** → **Figma**.
+2. Figma personal access token (read-only: File content + File metadata) yapıştır.
+3. Figma dosya URL'lerini ekle — minimum: **Design System** (mapping source). Components ve Screens opsiyonel ama takım Chromatic'te Figma'da arama yapabilmek için eklemeleri faydalı.
+4. İlk build'de Button (veya description'ında `storybook-id` olan ilk component) **Component snapshots** sayfasında "In sync" olarak görünmeli.
+
+> Access token organization-level read-only; tasarım editliği için ayrı bir token'a gerek yok. Token Chromatic dashboard'ında Chromatic tarafından encrypted saklanır.
+
+### Out of scope
+
+- Figma Dev Mode kullanımı — opsiyonel, takım kararı.
+- Figma yorumlarının PR'a sync'lenmesi — ayrı issue gerektirir.
+- Token/Tailwind/UI Kit entegrasyonu — #48 sonrası değerlendirilecek.
+
 ## Sorun giderme
 
 - **"Missing project token"** → `CHROMATIC_PROJECT_TOKEN` secret'ı ekli mi? Fork PR'larında secret erişilemez — fork katkıları için Chromatic check beklenmez.
@@ -140,10 +199,13 @@ Repo-scoped `.mcp.json`'ı kullanmak istemeyen developer'lar aynı config'i `cla
 - **Baseline sapmış** → Chromatic UI → Settings → "Clear baseline" (sadece kasıtlı reset için).
 - **MCP client bağlanmıyor** → Chromatic'te en az bir başarılı build olmalı; yoksa MCP endpoint boş. `curl <mcp-url>` ile JSON-RPC cevabı kontrol et.
 - **`.mcp.json` HTTP 404 dönüyor** → URL'deki branch permalink'i kontrol et. Glaon'un default branch'i `development` — `main--` ile başlayan URL'ler 404 verir.
+- **Chromatic'te Figma preview yok ama component description doğru** → Design System dosyası Chromatic'e bağlı mı? Dashboard → Manage → Integrations → Figma → dosya listesini kontrol et.
+- **Figma preview "Not implemented" diyor ama Storybook'ta story var** → Figma component description'daki `storybook-id` formatı kebab-case mi? Boşluk, slash veya camelCase olursa parse edemez. Örn. `storybook-id: Web Primitives/Button` ❌ → `storybook-id: web-primitives-button` ✅.
 
 ## Referanslar
 
 - Chromatic MCP: <https://www.chromatic.com/docs/mcp/>
+- Chromatic Figma integration: <https://www.chromatic.com/docs/figma/>
 - GitHub Actions: <https://www.chromatic.com/docs/github-actions/>
 - TurboSnap (`onlyChanged`): <https://www.chromatic.com/docs/turbosnap/>
-- İlgili issue: #50
+- İlgili issue'lar: #50, #53

--- a/docs/figma.md
+++ b/docs/figma.md
@@ -14,13 +14,13 @@ Bu sayfa:
 
 Üç ayrı Figma dosyası (aynı takım / workspace altında):
 
-| Dosya             | İçerik                                                                               | URL                |
-| ----------------- | ------------------------------------------------------------------------------------ | ------------------ |
-| **Design System** | Primitive'ler, color palette, type scale, spacing, radii, shadow — published library | _TBD (bkz. aşağı)_ |
-| **Components**    | Design System'i tüketen composite component'ler (Card, Dialog, DeviceTile…)          | _TBD_              |
-| **Screens**       | Web + mobile ekran mockup'ları (dashboard, detail, settings…)                        | _TBD_              |
+| Dosya             | İçerik                                                                               | URL                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| **Design System** | Primitive'ler, color palette, type scale, spacing, radii, shadow — published library | <https://www.figma.com/design/KP0SVNxQEjT0gotajwc9I0/Design-System> |
+| **Components**    | Design System'i tüketen composite component'ler (Card, Dialog, DeviceTile…)          | <https://www.figma.com/design/auyB12SfWNs3eUho4UpI2k/Components>    |
+| **Screens**       | Web + mobile ekran mockup'ları (dashboard, detail, settings…)                        | <https://www.figma.com/design/JdUxahXzXwVAsjkgzIjIT9/Screens>       |
 
-> Dosyalar oluşturulduktan sonra URL'ler bu tabloya işlenir (küçük follow-up commit). Tüm takım üyeleri üçüne de en az "can view" seviyesinde erişime sahip olur.
+Tüm takım üyeleri üçüne de en az "can view" seviyesinde erişime sahip olur.
 
 ### Neden üç dosya?
 
@@ -118,6 +118,18 @@ storybook-id: web-primitives-button
 ```
 
 Chromatic Figma plugin (#53) bu etiketi okuyup pixel diff map'ini kurar. Storybook ID formatı: CSF path'inin kebab-case'i (`Web Primitives/Button` → `web-primitives-button`).
+
+## Chromatic ile design-code diff
+
+Figma'daki tasarım ile Storybook'taki kod karşılığı Chromatic üzerinden yan yana görünür. Bu bağlantı tasarım ↔ kod drift'ini PR review anında yakalar — tasarımcı Figma'da renk değiştirdiğinde Chromatic build'i component snapshot'ında "Design changed" badge'i basar, developer kod tarafında takip edip etmediğini tek ekranda görür.
+
+Detaylar [docs/chromatic.md](chromatic.md#figma-entegrasyonu)'daki "Figma entegrasyonu" bölümünde. Mapping mekaniği buradaki [naming convention](#naming-convention-figma--kod) bölümüne dayanır.
+
+### Kısa özet (developer tarafı)
+
+- PR açtığında Chromatic build'inin **Component snapshots** sayfasına gir → her story için Figma preview + Storybook preview + diff badge görünür.
+- Badge "In sync" ise iş tamam. "Design changed" ise tasarımcıdan gelen değişikliği kod tarafında takip et. "Code changed" (design'a göre) ise tasarımcı onay verene kadar bekle.
+- Storybook'ta olmayan Figma component'leri "Not implemented" olarak işaretlenir — bu bir signal, Storybook Rule'a göre zorunlu follow-up.
 
 ## Design review akışı
 


### PR DESCRIPTION
## Summary

- Document the Chromatic–Figma integration so \`Design changed\` / \`Code changed\` / \`Not implemented\` badges have a clear owner and workflow.
- Fill the real Figma file URLs (Design System / Components / Screens) now that the files exist.
- Codify the \`storybook-id: <kebab-case>\` Figma ⇄ Storybook mapping contract in a single place.

Docs-only PR. No code, config, or dependency changes.

## Scope

### In

- \`docs/figma.md\`: replace \`_TBD_\` URL placeholders with the three real Figma files; new "Chromatic ile design-code diff" pointer section linking to the detailed writeup.
- \`docs/chromatic.md\`: new "Figma entegrasyonu" section — auto-mapping via \`storybook-id\`, PR experience 3-column table, two-directional design review flow, one-time Chromatic dashboard setup, 2 troubleshooting entries, reference link to Chromatic Figma docs.
- \`CLAUDE.md\`: one line added to the Chromatic Visual Regression rule so agents treat Figma diff badges as coordination signals instead of CI config glitches.

### Out

- Actual Chromatic dashboard setup (paste Figma token, add file URLs) — user action, listed below.
- Pixel-diff accept/reject workflow changes beyond what's already in \`docs/chromatic.md\`.
- Token pipeline (Figma Tokens plugin → Style Dictionary) — tracked on a separate follow-up from #52.

## Test plan

- [ ] CI green: type-check · lint · audit · gitleaks · commitlint · Chromatic.
- [ ] Links inside the new sections resolve (\`docs/figma.md\` ↔ \`docs/chromatic.md\` anchors, \`CLAUDE.md\` → \`docs/figma.md#component-description--storybook-id\`).
- [ ] Chromatic build on this PR stays green (docs-only change, no story diff expected).

## User actions (after merge)

- [ ] [chromatic.com](https://www.chromatic.com) → Glaon → **Manage** → **Integrations** → **Figma** → paste Figma read-only token.
- [ ] Add at minimum the Design System file URL (\`https://www.figma.com/design/KP0SVNxQEjT0gotajwc9I0/Design-System\`). Adding Components + Screens is optional but recommended.
- [ ] On the next PR, open **Component snapshots** and confirm Button shows **In sync** (it has \`storybook-id: web-primitives-button\` in its Figma description).

Closes #53
Refs #52