### PR TITLE
chore(web): add size-limit bundle budget enforced in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,32 @@ jobs:
       - name: Run unit tests with coverage
         run: pnpm turbo run test:coverage
 
+  size-check:
+    name: size-check
+    runs-on: ubuntu-latest
+    env:
+      # Dummy value so Vite's prod-build guard passes. The Sentry runtime
+      # plugin stays off (needs SENTRY_AUTH_TOKEN + ORG + PROJECT to load)
+      # and these artifacts are never published.
+      VITE_SENTRY_DSN: size-check-dummy
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web + enforce bundle-size budget
+        run: pnpm size
+
   secret-scan:
     name: gitleaks
     runs-on: ubuntu-latest

--- a/apps/web/.size-limit.json
+++ b/apps/web/.size-limit.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "Initial JS (gzipped)",
+    "path": "dist/assets/index-*.js",
+    "limit": "180 kB",
+    "gzip": true
+  },
+  {
+    "name": "Total JS (gzipped)",
+    "path": "dist/assets/**/*.js",
+    "limit": "250 kB",
+    "gzip": true
+  }
+]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "dev": "vite",
     "lint": "eslint .",
     "preview": "vite preview",
+    "size": "size-limit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "type-check": "tsc --noEmit"

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,86 @@
+# Performans bütçeleri
+
+Glaon'un birincil hedefi tablet + mobil — ağır olduğu an kullanıcının hissedeceği yer. Bu dökümantasyonun amacı: bundle şişkinliğini upgrade akışında (yeni dep, yeni import, transitive bloat) geç değil, PR zamanında yakalamak.
+
+## Web bundle budget (`size-limit`)
+
+[size-limit](https://github.com/ai/size-limit) `apps/web` Vite production build'ı üzerinden gzipped byte-size ölçer. Config `apps/web/.size-limit.json` içinde; değer aşıldığında CI fail eder.
+
+### Mevcut bütçeler
+
+| İsim                     | Glob                     | Limit (gzipped) | Şu anki baseline |
+| ------------------------ | ------------------------ | --------------- | ---------------- |
+| **Initial JS (gzipped)** | `dist/assets/index-*.js` | 180 kB          | ~88 kB           |
+| **Total JS (gzipped)**   | `dist/assets/**/*.js`    | 250 kB          | ~88 kB           |
+
+CSS bütçesi (40 kB gzipped) şu an config'te yok — web henüz CSS emit etmiyor (inline style + tailwind olmadığı için). `size-limit` glob'u boş eşleşirse fail eder, bu yüzden entry'yi ilk stylesheet import'u eklendiği anda (aynı PR'da) config'e eklemek gerekir. O ana kadar CSS kategorisinin bütçesi yok; bu bilinçli bir carve-out.
+
+### Neden bu değerler
+
+- **180 kB initial** — Current baseline ~88 kB, ~2x headroom. React 19 + routing + core auth + HA WebSocket client (henüz hiçbiri yok; scaffold only) girdiği noktada bu alan dolar. Tablet 3G fallback scenario'sunda 180 kB gzipped ~2s indirme; cold-load'u kabul edilebilir tutuyor.
+- **250 kB total** — Initial JS + async chunks. Code-splitting henüz yok; split başladığında async chunk'lar bu headroom'un içinden gider. Total bütçe, initial'ın ~1.4x'i — code-splitting'in asıl faydasını (initial shrink) yakalar.
+
+Bütçeler "tune after baseline" ile başlamış bir rakam. Baseline'dan ~2x sınırı ilk sürüm için bilinçli bir "gelişim alanı var ama regresyon yakalanır" dengesi.
+
+### Yerel çalıştırma
+
+```bash
+# Kök-level (tüm workspace'ler, turbo cache'li):
+pnpm size
+
+# Sadece web:
+pnpm --filter @glaon/web size
+```
+
+İkisi de önce `pnpm build` koşar (turbo `dependsOn: ["build"]`), sonra `size-limit` ile ölçer. İlk çalıştırmada build tamamı; sonraki çalıştırmalarda cache hit.
+
+Lokalde `VITE_SENTRY_DSN` dummy bir değer olmadan `vite build` fail eder (prod-build guard). Kullanışlı örnek:
+
+```bash
+VITE_SENTRY_DSN="size-check-dummy" pnpm size
+```
+
+CI bu env değerini job-level olarak sağlıyor — lokal'de CI'daki gibi çalıştırmak istersen aynı şeyi yap.
+
+### CI entegrasyonu
+
+`.github/workflows/ci.yml` → `size-check` job:
+
+- Her PR'da koşar (path filter yok — iş ~30s, filter için ek action dependency şu an overkill).
+- `VITE_SENTRY_DSN=size-check-dummy` env ile prod-build guard'ı geçer; Sentry plugin'i `SENTRY_AUTH_TOKEN + ORG + PROJECT` olmadan yüklenmiyor, artifact'lar da hiçbir yere publish edilmiyor.
+- Bütçe aşıldığında job fail eder; PR body'sindeki delta ile görünür.
+
+### Bütçe değişiklik kuralı
+
+Bütçe yukarı bump edilmeden önce **nedeni bağımsız bir issue'da tartışılır**. Tipik senaryolar:
+
+- **Kabul edilen yeni feature** (örn. chart library) — issue'da beklenen byte maliyeti + alternatifler değerlendirilir, sonra bütçe artırılır.
+- **Regression sonrası tune-down** — baseline kendi doğal haliyle düştüyse bütçe de daralır (baseline'a ~2x tamponun altında tutulur).
+
+Bir dep upgrade'i "istemeden" bütçeyi aştığında çözüm bütçeyi yükseltmek değil — dep'in alternatifini veya code-splitting stratejisini düşünmek. Bütçe sinyal olarak çalışmak için dar tutulur.
+
+### Yeni budget entry'si nasıl eklenir
+
+1. `apps/web/.size-limit.json` → yeni obje:
+   ```jsonc
+   {
+     "name": "İsim (gzipped)",
+     "path": "dist/assets/<glob>",
+     "limit": "N kB",
+     "gzip": true,
+   }
+   ```
+2. `path` boş eşleşirse `size-limit` fail eder — entry'yi yalnızca eşleşen artifact build çıktısında garantili olduğunda ekle.
+3. Baseline + 1.5–2x headroom ile başla; öncesinde 1-2 haftalık gerçek kullanımda sabitle.
+4. Bu dökümanın tablosuna satır ekle, "Neden bu değer" listesine gerekçe.
+
+## İlişkili kontrolller
+
+- **Lighthouse CI** (#102) — performance/perceived metrics (LCP, TBT). size-limit'i tamamlar: byte-size vs render-time.
+- **Vite build warnings** — `pnpm --filter @glaon/web build` zaten her chunk için gzipped boyutu yazar; size-limit bu rapora policy ekler.
+
+## Referanslar
+
+- size-limit config: [apps/web/.size-limit.json](../apps/web/.size-limit.json)
+- CI job: [.github/workflows/ci.yml](../.github/workflows/ci.yml) `size-check`
+- İlgili issue: #93 (size-limit), #102 (Lighthouse CI planned).

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "version": "0.0.0",
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
+    "@size-limit/file": "^12.1.0",
     "husky": "^9.1.7",
     "knip": "^6.6.1",
-    "publint": "^0.3.18",
     "lint-staged": "^16.4.0",
     "prettier": "^3.3.3",
+    "publint": "^0.3.18",
+    "size-limit": "^12.1.0",
     "syncpack": "^14.3.0",
     "turbo": "^2.3.3",
     "typescript": "^5.7.2"
@@ -40,6 +42,7 @@
     "knip": "knip",
     "package-contract": "turbo run package-contract --filter=./packages/*",
     "lint": "turbo run lint",
+    "size": "turbo run size",
     "prepare": "husky",
     "syncpack:fix": "syncpack fix-mismatches --dependency-types prod,dev,overrides && syncpack set-semver-ranges --dependency-types prod,dev,overrides",
     "syncpack:lint": "syncpack lint --dependency-types prod,dev,overrides",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
         version: 0.18.2
+      '@size-limit/file':
+        specifier: ^12.1.0
+        version: 12.1.0(size-limit@12.1.0(jiti@2.6.1))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -26,6 +29,9 @@ importers:
       publint:
         specifier: ^0.3.18
         version: 0.3.18
+      size-limit:
+        specifier: ^12.1.0
+        version: 12.1.0(jiti@2.6.1)
       syncpack:
         specifier: ^14.3.0
         version: 14.3.0
@@ -2104,6 +2110,12 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2753,6 +2765,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -4062,6 +4078,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
     engines: {node: '>=20.17'}
@@ -4359,6 +4379,9 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -4976,6 +4999,16 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -7716,6 +7749,10 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@size-limit/file@12.1.0(size-limit@12.1.0(jiti@2.6.1))':
+    dependencies:
+      size-limit: 12.1.0(jiti@2.6.1)
+
   '@standard-schema/spec@1.1.0': {}
 
   '@storybook/addon-a11y@10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
@@ -8493,6 +8530,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes-iec@3.1.1: {}
 
   bytes@3.1.2: {}
 
@@ -9979,6 +10018,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
   lint-staged@16.4.0:
     dependencies:
       commander: 14.0.3
@@ -10491,6 +10532,10 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
 
   natural-compare@1.4.0: {}
 
@@ -11270,6 +11315,16 @@ snapshots:
       plist: 3.1.0
 
   sisteransi@1.0.5: {}
+
+  size-limit@12.1.0(jiti@2.6.1):
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      jiti: 2.6.1
 
   skin-tone@2.0.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -35,6 +35,11 @@
     "package-contract": {
       "dependsOn": ["build"],
       "outputs": []
+    },
+    "size": {
+      "dependsOn": ["build"],
+      "inputs": [".size-limit.json", "dist/**/*.{js,css}"],
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary

Wires [`size-limit`](https://github.com/ai/size-limit) against the web Vite production build so bundle bloat surfaces at PR time rather than in user-perceived cold-load latency. Initial budgets sized at ~2x current baseline — tight enough to catch regressions, loose enough not to block Phase 0 feature landings.

- Budgets (gzipped):
  - **Initial JS** (`dist/assets/index-*.js`): **180 kB** — baseline ~88 kB
  - **Total JS** (`dist/assets/**/*.js`): **250 kB** — baseline ~88 kB
- CSS budget deferred — the web app emits zero CSS today, and `size-limit` errors on empty glob matches. First PR introducing a stylesheet import adds the 40 kB CSS entry.
- `pnpm size` (root or `--filter @glaon/web`) runs the full build + check via a turbo task depending on `build`.
- CI `size-check` job runs on every PR; budget exceedance blocks merge.

## Scope

### In

- `apps/web/.size-limit.json`: JSON config with the two active budgets.
- `apps/web/package.json`: `size` script.
- `package.json`: root `size` → `turbo run size`, new devDeps `size-limit` + `@size-limit/file`.
- `turbo.json`: `size` task `dependsOn: ["build"]`, narrow `inputs`.
- `.github/workflows/ci.yml`: new `size-check` job with `VITE_SENTRY_DSN=size-check-dummy` job-level env so the Vite prod-build guard passes. Sentry runtime plugin stays off (needs `SENTRY_AUTH_TOKEN + ORG + PROJECT`) and the artifacts are never published.
- `docs/performance.md`: new doc — budgets, rationale, local run, CI integration, budget-change policy.

### Out

- **Path filtering** on the CI job. The job runs ~30s; filtering requires an external action with SHA pinning, which is more machinery than it saves at this scale. Documented in `docs/performance.md` as a deliberate simplification.
- **CSS budget** — see above. Reactivation is the first-stylesheet PR's responsibility; the doc calls it out so it's not forgotten.
- **Per-route code-splitting / mobile bundle checks** — separate future issues (noted in the original issue's Scope-Out).

## Test plan

- [x] `pnpm install` — `size-limit` + `@size-limit/file` resolve, lockfile updated
- [x] `VITE_SENTRY_DSN=size-check-dummy pnpm size` locally — both budgets pass (Initial 88.41 kB / 180 kB, Total 88.41 kB / 250 kB)
- [x] `pnpm knip` — clean; the new root devDeps are recognized via the `size-limit` binary in apps/web's script
- [x] `pnpm type-check` — green
- [x] `pnpm lint` — green
- [x] `pnpm format:check` — clean
- [ ] CI `size-check` job runs and passes
- [ ] CI `verify` (knip + syncpack + audit + lint + type-check) stays green
- [ ] Chromatic baseline unaffected — no story or UI changes
- [ ] Intentionally verify the gate works: locally edit `.size-limit.json` Initial budget to `50 kB`, rerun `pnpm size`, confirm exit code is non-zero (**not pushed**)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)