### PR TITLE
chore(security): pin third-party GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/addon-build.yml
+++ b/.github/workflows/addon-build.yml
@@ -32,13 +32,13 @@ jobs:
             build_from: ghcr.io/home-assistant/aarch64-base:3.21
             platform: linux/arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -51,13 +51,13 @@ jobs:
 
       - name: Set up QEMU
         if: matrix.arch != 'amd64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build add-on image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./addon
           file: ./addon/Dockerfile

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,15 +22,15 @@ jobs:
       !startsWith(github.ref_name, 'dependabot/') &&
       !startsWith(github.ref_name, 'release-please--')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -39,7 +39,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Publish to Chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@c93e0bc3a63aa176e14a75b61a31847cbfdd341c # v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/ui

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
     name: type-check · lint · audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -44,10 +44,10 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -56,9 +56,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:
           configFile: commitlint.config.mjs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           version: 9.15.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -34,7 +34,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: apps/web-e2e/playwright-report/

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -65,6 +65,45 @@ Yeni bir required check eklemek istersen:
 3. `scripts/apply-rulesets.sh` çalıştır.
 4. Değişikliği PR ile commit et — UI'den değil.
 
+## Third-party GitHub Actions — SHA pinning
+
+Workflow'larımızdaki her üçüncü-taraf `uses:` referansı tag yerine tam commit SHA'sına pinlenir; tag'in hangi versiyona denk geldiği satır sonundaki yorumdan okunur:
+
+```yaml
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+```
+
+Neden:
+
+- Tag'ler mutable. Bir saldırgan action reposuna erişim kazanırsa `v4` tag'ini kötü niyetli bir commit'e taşıyabilir ve CI bir sonraki çalıştırmada sessizce onu çalıştırır. SHA immutable — repo compromise olsa bile bizim workflow'umuz bilinen iyi commit'te kalır.
+- `@latest`, `@main`, dallanan tag'ler (`@v1`) en kötü varyant: her çalıştırmada farklı kod çalışabilir, supply-chain tehditi + reproducibility kaybı.
+- OpenSSF Scorecard'ın "Pinned-Dependencies" kontrolü bu kuralı gerekçelendirir; #98'de Scorecard eklendiğinde bu check zaten yeşil olur.
+
+Kapsam:
+
+- Tüm `.github/workflows/**` ve repo içindeki composite action'lar.
+- GitHub-hosted first-party action'lar (`actions/*`, `github/*`) **da dahil**. İstisna tanımıyoruz — gelecekte birini içeriden compromise etmenin maliyeti, pin tutmanın maliyetinden kat kat yüksek.
+- Docker image referansları (`docker://...`) için aynı disiplin — digest ile pinlenir.
+
+Güncelleme akışı — Renovate otomatik:
+
+[`renovate.json`](../renovate.json) `config:best-practices` preset'ini extend ediyor; bu preset `helpers:pinGitHubActionDigests` kuralını devreye alır ve `github-actions` manager'ında `pinDigests: true` yapar. Haftalık schedule'da Renovate:
+
+1. Tag'in işaret ettiği yeni SHA'yı tespit eder (annotated tag'leri dereference ederek).
+2. SHA'yı günceller, yorumdaki versiyon etiketini de tazeler.
+3. CI yeşilse patch/minor bump'ları otomatik merge eder; major bump'lar dashboard'da onay bekler.
+
+Bu yüzden el ile re-pinning nadiren gerekir. Elle güncelleme yapmak zorunda kalırsan — örneğin acil bir güvenlik fix'i Renovate schedule'ını beklemek istemediğinde:
+
+```bash
+# pinact ile tüm workflow'ları tara ve güncelle
+pinact run .github/workflows/
+```
+
+[pinact](https://github.com/suzuki-shunsuke/pinact) tag → SHA çözümlemesini yapar ve yorumları ekler. Alternatif: her referansı tek tek `gh api repos/<owner>/<action>/git/ref/tags/<tag>` ile çözmek (annotated tag'se sonuç `git/tags/<sha>` endpoint'iyle dereference edilir).
+
+Yeni bir third-party action'ı workflow'a eklerken pin'siz bir `uses:` commit'lemek kural ihlalidir — PR review'unda bloklanır.
+
 ## CODEOWNERS
 
 [`.github/CODEOWNERS`](../.github/CODEOWNERS) her dosya path'ini en az bir sahibe bağlar. Tek maintainer (`@toss-cengiz`) olduğu için pratik etkisi henüz yok ama yapı hazır — yeni bir katılımcı geldiğinde path-based owner ataması tek commit.
@@ -135,4 +174,6 @@ Done.
 - CLAUDE.md: repo'nun davranış kuralları.
 - [GitHub Rulesets API](https://docs.github.com/en/rest/repos/rules) — ruleset schema'sı.
 - [CODEOWNERS syntax](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
-- İlgili issue: #69 (initial setup), #75 (merge method policy).
+- [pinact](https://github.com/suzuki-shunsuke/pinact) — GitHub Action SHA pinning aracı.
+- [OpenSSF Scorecard — Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) — SHA pinning kontrolünün gerekçesi.
+- İlgili issue: #69 (initial setup), #75 (merge method policy), #94 (SHA pinning).


### PR DESCRIPTION
## Summary

- Replace every `uses: <action>@<tag>` reference across `.github/workflows/**` with `uses: <action>@<full-40-char-SHA> # <version-comment>`. Tags are mutable; SHAs are immutable and survive upstream repo compromise.
- Remove the `chromaui/action@latest` dangling-branch reference (worst case — `latest` is a branch, silently floats).
- Document the policy in [docs/governance.md](docs/governance.md): scope, rationale, Renovate auto-repin behaviour, and `pinact` as the manual fallback.

## Scope

**In**
- `.github/workflows/ci.yml` — 7 refs pinned (checkout, pnpm setup, setup-node, gitleaks, commitlint).
- `.github/workflows/addon-build.yml` — 6 refs pinned (checkout, pnpm, setup-node, docker/setup-qemu, docker/setup-buildx, docker/build-push).
- `.github/workflows/e2e.yml` — 5 refs pinned (checkout, pnpm, setup-node, actions/cache, actions/upload-artifact).
- `.github/workflows/chromatic.yml` — 4 refs pinned (checkout, pnpm, setup-node, `chromaui/action@latest` → `@SHA # v1`).
- `docs/governance.md` — new "Third-party GitHub Actions — SHA pinning" section with rationale, scope, Renovate integration, and manual re-pinning via `pinact`.

**Out**
- `.github/workflows/release.yml` — already pinned (`googleapis/release-please-action@5c625bfb…`). No change needed.
- `pinact` installation/CI enforcement — policy documented, but adding `pinact` as a required CI check is a follow-up if Renovate ever drifts. OSSF Scorecard in #98 will cover automated verification.

## Test plan

- [x] `pnpm exec prettier --check '.github/workflows/**/*.yml' 'docs/governance.md'` → clean.
- [x] `grep -E 'uses:\s+[\w./-]+@(v\d|latest|main|master)' .github/workflows/` → no matches (no tag refs left).
- [x] Every pinned SHA verified via `gh api repos/<owner>/<action>/git/ref/tags/<tag>` (annotated tags dereferenced via `git/tags/{sha}`).
- [ ] CI green on this PR — the pinned actions actually resolve and run end-to-end.

## User action

None beyond normal review + merge. Going forward, Renovate will bump these pins weekly via the `config:best-practices` preset (`helpers:pinGitHubActionDigests`) — auto-merging patch/minor, holding major bumps in the Dependency Dashboard.

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)