### PR TITLE
chore(github): add issue templates for feature / bug / chore / docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,72 @@
+name: Bug
+description: Report a defect or regression.
+title: 'fix(<scope>): <symptom>'
+labels: ['type:fix']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Something's broken. Describe repro so another developer can confirm.
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      options:
+        - phase-0 (Foundation)
+        - phase-1 (HA integration)
+        - phase-2 (Core UI)
+        - phase-3 (Security hardening)
+        - phase-4 (Features)
+        - phase-5 (Polish & release)
+    validations:
+      required: true
+  - type: dropdown
+    id: areas
+    attributes:
+      label: Areas
+      multiple: true
+      options:
+        - area:web
+        - area:mobile
+        - area:core
+        - area:ui
+        - area:addon
+        - area:ci
+        - area:security
+        - area:docs
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro steps
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, browser/device, Node/pnpm version, HA version, branch or commit.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, traces
+      description: Paste with triple backticks. Sanitize tokens and PII before submitting.

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,66 @@
+name: Chore
+description: Tooling, CI, dependencies, refactors — no user-visible behavior change.
+title: 'chore(<scope>): <action>'
+labels: ['type:chore']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for repo hygiene: tooling, CI, dependencies, refactors without a user-visible behavior change. User-visible behavior goes in the feature or bug template.
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      options:
+        - phase-0 (Foundation)
+        - phase-1 (HA integration)
+        - phase-2 (Core UI)
+        - phase-3 (Security hardening)
+        - phase-4 (Features)
+        - phase-5 (Polish & release)
+    validations:
+      required: true
+  - type: dropdown
+    id: areas
+    attributes:
+      label: Areas
+      multiple: true
+      options:
+        - area:web
+        - area:mobile
+        - area:core
+        - area:ui
+        - area:addon
+        - area:ci
+        - area:security
+        - area:docs
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why now? What breaks or gets harder if we skip this?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What's in, what's out.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: input
+    id: related
+    attributes:
+      label: Related issues
+      description: 'Comma-separated: #12, #34'

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,59 @@
+name: Documentation
+description: Changes to user-facing docs or repo guides.
+title: 'docs(<scope>): <what>'
+labels: ['type:docs']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        User-facing docs (`docs/`, `README.md`) are Turkish. Repo guides (`CLAUDE.md`, inline) are English. See the language policy in [CLAUDE.md](../CLAUDE.md).
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      options:
+        - phase-0 (Foundation)
+        - phase-1 (HA integration)
+        - phase-2 (Core UI)
+        - phase-3 (Security hardening)
+        - phase-4 (Features)
+        - phase-5 (Polish & release)
+    validations:
+      required: true
+  - type: dropdown
+    id: areas
+    attributes:
+      label: Areas
+      multiple: true
+      options:
+        - area:web
+        - area:mobile
+        - area:core
+        - area:ui
+        - area:addon
+        - area:ci
+        - area:security
+        - area:docs
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What changes?
+      description: Concrete list of doc edits, not a vague "improve docs".
+    validations:
+      required: true
+  - type: input
+    id: where
+    attributes:
+      label: Where?
+      description: Path to the file or section (e.g. `docs/security.md#csp`).
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why?
+      description: What prompted this — user confusion, drift from code, policy change, stakeholder ask?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,81 @@
+name: Feature
+description: Propose a new feature or enhancement.
+title: 'feat(<scope>): <short imperative>'
+labels: ['type:feat']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Issue-First Rule applies — open this before touching code. See [CLAUDE.md](../CLAUDE.md).
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Phase
+      description: Which phase does this belong to?
+      options:
+        - phase-0 (Foundation)
+        - phase-1 (HA integration)
+        - phase-2 (Core UI)
+        - phase-3 (Security hardening)
+        - phase-4 (Features)
+        - phase-5 (Polish & release)
+    validations:
+      required: true
+  - type: dropdown
+    id: areas
+    attributes:
+      label: Areas
+      description: Which parts of the codebase does this touch?
+      multiple: true
+      options:
+        - area:web
+        - area:mobile
+        - area:core
+        - area:ui
+        - area:addon
+        - area:ci
+        - area:security
+        - area:docs
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why does this matter? What breaks or becomes easier?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed approach
+      description: High-level direction — not a full spec.
+    validations:
+      required: true
+  - type: textarea
+    id: scope-in
+    attributes:
+      label: Scope — In
+      description: What's explicitly included.
+    validations:
+      required: true
+  - type: textarea
+    id: scope-out
+    attributes:
+      label: Scope — Out
+      description: What's explicitly deferred to follow-ups.
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist the PR must satisfy before close.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: input
+    id: related
+    attributes:
+      label: Related issues
+      description: 'Comma-separated: #12, #34'


### PR DESCRIPTION
## Summary

- Add four structured GitHub issue forms under `.github/ISSUE_TEMPLATE/`: feature, bug, chore, docs.
- Disable blank issues via `config.yml` so the Issue-First Rule can't be accidentally bypassed.
- Each form auto-applies its `type:*` label and requires a phase + one or more area selections.

Docs/config-only PR. No code changes, no runtime impact.

## Scope

### In

- `.github/ISSUE_TEMPLATE/feature.yml` — motivation / proposed / scope (in-out) / acceptance / related.
- `.github/ISSUE_TEMPLATE/bug.yml` — expected / actual / repro / environment / logs.
- `.github/ISSUE_TEMPLATE/chore.yml` — motivation / scope / acceptance.
- `.github/ISSUE_TEMPLATE/docs.yml` — what / where / why + language-policy reminder.
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`.

### Out

- Workflow that maps dropdown selections (phase, areas) to GitHub labels automatically — not needed while we have a single maintainer. Follow-up if manual labeling becomes painful.
- Discussions contact link — Discussions not enabled yet.
- Updating existing issues retroactively to match the new shape.

## Test plan

- [ ] CI green: type-check · lint · audit · gitleaks · commitlint · visual regression.
- [ ] After merge, \`gh issue create\` interactively lists all four templates (feature / bug / chore / docs) and does not offer a blank option.
- [ ] Each template's form renders on GitHub without schema errors (visible via \"New issue\" UI).
- [ ] Test-file an issue via the feature template and confirm the resulting body matches the structure we've been using on #64–#71.

## User action (after merge)

- [ ] Sanity-check the \"New issue\" picker at https://github.com/toss-cengiz/glaon/issues/new/choose.
- [ ] If a rendering error appears, open a follow-up with the exact GitHub error message — I'll patch on a new branch.

Closes #71