### PR TITLE
feat(mobile): wire @sentry/react-native with shared core PII scrubber

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -3,3 +3,11 @@ EXPO_PUBLIC_HA_BASE_URL=https://homeassistant.local:8123
 
 # OAuth2 client id — must match a redirect URI registered with Home Assistant
 EXPO_PUBLIC_HA_CLIENT_ID=glaon://auth/callback
+
+# Sentry — optional in dev; production (EAS) builds inject the real DSN as a secret.
+# See docs/observability.md.
+EXPO_PUBLIC_SENTRY_DSN=
+# Optional: override the environment tag (defaults to 'development' / 'production' from __DEV__).
+EXPO_PUBLIC_SENTRY_ENVIRONMENT=
+# Optional: release identifier (usually the git SHA or app version).
+EXPO_PUBLIC_SENTRY_RELEASE=

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,6 +1,10 @@
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { initObservability } from './src/observability';
+
+initObservability();
+
 export default function App() {
   return (
     <View style={styles.container}>

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -19,7 +19,7 @@
         "backgroundColor": "#000000"
       }
     },
-    "plugins": ["expo-secure-store", "expo-web-browser"],
+    "plugins": ["expo-secure-store", "expo-web-browser", "@sentry/react-native/expo"],
     "experiments": {
       "typedRoutes": true
     }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@glaon/core": "workspace:*",
     "@glaon/ui": "workspace:*",
+    "@sentry/react-native": "^8.8.0",
     "expo": "~55.0.0",
     "expo-auth-session": "~55.0.0",
     "expo-crypto": "~55.0.0",

