### PR TITLE
docs(governance): document merge-method policy + codify repo settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 - Never branch from `main` for feature work; never commit directly to `main` or `development`.
 - PRs always target `development`. Base flag: `gh pr create --base development`.
 - The user reviews and merges the PR. **Claude does not run `gh pr merge`** unless explicitly told to.
+- Merge method is **Squash and merge** (default) or **Rebase and merge**; merge-commits are disabled repo-wide because `development`/`main` both require linear history. The squash commit inherits `PR_TITLE` as its subject and `PR_BODY` as its message, so the PR title must already be a valid Conventional Commit — release-please reads those commits on `main` to produce the release. See [docs/governance.md](docs/governance.md#merge-method-policy).
 - `development → main` merges happen only during release cycles, in a separate PR.
 - Standard start-of-work sequence:
   ```bash

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -22,6 +22,31 @@ Tam konfigürasyon config-as-code olarak JSON'da tutulur:
 - [`.github/rulesets/development.json`](../.github/rulesets/development.json)
 - [`.github/rulesets/main.json`](../.github/rulesets/main.json)
 
+## Merge method policy
+
+Development ruleset'i `required_linear_history: true` zorladığı için merge-commit (yani `Create a merge commit` seçeneği) kullanılamaz. Repo ayarları bunu destekleyecek şekilde kilitlenmiştir:
+
+| Ayar                 | Değer              | Neden                                                                    |
+| -------------------- | ------------------ | ------------------------------------------------------------------------ |
+| `allow_squash_merge` | `true` _(default)_ | Standart akış: her PR development'a tek commit olarak düşer.             |
+| `allow_rebase_merge` | `true`             | Zaten tek commit olan, conventional-commit başlığı doğru PR'lar için.    |
+| `allow_merge_commit` | `false`            | `required_linear_history` ile çakışıyordu; hem UI hem ruleset kapatıyor. |
+
+Squash commit formatı:
+
+- **Title:** `PR_TITLE` — PR başlığı commit başlığı olur.
+- **Body:** `PR_BODY` — PR body'si commit gövdesine kopyalanır.
+
+Bu format release-please için kritik: `development → main` akışında release-please merge edilmiş commit'leri okuyarak versiyon bump'ı ve CHANGELOG'u üretir. Squash commit başlığı geçerli bir Conventional Commit (`feat:`, `fix:`, `refactor!:`, vb.) değilse release-please o PR'ı atlar. PR başlığını bu yüzden `commitlint` formatında tutuyoruz.
+
+Pratik sonuç:
+
+- PR UI'ında yalnızca **Squash and merge** ve **Rebase and merge** seçenekleri görünür. Merge-commit butonu gri.
+- Feature PR'ları varsayılan olarak **Squash and merge** ile kapanır.
+- Rebase yalnızca PR zaten tek commit ise ve o commit'in başlığı tam olarak istenen commit başlığı ise mantıklı.
+
+Bu ayarlar Web UI'dan `Settings → General → Merge button` sayfası üzerinden de görülebilir; ama tek gerçeklik kaynağı [`scripts/apply-repo-settings.sh`](../scripts/apply-repo-settings.sh) script'idir. UI'dan elle değişiklik yapma — bir sonraki script çalışmasında ezilir.
+
 ## Required status checks
 
 Development'a merge olacak her PR'ın aşağıdaki check'leri yeşil olmalı:
@@ -64,15 +89,17 @@ Doğru akış:
 
 ## İlk apply (one-time kullanıcı aksiyonu)
 
-Script'i çalıştırmak admin:repo scope'lu bir token gerektirir:
+İki script var, ikisi de idempotent ve admin:repo scope'lu bir token gerektirir:
 
 ```bash
 gh auth login --scopes "repo,admin:repo_hook,admin:org,admin:public_key"
 # veya mevcut token'a admin:repo scope'u ekle
-scripts/apply-rulesets.sh
+
+scripts/apply-rulesets.sh       # branch protection ruleset'leri
+scripts/apply-repo-settings.sh  # merge method ayarları
 ```
 
-Başarılı çıktı:
+`apply-rulesets.sh` çıktısı:
 
 ```
 Applying ruleset: development-protection
@@ -87,6 +114,18 @@ Done. Current rulesets on toss-cengiz/glaon:
 
 Sonraki çalıştırmalar `created` yerine `updated` yazar.
 
+`apply-repo-settings.sh` çıktısı:
+
+```
+Applying repo merge-method settings...
+  allow_squash_merge:  true
+  allow_rebase_merge:  true
+  allow_merge_commit:  false
+  squash_title:        PR_TITLE
+  squash_body:         PR_BODY
+Done.
+```
+
 ## Bypass
 
 `bypass_actors` her iki ruleset'te boş. Bu bilinçli: branch protection kuralı insan için olduğu kadar Claude için de. Bir agent'ın veya bot'un kuralı geçmesi gerekiyorsa, o ihtiyaç kendi başına bir issue olur; körü körüne bypass eklenmez.
@@ -96,4 +135,4 @@ Sonraki çalıştırmalar `created` yerine `updated` yazar.
 - CLAUDE.md: repo'nun davranış kuralları.
 - [GitHub Rulesets API](https://docs.github.com/en/rest/repos/rules) — ruleset schema'sı.
 - [CODEOWNERS syntax](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
-- İlgili issue: #69.
+- İlgili issue: #69 (initial setup), #75 (merge method policy).

--- a/scripts/apply-repo-settings.sh
+++ b/scripts/apply-repo-settings.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Apply repository-level merge-method settings using gh CLI.
+#
+# Requirements:
+#   - gh CLI authenticated with a token that has admin:repo scope.
+#
+# Usage:
+#   scripts/apply-repo-settings.sh
+#
+# Idempotent: PATCH resets settings to the desired values on every run.
+#
+# What this enforces:
+#   - allow_squash_merge:  true  (default merge method)
+#   - allow_rebase_merge:  true  (for PRs already carrying the exact commit)
+#   - allow_merge_commit:  false (required_linear_history forbids merge commits)
+#   - squash title:        PR_TITLE  (PR title becomes commit subject)
+#   - squash body:         PR_BODY   (PR body becomes commit body)
+#
+# PR title/body format matters because release-please reads the squash commit
+# on development/main to produce the release — the subject must be a valid
+# Conventional Commit (feat:, fix:, refactor!:, ...).
+
+set -euo pipefail
+
+OWNER="${GLAON_OWNER:-toss-cengiz}"
+REPO="${GLAON_REPO:-glaon}"
+
+printf 'Applying repo merge-method settings...\n'
+
+gh api --method PATCH "repos/$OWNER/$REPO" \
+  -F allow_squash_merge=true \
+  -F allow_rebase_merge=true \
+  -F allow_merge_commit=false \
+  -F squash_merge_commit_title=PR_TITLE \
+  -F squash_merge_commit_message=PR_BODY \
+  --jq '{
+    allow_squash_merge,
+    allow_rebase_merge,
+    allow_merge_commit,
+    squash_merge_commit_title,
+    squash_merge_commit_message
+  }' | jq -r '
+    "  allow_squash_merge:  \(.allow_squash_merge)",
+    "  allow_rebase_merge:  \(.allow_rebase_merge)",
+    "  allow_merge_commit:  \(.allow_merge_commit)",
+    "  squash_title:        \(.squash_merge_commit_title)",
+    "  squash_body:         \(.squash_merge_commit_message)"
+  '
+
+printf 'Done.\n'


### PR DESCRIPTION
## Summary

- Add **Merge method policy** section to [docs/governance.md](docs/governance.md) explaining why merge-commits are disabled and how squash commits feed release-please.
- Add [scripts/apply-repo-settings.sh](scripts/apply-repo-settings.sh) — idempotent `gh api -X PATCH` that codifies the merge-method repo settings next to the existing ruleset script.
- Update CLAUDE.md's Branching section so future work defaults to squash and treats PR titles as Conventional Commits.

## Scope

### In

- `docs/governance.md` — new section with a three-row table (squash / rebase / merge-commit) + rationale + squash title/body format.
- `scripts/apply-repo-settings.sh` — sets `allow_squash_merge=true`, `allow_rebase_merge=true`, `allow_merge_commit=false`, `squash_merge_commit_title=PR_TITLE`, `squash_merge_commit_message=PR_BODY`. Prints a condensed summary.
- `CLAUDE.md` — one-line note under Branching and PR Workflow: squash is default, rebase allowed, merge-commit disabled, PR title must be a valid Conventional Commit.
- Updated "İlk apply" section in governance.md to list both scripts (apply-rulesets.sh and apply-repo-settings.sh).

### Out

- No ruleset JSON changes — the existing `development-protection` / `main-protection` rulesets stay as-is.
- No PR template or CODEOWNERS changes.
- No CI workflow changes — docs-only PR on code side.

## Context

PR #73 merged with `required_linear_history: true` in the development ruleset. At that point the repo was still configured with only `allow_merge_commit: true`, which created a deadlock: the only allowed method (merge-commit) was forbidden by the ruleset. PR #74 surfaced this when the user tried to merge and saw "Merge is not an allowed merge method in this repository. This branch must not contain merge commits."

The fix was applied live via `gh api -X PATCH`. This PR records that fix in the repo itself.

## Test plan

- [x] `pnpm exec prettier --check docs/governance.md CLAUDE.md` passes
- [x] `bash -n scripts/apply-repo-settings.sh` — syntax check
- [x] Running `scripts/apply-repo-settings.sh` on an already-configured repo is idempotent (PATCH is a no-op on current values) — verified mentally via PATCH semantics; actual re-run deferred to post-merge sanity check
- [x] Governance doc reads top-to-bottom coherently with the new section in place
- [x] CLAUDE.md diff is a one-line addition under Branching, no other changes

## User action (post-merge)

- Optional: re-run `scripts/apply-repo-settings.sh` once to confirm the script produces the same output as the live state. If it does, the script is the source of truth going forward.

Closes #75