### PR TITLE
feat(web): wire Sentry SDK with platform-agnostic PII scrubber

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,6 +49,10 @@ jobs:
 
       - name: Build web app
         run: pnpm --filter @glaon/web build
+        env:
+          # Placeholder DSN so the production-build DSN gate in vite.config.ts passes.
+          # Events would go nowhere (dummy host) — E2E doesn't assert on Sentry traffic.
+          VITE_SENTRY_DSN: https://public@sentry.invalid/0
 
       - name: Run Playwright smoke tests
         run: pnpm --filter @glaon/web-e2e e2e --project=chromium --grep @smoke

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -6,3 +6,17 @@ VITE_HA_CLIENT_ID=https://glaon.local/
 
 # Runtime mode: 'standalone' | 'ingress' | 'kiosk'
 VITE_APP_MODE=standalone
+
+# Sentry — required for production builds, optional in development.
+# See docs/observability.md.
+VITE_SENTRY_DSN=
+# Optional: override the environment tag (defaults to Vite mode).
+VITE_SENTRY_ENVIRONMENT=
+# Optional: release identifier (usually the git SHA or package version).
+VITE_SENTRY_RELEASE=
+
+# Build-time only — set in the deploy pipeline to upload source maps to Sentry.
+# Leave blank locally; enabling these without proper credentials will break the build.
+SENTRY_AUTH_TOKEN=
+SENTRY_ORG=
+SENTRY_PROJECT=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,11 +14,13 @@
   "dependencies": {
     "@glaon/core": "workspace:*",
     "@glaon/ui": "workspace:*",
+    "@sentry/browser": "^10.49.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },
   "devDependencies": {
     "@glaon/config": "workspace:*",
+    "@sentry/vite-plugin": "^5.2.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^4.4.0",

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,9 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { initObservability } from './observability';
+
+initObservability();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/apps/web/src/observability.ts
+++ b/apps/web/src/observability.ts
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/browser';
+
+import type { ObservabilityEvent } from '@glaon/core/observability';
+import { buildBeforeSend } from '@glaon/core/observability';
+
+const CONSOLE_TAG = '[glaon/observability]';
+
+export function initObservability(): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  const mode = import.meta.env.MODE;
+  const isProd = import.meta.env.PROD;
+
+  if (!dsn) {
+    if (isProd) {
+      // Loud but non-fatal at runtime — the build-time check in vite.config.ts
+      // is the real gate for production deploys. Logging here covers the case
+      // where a production bundle is served through an environment that
+      // bypassed the build gate (e.g. a pre-built artifact from a different
+      // pipeline).
+      console.error(
+        `${CONSOLE_TAG} VITE_SENTRY_DSN is missing in a production bundle — errors will not be reported.`,
+      );
+    } else {
+      console.warn(`${CONSOLE_TAG} Sentry disabled (no DSN set, mode=${mode}).`);
+    }
+    return;
+  }
+
+  const scrub = buildBeforeSend();
+
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? mode,
+    release: import.meta.env.VITE_SENTRY_RELEASE,
+    tracesSampleRate: isProd ? 0.1 : 1.0,
+    sendDefaultPii: false,
+    beforeSend: (event) => {
+      const scrubbed = scrub(event as unknown as ObservabilityEvent);
+      return scrubbed as unknown as Sentry.ErrorEvent;
+    },
+  });
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_HA_BASE_URL: string;
+  readonly VITE_HA_CLIENT_ID: string;
+  readonly VITE_APP_MODE: 'standalone' | 'ingress' | 'kiosk';
+  readonly VITE_SENTRY_DSN?: string;
+  readonly VITE_SENTRY_ENVIRONMENT?: string;
+  readonly VITE_SENTRY_RELEASE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,12 +3,13 @@ import react from '@vitejs/plugin-react';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import type { PluginOption } from 'vite';
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const isProd = mode === 'production';
+  const isBuild = command === 'build';
   const dsn = env.VITE_SENTRY_DSN;
 
