### PR TITLE
chore(github): enable blank issues + contact links, unify CLAUDE.md refs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Something's broken. Describe repro so another developer can confirm.
+        Something's broken. Describe repro so another developer can confirm. Issue-First Rule applies — see [CLAUDE.md](../CLAUDE.md).
   - type: dropdown
     id: phase
     attributes:

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this for repo hygiene: tooling, CI, dependencies, refactors without a user-visible behavior change. User-visible behavior goes in the feature or bug template.
+        Use this for repo hygiene: tooling, CI, dependencies, refactors without a user-visible behavior change. User-visible behavior goes in the feature or bug template. Issue-First Rule applies — see [CLAUDE.md](../CLAUDE.md).
   - type: dropdown
     id: phase
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
+contact_links:
+  - name: Security advisory (private)
+    url: https://github.com/toss-cengiz/glaon/security/advisories/new
+    about: Report a vulnerability privately. Do not open a public issue for security findings — use the advisory flow so the fix can land before disclosure.
+  - name: Claude Code + contribution conventions
+    url: https://github.com/toss-cengiz/glaon/blob/development/CLAUDE.md
+    about: Issue-First Rule, branching, PR hygiene, security rules, and test-plan sync all live in CLAUDE.md. Read before opening a non-trivial issue.


### PR DESCRIPTION
## Summary

- Complete the issue template set with a real `config.yml` — contact links point to the private security advisory flow and to `CLAUDE.md`, blank issues stay enabled as an escape hatch.
- Align `bug.yml` and `chore.yml` with the CLAUDE.md pointer that `feature.yml` and `docs.yml` already carry so every template explains the Issue-First Rule up front.

## Scope

### In

- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: true`, two contact links (security advisory, contribution guide).
- `.github/ISSUE_TEMPLATE/bug.yml` — markdown intro references CLAUDE.md.
- `.github/ISSUE_TEMPLATE/chore.yml` — same.

### Out

- Rewriting existing `feature.yml`, `docs.yml`, `pull_request_template.md` — already carry the conventions (Scope In/Out, Test plan, `Closes #N`, CLAUDE.md reference). Preserving them avoids churn for templates already in use.
- Required-field tightening on issue forms — deferred until we see a real pattern of under-specified issues; over-enforcing now would slow down Claude-authored issues too.
- Enabling GitHub Discussions + a Discussions contact link — the repo has Discussions disabled today; enabling is a separate governance call.

## Test plan

- [ ] CI green: type-check · lint · audit · gitleaks · commitlint · visual regression.
- [ ] On GitHub, **Issues → New issue** shows the four form cards plus an "Open a blank issue" link and the two contact entries (security advisory, CLAUDE.md).
- [ ] Picking **Bug** or **Chore** shows the CLAUDE.md reference in the markdown preamble.
- [ ] Clicking the **Security advisory (private)** contact link lands on `/security/advisories/new`.
- [ ] The PR template preview on this PR already matches `pull_request_template.md` (Summary / Scope In-Out / Test plan / `Closes #`).

Closes #90