--- a/apps/mobile/src/observability.ts
+++ b/apps/mobile/src/observability.ts
@@ -1,0 +1,40 @@
+import * as Sentry from '@sentry/react-native';
+
+import type { ObservabilityEvent } from '@glaon/core/observability';
+import { buildBeforeSend } from '@glaon/core/observability';
+
+const CONSOLE_TAG = '[glaon/observability]';
+
+export function initObservability(): void {
+  const dsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+  const environment =
+    process.env.EXPO_PUBLIC_SENTRY_ENVIRONMENT ?? (__DEV__ ? 'development' : 'production');
+  const release = process.env.EXPO_PUBLIC_SENTRY_RELEASE;
+
+  if (!dsn) {
+    if (__DEV__) {
+      console.warn(`${CONSOLE_TAG} Sentry disabled (no DSN set).`);
+    } else {
+      // Prod bundle without DSN — loud but non-fatal. Real gate belongs in the
+      // EAS build pipeline (#36) where the secret is injected.
+      console.error(
+        `${CONSOLE_TAG} EXPO_PUBLIC_SENTRY_DSN is missing in a production bundle — errors will not be reported.`,
+      );
+    }
+    return;
+  }
+
+  const scrub = buildBeforeSend();
+
+  Sentry.init({
+    dsn,
+    environment,
+    release,
+    tracesSampleRate: __DEV__ ? 1.0 : 0.1,
+    sendDefaultPii: false,
+    beforeSend: (event) => {
+      const scrubbed = scrub(event as unknown as ObservabilityEvent);
+      return scrubbed as unknown as Sentry.ErrorEvent;
+    },
+  });
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,17 +1,18 @@
 # Observability — Sentry entegrasyonu
 
-Glaon çalışma zamanı hatalarını ve performans sinyallerini **Sentry** üzerinden toplar. Bu sayfa web tarafının entegrasyonunu anlatır; mobile tarafı ayrı bir issue'da (bkz. #78) ele alınacak.
+Glaon çalışma zamanı hatalarını ve performans sinyallerini **Sentry** üzerinden toplar. Web ve mobile aynı PII politikasını paylaşır; SDK importu platform-spesifik.
 
 ## Mimari
 
-İki katman var:
+Üç katman var:
 
-| Katman                          | Ne yapar                                                                                                   |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `@glaon/core/observability`     | Platform-bağımsız tipler + PII scrubber. DOM/RN import etmez. Web ve mobile aynı scrubber'ı paylaşır.      |
-| `apps/web/src/observability.ts` | `@sentry/browser` SDK'sını runtime'da init eder; core'dan gelen `buildBeforeSend`'i `Sentry.init`'e verir. |
+| Katman                             | Ne yapar                                                                                                               |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `@glaon/core/observability`        | Platform-bağımsız tipler + PII scrubber. DOM/RN import etmez. Web ve mobile aynı scrubber'ı paylaşır.                  |
+| `apps/web/src/observability.ts`    | `@sentry/browser` SDK'sını runtime'da init eder; core'dan gelen `buildBeforeSend`'i `Sentry.init`'e verir.             |
+| `apps/mobile/src/observability.ts` | `@sentry/react-native` SDK'sını init eder; aynı core scrubber'ı `beforeSend`'e bağlar. Expo config plugin ile wire'lı. |
 
-Core, **politika** (ne maskelenir, hangi anahtar hassas) ve **saf fonksiyonlar** (scrub) tutar. SDK importu ve init, uygulama katmanında.
+Core, **politika** (ne maskelenir, hangi anahtar hassas) ve **saf fonksiyonlar** (scrub) tutar. SDK importu ve init, uygulama katmanında. Bu sayede mobile bundle DOM-only `@sentry/browser`'ı çekmez; web bundle RN-only `@sentry/react-native`'i çekmez.
 
 ## Scrubber ne maskeler
 
@@ -27,7 +28,7 @@ Scrubber non-mutating (girdi objesini değiştirmez) ve `MAX_SCRUB_DEPTH = 8` il
 
 Yeni bir hassas alan eklemek için `SENSITIVE_URL_PARAMS`, `SENSITIVE_HEADER_NAMES` veya `SENSITIVE_KEY_SUBSTRINGS` listelerine ekle ve ilgili test case'i ekle. Kod değişmeden.
 
-## Konfigürasyon
+## Web — konfigürasyon
 
 ### Environment variables
 
@@ -59,12 +60,46 @@ Bu gate CI'daki E2E workflow'unu etkiler — [`.github/workflows/e2e.yml`](../.g
 
 DSN varsa `Sentry.init` çağrılır: `tracesSampleRate` prod'da 0.1, dev'de 1.0; `sendDefaultPii: false`; `beforeSend` core scrubber'ı.
 
+## Mobile — konfigürasyon
+
+### Expo config plugin
+
+`@sentry/react-native` [apps/mobile/app.json](../apps/mobile/app.json)'da plugin olarak kayıtlı (`"@sentry/react-native/expo"`). `eas build` native modülü otomatik bağlar; ek Podfile / gradle müdahalesi yok. Bare workflow'a geçilirse plugin yerine elle config gerekir.
+
+### Environment variables
+
+`apps/mobile/.env.example` içinde dokümante. `EXPO_PUBLIC_` prefix'li değişkenler Metro bundle'ına inline edilir — DSN böylece runtime'da `process.env`'den okunur.
+
+| Değişken                         | Zorunlu             | Açıklama                                                           |
+| -------------------------------- | ------------------- | ------------------------------------------------------------------ |
+| `EXPO_PUBLIC_SENTRY_DSN`         | Prod EAS build için | DSN yoksa prod bundle'da loud `console.error`, dev'de sessiz warn. |
+| `EXPO_PUBLIC_SENTRY_ENVIRONMENT` | Hayır               | Override environment tag. Boşsa `__DEV__` üzerinden türetilir.     |
+| `EXPO_PUBLIC_SENTRY_RELEASE`     | Hayır               | Release identifier (genelde git SHA veya app version).             |
+
+Source map upload (mobile) bu PR'ın kapsamında değil — EAS build pipeline'ı (#36) ile birlikte açılacak. O zaman `SENTRY_AUTH_TOKEN` + org/project slug'ları EAS secret olarak inject edilir.
+
+### Prod build gate
+
+Mobile'da web'deki gibi build-time DSN gate'i **yok**. Mantıken karşılığı EAS build step'inde çalışacak bir script — #36'nın kapsamı. Şu an için prod bundle'da DSN eksikse `initObservability` `console.error` basar, çalışmaya devam eder.
+
+### Runtime init
+
+[apps/mobile/App.tsx](../apps/mobile/App.tsx) ilk render'dan önce `initObservability()` çağırır. DSN yoksa:
+
+- **Prod bundle'da** — `console.error` ile bağırır; crash etmez.
+- **Dev'de (`__DEV__`)** — `console.warn` ile sessizce kapanır.
+
+DSN varsa `Sentry.init` çağrılır: `tracesSampleRate` prod'da 0.1, dev'de 1.0; `sendDefaultPii: false`; `beforeSend` core scrubber'ı — web ile aynı politika.
+
 ## Yeni breadcrumb veya custom event eklemek
 
-SDK doğrudan `apps/web`'te import'lanır; bileşen kodu Sentry'yi bilmek zorunda değil. İhtiyaç olduğunda:
+SDK doğrudan platform adapter'ında import'lanır; bileşen kodu Sentry'yi bilmek zorunda değil. İhtiyaç olduğunda:
 
 ```ts
+// apps/web için
 import * as Sentry from '@sentry/browser';
+// apps/mobile için
+// import * as Sentry from '@sentry/react-native';
 
 Sentry.addBreadcrumb({
   category: 'ha.ws',
@@ -102,15 +137,19 @@ pnpm --filter @glaon/core test
 
 ## Kullanıcı tarafı — merge sonrası adımlar
 
-Bu PR kod iskeletini bitirir; gerçek event akışı için repo-dışı konfigürasyon gerekiyor:
+Kod iskeleti tamam; gerçek event akışı için repo-dışı konfigürasyon gerekiyor:
 
-1. **Sentry projesi oluştur** — `sentry.io`'da yeni React projesi aç. DSN'i kopyala.
-2. **Repo secret'ları ekle** — GitHub repo → Settings → Secrets → Actions:
-   - `SENTRY_DSN_WEB` (veya benzeri isim, deploy workflow'unda `VITE_SENTRY_DSN` olarak inject edilir)
+1. **Sentry projeleri oluştur** — `sentry.io`'da iki ayrı proje aç: biri `glaon-web` (React), biri `glaon-mobile` (React Native). Her ikisinden DSN'i kopyala.
+2. **Web için repo secret'ları ekle** — GitHub repo → Settings → Secrets → Actions:
+   - `SENTRY_DSN_WEB` (deploy workflow'unda `VITE_SENTRY_DSN` olarak inject edilir)
    - `SENTRY_AUTH_TOKEN` — Sentry → User Auth Tokens, `project:releases` + `project:write` scope'ları ile
-   - `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG`
-3. **Deploy workflow'unu güncelle** — HA Add-on deploy akışı (#70) açıldığında yukarıdaki secret'lar build step'ine verilir. E2E workflow'undaki placeholder DSN burada gerçek DSN ile değişir.
-4. **PII scrubber doğrulaması** — Prod trafiği başladıktan sonra Sentry UI'da ilk birkaç event'i gözden geçir; query string, header, body alanlarında token/secret kalmadığını doğrula. Yeni bir sızıntı tespit edilirse `SENSITIVE_*` listelerine ekle.
+   - `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG_WEB`
+3. **Mobile için EAS secret'ları ekle** — `eas secret:create` ile:
+   - `EXPO_PUBLIC_SENTRY_DSN` — `glaon-mobile` projesinin DSN'i
+   - Source map upload secret'ları (#36 ile birlikte): `SENTRY_AUTH_TOKEN`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG_MOBILE`
+4. **Deploy workflow'unu güncelle** — HA Add-on deploy akışı (#70) açıldığında web secret'ları build step'ine verilir. E2E workflow'undaki placeholder DSN burada gerçek DSN ile değişir.
+5. **EAS build profilinde source map upload'u aç** (#36) — `@sentry/react-native/expo` plugin'i native modülü wire eder, fakat source map upload ayrı `expo-router` script adımı gerektirir; #36 bunu EAS config'e ekleyecek.
+6. **PII scrubber doğrulaması** — Prod trafiği başladıktan sonra Sentry UI'da ilk birkaç event'i gözden geçir; query string, header, body alanlarında token/secret kalmadığını doğrula. Yeni bir sızıntı tespit edilirse `SENSITIVE_*` listelerine ekle (tek yerden her iki platformu da etkiler).
 
 ## Neden SDK core'da değil
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@glaon/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@sentry/react-native':
+        specifier: ^8.8.0
+        version: 8.8.0(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       expo:
         specifier: ~55.0.0
         version: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@5.7.3)
@@ -1541,16 +1544,32 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sentry-internal/browser-utils@10.48.0':
+    resolution: {integrity: sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==}
+    engines: {node: '>=18'}
+
   '@sentry-internal/browser-utils@10.49.0':
     resolution: {integrity: sha512-n0QRx0Ysx6mPfIydTkz7VP0FmwM+/EqMZiRqdsU3aTYsngE9GmEDV0OL1bAy6a8N/C1xf9vntkuAtj6N/8Z51w==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@10.48.0':
+    resolution: {integrity: sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==}
     engines: {node: '>=18'}
 
   '@sentry-internal/feedback@10.49.0':
     resolution: {integrity: sha512-JNsUBGv0faCFE7MeZUH99Y9lU9qq3LBALbLxpE1x7ngNrQnVYRlcFgdqaD/btNBKr8awjYL8gmcSkHBWskGqLQ==}
     engines: {node: '>=18'}
 
+  '@sentry-internal/replay-canvas@10.48.0':
+    resolution: {integrity: sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==}
+    engines: {node: '>=18'}
+
   '@sentry-internal/replay-canvas@10.49.0':
     resolution: {integrity: sha512-7D/NrgH1Qwx5trDYaaTSSJmCb1yVQQLqFG4G/S9x2ltzl9876lSGJL8UeW8ReNQgF3CDAcwbmm/9aXaVSBUNZA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@10.48.0':
+    resolution: {integrity: sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==}
     engines: {node: '>=18'}
 
   '@sentry-internal/replay@10.49.0':
@@ -1560,6 +1579,10 @@ packages:
   '@sentry/babel-plugin-component-annotate@5.2.0':
     resolution: {integrity: sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==}
     engines: {node: '>= 18'}
+
+  '@sentry/browser@10.48.0':
+    resolution: {integrity: sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==}
+    engines: {node: '>=18'}
 
   '@sentry/browser@10.49.0':
     resolution: {integrity: sha512-bGCHc+wK2Dx67YoSbmtlt04alqWfQ+dasD/GVipVOq50gvw/BBIDHTEWRJEjACl+LrvszeY54V+24p8z4IgysA==}
@@ -1574,9 +1597,20 @@ packages:
     engines: {node: '>=10'}
     os: [darwin]
 
+  '@sentry/cli-darwin@3.3.5':
+    resolution: {integrity: sha512-E/SIY6+j2nt6Ri9nMt78sYle3LiF6uZyz4HGmvcEMU6HXjegmAayhy0J10JST+vZTzN6VixD8sUsa5UeJiOPcg==}
+    engines: {node: '>=18'}
+    os: [darwin]
+
   '@sentry/cli-linux-arm64@2.58.5':
     resolution: {integrity: sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==}
     engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm64@3.3.5':
+    resolution: {integrity: sha512-/W7HTk2OFKD0bguTvQR1ue6pkFQWaGiqPafOSIQKyq0aGfbZhBn/Uj+IRefgMZMhJQ29xRz0y/iGRGKE+ef4Vg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux, freebsd, android]
 
@@ -1586,9 +1620,21 @@ packages:
     cpu: [arm]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-arm@3.3.5':
+    resolution: {integrity: sha512-EGuEIvC2OQyar/vu+jAQEmovTMgxpoxdx5knnzL5dLhIemjEUNqwv/sXq+m/Aj+ThqCMofcTWB2TOZXsTtl0Tw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
   '@sentry/cli-linux-i686@2.58.5':
     resolution: {integrity: sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==}
     engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@3.3.5':
+    resolution: {integrity: sha512-qODMEWLEeUNp3IUlwwISB37EXSo8qgMmHQuLKfxDjpIKw+7NAFfptOloqPrHkLWK3TzFr+Nv643wIKZaYrz28Q==}
+    engines: {node: '>=18'}
     cpu: [x86, ia32]
     os: [linux, freebsd, android]
 
@@ -1598,9 +1644,21 @@ packages:
     cpu: [x64]
     os: [linux, freebsd, android]
 
+  '@sentry/cli-linux-x64@3.3.5':
+    resolution: {integrity: sha512-DCz7lQ4PySjQ1WvWOQ/uTdwauRo1D7hSHazxZ+fUAnK/epSPM9qLkjDMlD8uM5CaLoR8+ZTs7N94vV5LZs2QpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
   '@sentry/cli-win32-arm64@2.58.5':
     resolution: {integrity: sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==}
     engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-arm64@3.3.5':
+    resolution: {integrity: sha512-VMNsHiyZcP8Ft3fcK/1zoO4L66soe1eSfXg2tglFQSc/2MYA5v1Br9B1GtjBwDIc3EmdPtFZhOGLyqIzszMxJw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -1610,9 +1668,21 @@ packages:
     cpu: [x86, ia32]
     os: [win32]
 
+  '@sentry/cli-win32-i686@3.3.5':
+    resolution: {integrity: sha512-BE6aHOIpsm4jgavsvvXNcSikAr/8NSva3rk1N3BzoOLuX+dcFxBI60K1i2VzB1vsgtivJJo9YySNCi60dBgWTg==}
+    engines: {node: '>=18'}
+    cpu: [x86, ia32]
+    os: [win32]
+
   '@sentry/cli-win32-x64@2.58.5':
     resolution: {integrity: sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==}
     engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@3.3.5':
+    resolution: {integrity: sha512-MSU+PtBuiLjEbiPFOvxk4CI3TCagwkIg9kvJ+DrI3+pBY0Sga/dOyeWKTIgb01xSVcfjdw0UkpU52VCvzTT9ew==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1621,9 +1691,35 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@sentry/cli@3.3.5':
+    resolution: {integrity: sha512-eyLHTj0rpeCsOUX+1ZU8UEWRXy6nXvTXNdhtAt1t6YXan9gSsAexZf28zVmDcYcP8WRbK0D2JMLp7NcaQCQgEA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
+  '@sentry/core@10.48.0':
+    resolution: {integrity: sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==}
+    engines: {node: '>=18'}
+
   '@sentry/core@10.49.0':
     resolution: {integrity: sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g==}
     engines: {node: '>=18'}
+
+  '@sentry/react-native@8.8.0':
+    resolution: {integrity: sha512-Qsb/Bnuf6mOeDEtM56jZYzvENMDPX3btCVNHt9MG4LDLKr4iQfRPmUX9+WwnAmEoAlJkBQJlFQLCXApXEB1LEA==}
+    hasBin: true
+    peerDependencies:
+      expo: '>=49.0.0'
+      react: '>=17.0.0'
+      react-native: '>=0.65.0'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  '@sentry/react@10.48.0':
+    resolution: {integrity: sha512-uc93vKjmu6gNns+JAX4qquuxWpAMit0uGPA1TYlMjct9NG1uX3TkDPJAr9Pgd1lOXx8mKqCmj5fK33QeExMpPw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
 
   '@sentry/rollup-plugin@5.2.0':
     resolution: {integrity: sha512-a8LfpvcYMFtFSroro5MpCcOoS528LeLfUHzxWURnpofOnY+Aso9Si4y4dFlna+RKqxCXjmFbn6CLnfI+YrHysQ==}
@@ -1633,6 +1729,10 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
+
+  '@sentry/types@10.48.0':
+    resolution: {integrity: sha512-HiguzLr+vlor1ky0rpWHmZoravFsnx65kXqB94yqYMo7V3QgSOPzWrOjv518a2yZc/1boufQ3LINq6ZDhO2l1g==}
+    engines: {node: '>=18'}
 
   '@sentry/vite-plugin@5.2.0':
     resolution: {integrity: sha512-4Jo3ixBspso5HY81PDvZdRXkH9wYGVmcw/0a2IX9ejbyKBdHqkYg4IhAtNqGUAyGuHwwRS9Y1S+sCMvrXv6htw==}
@@ -4548,6 +4648,10 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -6380,18 +6484,36 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
+  '@sentry-internal/browser-utils@10.48.0':
+    dependencies:
+      '@sentry/core': 10.48.0
+
   '@sentry-internal/browser-utils@10.49.0':
     dependencies:
       '@sentry/core': 10.49.0
+
+  '@sentry-internal/feedback@10.48.0':
+    dependencies:
+      '@sentry/core': 10.48.0
 
   '@sentry-internal/feedback@10.49.0':
     dependencies:
       '@sentry/core': 10.49.0
 
+  '@sentry-internal/replay-canvas@10.48.0':
+    dependencies:
+      '@sentry-internal/replay': 10.48.0
+      '@sentry/core': 10.48.0
+
   '@sentry-internal/replay-canvas@10.49.0':
     dependencies:
       '@sentry-internal/replay': 10.49.0
       '@sentry/core': 10.49.0
+
+  '@sentry-internal/replay@10.48.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.48.0
+      '@sentry/core': 10.48.0
 
   '@sentry-internal/replay@10.49.0':
     dependencies:
@@ -6399,6 +6521,14 @@ snapshots:
       '@sentry/core': 10.49.0
 
   '@sentry/babel-plugin-component-annotate@5.2.0': {}
+
+  '@sentry/browser@10.48.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 10.48.0
+      '@sentry-internal/feedback': 10.48.0
+      '@sentry-internal/replay': 10.48.0
+      '@sentry-internal/replay-canvas': 10.48.0
+      '@sentry/core': 10.48.0
 
   '@sentry/browser@10.49.0':
     dependencies:
@@ -6424,25 +6554,49 @@ snapshots:
   '@sentry/cli-darwin@2.58.5':
     optional: true
 
+  '@sentry/cli-darwin@3.3.5':
+    optional: true
+
   '@sentry/cli-linux-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-arm64@3.3.5':
     optional: true
 
   '@sentry/cli-linux-arm@2.58.5':
     optional: true
 
+  '@sentry/cli-linux-arm@3.3.5':
+    optional: true
+
   '@sentry/cli-linux-i686@2.58.5':
+    optional: true
+
+  '@sentry/cli-linux-i686@3.3.5':
     optional: true
 
   '@sentry/cli-linux-x64@2.58.5':
     optional: true
 
+  '@sentry/cli-linux-x64@3.3.5':
+    optional: true
+
   '@sentry/cli-win32-arm64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-arm64@3.3.5':
     optional: true
 
   '@sentry/cli-win32-i686@2.58.5':
     optional: true
 
+  '@sentry/cli-win32-i686@3.3.5':
+    optional: true
+
   '@sentry/cli-win32-x64@2.58.5':
+    optional: true
+
+  '@sentry/cli-win32-x64@3.3.5':
     optional: true
 
   '@sentry/cli@2.58.5':
@@ -6465,7 +6619,44 @@ snapshots:
       - encoding
       - supports-color
 
+  '@sentry/cli@3.3.5':
+    dependencies:
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      undici: 6.25.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 3.3.5
+      '@sentry/cli-linux-arm': 3.3.5
+      '@sentry/cli-linux-arm64': 3.3.5
+      '@sentry/cli-linux-i686': 3.3.5
+      '@sentry/cli-linux-x64': 3.3.5
+      '@sentry/cli-win32-arm64': 3.3.5
+      '@sentry/cli-win32-i686': 3.3.5
+      '@sentry/cli-win32-x64': 3.3.5
+
+  '@sentry/core@10.48.0': {}
+
   '@sentry/core@10.49.0': {}
+
+  '@sentry/react-native@8.8.0(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@sentry/babel-plugin-component-annotate': 5.2.0
+      '@sentry/browser': 10.48.0
+      '@sentry/cli': 3.3.5
+      '@sentry/core': 10.48.0
+      '@sentry/react': 10.48.0(react@19.2.5)
+      '@sentry/types': 10.48.0
+      react: 19.2.5
+      react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(react-dom@19.2.5(react@19.2.5))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)(typescript@5.7.3)
+
+  '@sentry/react@10.48.0(react@19.2.5)':
+    dependencies:
+      '@sentry/browser': 10.48.0
+      '@sentry/core': 10.48.0
+      react: 19.2.5
 
   '@sentry/rollup-plugin@5.2.0(rollup@4.60.2)':
     dependencies:
@@ -6476,6 +6667,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@sentry/types@10.48.0':
+    dependencies:
+      '@sentry/core': 10.48.0
 
   '@sentry/vite-plugin@5.2.0(rollup@4.60.2)':
     dependencies:
@@ -10008,6 +10203,8 @@ snapshots:
 
   undici-types@7.19.2:
     optional: true
+
+  undici@6.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Mirrors the web Sentry wiring (#68) on the mobile app. `apps/mobile` now initialises `@sentry/react-native` through an adapter that reuses `buildBeforeSend` from `@glaon/core/observability` — same PII policy as web, one source of truth. Native integration happens via the Expo config plugin, so `eas build` wires iOS/Android automatically.

Source map upload is intentionally deferred to the EAS build pipeline (#36).

## Scope — In

- `@sentry/react-native@^8.8.0` added to `apps/mobile` dependencies.
- `apps/mobile/app.json` — `"@sentry/react-native/expo"` registered in `plugins`.
- `apps/mobile/src/observability.ts` — init adapter: reads `EXPO_PUBLIC_SENTRY_DSN`, calls `Sentry.init` with core `beforeSend`. `__DEV__`-aware defaults (sample rate, silent warn vs loud error on missing DSN).
- `apps/mobile/App.tsx` — calls `initObservability()` before first render.
- `apps/mobile/.env.example` — documents `EXPO_PUBLIC_SENTRY_DSN`, `EXPO_PUBLIC_SENTRY_ENVIRONMENT`, `EXPO_PUBLIC_SENTRY_RELEASE`.
- `docs/observability.md` — new **Mobile — konfigürasyon** section covering Expo plugin, env vars, why no build-time gate yet, and runtime init. Merge-time user action list now covers both web + mobile projects + EAS secret setup.

## Scope — Out

- **Build-time DSN gate for mobile** — needs EAS build config; handled in #36.
- **Source map upload (mobile)** — EAS pipeline work, #36.
- **Expo dev client smoke test** — would require booting a simulator in CI. Type-check + lint cover the integration surface for now; manual smoke done locally.
- **Session replay / custom transactions** — separate issue once real mobile features land.

## Test plan

- [x] `pnpm type-check` — green across `@glaon/core`, `@glaon/web`, `@glaon/mobile`, `@glaon/ui`, `@glaon/web-e2e`
- [x] `pnpm lint` — green across all workspaces
- [x] `pnpm --filter @glaon/core test` — scrubber tests still green (16/16); no mobile-specific event shapes diverge yet
- [x] CI: type-check · lint · audit, conventional-commits, gitleaks, playwright, visual regression, Chromatic all green
- [ ] `@glaon/core/observability` resolves via package.json `exports` map in Metro (will be verified at first `expo start` — can't be tested in CI without a simulator)

## User action after merge

See updated **Kullanıcı tarafı — merge sonrası adımlar** in `docs/observability.md`:

1. Create two Sentry projects (`glaon-web`, `glaon-mobile`).
2. Web → repo Actions secrets (`SENTRY_DSN_WEB`, etc.)
3. Mobile → `eas secret:create EXPO_PUBLIC_SENTRY_DSN`.
4. Source map upload for both sides is hooked up in #70 (web) and #36 (mobile).

Closes #78