### PR TITLE
docs(adr): scaffold ADR workflow + backfill Phase 0 decisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,13 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 - CI enforces `pnpm audit --audit-level high`. High + critical severity vulnerabilities fail the build. Don't weaken the audit level to silence a finding — patch the dep (or open an issue to pin around it).
 - Major version bumps always require human review: Renovate lists them in the dashboard with approval-needed, and they only turn into PRs after the dashboard checkbox is ticked.
 
+## Architecture Decision Records
+
+- Non-trivial architectural decisions are captured as ADRs in [docs/adr/](docs/adr/README.md). The "why" gets frozen at decision time so we debate new evidence instead of re-opening old choices every quarter.
+- Write an ADR when the decision is expensive to reverse, had a real debate against alternatives, or will prompt "why is it like this?" from a future reader — framework/runtime choices, package boundaries, security model, delivery channel, supply-chain picks. Skip it for library version bumps, routine refactors, and minor tooling choices.
+- ADRs are immutable. To change a decision, write a new ADR and mark the old one `Superseded by ADR-NNNN`. Don't edit in place; history is the point.
+- The ADR lands in the same PR as the code that implements (or starts implementing) it so the rationale and the code ship together. Format + process are in [docs/adr/README.md](docs/adr/README.md).
+
 ## Home Assistant Notes
 
 - WebSocket protocol: https://developers.home-assistant.io/docs/api/websocket

