### PR TITLE
chore(governance): codify branch protection, CODEOWNERS, PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,38 @@
+# Glaon CODEOWNERS
+# Every path resolves to at least one owner. Last matching pattern wins, so
+# specific paths go after the catch-all.
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default fallback
+*                                   @toss-cengiz
+
+# Apps
+/apps/web/**                        @toss-cengiz
+/apps/mobile/**                     @toss-cengiz
+
+# Shared packages
+/packages/config/**                 @toss-cengiz
+/packages/core/**                   @toss-cengiz
+/packages/ui/**                     @toss-cengiz
+
+# HA Add-on delivery
+/addon/**                           @toss-cengiz
+
+# CI, governance, tooling
+/.github/**                         @toss-cengiz
+/.claude/**                         @toss-cengiz
+/.husky/**                          @toss-cengiz
+/renovate.json                      @toss-cengiz
+/release-please-config.json         @toss-cengiz
+/commitlint.config.mjs              @toss-cengiz
+/eslint.config.mjs                  @toss-cengiz
+/.gitleaks.toml                     @toss-cengiz
+/.mcp.json                          @toss-cengiz
+/turbo.json                         @toss-cengiz
+/tsconfig.base.json                 @toss-cengiz
+
+# Documentation
+/docs/**                            @toss-cengiz
+/README.md                          @toss-cengiz
+/CLAUDE.md                          @toss-cengiz

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+<!--
+Before pushing: re-read this body and confirm it still describes the diff.
+The Scope + Test plan lists MUST match the current diff (CLAUDE.md: PR
+Scope & Test Plan Sync rule).
+-->
+
+## Summary
+
+<!-- 1–3 bullets. What this PR does and why. Keep short. -->
+
+-
+
+## Scope
+
+### In
+
+-
+
+### Out
+
+<!-- What's explicitly NOT in this PR. Link follow-up issues where relevant. -->
+
+-
+
+## Test plan
+
+<!-- Checklist a reviewer can reproduce without asking questions. Delete items that don't apply; add items specific to this change. -->
+
+- [ ] CI green: type-check · lint · audit · gitleaks · commitlint · visual regression.
+- [ ]
+
+## User action (after merge)
+
+<!-- Delete this section if the PR requires no post-merge manual step. -->
+
+- [ ]
+
+Closes #

--- a/.github/rulesets/development.json
+++ b/.github/rulesets/development.json
@@ -1,0 +1,39 @@
+{
+  "name": "development-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/development"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "type-check · lint · audit" },
+          { "context": "conventional-commits" },
+          { "context": "gitleaks" },
+          { "context": "visual regression" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,38 @@
+{
+  "name": "main-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "type-check · lint · audit" },
+          { "context": "gitleaks" },
+          { "context": "visual regression" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
   - Intentional visual change → open the Chromatic build, review the diff, click **Accept**. Never work around the check by tweaking `.github/workflows/chromatic.yml` or suppressing stories.
 - `development` is the baseline branch (`autoAcceptChanges: development`). Story changes merged into `development` become the new baseline automatically.
 - Skip list: `dependabot/**` and `release-please--**`. Other bot branches should not be added without discussion.
-- `CHROMATIC_PROJECT_TOKEN` secret and branch protection rules are user-managed; see [docs/chromatic.md](docs/chromatic.md).
+- `CHROMATIC_PROJECT_TOKEN` secret is user-managed; see [docs/chromatic.md](docs/chromatic.md). Branch protection for `development` and `main` is codified as ruleset JSON — see [docs/governance.md](docs/governance.md).
 - Chromatic MCP: after the first successful publish, the remote endpoint exposes only `docs` tools. Dev/test tools stay on the local Storybook server — don't try to replicate them remotely.
 - The Chromatic MCP entry in `.mcp.json` is part of the repo contract — don't edit or remove it as a drive-by. New MCP servers get their own entry and their own issue; breaking changes to the existing Chromatic URL require a tracked migration PR.
 - Chromatic also runs a Figma design-code diff on each build. Every Storybook story is mapped to its Figma counterpart via the `storybook-id: <kebab-case>` string in the Figma component description (see [docs/figma.md](docs/figma.md#component-description--storybook-id)). When a build shows `Not implemented` or `Design changed`, treat it as a signal to coordinate a follow-up with design, not as a Chromatic config glitch.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,99 @@
+# Governance — yönetişim
+
+Glaon'un hangi kuralı neyin koruduğunu, kuralı kimin nasıl değiştireceğini ve bir kuralı bozmak istediğinde hangi yolu izleyeceğini bir arada tutan tek sayfa.
+
+## Neden bu sayfa var?
+
+CLAUDE.md, geliştirme sırasında uygulanan davranış kurallarını anlatır (Issue-First, Branching, PR Scope & Test Plan Sync, vb.). Bu doküman ise o kuralları **GitHub'da makineye öğretilen** tarafla — branch protection ruleset'leri, CODEOWNERS, PR template — eşler. İkisi birlikte: CLAUDE.md = insan kuralı, buradaki config'ler = GitHub'ın otomatik zorlaması.
+
+## Korunan branch'ler
+
+Repo'nun iki özel branch'i var:
+
+| Branch        | Ne için                                      | Koruma seviyesi                                                      |
+| ------------- | -------------------------------------------- | -------------------------------------------------------------------- |
+| `development` | Entegrasyon branch'i; feature PR'ları buraya | PR zorunlu · linear history · required status checks · no force-push |
+| `main`        | Release branch'i; sadece release-please PR'ı | PR zorunlu · linear history · required status checks · no force-push |
+
+Direkt push her iki branch'te de kapalı. Değişiklik **her zaman** PR üzerinden gider.
+
+Tam konfigürasyon config-as-code olarak JSON'da tutulur:
+
+- [`.github/rulesets/development.json`](../.github/rulesets/development.json)
+- [`.github/rulesets/main.json`](../.github/rulesets/main.json)
+
+## Required status checks
+
+Development'a merge olacak her PR'ın aşağıdaki check'leri yeşil olmalı:
+
+- `type-check · lint · audit` — TS + ESLint + `pnpm audit --audit-level high`
+- `conventional-commits` — commitlint, PR commit'leri için
+- `gitleaks` — secret tarama
+- `visual regression` — Chromatic
+
+`main`'deki liste aynı, sadece `conventional-commits` yok (main'e sadece release-please PR'ı ulaşır; commitlint PR-only event'lerde koşar, main direct push zaten yasak).
+
+Yeni bir required check eklemek istersen:
+
+1. CI workflow'unda job adını kesinleştir (bu ad ruleset'te `"context"` olur).
+2. İlgili JSON'daki `required_status_checks` listesine `{ "context": "<job adı>" }` ekle.
+3. `scripts/apply-rulesets.sh` çalıştır.
+4. Değişikliği PR ile commit et — UI'den değil.
+
+## CODEOWNERS
+
+[`.github/CODEOWNERS`](../.github/CODEOWNERS) her dosya path'ini en az bir sahibe bağlar. Tek maintainer (`@toss-cengiz`) olduğu için pratik etkisi henüz yok ama yapı hazır — yeni bir katılımcı geldiğinde path-based owner ataması tek commit.
+
+Ruleset'te `require_code_owner_review` şu an `false`. Ekip genişlediğinde `true`'ya alınır + `required_approving_review_count` yükseltilir.
+
+## PR template
+
+[`.github/pull_request_template.md`](../.github/pull_request_template.md) `gh pr create` çağrılırken otomatik yüklenir (body verilmezse). Yapı sabit: **Summary / Scope (In-Out) / Test plan / User action / Closes #N**.
+
+Bu şekil CLAUDE.md'deki "PR Scope & Test Plan Sync" mandatory kuralının pratik karşılığı — her PR aynı formatı taşır, reviewer ne olduğunu tek bakışta okur.
+
+## Bir kuralı değiştirme
+
+**UI'dan değiştirme.** GitHub → Settings'ten manuel edit kayıp bırakır: sonraki `apply-rulesets.sh` çalışması UI değişikliğini ezer.
+
+Doğru akış:
+
+1. İlgili JSON veya markdown dosyasını düzenle.
+2. PR aç (Issue-First Rule + bu dosyadaki branching kuralı geçerli).
+3. Merge sonrası `scripts/apply-rulesets.sh` çalıştır — idempotent.
+
+## İlk apply (one-time kullanıcı aksiyonu)
+
+Script'i çalıştırmak admin:repo scope'lu bir token gerektirir:
+
+```bash
+gh auth login --scopes "repo,admin:repo_hook,admin:org,admin:public_key"
+# veya mevcut token'a admin:repo scope'u ekle
+scripts/apply-rulesets.sh
+```
+
+Başarılı çıktı:
+
+```
+Applying ruleset: development-protection
+  → created
+Applying ruleset: main-protection
+  → created
+
+Done. Current rulesets on toss-cengiz/glaon:
+  - development-protection (active)
+  - main-protection (active)
+```
+
+Sonraki çalıştırmalar `created` yerine `updated` yazar.
+
+## Bypass
+
+`bypass_actors` her iki ruleset'te boş. Bu bilinçli: branch protection kuralı insan için olduğu kadar Claude için de. Bir agent'ın veya bot'un kuralı geçmesi gerekiyorsa, o ihtiyaç kendi başına bir issue olur; körü körüne bypass eklenmez.
+
+## Referanslar
+
+- CLAUDE.md: repo'nun davranış kuralları.
+- [GitHub Rulesets API](https://docs.github.com/en/rest/repos/rules) — ruleset schema'sı.
+- [CODEOWNERS syntax](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+- İlgili issue: #69.

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Apply branch protection rulesets to this repo using gh CLI.
+#
+# Requirements:
+#   - gh CLI authenticated with a token that has admin:repo scope.
+#   - jq on $PATH.
+#
+# Usage:
+#   scripts/apply-rulesets.sh
+#
+# Idempotent: a ruleset with the same "name" gets updated; otherwise created.
+
+set -euo pipefail
+
+OWNER="${GLAON_OWNER:-toss-cengiz}"
+REPO="${GLAON_REPO:-glaon}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+rulesets_dir="$script_dir/../.github/rulesets"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required on \$PATH" >&2
+  exit 1
+fi
+
+apply_ruleset() {
+  local file="$1"
+  local name
+  name=$(jq -r '.name' "$file")
+  printf 'Applying ruleset: %s\n' "$name"
+
+  local existing_id
+  existing_id=$(gh api "repos/$OWNER/$REPO/rulesets" --jq ".[] | select(.name == \"$name\") | .id" || true)
+
+  if [[ -n "$existing_id" ]]; then
+    gh api --method PUT "repos/$OWNER/$REPO/rulesets/$existing_id" --input "$file" >/dev/null
+    printf '  → updated (id: %s)\n' "$existing_id"
+  else
+    gh api --method POST "repos/$OWNER/$REPO/rulesets" --input "$file" >/dev/null
+    printf '  → created\n'
+  fi
+}
+
+for file in "$rulesets_dir"/*.json; do
+  apply_ruleset "$file"
+done
+
+printf '\nDone. Current rulesets on %s/%s:\n' "$OWNER" "$REPO"
+gh api "repos/$OWNER/$REPO/rulesets" --jq '.[] | "  - \(.name) (\(.enforcement))"'


### PR DESCRIPTION
## Summary

- Move Glaon's governance (branch protection, CODEOWNERS, PR template) from "user action after merge" to config-as-code. One idempotent script applies rulesets to GitHub.
- Add `docs/governance.md` as the single explainer for what's protected, how to change a rule, and how to re-apply.
- Fix a stale line in `CLAUDE.md` that said branch protection is user-managed — it now points to `docs/governance.md`.

## Scope

### In

- `.github/rulesets/development.json`, `.github/rulesets/main.json` — branch protection rules as JSON.
- `scripts/apply-rulesets.sh` — idempotent apply via `gh api`; requires `admin:repo` scope.
- `.github/CODEOWNERS` — path → owner mapping (single maintainer today; structure ready for contributors).
- `.github/pull_request_template.md` — Summary / Scope (In/Out) / Test plan / User action / Closes #N. Matches the "PR Scope & Test Plan Sync" mandatory rule.
- `docs/governance.md` — Turkish explainer per doc language policy.
- `CLAUDE.md` — one-line update: "branch protection user-managed" → "codified, see docs/governance.md".

### Out

- Team-based ownership or review-assignment automation — single-maintainer repo.
- A workflow that maps issue-form dropdowns to labels (covered in the deferred follow-up from #71).
- Merge queue setup — not needed at current throughput.
- Changing the `conventional-commits` check to also gate main — main only receives release-please PRs, which have their own commit format.

## Test plan

- [ ] CI green on this PR: type-check · lint · audit · gitleaks · commitlint · visual regression.
- [ ] \`jq . .github/rulesets/*.json\` validates — already verified locally.
- [ ] \`bash -n scripts/apply-rulesets.sh\` validates — already verified locally.
- [ ] After merge, \`gh pr create\` with no \`--body\` loads the new PR template.

## User action (after merge)

- [ ] Re-auth gh with \`admin:repo\` scope if not already: \`gh auth refresh --scopes "repo,admin:repo_hook"\`.
- [ ] Run \`scripts/apply-rulesets.sh\` once to push both rulesets into GitHub. Expected output lists both as \`created\` on first run, \`updated\` afterwards.
- [ ] Confirm at https://github.com/toss-cengiz/glaon/rules that \`development-protection\` and \`main-protection\` are both \`active\`.
- [ ] Open a throwaway branch, push an empty commit to \`development\`, and confirm GitHub blocks the direct push with "protected branch".

Closes #69