### PR TITLE
chore(claude): add brand-design skill + Figma plugin scaffold

### DIFF
--- a/.claude/skills/brand-design/SKILL.md
+++ b/.claude/skills/brand-design/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: brand-design
+description: Answer brand-level design questions for Glaon — color/typography/spacing tokens, component personality, and do/don't guidance. Invoke when the user asks about Glaon's visual identity, proposes a new token, drafts a primitive variant, or needs a Figma Plugin script to mutate the design file. Skill is read-only: Figma stays the canonical source, and any design mutation is authored as a Figma Plugin script for the user to run manually in Figma.
+---
+
+# Brand Design — Glaon
+
+This skill encodes Glaon's brand decisions and the contract for Claude-authored design changes. Read [docs/figma.md](../../../docs/figma.md) first — it fixes the design source-of-truth rules this skill operates under.
+
+## Invocation contract
+
+- **Read-only by default.** Claude does not write to Figma. Brand/token decisions live in Figma; this skill references them and proposes changes as Figma Plugin scripts the user runs manually.
+- **Figma Plugin over REST.** Any design mutation is delivered as a plugin script under [`tools/figma-plugin/`](../../../tools/figma-plugin/). REST write scope is explicitly out of Phase 0 (see `docs/figma.md` follow-ups).
+- **One review step.** Claude outputs the script → user loads it in Figma's plugin runner → reviews the preview → accepts or discards. No autonomous design mutation ever.
+- **Defer token values to Figma.** This skill holds _policy and rationale_, not hex codes. When Figma Variables are populated, the token generator issue (see `docs/figma.md`) produces the JSON and transforms; this skill points at them, never duplicates.
+
+## When to use this skill
+
+Typical prompts that should route here:
+
+- "Propose a warning-state color for Glaon."
+- "Which token should this card background use?"
+- "Draft a modal pattern that fits Glaon's personality."
+- "Write a Figma Plugin script that renames all `color/gray/*` variables to `color/neutral/*`."
+- "Is this component density on-brand?"
+
+Out of scope (route elsewhere):
+
+- Accessibility lint or contrast auditing → Storybook `addon-a11y` is authoritative; open a separate issue for a skill if needed.
+- Copy tone / microcopy → separate concern, not in this skill.
+- Token JSON export from Figma → token generator issue (deferred in `docs/figma.md`).
+
+## Brand inputs
+
+Glaon's Design System Figma file is the canonical source. When the file is populated, the tokens and primitives land there first; this skill references them via the naming convention in `docs/figma.md`.
+
+### Color palette
+
+_TBD — first pass lands when Design System Figma gets its color variables. Until then, defer color questions to Figma._ Rationale captured here once published:
+
+- Base palette + semantic roles (brand, surface, text, state).
+- Light/dark mode mapping (Figma Variables `Theme` mode).
+- Accessibility contrast floors per role.
+
+### Typography
+
+_TBD — typography scale lands with Design System Figma text styles._ Once fixed, record:
+
+- Font family decisions (web stack + RN stack, since they diverge).
+- Scale ratio and size steps.
+- Weight + line-height pairings per role (display, heading, body, caption).
+
+### Spacing / radii / shadow
+
+_TBD — lands with Figma Variables._ Keep in mind:
+
+- Spacing scale is one source; RN multiplier lives in the Style Dictionary transform, not in this skill.
+- Radii: aim for a small set (e.g. `sm`, `md`, `lg`, `pill`) — resist per-component custom radii.
+- Shadow: distinct levels, each tied to an elevation role (card, dialog, popover).
+
+### Component personality
+
+Glaon is a secure Home Assistant frontend — tablet-first, long sessions, family-shared context. The visual language should match:
+
+- **Calm, not flashy.** Muted surfaces, minimal chrome, typography does the heavy lifting.
+- **Dense but breathable.** Wall-tablet use means information density matters; let spacing tokens do the breathing room, don't waste it on decoration.
+- **Motion is restraint.** Transitions communicate state (loading, success), not delight. Avoid bounce/spring unless it reinforces a physical metaphor.
+- **Trust cues are explicit.** Security-facing UI (auth, device state, permission) uses a clearly distinct visual register — not buried in general chrome.
+
+### Do / don't
+
+- **Do** reuse tokens — if a value isn't in the token set, propose a token, don't hard-code.
+- **Do** prefer primitives over one-off styles. A new variant of an existing primitive beats a new component.
+- **Do** match the wall-tablet use case: large touch targets, legible at arm's length, no hover-only affordances.
+- **Don't** propose hex codes or raw px values in code. References only.
+- **Don't** invent a new spacing step "just this once" — pick the closest existing one or raise a token issue.
+- **Don't** duplicate brand decisions here and in Figma. Figma wins; this file references.
+- **Don't** use motion for delight. Motion must carry signal.
+
+## Figma Plugin bridge
+
+When a design change is needed — renaming variables, bulk-applying a color, generating variants — Claude writes a Figma Plugin script that the user runs manually.
+
+Scaffold: [`tools/figma-plugin/`](../../../tools/figma-plugin/) — manifest + entry. Replace `code.js` with the Claude-authored script for the current task, then load/reload the plugin in Figma and run it.
+
+Script shape:
+
+```js
+// code.js — Claude-authored, replace per task
+(async () => {
+  try {
+    // Read-side: inspect what's there.
+    const variables = await figma.variables.getLocalVariablesAsync();
+
+    // Mutation-side: propose, don't commit silently. Log a summary.
+    // ... mutation logic ...
+
+    figma.notify('Glaon: done. Review changes in Figma and publish the library.');
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();
+```
+
+Guardrails for Claude-authored scripts:
+
+- **Dry-run by default.** If the script mutates, first log a summary of what it _would_ change, then require a `CONFIRM = true` constant the user flips to actually apply.
+- **Scoped calls only.** Touch the specific nodes/variables the task asks for. No sweeping changes.
+- **No network.** Plugin manifest does not grant network access. If a task needs external data, block and ask the user.
+- **Always `figma.closePlugin()` at the end.** Even on error paths.
+- **Notify on completion.** `figma.notify(...)` is the minimum UX — the user must see confirmation.
+
+## Handoff back to code
+
+A plugin mutation is not the end of the change. Once the user accepts and publishes in Figma:
+
+1. If tokens changed → the token generator (deferred issue, see `docs/figma.md`) regenerates the JSON. Until that exists, the user manually exports and commits.
+2. If a component changed → Chromatic design-code diff flags the drift on the next build (see `docs/chromatic.md`). A follow-up code PR wires the update.
+3. If a new primitive was drawn → Storybook Rule kicks in: the primitive's story gets written in the same PR that wires it (see `docs/storybook.md`).
+
+This skill does not close loops on its own — it proposes and hands off.

