### PR TITLE
chore(security): add Dependency Review Action for PR-time vuln check

### DIFF
--- a/.github/rulesets/development.json
+++ b/.github/rulesets/development.json
@@ -30,6 +30,7 @@
           { "context": "type-check · lint · audit" },
           { "context": "conventional-commits" },
           { "context": "gitleaks" },
+          { "context": "review" },
           { "context": "visual regression" }
         ]
       }

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -29,6 +29,7 @@
         "required_status_checks": [
           { "context": "type-check · lint · audit" },
           { "context": "gitleaks" },
+          { "context": "review" },
           { "context": "visual regression" }
         ]
       }

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency review
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -54,6 +54,7 @@ Development'a merge olacak her PR'ın aşağıdaki check'leri yeşil olmalı:
 - `type-check · lint · audit` — TS + ESLint + `pnpm audit --audit-level high`
 - `conventional-commits` — commitlint, PR commit'leri için
 - `gitleaks` — secret tarama
+- `review` — [Dependency review](#dependency-review), PR'da eklenmekte olan bağımlılıkları tarar
 - `visual regression` — Chromatic
 
 `main`'deki liste aynı, sadece `conventional-commits` yok (main'e sadece release-please PR'ı ulaşır; commitlint PR-only event'lerde koşar, main direct push zaten yasak).
@@ -64,6 +65,23 @@ Yeni bir required check eklemek istersen:
 2. İlgili JSON'daki `required_status_checks` listesine `{ "context": "<job adı>" }` ekle.
 3. `scripts/apply-rulesets.sh` çalıştır.
 4. Değişikliği PR ile commit et — UI'den değil.
+
+## Dependency review
+
+[`.github/workflows/dependency-review.yml`](../.github/workflows/dependency-review.yml) her PR'da çalışır ve `pnpm-lock.yaml` diff'ini inceler: o PR'la birlikte eklenen (veya major bump yapılan) bağımlılıklarda bilinen bir advisory varsa job fail olur.
+
+`pnpm audit` ile ne farkı var:
+
+- `pnpm audit` CI'ın `type-check · lint · audit` job'unda çalışır ve lockfile'ın **tamamını** tarar — "şu an repo'da savunmasız bir dep var mı?" sorusuna cevap verir. Sorun mevcutsa merge'i bloklar, ama sorunu kimin eklediğini söylemez ve Renovate bir fix sunana kadar PR'ları stale yapar.
+- `Dependency review` action sadece o PR'ın **getirdiği değişikliği** tarar. Yeni bir zayıf dep PR ile repo'ya girmeye çalışırsa merge zaten olamaz; geri kalan zamanlarda job gürültüsüzdür. Renovate advisory bump'larıyla da uyumlu (bump'ı kendisi blocklaayacak ufak bir pencere olsa da Renovate otomatik merge eden patch'leri hızla getirir).
+
+İki katman birbirinin yerini tutmaz, üst üste biner: "şu an temiz mi?" (`audit`) + "bu PR durumu kötüleştiriyor mu?" (`review`).
+
+Konfigürasyon:
+
+- `fail-on-severity: high` — audit ile aynı eşik.
+- `comment-summary-in-pr: always` — lockfile değişen her PR'a özet yorum bırakılır.
+- `deny-licenses` şu an boş — lisans politikası ayrı bir karar (bkz. #92'nin "Out of scope" notu).
 
 ## Third-party GitHub Actions — SHA pinning
 
@@ -176,4 +194,4 @@ Done.
 - [CODEOWNERS syntax](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
 - [pinact](https://github.com/suzuki-shunsuke/pinact) — GitHub Action SHA pinning aracı.
 - [OpenSSF Scorecard — Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) — SHA pinning kontrolünün gerekçesi.
-- İlgili issue: #69 (initial setup), #75 (merge method policy), #94 (SHA pinning).
+- İlgili issue: #69 (initial setup), #75 (merge method policy), #92 (dependency review), #94 (SHA pinning).


### PR DESCRIPTION
## Summary

- Add `.github/workflows/dependency-review.yml` — GitHub's [Dependency Review Action](https://github.com/actions/dependency-review-action) pinned to `v4.9.0` (`actions/dependency-review-action@2031cfc…`), triggered on every `pull_request`.
- Wire the new `review` job into both ruleset files (`development.json`, `main.json`) as a required status check.
- Extend [docs/governance.md](docs/governance.md) with a new "Dependency review" section + bump `review` into the required-check list.

## Why this closes a real gap

`pnpm audit --audit-level high` in CI answers **"is the repo currently clean?"** — it scans the full lockfile on every run. Renovate bumps vulnerable deps on schedule. Neither of those stops a PR from *adding* a new vulnerable dep mid-flight; the gap is the window between Renovate cycles.

Dependency Review inspects the **diff** of `pnpm-lock.yaml` on the PR and fails the job if that diff introduces a high/critical advisory. Two complementary layers: "is the repo clean?" (audit) and "does this PR make it worse?" (review).

## Scope

**In**
- `.github/workflows/dependency-review.yml` with `fail-on-severity: high` and `comment-summary-in-pr: always`.
- `actions/checkout` + `actions/dependency-review-action` both SHA-pinned per #94's policy.
- `permissions` locked to `contents: read` + `pull-requests: write` (latter is required for the summary comment).
- Required-check wiring: `review` added to `development-protection` and `main-protection` rulesets.
- Governance doc update + #92 added to references.

**Out**
- License policy enforcement (`deny-licenses` left empty) — separate decision, tracked as a follow-up when we pick an allowed-license list.
- Auto-fix / auto-bump — that's Renovate's job, not this action's.

## Test plan

- [x] `pnpm exec prettier --check` clean on all 4 touched files.
- [x] `v4.9.0` SHA verified via `gh api repos/actions/dependency-review-action/git/ref/tags/v4.9.0`.
- [ ] CI: `review` job runs and passes on this PR (this PR doesn't change `pnpm-lock.yaml`, so the diff is empty — expected quick pass).
- [ ] Follow-up after merge: **user runs `scripts/apply-rulesets.sh`** to push the updated required-check lists to GitHub. Without that step the ruleset JSON changes are code-only — the new `review` context won't block merges until applied.

## User action

After merge, run:

\`\`\`bash
scripts/apply-rulesets.sh
\`\`\`

to sync the updated rulesets to GitHub so `review` becomes a blocking check on `development` and `main`. Until then the workflow runs and reports status but does not gate merges.

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)