### PR TITLE
feat(storybook): enable addon-designs for Figma frame embeds

### DIFF
--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -9,6 +9,7 @@ Glaon'un tüm UI component'leri — web ve (ileride) React Native — tek bir St
 - Framework: `@storybook/react-native-web-vite` (v10) — tek config hem web hem React Native story'yi render eder. `react-native` → `react-native-web` alias'ını otomatik kurar.
 - Addon'lar:
   - `@storybook/addon-a11y` — accessibility paneli + `a11y.test: 'error'`
+  - `@storybook/addon-designs` — story'nin yanında Figma frame embed'i (**Design** tab)
   - `@storybook/addon-mcp` — AI agent'ların Storybook'u MCP üzerinden kullanması
   - `storybook-dark-mode` — toolbar'dan tema değiştirici
 - Not: v10'da "essentials" ve "interactions" core'a taşındı, ayrı paket gerekmez.
@@ -81,6 +82,38 @@ Her component için en az:
 - `UI Kit/*` — Untitled UI wrap'leri (ayrı issue #48)
 
 Aynı Storybook instance'ında Web ve RN story'leri yan yana yaşar; sidebar'da ilk kırılım platformu belirtir.
+
+### Figma embed (`parameters.design`)
+
+Her component, Figma Design System dosyasındaki karşılığı ile `@storybook/addon-designs` üzerinden bağlanır. Bağlantı kurulunca Storybook'ta story'nin yanında **Design** tab'ı belirir ve Figma frame inline render olur.
+
+Konvansiyon: `meta.parameters.design` objesi — component seviyesinde, story seviyesinde değil. Sebep: bir component'in tüm variant'ları aynı kanonik Figma frame'e bakar.
+
+```tsx
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { Button } from './Button';
+
+const meta = {
+  title: 'Web Primitives/Button',
+  component: Button,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/KP0SVNxQEjT0gotajwc9I0/Design-System?node-id=123-456&t=abc',
+    },
+  },
+  args: { children: 'Click me', variant: 'primary' },
+} satisfies Meta<typeof Button>;
+```
+
+URL'i Figma'da almak için:
+
+1. Frame'i seç (component'in kanonik state'i — genelde Design System dosyasındaki published instance).
+2. Sağ tıkla → **Copy link to selection**. URL'de `?node-id=X-Y` query parametresi olmak zorunda; bu parametre olmadan addon Figma dosyasının kökünü gösterir.
+3. Component'in Figma description'ındaki `storybook-id` [docs/figma.md](figma.md#component-description--storybook-id)'de anlatılan formatla aynı component'i işaret etmeli — Chromatic'ın design-code diff akışı bu eşleşmeye bağımlı (#53).
+
+Figma frame henüz çizilmediyse `parameters.design` boş bırakılır ve component Figma'da çizildikten sonra ayrı bir küçük PR'da wire edilir — "design yok, story de yok" değil; primitive design review gate'i zaten `docs/figma.md`'de bu sırayı zorluyor.
 
 ## React Native story yazımı
 

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -5,6 +5,7 @@ export default defineMain({
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
   addons: [
     '@storybook/addon-a11y',
+    '@storybook/addon-designs',
     'storybook-dark-mode',
     {
       name: '@storybook/addon-mcp',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@glaon/config": "workspace:*",
     "@storybook/addon-a11y": "^10.3.5",
+    "@storybook/addon-designs": "^11.1.3",
     "@storybook/addon-mcp": "^0.6.0",
     "@storybook/react-native-web-vite": "^10.3.5",
     "@types/react": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@storybook/addon-a11y':
         specifier: ^10.3.5
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      '@storybook/addon-designs':
+        specifier: ^11.1.3
+        version: 11.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@storybook/addon-mcp':
         specifier: ^0.6.0
         version: 0.6.0(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.7.3)
@@ -1133,6 +1136,14 @@ packages:
     resolution: {integrity: sha512-wC562eD3gS6vO2tWHToFhlFnmHKfKHgF1oyvojeSkLK/ZYop1bMU+7cOMiF9Sq70CzcsLy/EMRy/uRc76QmNRw==}
     hasBin: true
 
+  '@figspec/components@2.1.0':
+    resolution: {integrity: sha512-PFKBX2oFz+vhThKTNsu7Mh4ZT3X7YCiM694UkAMT36j/p0tdmXs9Je0Sf88stTEcMgwYvNv9TZtvniYmgaE+bw==}
+
+  '@figspec/react@2.0.1':
+    resolution: {integrity: sha512-xflqJ3XQZVzm8+7dsm8OFxVAmBNNA3Mg65sqwNHiq7VRSMSD7qwH4BPsBy07ZaX+9nHeaacBpFZd3Q0aIsISqw==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1192,6 +1203,14 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lit-labs/react@2.1.3':
+    resolution: {integrity: sha512-OD9h2JynerBQUMNzb563jiVpxfvPF0HjQkKY2mx0lpVYvD7F+rtJpOGz6ek+6ufMidV3i+MPT9SX62OKWHFrQg==}
+
+  '@lit/react@1.0.8':
+    resolution: {integrity: sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==}
+    peerDependencies:
+      '@types/react': 17 || 18 || 19
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1748,6 +1767,21 @@ packages:
     resolution: {integrity: sha512-5k6lpgfIeLxvNhE8v3wEzdiu73ONKjF4gmH1AHvfqYd8kIVzQJai0KCDxgvqNncXHQhIWkaf1fg6+9hKaYJyaw==}
     peerDependencies:
       storybook: ^10.3.5
+
+  '@storybook/addon-designs@11.1.3':
+    resolution: {integrity: sha512-AK+ij478Y6S16TCNPwm7H90OipVe2wZApOlHjC6qDvMW61zyd4yP1icrRtjehSadw5SCoz8HcAmIYfQCOY6E4A==}
+    peerDependencies:
+      '@storybook/addon-docs': ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0
+    peerDependenciesMeta:
+      '@storybook/addon-docs':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@storybook/addon-mcp@0.6.0':
     resolution: {integrity: sha512-E79m2S7ik9wiF1AnI49fwbLQkrD03PicIZpCdeFhbbB19MF4tKFKyaQtbT3f6eaAP4EP2+COLDVLCQ7B3rGF4w==}
@@ -6088,6 +6122,16 @@ snapshots:
       chalk: 4.1.2
       js-yaml: 4.1.1
 
+  '@figspec/components@2.1.0': {}
+
+  '@figspec/react@2.0.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@figspec/components': 2.1.0
+      '@lit-labs/react': 2.1.3(@types/react@19.2.14)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -6150,6 +6194,16 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lit-labs/react@2.1.3(@types/react@19.2.14)':
+    dependencies:
+      '@lit/react': 1.0.8(@types/react@19.2.14)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@lit/react@1.0.8(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -6690,6 +6744,16 @@ snapshots:
       '@storybook/global': 5.0.0
       axe-core: 4.11.3
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  '@storybook/addon-designs@11.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+    dependencies:
+      '@figspec/react': 2.0.1(@types/react@19.2.14)(react@19.2.5)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@storybook/addon-mcp@0.6.0(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.7.3)':
     dependencies:


### PR DESCRIPTION
## Summary

Adds `@storybook/addon-designs` so every CSF story can render its Figma frame inline via a **Design** tab. Closes the Chromatic-Figma loop (#53) by putting the target design next to the story while developers write it — no more tabbing to Figma mid-edit.

## Scope — In

- `@storybook/addon-designs@^11.1.3` added to `packages/ui` devDependencies.
- `.storybook/main.ts` registers the addon in the `addons` array, between `addon-a11y` and `storybook-dark-mode`.
- `docs/storybook.md` — new **Figma embed (`parameters.design`)** subsection under *Story yazım kuralları*:
  - Contract: `meta.parameters.design` lives at component level, not per story (one canonical frame per component).
  - URL shape: `https://www.figma.com/design/<fileKey>/<name>?node-id=X-Y` — the `node-id` query param is required or the addon shows the file root.
  - Cross-link to the Figma component-description `storybook-id` convention ([docs/figma.md](../docs/figma.md#component-description--storybook-id)) that Chromatic's design-code diff relies on.

## Scope — Out

- **Wiring `Button.stories.tsx` with a Figma frame URL** — the Button primitive is not drawn in the Design System Figma file yet. Wiring is a one-line `parameters.design` addition once the Figma Button lands; will be tracked as a small follow-up issue at that point. The #64 acceptance criterion "Button story's Design tab renders the Figma frame inline" is therefore **deferred**.
- **Auto-sync between Figma `storybook-id` and addon-designs URL** — covered in scope-out of the original issue; separate mini-issue if needed after the first handful of primitives ship.

## Test plan

- [x] `pnpm --filter @glaon/ui build-storybook` — static build completes, addon bundles cleanly
- [x] `pnpm type-check` — green across all workspaces
- [x] `pnpm lint` — green across all workspaces
- [x] `pnpm --filter @glaon/core test` — scrubber tests still 16/16 (sanity check, unaffected)
- [x] CI: type-check · lint · audit, conventional-commits, gitleaks, playwright, visual regression, Chromatic all green
- [ ] Manual: `pnpm --filter @glaon/ui storybook` → Button story shows **Design** tab (empty state expected until Button Figma frame exists)

## Follow-up

Open a small issue/PR to wire `Button.stories.tsx` `parameters.design` once the Button primitive is drawn in Design System Figma.

Closes #64