### PR TITLE
chore(monorepo): enforce cross-workspace dep version consistency with syncpack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Audit dependencies (high + critical)
         run: pnpm audit --audit-level high
 
+      - name: Cross-workspace dep consistency (syncpack)
+        run: pnpm syncpack:lint
+
   unit-tests:
     name: unit-tests
     runs-on: ubuntu-latest

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://jamiemason.github.io/syncpack/schema.json",
+  "semverGroups": [
+    {
+      "label": "Workspace-local references carry no range (pnpm workspace:* protocol)",
+      "dependencies": ["@glaon/**"],
+      "packages": ["**"],
+      "range": ""
+    },
+    {
+      "label": "Expo ecosystem in @glaon/mobile tracks Expo SDK pins — exact for react/react-native, ~ for expo-*",
+      "dependencies": [
+        "react",
+        "react-dom",
+        "react-native",
+        "expo",
+        "expo-*",
+        "typescript",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "packages": ["@glaon/mobile"],
+      "isIgnored": true
+    },
+    {
+      "label": "Default range policy: caret for minor+patch flexibility",
+      "dependencies": ["**"],
+      "packages": ["**"],
+      "range": "^"
+    }
+  ],
+  "versionGroups": [
+    {
+      "label": "Workspace-local packages resolve via pnpm protocol — pinning is automatic",
+      "dependencies": ["@glaon/**"],
+      "packages": ["**"],
+      "isIgnored": true
+    },
+    {
+      "label": "Expo SDK pins — @glaon/mobile follows Expo's own upgrade cadence (Expo CLI manages these)",
+      "dependencies": [
+        "react",
+        "react-dom",
+        "react-native",
+        "expo",
+        "expo-*",
+        "typescript",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "packages": ["@glaon/mobile"],
+      "isIgnored": true
+    },
+    {
+      "label": "Intentional drift: @glaon/ui tracks Storybook's Vite 8 / plugin-react 6; @glaon/web stays on Vite 6 / plugin-react 4 for app build. Revisit when Storybook supports Vite 6 again or when web needs Vite 8.",
+      "dependencies": ["vite", "@vitejs/plugin-react"],
+      "packages": ["**"],
+      "isIgnored": true
+    }
+  ]
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,18 +1,6 @@
 {
   "name": "@glaon/mobile",
   "version": "0.0.0",
-  "private": true,
-  "main": "index.ts",
-  "scripts": {
-    "dev": "expo start",
-    "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
-    "build": "echo 'Use EAS Build: eas build --platform all'",
-    "lint": "eslint .",
-    "type-check": "tsc --noEmit",
-    "clean": "rm -rf .expo dist .turbo"
-  },
   "dependencies": {
     "@glaon/core": "workspace:*",
     "@glaon/ui": "workspace:*",
@@ -31,5 +19,17 @@
     "@glaon/config": "workspace:*",
     "@types/react": "~19.2.0",
     "typescript": "~5.7.2"
+  },
+  "main": "index.ts",
+  "private": true,
+  "scripts": {
+    "android": "expo start --android",
+    "build": "echo 'Use EAS Build: eas build --platform all'",
+    "clean": "rm -rf .expo dist .turbo",
+    "dev": "expo start",
+    "ios": "expo start --ios",
+    "lint": "eslint .",
+    "start": "expo start",
+    "type-check": "tsc --noEmit"
   }
 }

--- a/apps/web-e2e/package.json
+++ b/apps/web-e2e/package.json
@@ -1,18 +1,18 @@
 {
   "name": "@glaon/web-e2e",
   "version": "0.0.0",
-  "private": true,
-  "scripts": {
-    "e2e": "playwright test",
-    "e2e:ui": "playwright test --ui",
-    "e2e:report": "playwright show-report",
-    "type-check": "tsc --noEmit",
-    "clean": "rm -rf playwright-report test-results .turbo"
-  },
   "devDependencies": {
     "@glaon/config": "workspace:*",
     "@playwright/test": "^1.49.1",
     "@types/node": "^22.10.2",
     "typescript": "^5.7.2"
+  },
+  "private": true,
+  "scripts": {
+    "clean": "rm -rf playwright-report test-results .turbo",
+    "e2e": "playwright test",
+    "e2e:report": "playwright show-report",
+    "e2e:ui": "playwright test --ui",
+    "type-check": "tsc --noEmit"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,19 +1,6 @@
 {
   "name": "@glaon/web",
   "version": "0.0.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "build:addon": "tsc -b && vite build --base=./ --mode development",
-    "preview": "vite preview",
-    "lint": "eslint .",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "type-check": "tsc --noEmit",
-    "clean": "rm -rf dist .turbo coverage"
-  },
   "dependencies": {
     "@glaon/core": "workspace:*",
     "@glaon/ui": "workspace:*",
@@ -34,5 +21,18 @@
     "typescript": "^5.7.2",
     "vite": "^6.0.3",
     "vitest": "^2.1.8"
-  }
+  },
+  "private": true,
+  "scripts": {
+    "build": "tsc -b && vite build",
+    "build:addon": "tsc -b && vite build --base=./ --mode development",
+    "clean": "rm -rf dist .turbo coverage",
+    "dev": "vite",
+    "lint": "eslint .",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "type-check": "tsc --noEmit"
+  },
+  "type": "module"
 }

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -4,13 +4,15 @@ Glaon'un npm paketlerini güncel ve güvenli tutan otomasyon katmanı. Amacı: "
 
 ## Aktörler
 
-| Bileşen                                   | Ne yapar                                                           |
-| ----------------------------------------- | ------------------------------------------------------------------ |
-| [Renovate](https://docs.renovatebot.com/) | Haftalık outdated taraması + otomatik güncelleme PR'ları           |
-| `pnpm audit --audit-level high`           | CI'da her PR'da çalışır; high/critical açıklık bulursa build kırar |
-| GitHub Dependabot alerts                  | Repo-level UI uyarıları (user tarafından açılır)                   |
+| Bileşen                                              | Ne yapar                                                                                         |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [Renovate](https://docs.renovatebot.com/)            | Haftalık outdated taraması + otomatik güncelleme PR'ları                                         |
+| `pnpm audit --audit-level high`                      | CI'da her PR'da çalışır; high/critical açıklık bulursa build kırar                               |
+| [`syncpack`](https://jamiemason.github.io/syncpack/) | Cross-workspace tek-versiyon politikası; PR'da drift varsa CI kırar                              |
+| Dependency Review action                             | Her PR'da `pnpm-lock.yaml` diff'ini tarar — bkz. [governance](./governance.md#dependency-review) |
+| GitHub Dependabot alerts                             | Repo-level UI uyarıları (user tarafından açılır)                                                 |
 
-Üç aktör birbiriyle çakışmaz — Dependabot alerts sadece sinyal üretir, düzeltmeyi Renovate yapar; audit CI'da son kontrol.
+Aktörler birbiriyle çakışmaz — Dependabot alerts sadece sinyal üretir, düzeltmeyi Renovate yapar; `syncpack` cross-workspace tutarlılığı zorlar; audit ve dependency review CI'da son kontrol.
 
 ## Renovate iş akışı
 
@@ -69,6 +71,40 @@ Major'lar auto-PR açmaz — önce dashboard'da "approval needed" olarak durur. 
 3. Kod tarafında migration gerekliyse **aynı PR'a commit ekle**. Bu hâlâ Renovate PR'ı ama insan değişikliği de eklenebilir.
 4. Type-check + lint + audit + Chromatic tümü yeşil olmadan merge etme. Chromatic'te unintended görsel değişiklik varsa migration tamam değil demektir.
 
+## Cross-workspace tutarlılık (syncpack)
+
+[syncpack](https://jamiemason.github.io/syncpack/) aynı paketin farklı workspace'lerde farklı versiyonlara kayma riskini kesiyor. Örnek: `@glaon/core` `react@19.2.5` kullanırken `@glaon/web`'in `react@19.3.0`'e geçmesi — CI drift olarak yakalar.
+
+### Tetikleme
+
+- Lokal: `pnpm syncpack:lint` — sadece rapor.
+- Lokal fix: `pnpm syncpack:fix` — `fix-mismatches` (tüm workspace'leri aynı versiyona hizalar) + `set-semver-ranges` (range operatörünü politikaya uydurur).
+- CI: her PR'da `verify` job'u içinde `pnpm syncpack:lint` koşar; drift varsa job fail olur.
+
+### Politika (`.syncpackrc.json`)
+
+- **Varsayılan range**: `^` — minör/patch güncellemeleri auto.
+- **`@glaon/*` workspace ref'leri**: range yok (`workspace:*` pnpm protokolü).
+- **Tek-versiyon zorlaması**: `prod`, `dev`, `overrides` dependency type'larında. `peerDependencies` policy dışında — peer'ler bilinçli geniş olabilir (ör. `@glaon/ui`'ın `react: ">=19"` peer'i).
+
+### Bilinçli istisnalar (`versionGroups`)
+
+Drift her zaman hata değil. İki bilinçli carve-out var:
+
+1. **Expo ekosistemi** (`@glaon/mobile`) — `react`, `react-native`, `expo`, `expo-*`, `typescript`, `@types/react*` Expo SDK konvansiyonunu izler (exact pin veya `~`). Expo CLI bu versiyonları kendi SDK alignment'ı için yönetir; cross-workspace tek-versiyona zorlamak, Expo upgrade akışını kırar. Mobile Expo SDK güncellediğinde bu paketler kendi cadence'inde hareket eder.
+2. **Vite hattı** — `@glaon/ui` Storybook'un `react-native-web-vite` gereği Vite 8 + `@vitejs/plugin-react` v6, `@glaon/web` ise stabil Vite 6 + plugin-react v4 kullanıyor. Storybook Vite 6'ya döndüğünde veya web Vite 8'e geçince tek-versiyona geçilir.
+
+Her istisna `.syncpackrc.json` içinde `label` yorumuyla açıklanır — "neden ignored?" sorusu config'i okuyunca cevaplanmalı.
+
+### Yeni istisna nasıl eklenir
+
+1. Drift'in gerekçesi var mı? (SDK constraint, upstream runtime farkı, geçici migration penceresi — hepsi geçerli.)
+2. `.syncpackrc.json`'da `versionGroups` listesine yeni bir entry ekle. `label` o gerekçeyi açık yaz — gelecekteki okuyan bizden birimizin kontrol'ünü kolaylaştırır.
+3. Gerekliyse `semverGroups`'a da benzer bir carve-out (range politikası farklıysa).
+4. `pnpm syncpack:lint` yerel yeşil olduktan sonra PR ile commit et.
+
+Drift'e keyfi izin vermek yok — her istisna config'te gerekçeli.
+
 ## Rollback / pin
 
 Bir paket yeni sürüm sonrası sorun çıkarırsa:
@@ -98,5 +134,6 @@ Bir paket yeni sürüm sonrası sorun çıkarırsa:
 ## Referanslar
 
 - Renovate config: [renovate.json](../renovate.json)
-- CI audit: [.github/workflows/ci.yml](../.github/workflows/ci.yml)
-- İlgili issue: #57
+- Syncpack config: [.syncpackrc.json](../.syncpackrc.json)
+- CI audit + syncpack: [.github/workflows/ci.yml](../.github/workflows/ci.yml)
+- İlgili issue: #57 (Renovate), #95 (syncpack).

--- a/package.json
+++ b/package.json
@@ -1,29 +1,18 @@
 {
   "name": "glaon",
-  "version": "0.0.0",
-  "private": true,
   "description": "Glaon — a secure, custom frontend for Home Assistant (web, wall tablet, mobile).",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/toss-cengiz/glaon.git"
+  "version": "0.0.0",
+  "devDependencies": {
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
+    "prettier": "^3.3.3",
+    "syncpack": "^14.3.0",
+    "turbo": "^2.3.3",
+    "typescript": "^5.7.2"
   },
-  "packageManager": "pnpm@9.15.0",
   "engines": {
     "node": ">=20.11.0",
     "pnpm": ">=9"
-  },
-  "scripts": {
-    "build": "turbo run build",
-    "build:addon": "pnpm --filter @glaon/web build:addon && rm -rf addon/dist && cp -R apps/web/dist addon/dist",
-    "dev": "turbo run dev",
-    "lint": "turbo run lint",
-    "test": "turbo run test",
-    "e2e": "turbo run e2e",
-    "type-check": "turbo run type-check",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
-    "clean": "turbo run clean && rm -rf node_modules .turbo",
-    "prepare": "husky"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -34,11 +23,22 @@
       "prettier --check"
     ]
   },
-  "devDependencies": {
-    "husky": "^9.1.7",
-    "lint-staged": "^16.4.0",
-    "prettier": "^3.3.3",
-    "turbo": "^2.3.3",
-    "typescript": "^5.7.2"
+  "packageManager": "pnpm@9.15.0",
+  "private": true,
+  "repository": "toss-cengiz/glaon.git",
+  "scripts": {
+    "build": "turbo run build",
+    "build:addon": "pnpm --filter @glaon/web build:addon && rm -rf addon/dist && cp -R apps/web/dist addon/dist",
+    "clean": "turbo run clean && rm -rf node_modules .turbo",
+    "dev": "turbo run dev",
+    "e2e": "turbo run e2e",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "turbo run lint",
+    "prepare": "husky",
+    "syncpack:fix": "syncpack fix-mismatches --dependency-types prod,dev,overrides && syncpack set-semver-ranges --dependency-types prod,dev,overrides",
+    "syncpack:lint": "syncpack lint --dependency-types prod,dev,overrides",
+    "test": "turbo run test",
+    "type-check": "turbo run type-check"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,16 +1,6 @@
 {
   "name": "@glaon/config",
   "version": "0.0.0",
-  "private": true,
-  "type": "module",
-  "exports": {
-    "./eslint": "./eslint.config.js",
-    "./tsconfig.base.json": "../../tsconfig.base.json"
-  },
-  "scripts": {
-    "lint": "echo 'nothing to lint'",
-    "type-check": "echo 'no-op'"
-  },
   "dependencies": {
     "@eslint/js": "^9.17.0",
     "eslint": "^9.17.0",
@@ -18,5 +8,15 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "globals": "^15.13.0",
     "typescript-eslint": "^8.18.1"
-  }
+  },
+  "exports": {
+    "./eslint": "./eslint.config.js",
+    "./tsconfig.base.json": "../../tsconfig.base.json"
+  },
+  "private": true,
+  "scripts": {
+    "lint": "echo 'nothing to lint'",
+    "type-check": "echo 'no-op'"
+  },
+  "type": "module"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@glaon/core",
   "version": "0.0.0",
-  "private": true,
-  "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "devDependencies": {
+    "@glaon/config": "workspace:*",
+    "@vitest/coverage-v8": "^2.1.8",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./auth": "./src/auth/index.ts",
@@ -12,18 +14,16 @@
     "./observability": "./src/observability/index.ts",
     "./types": "./src/types.ts"
   },
+  "main": "./src/index.ts",
+  "private": true,
   "scripts": {
     "build": "tsc -b",
+    "clean": "rm -rf dist .turbo coverage",
     "lint": "eslint .",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "type-check": "tsc --noEmit",
-    "clean": "rm -rf dist .turbo coverage"
+    "type-check": "tsc --noEmit"
   },
-  "devDependencies": {
-    "@glaon/config": "workspace:*",
-    "@vitest/coverage-v8": "^2.1.8",
-    "typescript": "^5.7.2",
-    "vitest": "^2.1.8"
-  }
+  "type": "module",
+  "types": "./src/index.ts"
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,27 +1,6 @@
 {
   "name": "@glaon/ui",
   "version": "0.0.0",
-  "private": true,
-  "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
-  "exports": {
-    ".": "./src/index.ts"
-  },
-  "scripts": {
-    "build": "tsc -b",
-    "chromatic": "chromatic",
-    "lint": "eslint .",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "type-check": "tsc --noEmit",
-    "clean": "rm -rf dist .turbo storybook-static coverage",
-    "storybook": "storybook dev -p 6006 --no-open",
-    "build-storybook": "storybook build"
-  },
-  "peerDependencies": {
-    "react": ">=19"
-  },
   "devDependencies": {
     "@glaon/config": "workspace:*",
     "@storybook/addon-a11y": "^10.3.5",
@@ -45,5 +24,26 @@
     "typescript": "^5.7.2",
     "vite": "^8.0.9",
     "vitest": "^2.1.8"
-  }
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "main": "./src/index.ts",
+  "peerDependencies": {
+    "react": ">=19"
+  },
+  "private": true,
+  "scripts": {
+    "build": "tsc -b",
+    "build-storybook": "storybook build",
+    "chromatic": "chromatic",
+    "clean": "rm -rf dist .turbo storybook-static coverage",
+    "lint": "eslint .",
+    "storybook": "storybook dev -p 6006 --no-open",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "type-check": "tsc --noEmit"
+  },
+  "type": "module",
+  "types": "./src/index.ts"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.8.3
+      syncpack:
+        specifier: ^14.3.0
+        version: 14.3.0
       turbo:
         specifier: ^2.3.3
         version: 2.9.6
@@ -4772,6 +4775,51 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  syncpack-darwin-arm64@14.3.0:
+    resolution: {integrity: sha512-gpbkBzO7yqa3BONc4EU3jY07yiPSZdoAxcpnz8REV9Bc6FkmKfOejCpYIh8RaogGPS4gOLJ/RUJEECqAaHTcjA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  syncpack-darwin-x64@14.3.0:
+    resolution: {integrity: sha512-wTpl6Qj5qGIHrYhpCrlNnosmhQqvUoidqqmxtdM3f+j+b+OkTtpkUl2tdE28h3aeEEUPf9ClQnHuwRJMYNlrJw==}
+    cpu: [x64]
+    os: [darwin]
+
+  syncpack-linux-arm64-musl@14.3.0:
+    resolution: {integrity: sha512-AezJ5dv0s+l/p1l4/wBatYhM6SZEKLcyNKggSOX5uISzqbSKwj/Aak13pBXWarzS+N6LnOl4PMcwRMJPOUfN/g==}
+    cpu: [arm64]
+    os: [linux]
+
+  syncpack-linux-arm64@14.3.0:
+    resolution: {integrity: sha512-Vcf9zWkJGRqb5mGPKi9E+s/mB/Tw08LmKGRaiyKJjK8bhd1Ds65O8A2lOidy3jg0NOOojqREmDsli74Xd0z6KA==}
+    cpu: [arm64]
+    os: [linux]
+
+  syncpack-linux-x64-musl@14.3.0:
+    resolution: {integrity: sha512-tIRF0lvBJcoIwcO05/Q6j30CAg0jzn+A5eQL+06Ncq8CE5i8fBWrVwN1U/QQ4fzT+tondNWH/2BR5zlaB1VUpQ==}
+    cpu: [x64]
+    os: [linux]
+
+  syncpack-linux-x64@14.3.0:
+    resolution: {integrity: sha512-n/4iBJnoOCe5An+WYlaqfSxOKQ7Id3TZTpxOpI60Cucq3yqwq0JHQUielj6JBtVaxvo2rAsTwbCLyp2aB0SD2g==}
+    cpu: [x64]
+    os: [linux]
+
+  syncpack-windows-arm64@14.3.0:
+    resolution: {integrity: sha512-ZTX0rSUTJZjIde3qPKLEqU7IEt4KxFsmq6gKLfESx5rB1rxk/B1Ljv6nTYph5QVItEzHQHUXDWnqa9yCb15myw==}
+    cpu: [arm64]
+    os: [win32]
+
+  syncpack-windows-x64@14.3.0:
+    resolution: {integrity: sha512-zvbphZw40wFZYeEW2oJYqA9Uw6IOwNIpgFmVNdWdGmShPF/Zu1cavHEcGwtQmvVzwuTEyiu67uxQ3hDC2q6vtg==}
+    cpu: [x64]
+    os: [win32]
+
+  syncpack@14.3.0:
+    resolution: {integrity: sha512-8/WtPPxxGFqE21JPFz6Bpw0m9BT3lzMYDcewJFj++EBPmCaDWowTnx0R4V7ofH/1z3HAIaAps6g2GHL76l1Y2g==}
+    engines: {node: '>=14.17.0'}
+    hasBin: true
 
   terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
@@ -10657,6 +10705,41 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  syncpack-darwin-arm64@14.3.0:
+    optional: true
+
+  syncpack-darwin-x64@14.3.0:
+    optional: true
+
+  syncpack-linux-arm64-musl@14.3.0:
+    optional: true
+
+  syncpack-linux-arm64@14.3.0:
+    optional: true
+
+  syncpack-linux-x64-musl@14.3.0:
+    optional: true
+
+  syncpack-linux-x64@14.3.0:
+    optional: true
+
+  syncpack-windows-arm64@14.3.0:
+    optional: true
+
+  syncpack-windows-x64@14.3.0:
+    optional: true
+
+  syncpack@14.3.0:
+    optionalDependencies:
+      syncpack-darwin-arm64: 14.3.0
+      syncpack-darwin-x64: 14.3.0
+      syncpack-linux-arm64: 14.3.0
+      syncpack-linux-arm64-musl: 14.3.0
+      syncpack-linux-x64: 14.3.0
+      syncpack-linux-x64-musl: 14.3.0
+      syncpack-windows-arm64: 14.3.0
+      syncpack-windows-x64: 14.3.0
 
   terminal-link@2.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

Add [syncpack](https://jamiemason.github.io/syncpack/) to enforce a single-version policy across the @glaon/* workspaces. Drift (e.g. `@glaon/core` on `react@19.2.5` while `@glaon/web` slips to `19.3.0`) is caught at lint time before it leads to install duplication or subtle runtime mismatch.

## Scope — In

- `.syncpackrc.json` with `semverGroups` + `versionGroups` policy.
- Root devDep `syncpack@^14.3.0` + scripts: `syncpack:lint` (report) and `syncpack:fix` (`fix-mismatches` + `set-semver-ranges`). Both explicitly pass `--dependency-types prod,dev,overrides` so `peer` ranges are not enforced (they're deliberately loose, e.g. `@glaon/ui`'s `react: ">=19"`).
- New step in the CI `verify` job: `pnpm syncpack:lint` — fails on drift.
- Two intentional carve-outs, each labelled in `.syncpackrc.json`:
  - **Expo ecosystem** in `@glaon/mobile` (`react`, `react-dom`, `react-native`, `expo`, `expo-*`, `typescript`, `@types/react*`) follows Expo SDK cadence. Expo CLI pins these exactly or with `~` per SDK alignment; cross-workspace single-version enforcement would break `expo upgrade`.
  - **Vite line** drift: `@glaon/ui` is on Vite 8 + `@vitejs/plugin-react@6` (required by Storybook's `react-native-web-vite`), `@glaon/web` stays on stable Vite 6 + `plugin-react@4`. Revisit when Storybook supports Vite 6 again or when web needs Vite 8.
- `docs/dependencies.md`: new "Cross-workspace tutarlılık (syncpack)" section, updated actors table, referanslar pointing to `.syncpackrc.json` + workflow.
- One-time `syncpack format` pass across the seven package.json files — alphabetises keys, collapses `repository` shorthand.

## Scope — Out

- Auto-fix on push — run `pnpm syncpack:fix` locally, commit, push.
- Renovate preset integration for syncpack — separate issue once we see drift patterns.
- `peerDependencies` enforcement — excluded via `--dependency-types` flag; peer ranges are deliberately loose.

## Why syncpack 14 (not 13)

First push landed on `syncpack@13.0.4`, which transitively depends on `minimatch@9.0.5`. Three high-severity ReDoS advisories (GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74) are patched in `minimatch>=9.0.7`, so `pnpm audit --audit-level high` and the Dependency Review Action both blocked the first push.

syncpack 14 is a Rust rewrite with zero bundled deps (`npm view syncpack@14.3.0` → `deps: none`), which eliminates the problematic transitive entirely. Config schema in v14 keeps the same `semverGroups` / `versionGroups` / `isIgnored` / `range` semantics this PR uses; the only breakage is that `dependencyTypes` moved from config file to CLI flag — handled in the script wiring.

## How overrides work

New exceptions go into `.syncpackrc.json` `versionGroups` (and `semverGroups` if the range policy differs) with a `label` explaining the reason. Gerekçesiz drift yok — full workflow in [docs/dependencies.md](docs/dependencies.md#cross-workspace-tutarlılık-syncpack).

## Test plan

- [x] `pnpm syncpack:lint` — clean locally (all drift either in an ignored group or already aligned).
- [x] `pnpm type-check` — green.
- [x] `pnpm lint` — green.
- [x] `pnpm audit --audit-level high` — clean (only 2 moderate advisories remain, below threshold).
- [x] `pnpm prettier --check` on `.syncpackrc.json` + `docs/dependencies.md` + `package.json` — clean.
- [ ] CI `verify` job passes with the new `Cross-workspace dep consistency (syncpack)` step.
- [ ] All required checks green on this PR (including commitlint — initial header was 78 chars; rewritten to 66).

## Refs

- Dependency Dashboard (Issue-First Rule exception does not apply — this is a non-Renovate change).

Closes #95