-  if (isProd && !dsn) {
+  if (isBuild && isProd && !dsn) {
     throw new Error(
       '[glaon/web] VITE_SENTRY_DSN is required for production builds. ' +
         'Set it in the build environment (e.g. repo secret for the deploy workflow) or build with --mode development.',
@@ -21,7 +22,7 @@ export default defineConfig(({ mode }) => {
   const org = env.SENTRY_ORG;
   const project = env.SENTRY_PROJECT;
 
-  if (isProd && authToken && org && project) {
+  if (isBuild && isProd && authToken && org && project) {
     const releaseOpts = env.VITE_SENTRY_RELEASE
       ? { release: { name: env.VITE_SENTRY_RELEASE } }
       : {};

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,14 +1,51 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import { sentryVitePlugin } from '@sentry/vite-plugin';
+import type { PluginOption } from 'vite';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    strictPort: true,
-  },
-  build: {
-    target: 'es2022',
-    sourcemap: true,
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const isProd = mode === 'production';
+  const dsn = env.VITE_SENTRY_DSN;
+
+  if (isProd && !dsn) {
+    throw new Error(
+      '[glaon/web] VITE_SENTRY_DSN is required for production builds. ' +
+        'Set it in the build environment (e.g. repo secret for the deploy workflow) or build with --mode development.',
+    );
+  }
+
+  const plugins: PluginOption[] = [react()];
+
+  const authToken = env.SENTRY_AUTH_TOKEN;
+  const org = env.SENTRY_ORG;
+  const project = env.SENTRY_PROJECT;
+
+  if (isProd && authToken && org && project) {
+    const releaseOpts = env.VITE_SENTRY_RELEASE
+      ? { release: { name: env.VITE_SENTRY_RELEASE } }
+      : {};
+    plugins.push(
+      sentryVitePlugin({
+        org,
+        project,
+        authToken,
+        ...releaseOpts,
+        sourcemaps: { assets: './dist/**' },
+        telemetry: false,
+      }),
+    );
+  }
+
+  return {
+    plugins,
+    server: {
+      port: 5173,
+      strictPort: true,
+    },
+    build: {
+      target: 'es2022',
+      sourcemap: true,
+    },
+  };
 });

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,117 @@
+# Observability — Sentry entegrasyonu
+
+Glaon çalışma zamanı hatalarını ve performans sinyallerini **Sentry** üzerinden toplar. Bu sayfa web tarafının entegrasyonunu anlatır; mobile tarafı ayrı bir issue'da (bkz. #78) ele alınacak.
+
+## Mimari
+
+İki katman var:
+
+| Katman                          | Ne yapar                                                                                                   |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `@glaon/core/observability`     | Platform-bağımsız tipler + PII scrubber. DOM/RN import etmez. Web ve mobile aynı scrubber'ı paylaşır.      |
+| `apps/web/src/observability.ts` | `@sentry/browser` SDK'sını runtime'da init eder; core'dan gelen `buildBeforeSend`'i `Sentry.init`'e verir. |
+
+Core, **politika** (ne maskelenir, hangi anahtar hassas) ve **saf fonksiyonlar** (scrub) tutar. SDK importu ve init, uygulama katmanında.
+
+## Scrubber ne maskeler
+
+`buildBeforeSend()` her event için şu işlemleri yapar (kaynak: [packages/core/src/observability/scrubber.ts](../packages/core/src/observability/scrubber.ts)):
+
+- **URL query param'ları** — `access_token`, `refresh_token`, `id_token`, `token`, `code`, `state`, `client_secret`, `api_key`. OAuth2 callback URL'lerinin Sentry'ye sızmasını engeller.
+- **Header'lar** — `Authorization`, `Cookie`, `Set-Cookie`, `X-Auth-Token`, `X-Hasura-Admin-Secret` (case-insensitive).
+- **Objede anahtar adı geçen alanlar** (recursive) — anahtar adı `access_token`, `refresh_token`, `id_token`, `bearer`, `password`, `secret`, `api_key`, `client_secret`, `authorization` substring'lerinden birini içeriyorsa değer `[Filtered]` ile değiştirilir.
+- **Request cookie** — direkt `[Filtered]`.
+- **Breadcrumb `data.url` ve `data.query_string`** — URL scrubber'ından geçer. `breadcrumb.message` serbest metin kabul edilir, dokunulmaz (URL'ler breadcrumb.data.url altında taşınır).
+
+Scrubber non-mutating (girdi objesini değiştirmez) ve `MAX_SCRUB_DEPTH = 8` ile sonsuz dallanmayı keser. Davranışsal kontrat [scrubber.test.ts](../packages/core/src/observability/scrubber.test.ts) içindeki 16 test ile donmuş — politikayı değiştirirken test de güncellenir.
+
+Yeni bir hassas alan eklemek için `SENSITIVE_URL_PARAMS`, `SENSITIVE_HEADER_NAMES` veya `SENSITIVE_KEY_SUBSTRINGS` listelerine ekle ve ilgili test case'i ekle. Kod değişmeden.
+
+## Konfigürasyon
+
+### Environment variables
+
+`apps/web/.env.example` içinde hepsi dokümante:
+
+| Değişken                  | Zorunlu                | Açıklama                                                                                    |
+| ------------------------- | ---------------------- | ------------------------------------------------------------------------------------------- |
+| `VITE_SENTRY_DSN`         | Prod build'te **evet** | Sentry project DSN'i. Yoksa prod build başarısız (vite.config.ts gate'i). Dev'de opsiyonel. |
+| `VITE_SENTRY_ENVIRONMENT` | Hayır                  | Override environment tag. Boşsa Vite `mode` kullanılır.                                     |
+| `VITE_SENTRY_RELEASE`     | Hayır                  | Release identifier (genelde git SHA veya paket versiyonu).                                  |
+| `SENTRY_AUTH_TOKEN`       | Source map upload için | Build-time only. CI'da secret; lokalde genelde boş.                                         |
+| `SENTRY_ORG`              | Source map upload için | Sentry organizasyon slug'ı.                                                                 |
+| `SENTRY_PROJECT`          | Source map upload için | Sentry proje slug'ı.                                                                        |
+
+Üçü (`AUTH_TOKEN`, `ORG`, `PROJECT`) aynı anda set edildiğinde `@sentry/vite-plugin` build sırasında source map'leri yükler ve dist'ten silmez — release'e bağlanır. Aksi durumda plugin devreye girmez.
+
+### Prod build gate
+
+[apps/web/vite.config.ts](../apps/web/vite.config.ts) production build'lerde `VITE_SENTRY_DSN` yoksa hata fırlatır. Amaç: DSN'siz prod artifact deploy etme olasılığını CI-time'da kapatmak.
+
+Bu gate CI'daki E2E workflow'unu etkiler — [`.github/workflows/e2e.yml`](../.github/workflows/e2e.yml) Build web app adımında placeholder bir DSN (`https://public@sentry.invalid/0`) set eder. Event'ler hiçbir yere gitmez; E2E zaten Sentry trafiğine assert etmez.
+
+### Runtime init
+
+[apps/web/src/main.tsx](../apps/web/src/main.tsx), render'dan önce `initObservability()` çağırır. DSN yoksa:
+
+- **Prod bundle'da** — `console.error` ile bağırır ama crash etmez. Build gate'i bypass'lanmış bir artifact'ı tespit etmek için sessiz fallback.
+- **Dev'de** — `console.info` ile sessizce kapanır.
+
+DSN varsa `Sentry.init` çağrılır: `tracesSampleRate` prod'da 0.1, dev'de 1.0; `sendDefaultPii: false`; `beforeSend` core scrubber'ı.
+
+## Yeni breadcrumb veya custom event eklemek
+
+SDK doğrudan `apps/web`'te import'lanır; bileşen kodu Sentry'yi bilmek zorunda değil. İhtiyaç olduğunda:
+
+```ts
+import * as Sentry from '@sentry/browser';
+
+Sentry.addBreadcrumb({
+  category: 'ha.ws',
+  message: 'websocket reconnect attempt',
+  level: 'info',
+  data: { url: wsUrl, attempt: retryCount },
+});
+```
+
+`data.url` otomatik olarak URL scrubber'ından geçer — elle temizlemeye gerek yok.
+
+`Sentry.captureException(err)` benzer şekilde, core politika beforeSend'te devreye girer.
+
+## Manuel doğrulama
+
+Lokal prod build DSN olmadan:
+
+```bash
+pnpm --filter @glaon/web build
+# Error: [glaon/web] VITE_SENTRY_DSN is required for production builds. ...
+```
+
+Placeholder DSN ile:
+
+```bash
+VITE_SENTRY_DSN=https://public@sentry.invalid/0 pnpm --filter @glaon/web build
+# Build geçer, source map plugin devreye girmez (AUTH_TOKEN boş).
+```
+
+Core test'i:
+
+```bash
+pnpm --filter @glaon/core test
+```
+
+## Kullanıcı tarafı — merge sonrası adımlar
+
+Bu PR kod iskeletini bitirir; gerçek event akışı için repo-dışı konfigürasyon gerekiyor:
+
+1. **Sentry projesi oluştur** — `sentry.io`'da yeni React projesi aç. DSN'i kopyala.
+2. **Repo secret'ları ekle** — GitHub repo → Settings → Secrets → Actions:
+   - `SENTRY_DSN_WEB` (veya benzeri isim, deploy workflow'unda `VITE_SENTRY_DSN` olarak inject edilir)
+   - `SENTRY_AUTH_TOKEN` — Sentry → User Auth Tokens, `project:releases` + `project:write` scope'ları ile
+   - `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`
+3. **Deploy workflow'unu güncelle** — HA Add-on deploy akışı (#70) açıldığında yukarıdaki secret'lar build step'ine verilir. E2E workflow'undaki placeholder DSN burada gerçek DSN ile değişir.
+4. **PII scrubber doğrulaması** — Prod trafiği başladıktan sonra Sentry UI'da ilk birkaç event'i gözden geçir; query string, header, body alanlarında token/secret kalmadığını doğrula. Yeni bir sızıntı tespit edilirse `SENSITIVE_*` listelerine ekle.
+
+## Neden SDK core'da değil
+
+`@glaon/core` hem web (Vite/React) hem mobile (Expo/RN) tarafından import edilir. `@sentry/browser` DOM API'lerine (`window`, `document`, `XMLHttpRequest`) dayanır; RN bundle'ına sokulursa runtime'da patlar. Mobile tarafı ayrı bir SDK (`@sentry/react-native`) kullanır. Core sadece politika + scrubber tutarak her iki tarafın SDK'sına aynı `beforeSend`'i pas etmeyi mümkün kılar.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -46,7 +46,7 @@ Yeni bir hassas alan eklemek için `SENSITIVE_URL_PARAMS`, `SENSITIVE_HEADER_NAM
 
 ### Prod build gate
 
-[apps/web/vite.config.ts](../apps/web/vite.config.ts) production build'lerde `VITE_SENTRY_DSN` yoksa hata fırlatır. Amaç: DSN'siz prod artifact deploy etme olasılığını CI-time'da kapatmak.
+[apps/web/vite.config.ts](../apps/web/vite.config.ts) production build'lerde (`command === 'build' && mode === 'production'`) `VITE_SENTRY_DSN` yoksa hata fırlatır. Amaç: DSN'siz prod artifact deploy etme olasılığını CI-time'da kapatmak. `vite preview` ve dev server gate'i tetiklemez — preview zaten önceden üretilmiş dist'i servis eder, yeni artifact üretmez.
 
 Bu gate CI'daki E2E workflow'unu etkiler — [`.github/workflows/e2e.yml`](../.github/workflows/e2e.yml) Build web app adımında placeholder bir DSN (`https://public@sentry.invalid/0`) set eder. Event'ler hiçbir yere gitmez; E2E zaten Sentry trafiğine assert etmez.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts",
     "./auth": "./src/auth/index.ts",
     "./ha": "./src/ha/index.ts",
+    "./observability": "./src/observability/index.ts",
     "./types": "./src/types.ts"
   },
   "scripts": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * as auth from './auth';
 export * as ha from './ha';
+export * as observability from './observability';

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -1,0 +1,20 @@
+export type {
+  BeforeSendFunction,
+  ObservabilityBreadcrumb,
+  ObservabilityConfig,
+  ObservabilityEvent,
+  ObservabilityRequest,
+} from './types';
+
+export {
+  REDACTED,
+  SENSITIVE_HEADER_NAMES,
+  SENSITIVE_KEY_SUBSTRINGS,
+  SENSITIVE_URL_PARAMS,
+  buildBeforeSend,
+  scrubEvent,
+  scrubHeaders,
+  scrubQueryString,
+  scrubRecursive,
+  scrubUrl,
+} from './scrubber';

--- a/packages/core/src/observability/scrubber.test.ts
+++ b/packages/core/src/observability/scrubber.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ObservabilityEvent } from './types';
+import {
+  REDACTED,
+  buildBeforeSend,
+  scrubEvent,
+  scrubHeaders,
+  scrubQueryString,
+  scrubRecursive,
+  scrubUrl,
+} from './scrubber';
+
+describe('scrubUrl', () => {
+  it('redacts sensitive query params', () => {
+    const result = scrubUrl('https://ha.local/api/auth?access_token=abc&code=xyz&other=keep');
+    expect(result).not.toContain('abc');
+    expect(result).not.toContain('xyz');
+    expect(result).toContain('other=keep');
+    expect(result).toContain(encodeURIComponent(REDACTED));
+  });
+
+  it('leaves unrelated URLs untouched', () => {
+    const url = 'https://ha.local/api/entity/light.kitchen';
+    expect(scrubUrl(url)).toBe(url);
+  });
+
+  it('returns the original string for malformed URLs', () => {
+    expect(scrubUrl('not a url')).toBe('not a url');
+  });
+
+  it('redacts token, refresh_token, id_token, state, client_secret, api_key', () => {
+    const url =
+      'https://example.com/x?token=a&refresh_token=b&id_token=c&state=d&client_secret=e&api_key=f';
+    const result = scrubUrl(url);
+    for (const secret of ['a', 'b', 'c', 'd', 'e', 'f']) {
+      expect(result).not.toContain(`=${secret}`);
+    }
+  });
+});
+
+describe('scrubQueryString', () => {
+  it('redacts sensitive params in a query string', () => {
+    const result = scrubQueryString('access_token=xyz&foo=bar');
+    expect(result).not.toContain('xyz');
+    expect(result).toContain('foo=bar');
+  });
+
+  it('handles a leading question mark', () => {
+    const result = scrubQueryString('?code=abc&q=hello');
+    expect(result).not.toContain('abc');
+    expect(result).toContain('q=hello');
+  });
+});
+
+describe('scrubHeaders', () => {
+  it('redacts Authorization, Cookie, Set-Cookie regardless of case', () => {
+    const result = scrubHeaders({
+      Authorization: 'Bearer token123',
+      cookie: 'session=abc',
+      'Set-Cookie': 'x=y',
+      'X-Auth-Token': 'zzz',
+      'X-Request-Id': 'keep-me',
+    });
+    expect(result.Authorization).toBe(REDACTED);
+    expect(result.cookie).toBe(REDACTED);
+    expect(result['Set-Cookie']).toBe(REDACTED);
+    expect(result['X-Auth-Token']).toBe(REDACTED);
+    expect(result['X-Request-Id']).toBe('keep-me');
+  });
+});
+
+describe('scrubRecursive', () => {
+  it('redacts keys whose name contains a sensitive substring', () => {
+    const input = {
+      user_access_token: 'abc',
+      nested: { refresh_token: 'xyz', name: 'alice' },
+      list: [{ password: 'p1' }, { safe: 'ok' }],
+    };
+    const result = scrubRecursive(input) as Record<string, unknown>;
+    expect(result.user_access_token).toBe(REDACTED);
+    const nested = result.nested as Record<string, unknown>;
+    expect(nested.refresh_token).toBe(REDACTED);
+    expect(nested.name).toBe('alice');
+    const list = result.list as Record<string, unknown>[];
+    expect(list[0]?.password).toBe(REDACTED);
+    expect(list[1]?.safe).toBe('ok');
+  });
+
+  it('stops recursing at the safety depth and returns the deep value as-is', () => {
+    let node: Record<string, unknown> = { access_token: 'leaf' };
+    for (let i = 0; i < 10; i++) {
+      node = { child: node };
+    }
+    const result = scrubRecursive(node, 0) as Record<string, unknown>;
+    // We don't assert exact redaction at depth; only that it didn't throw and returned an object.
+    expect(result).toBeTypeOf('object');
+  });
+
+  it('passes through null, primitives, and undefined unchanged', () => {
+    expect(scrubRecursive(null)).toBe(null);
+    expect(scrubRecursive(42)).toBe(42);
+    expect(scrubRecursive('plain')).toBe('plain');
+    expect(scrubRecursive(undefined)).toBe(undefined);
+  });
+});
+
+describe('scrubEvent', () => {
+  it('scrubs request.url, headers, cookies, and data', () => {
+    const event: ObservabilityEvent = {
+      request: {
+        url: 'https://ha.local/api/auth/token?access_token=leak',
+        headers: { Authorization: 'Bearer xxx', 'X-Ok': 'y' },
+        cookies: 'session=abc',
+        data: { password: 'p', name: 'glaon' },
+        query_string: 'code=abc&q=hello',
+      },
+    };
+    const result = scrubEvent(event);
+    expect(result.request?.url).not.toContain('leak');
+    expect(result.request?.headers?.Authorization).toBe(REDACTED);
+    expect(result.request?.cookies).toBe(REDACTED);
+    const data = result.request?.data as Record<string, unknown>;
+    expect(data.password).toBe(REDACTED);
+    expect(data.name).toBe('glaon');
+    expect(result.request?.query_string).not.toContain('abc');
+    expect(result.request?.query_string).toContain('q=hello');
+  });
+
+  it('scrubs extra, contexts, tags, and http breadcrumbs', () => {
+    const event: ObservabilityEvent = {
+      extra: { access_token: 'leak', keep: 1 },
+      contexts: { auth: { refresh_token: 'r1' } },
+      tags: { client_secret: 's1', env: 'prod' },
+      breadcrumbs: [
+        {
+          category: 'http',
+          message: 'GET /api/auth/token',
+          data: { url: 'https://ha/x?code=y', method: 'GET', api_key: 'k' },
+        },
+      ],
+    };
+    const result = scrubEvent(event);
+    const extra: Record<string, unknown> = result.extra ?? {};
+    expect(extra.access_token).toBe(REDACTED);
+    expect(extra.keep).toBe(1);
+    const contexts = (result.contexts ?? {}) as Record<string, Record<string, unknown>>;
+    expect(contexts.auth?.refresh_token).toBe(REDACTED);
+    const tags: Record<string, unknown> = result.tags ?? {};
+    expect(tags.client_secret).toBe(REDACTED);
+    expect(tags.env).toBe('prod');
+    const bc = result.breadcrumbs?.[0];
+    // Free-text message is passed through unchanged.
+    expect(bc?.message).toBe('GET /api/auth/token');
+    const bcData: Record<string, unknown> = bc?.data ?? {};
+    // URL-keyed values in breadcrumb data get URL-scrubbed.
+    expect(bcData.url).not.toContain('=y');
+    // Sensitive keys anywhere in data get redacted.
+    expect(bcData.api_key).toBe(REDACTED);
+    expect(bcData.method).toBe('GET');
+  });
+
+  it('returns a new object and does not mutate the input', () => {
+    const event: ObservabilityEvent = {
+      extra: { access_token: 'leak' },
+    };
+    const original = JSON.parse(JSON.stringify(event)) as ObservabilityEvent;
+    scrubEvent(event);
+    expect(event).toEqual(original);
+  });
+});
+
+describe('buildBeforeSend', () => {
+  it('returns a function that scrubs events', () => {
+    const beforeSend = buildBeforeSend();
+    const event: ObservabilityEvent = {
+      request: { url: 'https://ha.local/x?token=leak' },
+    };
+    const result = beforeSend(event);
+    expect(result).not.toBeNull();
+    expect(result?.request?.url).not.toContain('leak');
+  });
+});
+
+describe('HA-specific leak scenarios', () => {
+  it('redacts a realistic HA access token passed via query param', () => {
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJoYS5sb2NhbCJ9.fake-sig';
+    const event: ObservabilityEvent = {
+      request: {
+        url: `https://ha.local/auth/token?access_token=${token}`,
+      },
+    };
+    const result = scrubEvent(event);
+    expect(result.request?.url).not.toContain(token);
+  });
+
+  it('redacts Authorization header with Bearer token', () => {
+    const event: ObservabilityEvent = {
+      request: {
+        headers: { Authorization: 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig' },
+      },
+    };
+    const result = scrubEvent(event);
+    expect(result.request?.headers?.Authorization).toBe(REDACTED);
+  });
+});

--- a/packages/core/src/observability/scrubber.ts
+++ b/packages/core/src/observability/scrubber.ts
@@ -1,0 +1,156 @@
+import type {
+  BeforeSendFunction,
+  ObservabilityBreadcrumb,
+  ObservabilityEvent,
+  ObservabilityRequest,
+} from './types';
+
+export const REDACTED = '[Filtered]';
+
+export const SENSITIVE_URL_PARAMS: readonly string[] = [
+  'access_token',
+  'refresh_token',
+  'id_token',
+  'token',
+  'code',
+  'state',
+  'client_secret',
+  'api_key',
+];
+
+export const SENSITIVE_HEADER_NAMES: readonly string[] = [
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-auth-token',
+  'x-hasura-admin-secret',
+];
+
+export const SENSITIVE_KEY_SUBSTRINGS: readonly string[] = [
+  'access_token',
+  'refresh_token',
+  'id_token',
+  'bearer',
+  'password',
+  'secret',
+  'api_key',
+  'client_secret',
+  'authorization',
+];
+
+const MAX_SCRUB_DEPTH = 8;
+
+export function scrubUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  for (const param of SENSITIVE_URL_PARAMS) {
+    if (parsed.searchParams.has(param)) {
+      parsed.searchParams.set(param, REDACTED);
+    }
+  }
+  return parsed.toString();
+}
+
+export function scrubQueryString(query: string): string {
+  const params = new URLSearchParams(query.startsWith('?') ? query.slice(1) : query);
+  for (const param of SENSITIVE_URL_PARAMS) {
+    if (params.has(param)) {
+      params.set(param, REDACTED);
+    }
+  }
+  return params.toString();
+}
+
+export function scrubHeaders(headers: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (SENSITIVE_HEADER_NAMES.includes(key.toLowerCase())) {
+      result[key] = REDACTED;
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export function scrubRecursive(input: unknown, depth = 0): unknown {
+  if (depth >= MAX_SCRUB_DEPTH) return input;
+  if (input === null || typeof input !== 'object') return input;
+  if (Array.isArray(input)) {
+    return input.map((item) => scrubRecursive(item, depth + 1));
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    const keyLower = key.toLowerCase();
+    if (SENSITIVE_KEY_SUBSTRINGS.some((s) => keyLower.includes(s))) {
+      result[key] = REDACTED;
+    } else if (keyLower === 'url' && typeof value === 'string') {
+      result[key] = scrubUrl(value);
+    } else if (keyLower === 'query_string' && typeof value === 'string') {
+      result[key] = scrubQueryString(value);
+    } else {
+      result[key] = scrubRecursive(value, depth + 1);
+    }
+  }
+  return result;
+}
+
+function scrubRequest(request: ObservabilityRequest): ObservabilityRequest {
+  const result: ObservabilityRequest = { ...request };
+  if (typeof result.url === 'string') {
+    result.url = scrubUrl(result.url);
+  }
+  if (typeof result.query_string === 'string') {
+    result.query_string = scrubQueryString(result.query_string);
+  }
+  if (result.headers) {
+    result.headers = scrubHeaders(result.headers);
+  }
+  if (result.cookies !== undefined) {
+    result.cookies = REDACTED;
+  }
+  if (result.data !== undefined) {
+    result.data = scrubRecursive(result.data);
+  }
+  return result;
+}
+
+function scrubBreadcrumb(breadcrumb: ObservabilityBreadcrumb): ObservabilityBreadcrumb {
+  const result: ObservabilityBreadcrumb = { ...breadcrumb };
+  if (result.data) {
+    result.data = scrubRecursive(result.data) as Record<string, unknown>;
+  }
+  // breadcrumb.message is free-text; URLs in breadcrumbs live under breadcrumb.data.url
+  // where scrubRecursive picks them up via the url-key convention.
+  return result;
+}
+
+export function scrubEvent<T extends ObservabilityEvent>(event: T): T {
+  const scrubbed: T = { ...event };
+  if (scrubbed.request) {
+    scrubbed.request = scrubRequest(scrubbed.request);
+  }
+  if (scrubbed.extra) {
+    scrubbed.extra = scrubRecursive(scrubbed.extra) as Record<string, unknown>;
+  }
+  if (scrubbed.contexts) {
+    scrubbed.contexts = scrubRecursive(scrubbed.contexts) as Record<string, unknown>;
+  }
+  if (scrubbed.tags) {
+    scrubbed.tags = scrubRecursive(scrubbed.tags) as Record<string, unknown>;
+  }
+  if (scrubbed.breadcrumbs) {
+    scrubbed.breadcrumbs = scrubbed.breadcrumbs.map(scrubBreadcrumb);
+  }
+  return scrubbed;
+}
+
+export function buildBeforeSend<
+  T extends ObservabilityEvent = ObservabilityEvent,
+>(): BeforeSendFunction<T> {
+  return (event: T) => scrubEvent(event);
+}

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -1,0 +1,42 @@
+// Platform-agnostic observability types. Keep free of DOM / React Native imports.
+// These types are a structural subset of Sentry's Event + EventHint — small enough
+// to stay portable across web and React Native, large enough to drive the scrubber.
+
+export interface ObservabilityRequest {
+  url?: string;
+  query_string?: string;
+  headers?: Record<string, unknown>;
+  data?: unknown;
+  cookies?: string | Record<string, string>;
+}
+
+export interface ObservabilityBreadcrumb {
+  category?: string;
+  message?: string;
+  data?: Record<string, unknown>;
+  type?: string;
+  level?: string;
+  timestamp?: number;
+  [extra: string]: unknown;
+}
+
+export interface ObservabilityEvent {
+  request?: ObservabilityRequest;
+  contexts?: Record<string, unknown>;
+  extra?: Record<string, unknown>;
+  tags?: Record<string, unknown>;
+  breadcrumbs?: ObservabilityBreadcrumb[];
+  user?: Record<string, unknown>;
+  [extra: string]: unknown;
+}
+
+export type BeforeSendFunction<T extends ObservabilityEvent = ObservabilityEvent> = (
+  event: T,
+) => T | null;
+
+export interface ObservabilityConfig {
+  dsn: string;
+  environment: string;
+  release?: string;
+  tracesSampleRate?: number;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@glaon/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@sentry/browser':
+        specifier: ^10.49.0
+        version: 10.49.0
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -88,6 +91,9 @@ importers:
       '@glaon/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@sentry/vite-plugin':
+        specifier: ^5.2.0
+        version: 5.2.0(rollup@4.60.2)
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.14
@@ -1535,6 +1541,103 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sentry-internal/browser-utils@10.49.0':
+    resolution: {integrity: sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.49.0':
+    resolution: {integrity: sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@10.49.0':
+    resolution: {integrity: sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.49.0':
+    resolution: {integrity: sha512-IEy4lwHVMiRE3JAcn+kFKjsTgalDOCSTf20SoFd+nkt6rN/k1RDyr4xpdfF//Kj3UdeTmbuibYjK5H/FLhhnGg==}
+    engines: {node: '>=18'}
+
+  '@sentry/babel-plugin-component-annotate@5.2.0':
+    resolution: {integrity: sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser@10.49.0':
+    resolution: {integrity: sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.2.0':
+    resolution: {integrity: sha512-+C0x4gEIJRgoMwyRFGx+TFiJ1Po2BZlT1v61+PnouiaprKL5qtZG8n5PXx/5LPLDsVjSIcXjnDrTz9aSm8SJ3w==}
+    engines: {node: '>= 18'}
+
+  '@sentry/cli-darwin@2.58.5':
+    resolution: {integrity: sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.5':
+    resolution: {integrity: sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.5':
+    resolution: {integrity: sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.5':
+    resolution: {integrity: sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.5':
+    resolution: {integrity: sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.5':
+    resolution: {integrity: sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.5':
+    resolution: {integrity: sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.5':
+    resolution: {integrity: sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.5':
+    resolution: {integrity: sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/core@10.49.0':
+    resolution: {integrity: sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==}
+    engines: {node: '>=18'}
+
+  '@sentry/rollup-plugin@5.2.0':
+    resolution: {integrity: sha512-a8LfpvcYMFtFSroro5MpCcOoS528LeLfUHzxWURnpofOnY+Aso9Si4y4dFlna+RKqxCXjmFbn6CLnfI+YrHysQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@sentry/vite-plugin@5.2.0':
+    resolution: {integrity: sha512-4Jo3ixBspso5HY81PDvZdRXkH9wYGVmcw/0a2IX9ejbyKBdHqkYg4IhAtNqGUAyGuHwwRS9Y1S+sCMvrXv6htw==}
+    engines: {node: '>= 18'}
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -1917,6 +2020,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2415,6 +2522,10 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2949,6 +3060,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -3827,6 +3942,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -6262,6 +6380,112 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
+  '@sentry-internal/browser-utils@10.49.0':
+    dependencies:
+      '@sentry/core': 10.49.0
+
+  '@sentry-internal/feedback@10.49.0':
+    dependencies:
+      '@sentry/core': 10.49.0
+
+  '@sentry-internal/replay-canvas@10.49.0':
+    dependencies:
+      '@sentry-internal/replay': 10.49.0
+      '@sentry/core': 10.49.0
+
+  '@sentry-internal/replay@10.49.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.49.0
+      '@sentry/core': 10.49.0
+
+  '@sentry/babel-plugin-component-annotate@5.2.0': {}
+
+  '@sentry/browser@10.49.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.49.0
+      '@sentry-internal/feedback': 10.49.0
+      '@sentry-internal/replay': 10.49.0
+      '@sentry-internal/replay-canvas': 10.49.0
+      '@sentry/core': 10.49.0
+
+  '@sentry/bundler-plugin-core@5.2.0':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@sentry/babel-plugin-component-annotate': 5.2.0
+      '@sentry/cli': 2.58.5
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.5':
+    optional: true
+
+  '@sentry/cli@2.58.5':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.5
+      '@sentry/cli-linux-arm': 2.58.5
+      '@sentry/cli-linux-arm64': 2.58.5
+      '@sentry/cli-linux-i686': 2.58.5
+      '@sentry/cli-linux-x64': 2.58.5
+      '@sentry/cli-win32-arm64': 2.58.5
+      '@sentry/cli-win32-i686': 2.58.5
+      '@sentry/cli-win32-x64': 2.58.5
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/core@10.49.0': {}
+
+  '@sentry/rollup-plugin@5.2.0(rollup@4.60.2)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.2.0
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.60.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/vite-plugin@5.2.0(rollup@4.60.2)':
+    dependencies:
+      '@sentry/bundler-plugin-core': 5.2.0
+      '@sentry/rollup-plugin': 5.2.0(rollup@4.60.2)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@sinclair/typebox@0.27.10': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -6731,6 +6955,12 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -7256,6 +7486,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -7955,6 +8187,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -9014,6 +9253,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## Summary

Wires `@sentry/browser` into `apps/web` behind a platform-neutral observability module in `@glaon/core`. Core holds the PII scrubber and types (DOM/RN-free); app-level code imports the SDK and calls `Sentry.init` with the core `beforeSend`. Mobile Sentry is scoped out and tracked in a separate issue (#78).

## Scope — In

- `@glaon/core/observability` — types + `buildBeforeSend()` PII scrubber (16 unit tests).
- Scrubber redacts URL params (`access_token`, `refresh_token`, `id_token`, `token`, `code`, `state`, `client_secret`, `api_key`), headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Auth-Token`, `X-Hasura-Admin-Secret`), object keys matching sensitive substrings, and request cookies.
- `apps/web/src/observability.ts` — runtime init with DSN guard. `main.tsx` calls it before render.
- `apps/web/vite.config.ts` — production **build** fails if `VITE_SENTRY_DSN` is missing (gate scoped to `command === 'build'` so `vite preview` in E2E still works). Source map upload enabled when `SENTRY_AUTH_TOKEN` + `SENTRY_ORG` + `SENTRY_PROJECT` are all set.
- `apps/web/src/vite-env.d.ts` — typed `ImportMetaEnv` for Vite env vars.
- `apps/web/.env.example` — new Sentry vars documented.
- `.github/workflows/e2e.yml` — placeholder DSN (`https://public@sentry.invalid/0`) on the build step so the prod-build gate passes in CI (events go nowhere).
- `docs/observability.md` — architecture, what the scrubber masks, how to add breadcrumbs, merge-time user action items.

## Scope — Out

- Mobile (`@sentry/react-native`) — #78.
- Session replay — data volume + privacy review needed first (parked, not in a sub-issue yet).
- Deploy pipeline wiring of real secrets (`SENTRY_DSN_WEB`, `SENTRY_AUTH_TOKEN`, org/project slugs) — follows HA Add-on delivery (#70).
- Custom Sentry dashboards.

## Test plan

- [x] `pnpm --filter @glaon/core test` — 16/16 scrubber tests green
- [x] `pnpm --filter @glaon/web build` with placeholder DSN — succeeds
- [x] `pnpm --filter @glaon/web build` without DSN — fails with the gate error
- [x] `pnpm --filter @glaon/web preview` without DSN — serves successfully (HTTP 200, confirms gate is build-only)
- [x] `pnpm lint` + `pnpm type-check` green across all workspaces
- [x] CI: lint, type-check, audit, unit, e2e, commitlint, gitleaks, Chromatic all green

## User action after merge

1. Create Sentry project, grab DSN.
2. Add repo secrets: `SENTRY_DSN_WEB`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`.
3. Deploy workflow (opens with #70) injects them into the build step.

Closes #68