--- a/docs/figma.md
+++ b/docs/figma.md
@@ -143,6 +143,42 @@ Detaylar [docs/chromatic.md](chromatic.md#figma-entegrasyonu)'daki "Figma entegr
 - Figma'da değişen bir component'in kodda karşılığı yoksa, kod PR'ı **zorunlu follow-up** (issue + PR). Design System'de orphan component bırakılmaz.
 - Kodda yeni bir primitive eklenmek isteniyorsa **önce Figma'da** tasarlanır; Figma olmadan eklenen component'in review'ı blocked.
 
+## Claude-authored design
+
+Figma Remote MCP (#52) read-only. "Yeni variant üret", "brand rengini tüm primitive'lerde güncelle", "verbal brief'ten token üret" gibi write-tarafı görevler için Claude'a ayrı bir kanal açılır — ama otomatik yazma yoktur. Akış: Claude plugin script'i yazar, kullanıcı Figma'da manuel çalıştırır, review eder, publish eder.
+
+### Parçalar
+
+1. **`brand-design` skill** — [`.claude/skills/brand-design/SKILL.md`](../.claude/skills/brand-design/SKILL.md). Glaon'un brand girdilerini (palette, typography, spacing, component personality, do/don't) ve Claude'un design sorularında uyacağı guardrail'leri tutar. Brand-seviyesi sorular ("warning rengi nasıl olsun?", "bu card hangi token'ı kullanmalı?") bu skill üzerinden çalışır.
+2. **Figma Plugin bridge** — [`tools/figma-plugin/`](../tools/figma-plugin/). Claude mutasyon gerektiren bir iş için plugin script'i üretir; kullanıcı Figma desktop'ta **Plugins → Development → Import plugin from manifest…** ile yükleyip çalıştırır. Plugin repo'da commit'li kalır, ama `code.js`'in task'a özel içeriği commit edilmez (scaffold hali korunur, task sonrası `git restore`).
+3. **REST write scope — Phase 0'da yok.** `file:write` token güçlü ama kazara mutasyon riski taşır; plugin akışı yetersiz olduğu iddia edilene kadar kapalı.
+
+### Neden plugin, neden REST değil?
+
+- Auth Figma desktop session'ında zaten var — ayrı token yönetimi, secret rotation yok.
+- Mutasyon **insan-tetikli**. Claude `run` edemez → CI'dan kazara design mutasyonu mümkün değil.
+- Figma undo/history plugin mutasyonlarını kapsar; rollback ucuz.
+- Publish (library bump) ayrı ve manuel bir adım — yayınlanmamış bir mutasyon tüketicileri etkilemez.
+
+### Script guardrails
+
+Claude-authored her Figma plugin script'i şu kalıba uyar:
+
+- **Dry-run default.** Mutasyon yapmadan önce script başında `CONFIRM = false` → neyi değiştireceğini `figma.notify` ile özetle. Kullanıcı `CONFIRM = true` yapıp tekrar çalıştırana kadar yazmaz.
+- **Scope dar.** Task'ın istediği node/variable/component dışına çıkmaz.
+- **Network yok.** `manifest.json` `networkAccess.allowedDomains: ["none"]`. Harici veriye ihtiyaç varsa script start'ta durur, kullanıcıdan ister.
+- **Her zaman `figma.closePlugin()`.** Error path dahil. Ve `figma.notify` ile sonuç özeti bas.
+
+### Handoff back to code
+
+Plugin mutasyonu Figma'da biter; değişikliğin kod tarafına yansıması için ayrı adımlar:
+
+- **Token değişti** → token generator (ayrı issue) JSON'u yeniden üretir; generator yokken kullanıcı Figma Tokens plugin'iyle manuel export eder.
+- **Component değişti** → Chromatic design-code diff bir sonraki build'de drift'i işaretler (bkz. [docs/chromatic.md](chromatic.md)), follow-up kod PR'ı açılır.
+- **Yeni primitive çizildi** → Storybook Rule devreye girer: primitive'in story'si aynı kod PR'ında yazılır (bkz. [docs/storybook.md](storybook.md)).
+
+Skill ve plugin loop'u _kendisi_ kapatmaz — önerir ve devretir.
+
 ## Follow-up işler (bu issue kapsamı dışı)
 
 | Konu                                             | Durum                                                           |
@@ -151,6 +187,7 @@ Detaylar [docs/chromatic.md](chromatic.md#figma-entegrasyonu)'daki "Figma entegr
 | Figma MCP `.mcp.json` entry                      | OAuth başarılı olunca küçük PR                                  |
 | Chromatic ⇄ Figma design-code diff               | #53                                                             |
 | Figma branching + design review Slack bot        | ayrı issue                                                      |
+| REST `file:write` scope değerlendirmesi          | plugin akışı yetersiz kalırsa ayrı issue                        |
 
 ## Sorun giderme
 

--- a/tools/figma-plugin/README.md
+++ b/tools/figma-plugin/README.md
@@ -1,0 +1,55 @@
+# Glaon Figma Plugin — Scaffold
+
+Bu dizin, Claude-authored design değişikliklerinin Figma'ya taşınması için kullanılan yerel Figma Plugin iskeletidir. Plugin **hiçbir yerde publish edilmez**; sadece geliştirici makinesinde "Development" plugin olarak yüklenir ve manuel çalıştırılır.
+
+Detaylı workflow ve kurallar: [docs/figma.md](../../docs/figma.md#claude-authored-design).
+
+## Dosyalar
+
+- `manifest.json` — Figma Plugin manifest (API 1.0). Network access kapalı; dynamic-page access açık (büyük dosyalarda page-by-page yükler).
+- `code.js` — plugin entry. Scaffold hali sadece notification gösterip kapanır. Her task için Claude bu dosyanın içeriğini yeniden yazar; commit etmeyiz, lokal kullanılır ve `git restore` ile scaffold'a dönülür.
+- `brand-design` skill (`.claude/skills/brand-design/SKILL.md`) — plugin script'i üretirken Claude'un uymak zorunda olduğu guardrail'leri tanımlar (dry-run default, `CONFIRM` flag, no network, notify+closePlugin).
+
+## Figma'ya nasıl yüklenir?
+
+1. Figma desktop app'i aç (browser'da plugin development desteklenmiyor).
+2. Menu: **Plugins → Development → Import plugin from manifest…**
+3. `tools/figma-plugin/manifest.json` dosyasını seç.
+4. Plugin listede "Glaon" olarak görünür.
+5. Çalıştırmak için: açık olduğun dosyada **Plugins → Development → Glaon**.
+
+İlk import sonrası değişiklikleri görmek için plugin'i yeniden açman yeterli — Figma her açılışta `code.js`'i diskten okur. Manifest değiştiğinde Figma uyarır ve tekrar import istenebilir.
+
+## Task akışı (Claude-authored script)
+
+1. İhtiyaç doğar: "bu variable'ları yeniden adlandır", "bu renk palette'ini ekle", vb.
+2. Claude görevi `brand-design` skill'i üzerinden analiz eder ve `code.js`'e uygun script'i yazar.
+3. Script default **dry-run**: mutasyon yerine ne değişeceğinin özetini `figma.notify` ile gösterir.
+4. Dry-run çıktısını doğruladıktan sonra script'in başındaki `CONFIRM = true` flag'ini elle aç ve yeniden çalıştır.
+5. Figma'da değişiklikleri review et → tatmin ediciyse Design System dosyasını **publish** et (library bump); değilse `Ctrl+Z` / Figma history ile geri al.
+6. `code.js`'i scaffold haline döndür (`git restore tools/figma-plugin/code.js`) — task'a özel script'ler repo'ya commit edilmez. Yeniden kullanılabilir bir operasyon çıkarsa ayrı issue + düzgün bir script modülü olarak eklenir.
+
+## Neden plugin, neden REST değil?
+
+Figma REST API `file:write` scope'u güçlü ama kazara/otomatik mutasyon riski taşır. Plugin workflow'u:
+
+- Auth Figma desktop session'ında; ayrı token yönetimi yok.
+- Mutasyon insan tetikli; Claude "run" edemez.
+- Figma history/undo plugin mutasyonlarını da kapsar → rollback ucuz.
+
+REST write scope'u Phase 0 kapsamında değil. Plugin akışı yetersiz kaldığı iddia edilirse ayrı issue'da değerlendirilir (bkz. [docs/figma.md](../../docs/figma.md#follow-up-işler-bu-issue-kapsamı-dışı) follow-up tablosu).
+
+## Guardrail hatırlatmaları
+
+- **Dry-run default, `CONFIRM = true` ile aç.** Claude-authored her script bu kalıba uyar.
+- **Network yok.** `manifest.json` `networkAccess.allowedDomains: ["none"]`. Harici veri gerekiyorsa script başında stop et ve kullanıcıdan iste.
+- **Her zaman `figma.closePlugin()`** — error path dahil.
+- **Scope dar.** Task'ın istediğinden fazlasına dokunmaz.
+- **`figma.notify`** ile özet bas — kullanıcı ne olduğunu plugin kapanmadan görmeli.
+
+## Sorun giderme
+
+- **"This file doesn't have an 'id' field"** → manifest'teki `id` zorunlu; local dev için herhangi bir unique string yeter.
+- **`figma is not defined`** → browser'da çalıştırmaya çalıştın; desktop app gerekli.
+- **Plugin listede görünmüyor** → manifest'te `editorType` içinde `"figma"` var mı, `main` path'i doğru mu? Desktop'ta Plugins → Development → **Open console** ile hata görülebilir.
+- **Mutasyon yaptı ama publish etmedim** → Figma "Assets publish" akışı manuel; plugin library'yi otomatik publish etmez.

--- a/tools/figma-plugin/code.js
+++ b/tools/figma-plugin/code.js
@@ -1,0 +1,13 @@
+// Glaon Figma Plugin — scaffold entry.
+//
+// Replace the body of the IIFE below with a Claude-authored script for
+// the current design task. See tools/figma-plugin/README.md for the
+// workflow and docs/figma.md "Claude-authored design" for the contract.
+//
+// Default behavior (scaffold): show a notification confirming the plugin
+// loads, then close. No mutation.
+
+(() => {
+  figma.notify('Glaon plugin scaffold — replace code.js with a task script.');
+  figma.closePlugin();
+})();

--- a/tools/figma-plugin/manifest.json
+++ b/tools/figma-plugin/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Glaon",
+  "id": "glaon-design-bridge",
+  "api": "1.0.0",
+  "main": "code.js",
+  "editorType": ["figma"],
+  "documentAccess": "dynamic-page",
+  "capabilities": [],
+  "enableProposedApi": false,
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
+}


### PR DESCRIPTION
## Summary

Opens the Claude-authored design lane for Phase 0. Claude can now answer brand-level questions via the `brand-design` skill and author Figma Plugin scripts that the user runs manually — no automatic write to Figma, no REST write scope, no duplicated token values.

Three pieces:

1. **`brand-design` skill** — `.claude/skills/brand-design/SKILL.md`. Encodes Glaon's brand inputs (color/typography/spacing, component personality, do/don't) and the invocation contract. Token values stay TBD until Design System Figma is populated; the skill holds policy + rationale, not hex codes.
2. **Figma Plugin scaffold** — `tools/figma-plugin/` with `manifest.json` + empty `code.js` + README. Loads in Figma Desktop via **Plugins → Development → Import plugin from manifest…**. Network access disabled in manifest. Task-specific scripts replace `code.js` locally and are not committed.
3. **Docs** — new "Claude-authored design" section in `docs/figma.md` codifying the plugin-over-REST contract, the dry-run + `CONFIRM` guardrail, and the handoff-to-code steps. REST `file:write` scope explicitly deferred.

## Scope

### In

- `.claude/skills/brand-design/SKILL.md`
- `tools/figma-plugin/manifest.json`, `code.js`, `README.md`
- `docs/figma.md` — new section + follow-up row for REST write scope

### Out

- Populating brand/token values (waits for Design System Figma to be drawn — token generator issue).
- Any REST write scope — out of Phase 0.
- Other design-adjacent skills (accessibility, copy tone) — separate concerns.

## Test plan

- [x] `pnpm type-check` — green (no code changes, cache hit).
- [x] `pnpm lint` — green (cache hit).
- [x] `pnpm exec prettier --write` applied to new/modified files; lint-staged prettier gate passes on commit.
- [x] `gitleaks` pre-commit hook — no leaks.
- [x] CI green on PR #83 — all 7 checks pass (Storybook Publish, UI Tests, conventional-commits, gitleaks, playwright, type-check·lint·audit, visual regression).
- [x] Manually verify plugin scaffold loads in Figma Desktop without error (Plugins → Development → Import plugin from manifest… → select `tools/figma-plugin/manifest.json` → Plugins → Development → Glaon → notification appears, plugin closes).
- [x] Manually verify `brand-design` skill is discoverable via `/brand-design` in Claude Code.

Closes #66