--- a/docs/adr/0001-turborepo-pnpm-workspaces.md
+++ b/docs/adr/0001-turborepo-pnpm-workspaces.md
@@ -1,0 +1,58 @@
+# ADR 0001 — Turborepo + pnpm workspaces
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-20
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** repo bootstrap commit, [CLAUDE.md](../../CLAUDE.md#stack)
+
+## Bağlam
+
+Glaon tek depoda web, tablet (kiosk), mobile ve paylaşılan paketler taşıyacak. İlk seçim tek-kök mono-repo mu yoksa çok-depolu (multi-repo) mu olduğuydu. Paylaşılan `@glaon/core` paketinin hem Vite (web) hem Metro (React Native) tarafından tüketilmesi, token + OAuth mantığının tek yerden akması gerektiği, ve release cycle'ın tek versiyon akışıyla yürüyeceği mono-repo tarafına kayırdı.
+
+Mono-repo aracı seçiminde değerlendirilenler:
+
+- **Nx:** Güçlü, tam özellik seti. Uygulama generatörleri, ML temelli test seçici, cloud cache. Dezavantaj: konfigürasyon ağır, kendi jargonunu dayatıyor (plugin sistemi, "targets"), Vite ve Expo ekosistemiyle Turborepo'ya kıyasla daha fazla adaptör gerektiriyor.
+- **Bazel:** Ölçek için mükemmel, reprodüksiyon kalitesi en yüksek. Dezavantaj: ön yatırım çok yüksek, JS/TS ekosistemine yabancı, tek kişilik projede değer üretmeden maliyet üretir.
+- **Lerna (klasik):** Artık bakım modunda; Nx tarafından satın alındı. Yeni proje için tavsiye edilmez.
+- **Turborepo + pnpm workspaces:** Minimal konfig, `pnpm` workspaces'ın protocol:workspace\* sembolünü doğrudan kullanır, remote cache opsiyonel ama gerektiğinde var. Ekosistem tercihi Vite/Expo ile uyumlu — resmi örneklerde Turborepo sık sık referans alınır.
+- **Yarn/npm workspaces + raw scripts:** Orkestrasyon yok. `pnpm run --parallel` ile başlasak bile task dependency graph yok, incremental build yok. Hızlı başlangıç ama 10+ paket sonrası yönetilemez hale gelir.
+
+## Karar
+
+**Turborepo 2.x + pnpm 9 workspaces** ile mono-repo kurulur.
+
+- Paket yöneticisi olarak pnpm (Node 22 LTS üzerinde) — `strict-peer-dependencies`, disk alanı verimliliği, ve workspaces protocol:workspace\* desteği için.
+- Task orkestrasyonu ve incremental build için Turborepo. `turbo.json` pipeline'ları: `build`, `dev`, `lint`, `type-check`, `test`, `test:e2e`.
+- Remote cache başlangıçta kapalı, ayrı bir iş olarak açılacak (bkz. #88).
+
+## Sonuçlar
+
+### Olumlu
+
+- Paylaşılan paketler (`@glaon/core`, `@glaon/ui`, `@glaon/config`) tek kök altında refactor edilebilir, paket versiyon eşitlemesi gereksiz.
+- `pnpm install` ile tek lock dosyası; supply-chain denetimi tek noktadan.
+- Turborepo incremental cache, CI sürelerini makul tutar; paketler büyüdükçe remote cache'e geçiş kolay.
+- Topluluk desteği yüksek, Vite/Expo/Storybook repo örneklerinin çoğu bu kombinasyonu kullanıyor.
+
+### Olumsuz / ödenecek bedel
+
+- `pnpm`'in strict mode'u bazen peer dep uyarıları üretiyor — IDE'nin anlayabilmesi için ek konfig gerekiyor.
+- Turborepo remote cache Vercel ekosistemine bağlı (şu an tek seçenek uygun olarak `@vercel/remote-cache`); self-host için eklenti gerekir. Bağımlılık kabul edildi, alternatif mevcut.
+
+### Etkileri
+
+- `packages/*` ve `apps/*` dizin yapısı standartlaştı.
+- Yeni paket eklemek bir `package.json` + pnpm `workspaces` içine otomatik pickup — manuel register adımı yok.
+- CI'da `pnpm install --frozen-lockfile` + `pnpm turbo run <task>` standart pipeline.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Ekip 5 kişiye çıkar ve Nx cloud özelliklerinden biri (distributed task execution, smart retry) zorunlu hale gelirse.
+- Bazel geçişini zorunlu kılacak düzeyde cross-language build gerektirirse (native modül, Rust, Go vs. JS/TS yan yana).
+- Turborepo v3 breaking change'i `turbo.json` formatını büyük ölçüde değiştirirse.
+
+## Referanslar
+
+- [Turborepo docs](https://turborepo.com/docs)
+- [pnpm workspaces](https://pnpm.io/workspaces)
+- [CLAUDE.md — Stack bölümü](../../CLAUDE.md#stack)

--- a/docs/adr/0002-vite-react-19-web.md
+++ b/docs/adr/0002-vite-react-19-web.md
@@ -1,0 +1,70 @@
+# ADR 0002 — Vite + React 19 (web)
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-20
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [CLAUDE.md — Stack](../../CLAUDE.md#stack), [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
+
+## Bağlam
+
+Glaon'un web tarafı iki farklı bağlamda çalışıyor:
+
+1. Home Assistant Add-on olarak **Ingress** üzerinden servis edilen panel (tablet + tarayıcı).
+2. İlerleyen sürümlerde doğrudan HA kullanıcılarının tarayıcıdan ulaşabileceği standalone kiosk modu (tablet için tam ekran).
+
+Her iki senaryo da **SSR ihtiyacı duymuyor**: HA kullanıcıları auth'lu (HA session cookie ile Ingress), sayfa indeks SEO ihtiyacı yok, edge caching gerek yok. Ihtiyaç duyulan şey SPA: istemci tarafı render, fast HMR, küçük bundle, CSP-dostu asset yolları.
+
+Değerlendirilen seçenekler:
+
+- **Next.js 15 (App Router):** Full-stack framework. SSR, RSC, edge runtime desteği var. Dezavantaj: Add-on Ingress dinamik URL prefix kullanıyor, Next'in file-system routing ve base path hesabı bu akışla iyi oynamıyor; RSC zaten kullanılmayacak; build output SPA için olandan ağır.
+- **Remix:** SSR-first, data loader felsefesi. Aynı SSR gerek-duymuyor sorunu, ek olarak HA Auth akışıyla loader pattern'i paralel geçiyor ama fazla abstraction.
+- **Create React App:** Topluluk artık bakım yapmıyor, önerilmiyor.
+- **Vite + React:** Pure SPA, sıfır SSR overhead, HMR elit düzeyde, Rollup tabanlı production build küçük bundle veriyor, `--base=./` ile relative asset paths HA Ingress dinamik prefix'ine uyuyor.
+- **Parcel:** Konfigürasyonsuz avantajı cazip ama plugin ekosistemi Vite'a göre ince, Sentry + MDX gibi eklentilerde sapma çıkıyor.
+
+React sürümü için React 19 tercih edildi; hem yeni API'lerin (Actions, `use()` hook, optimistic updates) Home Assistant state senkronizasyonunda işe yarayacağı, hem React 18'in end-of-life ufukta olduğu için.
+
+TypeScript strict mode zorunlu — CLAUDE.md güvenlik kuralları (`any` yasak, `ts-ignore` yorumsuz yasak) zaten bunu dayatıyor.
+
+## Karar
+
+Web uygulaması **Vite 6 + React 19 + TypeScript strict** üzerine kurulur.
+
+- `apps/web` paketi Vite ile build'lenir. Production build `vite build`, dev mode `vite`.
+- HA Add-on build akışı `vite build --base=./` ile relative asset paths üretir (Ingress'in değişken URL prefix'iyle çalışmak için zorunlu).
+- React 19'un concurrent mode özellikleri ve Suspense tabanlı data fetching varsayılan.
+- TypeScript 5.7+ strict mode, `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` açık.
+- Routing için React Router (client-side). SSR gerekirse ADR yeniden açılır.
+
+## Sonuçlar
+
+### Olumlu
+
+- Dev döngüsü hızlı: Vite HMR sub-100ms.
+- Bundle boyutu kontrol altında; Rollup tree-shaking + code splitting istenildiği gibi çalışıyor.
+- HA Ingress prefix sorunu `--base=./` ile çözüldü, ek adaptör gerekmedi.
+- React 19 Actions API HA service call orkestrasyonunda pattern olarak kullanılabilir.
+
+### Olumsuz / ödenecek bedel
+
+- SSR/RSC yolu gelecekte seçilirse ayrı bir framework'e geçiş gerekecek. Olasılık düşük ama lock-in kabul edildi.
+- Vite'ın Rollup bağımlılığı zaman zaman plugin API kırılması yaşatıyor (örn. Sentry plugin major bump'ları).
+- React 19'un ecosystem uyumu hâlâ olgunlaşıyor; bazı kütüphaneler 19 peer dep listesinde yok (şimdilik `--legacy-peer-deps` veya workspace override ile çözülüyor).
+
+### Etkileri
+
+- Add-on build pipeline'ı `pnpm --filter @glaon/web build:addon` → `addon/dist/` kopyasıyla standart hale geldi.
+- Vite dev server 5173 portunda; devcontainer forward edilen port listesine eklendi (bkz. #103).
+- CSP `script-src 'self'` sıkı; Vite'ın `unsafe-inline` ihtiyacı yok (Rollup build'de modül etiketleri self-hosted).
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Sayfa SEO veya non-authenticated public landing gerekirse (SSR zorunluluğu doğar).
+- Tablet cihazlarda Vite dev/preview sunucu yerine edge-rendered içerik ihtiyacı çıkarsa.
+- React 20 veya Vite 7 breaking change'leri framework geçişini zaten tetikleyecek düzeyde olursa.
+
+## Referanslar
+
+- [Vite docs](https://vitejs.dev)
+- [React 19 release notes](https://react.dev/blog/2024/12/05/react-19)
+- [docs/ARCHITECTURE.md](../ARCHITECTURE.md)

--- a/docs/adr/0003-expo-new-architecture-mobile.md
+++ b/docs/adr/0003-expo-new-architecture-mobile.md
@@ -1,0 +1,69 @@
+# ADR 0003 — Expo SDK + new architecture (mobile)
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-20
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [CLAUDE.md — Stack](../../CLAUDE.md#stack)
+
+## Bağlam
+
+Glaon mobile tarafı iOS ve Android'de tek kod tabanıyla yürüyecek. Gereksinimler:
+
+- OAuth2 Authorization Code + PKCE akışı (ADR 0005) — in-app browser için güvenli redirect gerekiyor.
+- Token'lar güvenli storage'da (iOS Keychain / Android Keystore) kalacak.
+- Home Assistant WebSocket bağlantısı arka planda yaşayacak.
+- `@glaon/core` paylaşımlı paketi aynı TS kaynağından Vite + Metro tüketecek (ADR 0004).
+- Geliştirme döngüsü hızlı olmalı — sadece tek mobil geliştirici var, native build süresi darboğaz yaratmamalı.
+
+Değerlendirilen seçenekler:
+
+- **Flutter:** UI kalitesi ve performans iyi, ama Dart ayrı dil, paylaşım paketi (`@glaon/core`) yeniden yazmak gerekecek. React 19 ile uyumlu değil.
+- **React Native (bare, yeni mimari):** Tam kontrol ama iOS/Android native proje dosyalarını tek kişilik ekiple yönetmek maliyetli. Auth için `expo-auth-session`'un bare eşdeğerini elle kurmak gerekir.
+- **Expo SDK (managed workflow, new architecture on):** OAuth için `expo-auth-session`, secure storage için `expo-secure-store`, Sentry entegrasyonu için hazır plugin. New architecture (Fabric + TurboModules) default olarak açık. Development client ile custom native modül gerektiğinde EAS Build ile çıkılır.
+- **Expo Go (dev only):** Custom native modül desteklemediği için sınırlı — OAuth akışı için production'da zaten dev client gerekiyor. Araç olarak kullanılır ama tek başına yeterli değil.
+- **Kotlin Multiplatform + SwiftUI:** Native UI kalitesi en yüksek, geliştirme maliyeti çok yüksek. Paylaşım paketi paradigması uyumsuz.
+
+React Native yeni mimarisi (Fabric renderer + TurboModules + JSI) 0.76'dan beri stabil ve 0.81'de default. Eski mimari deprecate yolunda. Yeni proje için eski mimariye start etmek önemli bir anti-pattern.
+
+## Karar
+
+Mobile uygulaması **Expo SDK 55 (managed) + React Native 0.81 (new architecture on) + React 19** üzerine kurulur.
+
+- `apps/mobile` paketi Expo managed workflow. Custom native modül gerektiğinde EAS Build + development client flow'una geçilir.
+- React Native yeni mimarisi (`newArchEnabled: true` app.json'da) baştan açık.
+- OAuth için `expo-auth-session`, secure storage için `expo-secure-store`, deep linking için `expo-linking`, observability için `@sentry/react-native` (Expo plugin).
+- TypeScript strict mode, @glaon/core'u Metro resolver ile tüketir.
+
+## Sonuçlar
+
+### Olumlu
+
+- OAuth2 PKCE akışı için `expo-auth-session` zaten PKCE destekli — güvenlik-kritik code'u kendimiz yazmıyoruz.
+- Secure store API'si iOS Keychain + Android Keystore'a tek API'den erişiyor.
+- Development cycle hızlı: dev client üzerinden Metro reload sub-saniye.
+- EAS Build ile iOS signing + Android release derlemesi native toolchain sahibi olmadan yürüyor.
+- New architecture açık olması → gelecekte web için `react-native-web-vite` köprüsü (Storybook'ta zaten var) ile paylaşılan primitive'lere yol açık.
+
+### Olumsuz / ödenecek bedel
+
+- Expo'nun "managed" seçimi bazı native modülleri dışarıda bırakıyor. Custom modül gerekirse dev client'a geçmek ve EAS Build hattına girmek şart — küçük ama gerçek friction.
+- SDK upgrade'leri yılda 2 kere major, ekosistem bu tempoyu takip ederken test yükü yüksek.
+- EAS Build ücretsiz katmanı aylık limit var; CI/CD yoğunluğu artınca maliyet gündeme gelir.
+
+### Etkileri
+
+- Mobile CI job'u `eas-cli` ile entegre edilecek (issue açılacak).
+- `@glaon/core` paketi Metro resolver'a `exports` field üzerinden çıkmak zorunda (ADR 0004).
+- Storybook'un React Native preview'i için `react-native-web-vite` adaptörü (issue #47) gerekti; paylaşılan primitive'lerin hem Metro hem Vite'dan tüketilmesinin yan etkisi.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Expo'nun EAS Build ücretsiz katmanı Glaon için yeterli olmazsa (CI self-host değerlendirilir).
+- New architecture'ın breaking change'i kütüphane ekosistemini ikiye bölerse.
+- Native modül ihtiyacı o kadar ağırlaşırsa ki bare RN'e geçmek daha verimli olur.
+
+## Referanslar
+
+- [Expo SDK docs](https://docs.expo.dev)
+- [React Native new architecture](https://reactnative.dev/docs/the-new-architecture/landing-page)
+- [`expo-auth-session` PKCE flow](https://docs.expo.dev/versions/latest/sdk/auth-session/)

--- a/docs/adr/0004-glaon-core-platform-agnostic.md
+++ b/docs/adr/0004-glaon-core-platform-agnostic.md
@@ -1,0 +1,72 @@
+# ADR 0004 — `@glaon/core` platform-agnostic paylaşım paketi
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-20
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [CLAUDE.md — Package Boundaries](../../CLAUDE.md#package-boundaries)
+
+## Bağlam
+
+Glaon üç istemci çeşidinden (web, tablet, mobile) aynı Home Assistant örneğine bağlanacak. Paylaşılan mantık:
+
+- OAuth2 PKCE akışı (code verifier/challenge üretimi, token exchange, refresh).
+- Home Assistant WebSocket istemcisi (mesaj serileştirme, subscription yönetimi, reconnection).
+- Durum yönetiminin platform bağımsız kısmı (entity cache, domain modelleri).
+- Yardımcı tipler (HA API şeması, error sınıfları).
+
+Bu mantık her istemcide yeniden yazılırsa:
+
+- Bug fix'ler üç yerde uygulanır; sürüm kayması kaçınılmaz olur.
+- Auth güvenliği gibi kritik yolda iki paralel implementasyon = iki paralel saldırı yüzeyi.
+- Geliştirici tempo yarıya düşer.
+
+Değerlendirilen yaklaşımlar:
+
+- **`@glaon/core` paketi, platform-agnostic:** Sadece Web Standart API'leri (Fetch, WebSocket, Web Crypto, URL). Web ve React Native 0.71+ zaten bu API'leri sağlıyor. Platform özel kod (`localStorage`, `document`, `expo-secure-store`, `AppRegistry`) girmez.
+- **`@glaon/web-core` + `@glaon/mobile-core` (ayrı paketler):** Her platform kendi runtime primitive'ini doğrudan tüketir. Dezavantaj: logic duplikasyonu geri geliyor, yalnızca "tipler" paylaşılıyor. Reddedildi.
+- **Tek paket, conditional imports (`react-native` field in package.json):** Metro ve Vite'ın farklı import resolver'ları olmasıyla entropi çok yüksek. Bazı edge case'ler (nested package.json, subpath exports) ile karmaşıklaşıyor. Reddedildi.
+- **Tek repo, `@glaon/core` paketi zero-platform-imports:** Platform özel kod (`SecureStore`, `WebBrowser`, DOM) `apps/*` katmanında. Core, platform'a "policy" enjekte ediliyor (dependency injection pattern) — örn. token store için bir `TokenStorage` interface'i tanımlıyor, web ve mobile ayrı implementasyon sağlıyor.
+
+## Karar
+
+**`@glaon/core` platform-agnostic paylaşım paketi olarak kurulur ve package boundary olarak enforce edilir.**
+
+- Kurallar:
+  - `window`, `document`, `localStorage` → yasak (web özel).
+  - `react-native`, `expo-*` → yasak (mobile özel).
+  - İzin verilen runtime API'leri: `fetch`, `WebSocket`, `crypto.subtle`, `URL`, `URLSearchParams`, `TextEncoder`/`TextDecoder`, `AbortController`, `structuredClone`.
+  - Tipler, iş kuralları, protokol implementasyonları burada.
+  - Platform bağımlı davranış → `apps/web` veya `apps/mobile` interface'i implement ederek enjekte eder.
+- ESLint kuralı ile `packages/core/src/**` altında `react-native` veya web global'lerinin import'u engellenir.
+- `exports` field iki format yayar: ESM (`./dist/esm/index.js`) + CJS fallback (`./dist/cjs/index.js`) + TypeScript types (`./dist/index.d.ts`). Metro + Vite ikisini de doğru resolve edebiliyor.
+
+## Sonuçlar
+
+### Olumlu
+
+- Auth + WebSocket gibi güvenlik-kritik kod tek yerde — denetim yüzeyi minimum.
+- Birim testler platform runtime'ına ihtiyaç duymadan Node üzerinde koşturulabiliyor (Vitest, ADR 0007'den bağımsız olarak test altyapısı hızlı).
+- Yeni istemci çeşidi (desktop Electron, CLI) eklersek yeniden yazma minimal.
+- TypeScript type-checking mono-repo boyunca tek pipeline — `turbo run type-check`.
+
+### Olumsuz / ödenecek bedel
+
+- Dependency injection pattern boilerplate getiriyor; küçük apilar için ek interface yazmak gerekebilir.
+- Platform özgü optimizasyonları core'a sızdırmamaya dikkat etmek gerek — code review disiplini.
+- `exports` field dual-format hazard'ı yaratıyor (aynı modülün ESM + CJS yükü çakışırsa); `publint` + `arethetypeswrong` (#97) bunu CI'da yakalıyor.
+
+### Etkileri
+
+- Storybook web preview React Native bileşenlerini `react-native-web-vite` ile tüketmek zorunda kaldı — ama bu `@glaon/ui` paketini etkiler; `@glaon/core`'un kendisi UI bileşeni içermediği için sorun değil.
+- CLAUDE.md'de [Package Boundaries](../../CLAUDE.md#package-boundaries) bölümü bu kuralı dayatıyor.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Web Standart API'lerinin React Native implementasyonu (özellikle Web Crypto) kritik bir bug yaşarsa ve polyfill kabul edilemez maliyette olursa.
+- Paylaşım paketi platform özel optimizasyon gerektiren bir darboğaza girerse (kesinlikle profiling ile kanıtlanmalı, önsezi ile değil).
+
+## Referanslar
+
+- [CLAUDE.md — Package Boundaries](../../CLAUDE.md#package-boundaries)
+- [Node.js `exports` field spec](https://nodejs.org/api/packages.html#exports)
+- [Metro package.json exports support](https://reactnative.dev/blog/2023/06/21/0.72-metro-package-exports-symlinks)

--- a/docs/adr/0005-oauth2-pkce-only-auth.md
+++ b/docs/adr/0005-oauth2-pkce-only-auth.md
@@ -1,0 +1,74 @@
+# ADR 0005 — OAuth2 Authorization Code + PKCE (tek auth yöntemi)
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-20
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [docs/SECURITY.md](../SECURITY.md), [docs/ARCHITECTURE.md](../ARCHITECTURE.md), [HA auth API](https://developers.home-assistant.io/docs/auth_api)
+
+## Bağlam
+
+Home Assistant iki auth mekanizması sunuyor:
+
+1. **OAuth2 Authorization Code** akışı — RFC 6749 + PKCE (RFC 7636). HA'nın `/auth/authorize` + `/auth/token` endpoint'leri. Access token + refresh token döner, access 30 dakika yaşar.
+2. **Long-Lived Access Token (LLAT)** — kullanıcının UI'dan ürettiği, dönmeyen, manuel revoke edilene kadar yaşayan token. Genelde script/entegrasyon için.
+
+Glaon bir kullanıcı istemcisi — panel, mobile, tablet. Her kullanıcı kendi HA hesabı ile giriş yapacak. Saldırı yüzeyi ve güvenlik gereksinimleri:
+
+- Token sızıntısının etkisi **minimum** olmalı — LLAT sızarsa revoke edilene kadar kullanılabilir, sınırsız.
+- Mobile uygulamada redirect URL'inde code intercept edilme riski → PKCE kaçınılmaz.
+- Tarayıcıda token XSS riski → in-memory + short-lived access + refresh rotation zorunlu (bkz. ADR 0006).
+- Çok kullanıcı (aile / misafir) — her kullanıcı kendi oturumu.
+
+Alternatifler:
+
+- **LLAT tek auth yöntemi:** UX: kullanıcı HA'ya git, "long-lived token oluştur", kopyala, Glaon'a yapıştır. Dezavantaj: token sızarsa sınırsız yaşam, kullanıcı-başı token yönetimi korkunç, sızıntıya karşı refresh/rotation yok. Reddedildi.
+- **Username + password basic auth:** HA artık desteklemiyor; MFA ile uyumsuz; legacy.
+- **HA'nın "webhook" ya da "trusted networks" auth'u:** Glaon'un ağ topolojisiyle iyi uymuyor (Add-on Ingress içinden HA cookie zaten geliyor ama mobile ve harici web için yetersiz).
+- **OAuth2 Authorization Code + PKCE:** HA'nın resmi SPA/mobile auth akışı. Short-lived access + refresh rotation + PKCE.
+
+## Karar
+
+**Tüm istemciler için tek auth yöntemi: OAuth2 Authorization Code akışı + PKCE.**
+
+- Web (tablet + tarayıcı): PKCE code verifier `@glaon/core` tarafından Web Crypto (`crypto.subtle.digest('SHA-256', ...)`) ile üretilir. Redirect URI `window.location.origin + '/auth/callback'`.
+- Mobile (Expo): `expo-auth-session` PKCE flow'u. Redirect URI deep link (`glaon://auth/callback`).
+- Add-on Ingress senaryosu: HA Session cookie Ingress auth'u hallettiği için web app Ingress içindeyken OAuth akışını tetiklemiyor — `auth_api: true` config flag HA kullanıcı session'ını delege ediyor. OAuth akışı standalone (Ingress dışı) web + mobile için.
+- LLAT **yasak**. CLAUDE.md'de güvenlik kuralları bunu netleştiriyor.
+- HA'nın `client_id` kuralı: redirect destination host'u işaret eden bir URL olmak zorunda. Her deploy için `client_id` = origin URL.
+
+## Sonuçlar
+
+### Olumlu
+
+- Short-lived access token (30 dk) → sızıntının etkisi sınırlı.
+- Refresh token rotation ile replay attack yüzeyi dar.
+- PKCE mobile redirect intercept'i nötralize ediyor — mobil platformda OAuth için endüstri standardı.
+- Kullanıcı başına oturum native olarak destekleniyor; multi-user HA kurulumlarında her kullanıcı kendi token'ıyla geliyor.
+- Token invalidation HA tarafından yönetiliyor (kullanıcı HA UI'dan oturumunu sonlandırabilir).
+
+### Olumsuz / ödenecek bedel
+
+- Implementasyon karmaşıklığı LLAT'a göre daha yüksek; PKCE code verifier, state parameter, redirect handling hepsi doğru yazılmalı.
+- Offline-first kullanım zorlaşıyor — access token süresi biter bitmez network gerekiyor; refresh cycle da online olmak zorunda.
+- Kurulum deneyimi bir "client_id" ve redirect URI konfigürasyonu gerektiriyor; LLAT kadar hızlı değil.
+- HA dev dokümantasyonu bazı akış detaylarında zayıf; implementasyon süresinde tuzaklar çıkacak.
+
+### Etkileri
+
+- `@glaon/core` içinde `AuthClient` sınıfı PKCE akışını platform-agnostic yapacak; platform-spesifik redirect + storage interface enjekte ediyor.
+- `apps/web/src/auth/` ve `apps/mobile/src/auth/` yalnızca redirect + storage bind'i yapıyor, iş mantığı core'da.
+- Security-review skill OAuth akışına dokunan her PR'da otomatik çağrılıyor ([CLAUDE.md — Security-First Rules](../../CLAUDE.md#security-first-rules)).
+
+## Tekrar değerlendirme tetikleyicileri
+
+- HA kendi OAuth modelini köklü değiştirirse (yeni endpoint, yeni flow, DPoP zorunluluğu).
+- LLAT'ın özel senaryolar (CLI aracı, script-only deploy) için gerekli olduğu ikinci bir use case doğarsa — o zaman **ikinci bir auth flow** olarak eklenir, ana flow olarak değil.
+- WebAuthn / passkey desteği HA tarafında eklendiğinde yeni ADR gerekebilir.
+
+## Referanslar
+
+- [HA Auth API](https://developers.home-assistant.io/docs/auth_api)
+- [RFC 7636 — PKCE](https://datatracker.ietf.org/doc/html/rfc7636)
+- [OAuth 2.0 for Browser-Based Apps (BCP)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps)
+- [docs/SECURITY.md](../SECURITY.md)
+- [CLAUDE.md — Security-First Rules](../../CLAUDE.md#security-first-rules)

--- a/docs/adr/0006-token-storage.md
+++ b/docs/adr/0006-token-storage.md
@@ -1,0 +1,87 @@
+# ADR 0006 — Token storage: in-memory + httpOnly cookie (web) / SecureStore (mobile)
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-20
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [docs/SECURITY.md](../SECURITY.md), [CLAUDE.md — Security-First Rules](../../CLAUDE.md#security-first-rules), ADR 0005
+
+## Bağlam
+
+ADR 0005 ile OAuth2 PKCE seçildi. Geriye access + refresh token'ları her istemcide güvenli saklama kararı kaldı. Saldırı modelleri:
+
+**Web:**
+
+- **XSS** → en büyük risk. Eğer token `localStorage` veya `sessionStorage`'da tutulursa, herhangi bir XSS (üçüncü parti script, eklenti, supply chain) token'ı çalabilir. CSP zaten sıkı (ADR'de yer almıyor, [docs/SECURITY.md](../SECURITY.md) tanımlıyor) ama XSS riskini sıfıra indirmiyor.
+- **CSRF** → cookie kullanırsak SameSite=Strict + CSRF token kombinasyonu.
+- **Network intercept** → HTTPS + TLS pinning mobile'da. Web'de HA Ingress zaten HA'nın TLS'i içinde.
+
+**Mobile:**
+
+- **Cihaz fiziksel erişim** → cihaz lock'u bypass edilirse storage sızabilir. iOS Keychain + Android Keystore hardware-backed korumayı kullanmak zorunlu.
+- **AsyncStorage veya plain file** → root'lu cihazda düz okunabilir; kullanılamaz.
+- **Memory dump** → root/jailbreak senaryosunda kaçınılmaz; kabul edilen risk.
+
+Değerlendirilen web stratejileri:
+
+- **localStorage:** XSS ile tamamen kompromize. CLAUDE.md bunu doğrudan yasaklıyor.
+- **sessionStorage:** Aynı XSS problemi, sadece tab kapanınca silinir — güvenlik artışı yok.
+- **In-memory (JS değişkeni):** XSS çalması için script'in aktif session'a ulaşması gerek. Refresh'te kaybolur → kullanıcı her sekme açtığında yeniden login. UX kötü.
+- **In-memory access + httpOnly+SameSite=Strict cookie'de refresh token:** Access token JS'e açık ama short-lived (30 dk); refresh token JS'e görünmez (XSS sızdıramaz). Glaon için HA proxy behind nginx (Add-on içinde) bu pattern'i destekleyebilir.
+- **Service Worker ile token proxy:** Service Worker arka planda request'leri intercept edip Authorization header'ı ekler. Token SW scope'unda kalır. Karmaşık ama güvenliği yüksek. Değerlendirildi ama ilk sürüm için overkill.
+
+Mobile stratejileri:
+
+- **AsyncStorage** — plain file, yasak.
+- **expo-secure-store** — iOS Keychain + Android Keystore wrapper. Hardware-backed encryption, biometric gate opsiyonel.
+- **Native modül ile keystore direkt erişim** — Expo managed workflow'u bozar, gerek yok.
+
+## Karar
+
+**Web:**
+
+- Access token **in-memory** değişkeninde (React context/store). Refresh'te kaybolur, silent refresh flow ile yeniden alınır.
+- Refresh token **httpOnly + SameSite=Strict + Secure cookie**'de. Add-on nginx proxy'si `/auth/token` endpoint'ini terminate edip Set-Cookie ayarlıyor. JS koduna refresh token asla girmiyor.
+- Standalone web (Ingress dışı) senaryoda nginx yerine HA reverse proxy bu cookie işini yapacak; ayrıntı deploy-time.
+
+**Mobile:**
+
+- Access + refresh token ikisi de **`expo-secure-store`**'da (`keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY`).
+- Biometric lock opsiyonu kullanıcı ayarı olarak eklenecek (issue açılacak).
+- AsyncStorage'a kesinlikle yazılmaz; ESLint kuralı `@react-native-async-storage/async-storage` import'unu `apps/mobile/src/**` dışında yasaklar.
+
+## Sonuçlar
+
+### Olumlu
+
+- Web'de XSS sızıntısı access token'ı 30 dakika içinde veriyor, refresh token'ı asla — saldırı zaman penceresi dar.
+- Cookie SameSite=Strict CSRF'i nötralize ediyor.
+- Mobile'da token hardware-backed keystore'da; root olmayan cihazda pratik olarak sızdırılamaz.
+- CLAUDE.md güvenlik kuralları netleştirilmiş, kural ihlali linter/security-review skill tarafından yakalanıyor.
+
+### Olumsuz / ödenecek bedel
+
+- Cookie tabanlı refresh flow backend'de (nginx / HA proxy) ek konfigürasyon istiyor — deployment ayarları karmaşıklaşıyor.
+- Silent refresh cycle'ı web'de user-experience için görünmez olmalı; tab'lar arası refresh token koordinasyonu (BroadcastChannel veya Web Lock API) gerekebilir.
+- `expo-secure-store`'un bazı Android sürümlerinde biometric gate davranışı tutarsız (özellikle eski OEM cihazlar); kullanıcı raporlarını takip etmek gerek.
+- Token rotation sırasında race condition riski — concurrent request'ler tek refresh'e kilitlenmeli (mutex pattern).
+
+### Etkileri
+
+- `@glaon/core` içindeki `AuthClient`, platform-spesifik `TokenStorage` interface'ini enjekte alacak.
+  - `WebHttpOnlyCookieStorage` — refresh token cookie üzerinden, access token memory.
+  - `ExpoSecureStoreStorage` — refresh + access secure store.
+- Nginx config (Add-on) `/auth/token` + `/auth/revoke` proxy rule'larına ek olarak `Set-Cookie` ve `Clear-Site-Data` header'larını yönetecek.
+- Security-review skill storage kurallarını enforce eder; bu ADR'dan sapma PR'ı otomatik flag alır.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Service Worker tabanlı token proxy pattern'ı olgunlaşır ve `http-only cookie` yaklaşımının ötesinde gerçek bir güvenlik kazancı üretirse.
+- HA tarafı DPoP (Demonstrating Proof-of-Possession) desteklemeye başlarsa — token binding sayesinde storage risk modeli değişir.
+- `expo-secure-store`'da ciddi CVE çıkarsa (alternatif `react-native-keychain` değerlendirilir).
+
+## Referanslar
+
+- [docs/SECURITY.md](../SECURITY.md)
+- [CLAUDE.md — Security-First Rules](../../CLAUDE.md#security-first-rules)
+- [OWASP JWT storage](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html)
+- [expo-secure-store docs](https://docs.expo.dev/versions/latest/sdk/securestore/)

--- a/docs/adr/0007-sentry-observability.md
+++ b/docs/adr/0007-sentry-observability.md
@@ -1,0 +1,75 @@
+# ADR 0007 — Sentry observability backend olarak
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-20
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [docs/observability.md](../observability.md), ADR 0004
+
+## Bağlam
+
+Glaon üç istemci (web, tablet, mobile) üzerinde koşuyor ve yerel kullanıcı cihazlarında çalışıyor. Gözlemlenebilirlik ihtiyaçları:
+
+- **Runtime hata toplama** — production bundle'da çöken exception'ların aggregation + alerting'i.
+- **Session replay / user feedback** — bir kullanıcı "şu ekranda çalışmıyor" dediğinde adım adım reprodüksiyon.
+- **Performans sinyalleri** — LCP, INP, ve özel transaction'ların kuyruk dağılımı.
+- **Native crash** — mobile tarafında Hermes + native crash'leri birleşik raporlama.
+- **Kaynak harita destekli stack trace** — minified JS'in production'da debug'lanabilir olması.
+- **PII scrubbing** — Glaon OAuth token'larla iş görüyor; sızmaması kritik.
+
+Değerlendirilen seçenekler:
+
+- **Sentry (SaaS):** Tüm ihtiyaçları tek platformda veriyor. React + React Native SDK olgun. Source map upload + release tracking hazır. Ücretsiz tier (5K event/ay) başlangıç için yeterli. Self-host seçeneği açık.
+- **OpenTelemetry + Jaeger/Grafana:** Vendor-neutral, uzun vadede taşınabilirlik iyi. Dezavantaj: istemci-tarafı crash reporting için out-of-the-box çözüm yok; RUM kurmak elle iş. Glaon ekip boyutu için altyapı yönetimi çok fazla.
+- **Datadog RUM:** Tam özellik ama fiyatlandırma küçük projelere uygun değil. 14 günlük retention ücretsiz tier.
+- **Honeycomb:** Tracing odaklı, client error collection ana use case değil.
+- **LogRocket:** Replay + hata toplama güçlü, ama Sentry'ye göre hata aggregation ve release tracking zayıf.
+- **Self-hosted GlitchTip:** Sentry ile API uyumlu open-source alternatif. İstemciden bakıldığında SDK ve akış aynı — geçiş kolay. Ama sunucu yönetimi şu an gereksiz yük.
+
+## Karar
+
+**Sentry (SaaS) web ve mobile için observability backend olarak kullanılır.**
+
+- Web SDK: `@sentry/browser` (vite plugin ile source map upload).
+- Mobile SDK: `@sentry/react-native` (Expo config plugin ile native modül bind'i).
+- PII scrubbing: `@glaon/core/observability/scrubber` — URL query param, header, key substring temelli filtreleme. Her iki platform aynı scrubber'ı `beforeSend`'te kullanıyor.
+- Session replay + user feedback: başlangıçta kapalı; gerek ve gizlilik değerlendirmesi yaparak ayrı issue ile açılacak.
+- DSN ve secret'lar `.env.example` üzerinden dokümante, gerçek DSN repo-dışı (GitHub Secrets + EAS secrets).
+- Production web build gate: `VITE_SENTRY_DSN` eksikse `vite build --mode production` hata fırlatır (ayrı issue ile refine edilebilir, şimdilik zorunlu — [docs/observability.md](../observability.md)).
+
+## Sonuçlar
+
+### Olumlu
+
+- Tek dashboard web + mobile hatalarını birleştiriyor; kullanıcı raporlarıyla eşleştirme hızlı.
+- Source map upload sayesinde prod stack trace debug edilebilir.
+- Core scrubber tek kaynaktan çalışıyor; yeni hassas alan eklemek her iki platformu etkiliyor.
+- SaaS olduğu için altyapı yönetim yükü sıfır.
+- Sentry'nin API'si GlitchTip ile uyumlu → gerekirse self-host'a sessizce geçilebilir (vendor lock-in düşük).
+
+### Olumsuz / ödenecek bedel
+
+- Ücretsiz tier event limiti (5K/ay) büyük kullanıcı tabanında aşılır — sampling ve quota yönetimi gerekiyor.
+- SaaS privacy politikasına bağımlılık: OAuth token'ları scrubber ile temizleniyor ama IP adresi ve user agent Sentry'ye gidiyor. KVKK/GDPR tarafında dokümantasyon gerekiyor (issue açılacak).
+- Source map upload pipeline'ı CI'da kurulum gerektiriyor; CI süresi uzuyor.
+- `@sentry/react-native`'un major version upgrade'leri bazen config drift istiyor (plugin API + native entegrasyon).
+
+### Etkileri
+
+- `@glaon/core/observability` paketi platform-agnostic scrubber + politika tutar (ADR 0004'e uyumlu).
+- `apps/web/vite.config.ts` production build gate + `@sentry/vite-plugin` ile source map upload.
+- `apps/mobile/app.json` Sentry Expo plugin konfigürasyonu.
+- E2E workflow'u placeholder DSN (`sentry.invalid`) ile build gate'ini tatmin ediyor.
+- Scrubber davranışı 16 birim test ile donmuş durumda — politika değişikliği test değişikliği ile beraber geliyor.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Sentry fiyatlandırması veya privacy politikası ciddi şekilde değişirse (KVKK uyumsuzluk).
+- Event hacmi Sentry quota'sını aşar hale gelirse ve sampling yetersiz kalırsa.
+- Self-host gereksinimi (veri egemenliği, offline deployment) zorunlu hale gelirse — GlitchTip'e geçiş ADR yeniden yazılır, istemci kodu büyük ölçüde aynı kalır.
+
+## Referanslar
+
+- [docs/observability.md](../observability.md)
+- [Sentry docs](https://docs.sentry.io)
+- [GlitchTip (Sentry API uyumlu self-host)](https://glitchtip.com)
+- [CLAUDE.md — Security-First Rules](../../CLAUDE.md#security-first-rules)

--- a/docs/adr/0008-chromatic-visual-regression.md
+++ b/docs/adr/0008-chromatic-visual-regression.md
@@ -1,0 +1,76 @@
+# ADR 0008 — Chromatic tek görsel regresyon aracı
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-21
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [docs/chromatic.md](../chromatic.md), [docs/storybook.md](../storybook.md), [CLAUDE.md — Chromatic Visual Regression](../../CLAUDE.md#chromatic-visual-regression-mandatory)
+
+## Bağlam
+
+Glaon UI'ını her platform için aynı tasarım sistemi beslerken, görsel kaymayı erken yakalamak zorunlu:
+
+- `@glaon/ui` paketi Untitled UI React kit'ini sarıyor — upstream paketten stil drift'i riski her zaman var.
+- Web + tablet + mobile paylaşılan primitive'ler üzerinden render ediliyor.
+- Manuel QA tek kişilik ekipte zaman darboğazı.
+- Storybook zaten var (Storybook 10), story'ler "component dokümantasyon + test fikstürü" olarak iki amaca hizmet ediyor.
+
+Değerlendirilen seçenekler:
+
+- **Chromatic (SaaS):** Storybook team tarafından sahipleniyor, Storybook ile sıkı entegre. Otomatik screenshot karşılaştırma, accept/deny akışı, Figma design-code diff, TurboSnap ile incremental build. Ücretsiz tier kişisel proje için yeterli.
+- **Percy (BrowserStack):** Chromatic'e rakip, Storybook entegrasyonu var ama daha zayıf. Pricing küçük projeler için Chromatic kadar cömert değil.
+- **Playwright + manuel screenshot diff:** Kendi yazdığımız screenshot testi + baseline depolama. Dezavantaj: baseline yönetimi elle, kolorimetrik tolerans, platform-farkı noise'u (font rendering) kendi kendine çözülmüyor.
+- **Loki / Storycap + reg-suit:** OSS Storybook visual regression stack. Kendi CI job'unu barındırmak gerekiyor. Kurulum ağır, aktif geliştirme yavaş.
+- **Vercel Toolbar + E2E visual:** Vercel ekosistemine bağlı; Glaon bu ekosistem dışında.
+
+Ek kriterler Glaon'a özel:
+
+- **Figma design-code diff** — tasarım kaynağı (ADR 0010) değiştiğinde kod tarafı da tetiklenmeli. Chromatic'in Figma entegrasyonu bu akışı kutudan sağlıyor (`storybook-id` ↔ Figma component description eşlemesi).
+- **MCP entegrasyonu** — Chromatic remote MCP endpoint'i Claude Code'dan okunabiliyor; docs ve workflow asistansı için değer yaratıyor (#54).
+
+## Karar
+
+**Chromatic, Glaon için tek görsel regresyon aracı olarak kullanılır.**
+
+- `CHROMATIC_PROJECT_TOKEN` repo secret'ı; `.github/workflows/chromatic.yml` her PR'da publish + tests.
+- `exitZeroOnChanges: false` — her piksel değişikliği merge'u bloklar.
+- `autoAcceptChanges: development` — `development` baseline branch; merge edilenler yeni baseline.
+- Skip list: `dependabot/**` ve `release-please--**` (dashboard eklenir).
+- Chromatic ↔ Figma design-code diff aktif; Storybook story'leri Figma description'ındaki `storybook-id: <kebab-case>` ile bağlı.
+- Chromatic MCP entry `.mcp.json`'da repo contract olarak tutulur; drive-by değişiklik yasak.
+
+## Sonuçlar
+
+### Olumlu
+
+- Her PR'da görsel regresyon bir status check; unintended pixel değişikliği merge'u bloklar.
+- Chromatic UI'daki accept/deny akışı baseline yönetimini netleştiriyor — kararlar PR tartışmasıyla aynı yerde.
+- TurboSnap ile incremental build CI süresini düşürüyor.
+- Figma design-code diff tasarım-kod drift'ini erken sinyalliyor; "implementasyon gerçekten spec'e uyuyor mu" sorusu otomatikleşiyor.
+- MCP entegrasyonu geliştirme sırasında docs/asistans için ek değer.
+
+### Olumsuz / ödenecek bedel
+
+- SaaS bağımlılığı: Chromatic down olursa CI bloklanıyor (retry mekanizması var ama edge case mevcut).
+- Ücretsiz tier snapshot limiti; büyüdükçe ödeme gündeme gelebilir.
+- TurboSnap bazı edge case'lerde eksik snapshot'tan kaynaklı false negative riski taşıyabilir; skip list yönetimi dikkat istiyor.
+- Figma design-code diff yeni özellik; "Not implemented" / "Design changed" işaretleri bazen gerçek drift değil configuration glitch — tasarımla manuel senkronizasyon gerek.
+
+### Etkileri
+
+- [CLAUDE.md — Chromatic Visual Regression](../../CLAUDE.md#chromatic-visual-regression-mandatory) kuralı her PR'da geçerli.
+- `packages/ui` içindeki her yeni primitive aynı PR'da bir Storybook story + story id + Figma eşlemesi getirmek zorunda ([docs/storybook.md](../storybook.md) + [docs/figma.md](../figma.md)).
+- `.github/workflows/chromatic.yml` zip'i ve `.mcp.json` entry'si repo contract parçası, drive-by edit yasak.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Chromatic fiyatlandırması küçük projeyi aşan düzeyde değişirse.
+- Chromatic SaaS'ın kritik downtime pattern'ı yaşarsa ve alternatif yeterince olgunlaşırsa.
+- OSS reg-suit ekosistemi kendi CI'ımızda sürdürebileceğimiz kalitede bir çözüm üretirse (çok düşük olasılık).
+
+## Referanslar
+
+- [docs/chromatic.md](../chromatic.md)
+- [docs/storybook.md](../storybook.md)
+- [docs/figma.md](../figma.md)
+- [Chromatic docs](https://www.chromatic.com/docs/)
+- [CLAUDE.md — Chromatic Visual Regression](../../CLAUDE.md#chromatic-visual-regression-mandatory)

--- a/docs/adr/0009-ha-addon-ingress-delivery.md
+++ b/docs/adr/0009-ha-addon-ingress-delivery.md
@@ -1,0 +1,83 @@
+# ADR 0009 — HA Add-on + Ingress teslim kanalı
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-20
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [docs/ARCHITECTURE.md](../ARCHITECTURE.md), [docs/SECURITY.md](../SECURITY.md), [addon/README.md](../../addon/README.md)
+
+## Bağlam
+
+Glaon'un web uygulaması Home Assistant kullanıcılarına ulaşmak zorunda. HA kurulumu tipik olarak ev-içi bir cihazda (Raspberry Pi, NUC, VM) çalışıyor ve internet üzerinden açık değil. Kullanıcı ihtiyaçları:
+
+- Tek tıkla erişim — kullanıcı HA panelinden Glaon'a girebilmeli, ayrı login formu görmemeli.
+- Harici port açmama — güvenlik minded HA kullanıcıları reverse proxy kurmak zorunda kalmamalı.
+- HA session ile entegre — zaten HA'ya giriş yaptıysa Glaon ayrıca istemiyor.
+- Multi-arch destek — amd64, aarch64 temel olarak; armv7/armhf sonradan.
+- Update yönetimi — kullanıcı HA Add-on Store'dan güncelleme alabilmeli.
+
+Değerlendirilen teslim kanalları:
+
+- **Standalone web app (Vercel/Netlify/self-host):** İnternetten erişim gerekiyor; kullanıcı kendi HA'sına tünel kurmak veya HA Cloud subscription almak zorunda. Add-on'un "harici port açmama" avantajı yok.
+- **HACS (Home Assistant Community Store) custom panel:** HACS Lovelace ecosystem odaklı; frontend yüklemek mümkün ama lifecycle yönetimi HACS'ta sınırlı. Versiyon update'i custom.
+- **HA Add-on (nginx ile statik serve) + Ingress:** Supervisor add-on container'ı Glaon web app'ini nginx üzerinden servis ediyor; HA'nın Ingress reverse proxy'si HA session cookie ile auth ediyor. Panel option ile HA UI içinde sidebar entrysi. Harici port yok.
+- **HA Core frontend patch:** HA'yı fork etmek; upstream değişikliklerle sürekli merge savaşı. Reddedildi.
+
+Ingress karakteristiği Glaon için uyumlu:
+
+- Dinamik URL prefix (her request'te farklı olabilir) → asset'lerin relative path'le build edilmesi gerek (ADR 0002, `vite build --base=./`).
+- HA kullanıcı session cookie Ingress tarafından yönetiliyor → add-on container ayrıca auth gereksinimi yok (panel için). Standalone auth akışı OAuth2 ile (ADR 0005) ayrı kurulum.
+- iframe embed: HA panel add-on'u iframe ile gösteriyor → CSP `frame-ancestors` dikkatli ayarlanmalı. [docs/SECURITY.md](../SECURITY.md) `frame-ancestors 'none'` policy'si ile HA Ingress iframe davranışı issue #24'te davranış testi olarak değerlendirilecek.
+
+## Karar
+
+**Glaon web uygulamasının birincil teslim kanalı HA Add-on + Ingress'tir.**
+
+- `addon/` klasörü HA Add-on manifest + Dockerfile + nginx config + bashio rootfs bootstrap içeriyor.
+- Multi-arch: amd64, aarch64 ilk sürümde. armv7/armhf sonradan (#24).
+- Ingress: `ingress: true` config flag, harici port açmaz.
+- Panel: `panel_icon` + `panel_title` ile HA sidebar'a entry.
+- Auth capability: `auth_api: true` (kullanıcı auth delegasyonu), `homeassistant_api: false`, `hassio_api: false` (minimum privilege).
+- AppArmor: `apparmor: true`, `apparmor.txt` profili aktif (#24 kapsamında hardening).
+- Build context: web app `vite build --base=./ --mode development` (şimdilik; production DSN gate'i #xx ile yeniden değerlendirilecek).
+- CI: `.github/workflows/addon-build.yml` PR'da her arch için Docker image build'i (QEMU ile aarch64); `push: false` — image publish #24'te.
+
+Standalone (Ingress dışı) web erişimi, mobile ve harici web kullanıcıları için OAuth2 akışı (ADR 0005) ile paralel sürecek. Add-on tek teslim kanalı değil — **birincil** teslim kanalı.
+
+## Sonuçlar
+
+### Olumlu
+
+- Kullanıcı sıfır konfigürasyonla panel içinden erişiyor.
+- Harici port açılmadığı için network güvenliği bozulmuyor.
+- HA Add-on Store'a submission (#35) ile update akışı otomatikleşiyor.
+- Multi-arch build CI'da doğrulanıyor; image hardening (non-root nginx, CSP compatibility) #24 kapsamında.
+- Ingress tarafında HA session cookie sayesinde panel senaryosunda ek auth adımı yok.
+
+### Olumsuz / ödenecek bedel
+
+- Ingress'in dinamik URL prefix'i Vite build'inin `--base=./` ile relative yapılmasını zorunlu kılıyor — bazı asset patterns (preload, lazy-loaded chunk'lar) ek dikkat istiyor.
+- iframe embed nedeniyle CSP `frame-ancestors` policy'si HA Ingress iframe davranışıyla test edilmeli (#24).
+- CSP strict olunca bazı Untitled UI kit bileşenleri `unsafe-inline` style'lar için ek konfig isteyebilir — `style-src 'self' 'unsafe-inline'` zaten [docs/SECURITY.md](../SECURITY.md)'de tanımlı, hardening turu ile bu esneme daraltılacak.
+- Add-on Docker image build süresi CI'da birkaç dakika alıyor (özellikle aarch64 QEMU ile); cache ile optimize edilecek.
+- Release pipeline (#36/sonrası) Sentry DSN inject + SBOM + signing eklemek zorunda (ADR 0007 gate ile koordine).
+
+### Etkileri
+
+- [CLAUDE.md — Stack](../../CLAUDE.md#stack) "HA Add-on served over Ingress" teslim kanalı olarak dokümante.
+- Vite build konfigürasyonu `--base=./` zorunlu → `build:addon` script'i ayrı.
+- Nginx config HA Ingress için 8099 portunda, `docs/SECURITY.md`'deki CSP ve güvenlik başlıkları birebir.
+- Add-on hardening (non-root nginx, AppArmor refinement, armv7 desteği, image publish, HA store submission) #24 ve #35'te takip ediliyor.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- HA Supervisor Ingress API'sinde kırılma (dinamik prefix modelinde değişiklik) olursa.
+- HA Add-on ekosistemi deprecate edilirse veya HACS gibi alternatif baskın olursa.
+- Standalone web deployment (Vercel vs.) birincil kanal olarak öne geçerse (örneğin HA Cloud-only kullanıcılar).
+
+## Referanslar
+
+- [addon/README.md](../../addon/README.md)
+- [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
+- [docs/SECURITY.md](../SECURITY.md)
+- [HA Add-on config docs](https://developers.home-assistant.io/docs/add-ons/configuration)
+- [HA Ingress docs](https://developers.home-assistant.io/docs/add-ons/presentation#ingress)

--- a/docs/adr/0010-figma-source-of-truth.md
+++ b/docs/adr/0010-figma-source-of-truth.md
@@ -1,0 +1,81 @@
+# ADR 0010 — Figma tasarım kaynağı + Figma Plugin bridge
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-22
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [docs/figma.md](../figma.md), [CLAUDE.md — Design Source of Truth](../../CLAUDE.md#design-source-of-truth-mandatory), ADR 0008
+
+## Bağlam
+
+Glaon bir frontend projesi — renk, aralık, tipografi, gölge, component görselleri hepsi belirli bir yerde "doğru" diye tanımlı olmalı. İki uçta iki yaklaşım var:
+
+- **Kod tasarımı dikte eder:** Design tokens elle yazılır (`colors.primary = '#2563eb'`), Figma dokümantasyon. Çabuk başlatılır; drift kaçınılmaz. Tasarımcı (veya gelecekte olacak kişi) kod tabanında çalışmak zorunda.
+- **Figma tasarımı dikte eder:** Figma Variables + Tokens plugin üzerinden export → Style Dictionary ile transform → per-platform output. Kod token **referanslarını** kullanır, raw değeri yazmaz. Tasarımcı Figma'da çalışır, tasarım değişince export + PR akışı işler.
+
+Chromatic Figma design-code diff entegrasyonu (ADR 0008) tasarımla kod arasında "Not implemented" / "Design changed" sinyalini CI'a getiriyor. Bu sinyalin anlamlı olması için tasarım tek bir kanonik yerde olmak zorunda — Figma.
+
+Ek bir Claude-spesifik konu: Claude Code Figma'ya tasarım yazabilmeli mi?
+
+- **REST API ile yazma:** Figma REST API genelde read-only + comment yazma. Node mutation (frame oluşturma, style güncelleme) REST'ten yapılamıyor.
+- **Figma Plugin API (Design + Dev Mode):** Plugin içinden tüm okuma/yazma mümkün. Plugin dev-mode manifest ile Dev Mode'da da çalışabiliyor (`editorType: ["figma", "dev"]`).
+- **Claude-authored plugin script:** Claude bir Figma Plugin script'i yazıyor, kullanıcı plugin'i import edip çalıştırıyor. Sonuç Figma dosyasına doğrudan yazılıyor (commit yok, Figma'nın kendi undo stack'i kullanılıyor).
+
+Plugin yolu neden tercih edildi:
+
+- Yazma kabiliyeti REST'te yok.
+- Kullanıcı plugin'i manuel çalıştırdığı için bir "review step" doğal olarak gerçekleşiyor (AI fantasy değişiklik yapamaz; kullanıcı ne yürüttüğünü görür).
+- Plugin ağ erişimi kapalı (`networkAccess: { allowedDomains: ["none"] }`) — Claude'un ürettiği kod sadece Figma üzerinde iş yapıyor, dışarıya veri sızdırmıyor.
+- Guardrail pattern: dry-run default, `CONFIRM` flag ile gerçek mutation, `notify` + `closePlugin` ile her koşul altında feedback.
+
+## Karar
+
+**Figma Glaon için tasarımın tek kanonik kaynağıdır. Claude-authored değişiklikler Figma Plugin bridge üzerinden yapılır; REST API yazma scope'u dışında.**
+
+- `@glaon/design-tokens` paketi (ileride) Figma Variables'dan export edilen JSON'u Style Dictionary ile per-platform output'a (CSS custom properties, TypeScript module, React Native StyleSheet) çeviriyor.
+- Hex kodu, raw spacing sayıları, tipografi değerleri **kod tabanında elle yazılmaz** — token referansı üzerinden erişiliyor.
+- Yeni primitive Figma'da önce tasarlanır — code-only primitive mergeable değil. Design review gate var.
+- Figma component description'ı `storybook-id: <kebab-case>` satırını taşıyor; Chromatic Figma plugin bu eşlemeyle design-code diff üretiyor.
+- Claude-authored write workflow:
+  - `.claude/skills/brand-design/SKILL.md` brand-level sorular + Figma Plugin script sözleşmesi.
+  - `tools/figma-plugin/` iskelet plugin: `manifest.json` (`editorType: ["figma", "dev"]`, `networkAccess: none`), `code.js` Claude tarafından task başına overwrite ediliyor.
+  - Kullanıcı plugin'i **Plugins → Development → Import plugin from manifest** ile local path'ten yüklüyor. Figma Dosyası dev mode'da da aynı plugin çalışıyor.
+  - Her task için script: dry-run default, `CONFIRM: true` flag'i manuel set edilince gerçek mutation, `figma.notify` ile feedback, `figma.closePlugin` ile kapanış.
+
+## Sonuçlar
+
+### Olumlu
+
+- Drift kontrol altında: design changes kod PR'ı tetikliyor (token export + regeneration), code changes tasarım review'ı tetikliyor (design-code diff).
+- Chromatic Figma entegrasyonu `storybook-id` üzerinden component-by-component eşleştirme yapabiliyor.
+- Claude Figma'ya tek tıkla yazabiliyor; kullanıcı plugin'i manuel tetiklemek zorunda olduğu için review step doğal.
+- Plugin network'ü kapalı — supply chain yüzeyi sıfır.
+- REST scope dar tutulduğu için Claude Figma'ya sessizce yazamaz; kullanıcı kontrolü her zaman var.
+
+### Olumsuz / ödenecek bedel
+
+- Plugin import workflow biraz manuel — plugin script'i değişince kullanıcı yeniden import etmek durumunda.
+- Design-code diff aracı Chromatic SaaS'a bağımlı; hesap downtime'ında sinyali kaybediyoruz.
+- Figma Variables → Style Dictionary pipeline'ı kurulum gerektiriyor; ilk sürümde (design tokens henüz tanımlanmamışken) yapı kurulmuş ama boş.
+- Brand-level kararlar (color palette, typography scale, personality) Figma'dan önce Claude ile konuşulduktan sonra Figma'ya yazılıyor — bu "bir kere tasarım gözden geçirilmeli" gerekliliğini tek tasarımcı (şimdilik) üzerinde yoğunlaştırıyor.
+
+### Etkileri
+
+- [CLAUDE.md — Design Source of Truth](../../CLAUDE.md#design-source-of-truth-mandatory) kuralı uygulanır; code-only primitive mergeable değil.
+- `packages/ui` yeni primitive eklerken Figma component + description + storybook-id + Storybook story + Chromatic snapshot birlikte geliyor.
+- `tools/figma-plugin/` klasörü plugin manifest + code.js + README'yi taşır; `tools/figma-plugin/README.md` import workflow ve troubleshooting'i (örn. `editorType does not include dev` hatası) dokümante ediyor.
+- `.claude/skills/brand-design/SKILL.md` Claude'un tasarım sorularına nasıl yaklaşacağını belirliyor.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Figma fiyatlandırması veya API politikası değişirse (Dev Mode subscription zorunluluğu, plugin sandbox kısıtı).
+- Chromatic Figma design-code diff özelliği deprecate edilirse (eşleşme yolu yeniden düşünülür).
+- Çoklu tasarımcı ekibe geçilirse — Figma collaboration akışı şimdiki tek kişilik flow'dan farklılaşır.
+- Design tokens için Figma Variables dışında endüstri standardı (W3C Design Tokens spec) Figma-native hale gelirse.
+
+## Referanslar
+
+- [docs/figma.md](../figma.md)
+- [CLAUDE.md — Design Source of Truth](../../CLAUDE.md#design-source-of-truth-mandatory)
+- [Figma Plugin API](https://www.figma.com/plugin-docs/)
+- [Style Dictionary](https://amzn.github.io/style-dictionary/)
+- [W3C Design Tokens spec](https://tr.designtokens.org/format/)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,70 @@
+# Mimari Karar Kayıtları (ADR)
+
+Bu klasör Glaon'un mimarisine dair kalıcı kararları Michael Nygard formatında tutar. ADR'lar "neden" sorusunu karar anında dondurur; kod ne yapıldığını zaten söyler, ADR **neden böyle yaptığımızı** söyler.
+
+## Ne zaman ADR yazılır?
+
+Bir karar ADR'ye hak ediyor mu diye sorman gereken üç soru:
+
+1. **Geri dönüş maliyetli mi?** — Değiştirmek için migrasyon, refactor veya eğitim gerekiyorsa evet.
+2. **Rakip seçeneklerle ciddi tartışma oldu mu?** — Alternatifleri değerlendirip birini seçtiysen evet.
+3. **Proje dışından biri "neden böyle?" sorar mı?** — Yeni ekip üyesi veya 6 ay sonraki sen soruyorsa evet.
+
+İki veya daha fazla soruya "evet" diyorsan ADR yaz. Örnekler:
+
+- Bir framework veya runtime seçimi (Vite vs Next, Expo vs bare RN).
+- Paket sınırları ve bağımlılık yönleri (`@glaon/core` platform-agnostic olmak zorunda).
+- Güvenlik modeli kararları (OAuth2 PKCE, token storage).
+- Tedarik zinciri kararları (Chromatic, Sentry, Renovate).
+- Teslim kanalı (HA Add-on + Ingress).
+
+ADR yazılmayacak olanlar: kütüphane version bump'ları, rutin refactor, bug fix'ler, kod stili kararları (linter yakalar), küçük kapsamlı tooling seçimleri (ESLint eklentisi gibi).
+
+## Süreç
+
+### Yeni ADR açmak
+
+1. Bu klasörde `NNNN-kisa-baslik.md` dosyası oluştur. Numara sıradaki boş numara (şu an `0011`'den başlıyor).
+2. [`template.md`](template.md)'i şablon olarak kullan.
+3. İlk hali **Status: Proposed** olarak açılır. Tartışma açıksa bu aşamada PR review üzerinden yürütülür.
+4. Karar kesinleştiğinde status'ü **Accepted**'e geçir ve karar tarihini yaz.
+5. ADR, onu hayata geçiren PR ile aynı branch'te merge edilir. Aynı PR'da ilgili kod değişiklikleri + ADR beraber landing yapar ki ileride hangi kodla hangi karar eşleşiyor izlenebilir olsun.
+
+### ADR'yi değiştirmek
+
+ADR'ler **immutable** dokümanlardır. İçeriklerini değiştirme, yeni bir ADR yazıp bu ADR'yi superseded olarak işaretle.
+
+- Eski ADR: Status: **Superseded by [ADR-NNNN](NNNN-...md)**
+- Yeni ADR: Bağlam bölümünde eski ADR'yi referansla, neyin değiştiğini ve neden gündemin yeniden açıldığını anlat.
+
+Deprecated durumu, kararı yapılacak işin dışına çıkarttığımızda kullanılır (ör. bir paketi tamamen kaldırdık ve onun ADR'si artık geçerli değil ama üstüne yeni karar gelmiyor).
+
+### ADR'yi süpersede etmek
+
+"X aracını değiştiriyoruz" gibi bir karar ADR'nin yeniden yazımını tetikler. Eski ADR dosyada kalır — tarih kaybetmemek için. Yeni dosya yeni numaradan açılır.
+
+## Index
+
+| #    | Başlık                                                                                  | Durum    | Tarih      |
+| ---- | --------------------------------------------------------------------------------------- | -------- | ---------- |
+| 0001 | [Turborepo + pnpm workspaces](0001-turborepo-pnpm-workspaces.md)                        | Accepted | 2026-04-20 |
+| 0002 | [Vite + React 19 (web)](0002-vite-react-19-web.md)                                      | Accepted | 2026-04-20 |
+| 0003 | [Expo SDK + new architecture (mobile)](0003-expo-new-architecture-mobile.md)            | Accepted | 2026-04-20 |
+| 0004 | [`@glaon/core` platform-agnostic paylaşım paketi](0004-glaon-core-platform-agnostic.md) | Accepted | 2026-04-20 |
+| 0005 | [OAuth2 Authorization Code + PKCE (tek auth yöntemi)](0005-oauth2-pkce-only-auth.md)    | Accepted | 2026-04-20 |
+| 0006 | [Token storage — in-memory + httpOnly / SecureStore](0006-token-storage.md)             | Accepted | 2026-04-20 |
+| 0007 | [Sentry observability backend olarak](0007-sentry-observability.md)                     | Accepted | 2026-04-20 |
+| 0008 | [Chromatic tek görsel regresyon aracı](0008-chromatic-visual-regression.md)             | Accepted | 2026-04-21 |
+| 0009 | [HA Add-on + Ingress teslim kanalı](0009-ha-addon-ingress-delivery.md)                  | Accepted | 2026-04-20 |
+| 0010 | [Figma tasarım kaynağı + plugin bridge](0010-figma-source-of-truth.md)                  | Accepted | 2026-04-22 |
+
+## Konvansiyonlar
+
+- Dosya adı: `NNNN-kisa-baslik.md`, numara 4 haneli sıfır-dolgulu, slug kebab-case + Türkçe karakter yok (ASCII). İçerikte Türkçe karakter serbest.
+- Dil: Türkçe (`docs/` klasörünün dil politikasıyla uyumlu — [CLAUDE.md](../../CLAUDE.md#language-policy)).
+- Uzunluk: Genelde 1-3 sayfa. Karar uzun olursa bağlamı ayrı dokümana taşı ve ADR'den linkle.
+- Kod örneği: Minimalde tut. ADR karar belgesidir, kullanım kılavuzu değil. Kullanım detayları ilgili `docs/*.md` veya inline README'ye gider.
+
+## Retrospektif ADR'ler
+
+Phase 0'daki ilk 10 karar retrospektif olarak yazıldı (bkz. #89). Bu kararlar issue açılmadan önce zaten CLAUDE.md, docs/ARCHITECTURE.md ve PR gövdelerinde alınmıştı — ADR'ler karar tarihlerini mümkün olduğunca kararın alındığı tarihi baz alır (genelde repo bootstrap'i olan 2026-04-20). Yeni kararlar bundan sonra karar alınırken yazılır, retrospektif değil.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,50 @@
+# ADR NNNN — <Kısa başlık>
+
+- **Durum:** Proposed | Accepted | Deprecated | Superseded by [ADR-XXXX](XXXX-...md)
+- **Karar tarihi:** YYYY-MM-DD
+- **Karar verenler:** @handle, @handle
+- **İlgili konular:** issue #N, PR #N, docs/...
+
+## Bağlam
+
+Bu kararın neden gündeme geldiğinin kısa açıklaması. Proje durumu, baskı yaratan kısıtlar (teknik, zaman, ekip, bütçe, yasal), değerlendirilen alternatifler, ve tartışmanın çerçevesi. "Ne" değil, "neden" ağır bassın — ne yaptığımızı kodun kendisi zaten söylüyor.
+
+Göz önünde bulundurulan alternatifler:
+
+- **Seçenek A:** kısa açıklama + neden seçilmedi.
+- **Seçenek B:** kısa açıklama + neden seçilmedi.
+- **Seçenek C (seçilen):** Karar bölümünde detay.
+
+## Karar
+
+Seçilen yaklaşımın net bir cümlesi. Daha sonra bu kararı arayan biri ilk paragrafta ne seçtiğimizi anlayabilmeli.
+
+Karar'ın teknik detayları:
+
+- Madde 1
+- Madde 2
+
+## Sonuçlar
+
+### Olumlu
+
+- Karar'ın sağladığı somut kazanımlar.
+
+### Olumsuz / ödenecek bedel
+
+- Karar'ın getirdiği maliyetler veya kısıtlar. Dürüst ol — "hiç dezavantajı yok" cümlesi ADR'yi değersiz yapar.
+
+### Etkileri
+
+- Kod organizasyonuna etkisi.
+- CI/build süresine etkisi.
+- Gelecekteki göçlere etkisi (lock-in var mı?).
+
+## Tekrar değerlendirme tetikleyicileri
+
+ADR'yi yeniden açmayı gerektirecek koşullar. Ör: "X aracı Y sürümü yayınlarsa", "Z performans hedefi karşılanamazsa", "N aydan sonra". Tetikleyici yoksa bu bölüm silinir.
+
+## Referanslar
+
+- Link / doküman
+- Link / doküman


### PR DESCRIPTION
## Summary

- Stand up a Nygard-format ADR workflow under `docs/adr/` — template, README with process + index, conventions.
- Backfill 10 retrospective ADRs for the Phase 0 decisions already baked into CLAUDE.md, `docs/`, and PR bodies so the rationale survives when we re-open the question a year from now.
- Add a short **Architecture Decision Records** section to `CLAUDE.md` pointing contributors at the process and when to write one.

## Scope

### In

- `docs/adr/template.md` — Nygard format (Durum, Bağlam, Karar, Sonuçlar, tekrar değerlendirme tetikleyicileri, referanslar).
- `docs/adr/README.md` — when to write an ADR, how to supersede/deprecate, numbered index, conventions.
- 10 backfilled ADRs, each with alternatives considered + consequences (honest trade-offs) + reopen triggers:
  - 0001 Turborepo + pnpm workspaces
  - 0002 Vite + React 19 (web)
  - 0003 Expo SDK + new architecture (mobile)
  - 0004 `@glaon/core` platform-agnostic shared package
  - 0005 OAuth2 Authorization Code + PKCE only
  - 0006 Token storage — in-memory + httpOnly cookie / SecureStore
  - 0007 Sentry as observability backend
  - 0008 Chromatic as single visual regression tool
  - 0009 HA Add-on + Ingress as delivery channel
  - 0010 Figma source of truth + Figma Plugin bridge for Claude writes
- `CLAUDE.md` — new **Architecture Decision Records** section referencing `docs/adr/README.md`.

### Out

- Open decisions (non-root nginx, AppArmor refinement, armv7 support, mobile release pipeline) — stay in their tracking issues (#24, #36, etc.) until actually decided.
- ADR-first enforcement as a CI gate — kept cultural, per the issue. Re-evaluate if drift becomes a pattern.
- Tooling to auto-generate the index or enforce numbering — manual for now; trivial to script later if the count grows.
- Translating ADRs to English — docs/ language policy is Turkish. English stays in code, code comments, commits, and the numeric ADR-NNNN identifier.

## Test plan

- [ ] CI green: type-check · lint · audit · gitleaks · commitlint · visual regression.
- [ ] Rendered on GitHub: `docs/adr/README.md` index links all 10 ADRs, each ADR renders cleanly (headings, tables, code blocks), internal cross-links between ADRs resolve (e.g. ADR 0006 → ADR 0005).
- [ ] Rendered on GitHub: the new **Architecture Decision Records** section in `CLAUDE.md` links to `docs/adr/README.md` and explains when to write one.
- [ ] Decision dates in each ADR match the approximate reality: bootstrap-era decisions (0001–0007, 0009) → 2026-04-20; Chromatic (0008) → 2026-04-21; Figma (0010) → 2026-04-22.
- [ ] `pnpm exec prettier --check 'docs/adr/**/*.md'` clean.

Closes #89