### PR TITLE
chore(security): enable CodeQL SAST on CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+  schedule:
+    # Monday 07:15 UTC — one fresh scan per week independent of PR activity.
+    - cron: '15 7 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          category: /language:javascript-typescript

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -63,6 +63,14 @@ Config: Repo kökündeki `.gitleaks.toml` default rule set'i miras alır. Yeni k
 - `pnpm audit --prod` CI'da kırar.
 - Renovate `automerge: false` ile PR açar; güvenlik güncellemeleri hızlı yol alır.
 - Versiyonlar range değil exact — `^` / `~` kullanımı `peerDependencies` dışında kaçınılır (devDeps için tolerans var).
+- [Dependency Review action](./governance.md#dependency-review) her PR'da `pnpm-lock.yaml` diff'ini tarar; yeni eklenen bağımlılıkta high/critical advisory varsa merge bloklanır (`pnpm audit`'in karşılayamadığı "PR ile kötüleşme" penceresi).
+
+## Statik analiz (SAST)
+
+- [CodeQL](https://codeql.github.com/) `javascript-typescript` dili için [.github/workflows/codeql.yml](../.github/workflows/codeql.yml) üzerinden çalışır. Tetikleyiciler: `development`/`main` push, her PR ve haftalık schedule (Pazartesi 07:15 UTC).
+- `security-extended` query pack kullanılır — `default`'tan geniş kapsam: taint flow, prototype pollution, ReDoS, unsafe deserialization, XSS sink'leri dahil.
+- Bulgular GitHub Security → Code scanning sekmesinde görünür; high severity bulgu gelirse bir **takip issue'su** açılır ve sessizce kapatılmaz.
+- Şimdilik required check **değil**; gürültü seviyesi ölçüldükten sonra ruleset'e eklenmesi #98 / sonraki işler kapsamında değerlendirilir.
 
 ## HA Add-on
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -59,6 +59,10 @@ Development'a merge olacak her PR'ın aşağıdaki check'leri yeşil olmalı:
 
 `main`'deki liste aynı, sadece `conventional-commits` yok (main'e sadece release-please PR'ı ulaşır; commitlint PR-only event'lerde koşar, main direct push zaten yasak).
 
+Bunların dışında CI'da çalışan ama **henüz required olmayan** kontroller:
+
+- `analyze (javascript-typescript)` — [CodeQL SAST](./SECURITY.md#statik-analiz-sast). Bulgular Security sekmesinde görünür; bloklama kararı gürültü seviyesi ölçüldükten sonra alınır.
+
 Yeni bir required check eklemek istersen:
 
 1. CI workflow'unda job adını kesinleştir (bu ad ruleset'te `"context"` olur).
@@ -194,4 +198,4 @@ Done.
 - [CODEOWNERS syntax](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
 - [pinact](https://github.com/suzuki-shunsuke/pinact) — GitHub Action SHA pinning aracı.
 - [OpenSSF Scorecard — Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) — SHA pinning kontrolünün gerekçesi.
-- İlgili issue: #69 (initial setup), #75 (merge method policy), #92 (dependency review), #94 (SHA pinning).
+- İlgili issue: #69 (initial setup), #75 (merge method policy), #91 (CodeQL SAST), #92 (dependency review), #94 (SHA pinning).


### PR DESCRIPTION
## Summary

- Add `.github/workflows/codeql.yml` — GitHub CodeQL action pinned to `v4.35.2` (`github/codeql-action/{init,analyze}@95e58e9a…`), scanning `javascript-typescript`.
- Triggers: push to `development`/`main`, every PR, and a weekly schedule (Monday 07:15 UTC) so coverage doesn't drop during quiet weeks.
- Query pack: `security-extended` — covers taint flow, prototype pollution, ReDoS, unsafe deserialization, XSS sinks.
- Results surface in **Security → Code scanning** and as PR annotations.

## Why not a required check (yet)

Per the tracking issue scope:

> Making CodeQL a required PR check — add later once noise level is measured.

First-run SAST on a young codebase is the wrong moment to block merges — the baseline needs to settle first. This PR therefore does **not** touch `.github/rulesets/*.json`. The check appears on PRs and reports status, but won't gate merges. When false-positive rate has stabilized we'll add `analyze (javascript-typescript)` to the required list in a follow-up PR (same shape as #92's `review` wire-up).

## Scope

**In**
- `.github/workflows/codeql.yml` — init + analyze job, SHA-pinned per #94, `permissions: { contents: read, security-events: write }`.
- [docs/SECURITY.md](docs/SECURITY.md) — new "Statik analiz (SAST)" section explaining query pack, triggers, and the follow-up-issue policy for high-severity findings.
- [docs/governance.md](docs/governance.md) — CodeQL listed as a non-required check, #91 added to references.

**Out**
- Custom CodeQL queries — deferred until false positives demand tuning (per issue).
- Other languages (Python, Go) — not used in this repo.
- Ruleset wiring — deferred as above.

## Test plan

- [x] `pnpm exec prettier --check` clean on all 3 touched files.
- [x] `v4.35.2` SHA verified via `gh api repos/github/codeql-action/git/ref/tags/v4.35.2` (annotated tag dereferenced).
- [ ] CI: `analyze (javascript-typescript)` job runs and completes on this PR.
- [ ] After CI: open GitHub **Security → Code scanning** tab and confirm the analysis appears.
- [ ] Any **high-severity** finding on this initial run gets a new tracking issue before we move on.

## User action

None required — the workflow is gated by `security-events: write` which is granted automatically to public repos. No secret setup.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)