### PR TITLE
test(e2e): inject axe-core into Playwright smokes for runtime a11y

### DIFF
--- a/apps/web-e2e/package.json
+++ b/apps/web-e2e/package.json
@@ -2,6 +2,7 @@
   "name": "@glaon/web-e2e",
   "version": "0.0.0",
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@glaon/config": "workspace:*",
     "@playwright/test": "^1.49.1",
     "@types/node": "^22.10.2",

--- a/apps/web-e2e/tests/smoke.spec.ts
+++ b/apps/web-e2e/tests/smoke.spec.ts
@@ -1,10 +1,13 @@
 import { expect, test } from '@playwright/test';
 
+import { assertA11y } from './support/a11y';
+
 test.describe('web app @smoke', () => {
   test('renders the root heading and tagline', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('heading', { level: 1 })).toHaveText('Glaon');
     await expect(page.getByText(/Secure Home Assistant frontend/i)).toBeVisible();
+    await assertA11y(page);
   });
 
   test('has a restrictive CSP meta tag', async ({ page }) => {

--- a/apps/web-e2e/tests/support/a11y.ts
+++ b/apps/web-e2e/tests/support/a11y.ts
@@ -1,0 +1,65 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page } from '@playwright/test';
+
+type A11yImpact = 'minor' | 'moderate' | 'serious' | 'critical';
+
+interface AssertA11yOptions {
+  /**
+   * Axe rules to disable for this call. Use sparingly — every entry
+   * should be justified in a comment at the call site (e.g. known
+   * upstream library bug, deliberate design decision).
+   */
+  disableRules?: string[];
+  /**
+   * Impact levels that cause the test to fail. Anything below this is
+   * attached to the test report for visibility but does not fail CI.
+   * Defaults to serious + critical.
+   */
+  failOn?: A11yImpact[];
+}
+
+const DEFAULT_FAIL_ON: A11yImpact[] = ['serious', 'critical'];
+
+export async function assertA11y(page: Page, options: AssertA11yOptions = {}): Promise<void> {
+  const { disableRules = [], failOn = DEFAULT_FAIL_ON } = options;
+  const info = test.info();
+
+  let builder = new AxeBuilder({ page });
+  if (disableRules.length > 0) {
+    builder = builder.disableRules(disableRules);
+  }
+
+  const results = await builder.analyze();
+
+  const failSet = new Set<string>(failOn);
+  const fatal = results.violations.filter((v) => (v.impact ? failSet.has(v.impact) : false));
+  const informational = results.violations.filter((v) =>
+    v.impact ? !failSet.has(v.impact) : true,
+  );
+
+  if (informational.length > 0) {
+    await info.attach('a11y-informational', {
+      body: JSON.stringify(informational, null, 2),
+      contentType: 'application/json',
+    });
+  }
+
+  if (fatal.length > 0) {
+    await info.attach('a11y-violations', {
+      body: JSON.stringify(fatal, null, 2),
+      contentType: 'application/json',
+    });
+    const summary = fatal
+      .map((v) => {
+        const impact = v.impact ?? 'unknown';
+        const count = v.nodes.length;
+        return `  [${impact}] ${v.id} — ${v.help} (${String(count)} node${count === 1 ? '' : 's'})`;
+      })
+      .join('\n');
+    const plural = fatal.length === 1 ? '' : 's';
+    expect(
+      fatal,
+      `axe-core found ${String(fatal.length)} ${failOn.join(' + ')} violation${plural}:\n${summary}\nSee the "a11y-violations" attachment for full details.`,
+    ).toEqual([]);
+  }
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,12 +2,12 @@
 
 Glaon'da testler dört katmana yayılır:
 
-| Katman               | Araç                           | Ne soruyu cevaplar                        |
-| -------------------- | ------------------------------ | ----------------------------------------- |
-| **Unit**             | Vitest + Testing Library       | Pure function / component logic doğru mu? |
-| **Görsel regresyon** | Chromatic (Storybook snapshot) | Component pixel-level değişti mi?         |
-| **Erişilebilirlik**  | Storybook `addon-a11y`         | Axe kuralları kırılıyor mu?               |
-| **Davranışsal E2E**  | Playwright                     | Kullanıcı akışı uçtan uca çalışıyor mu?   |
+| Katman               | Araç                                            | Ne soruyu cevaplar                                                               |
+| -------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------- |
+| **Unit**             | Vitest + Testing Library                        | Pure function / component logic doğru mu?                                        |
+| **Görsel regresyon** | Chromatic (Storybook snapshot)                  | Component pixel-level değişti mi?                                                |
+| **Erişilebilirlik**  | Storybook `addon-a11y` + `@axe-core/playwright` | Axe kuralları hem izole component'te hem de render edilmiş sayfada kırılıyor mu? |
+| **Davranışsal E2E**  | Playwright                                      | Kullanıcı akışı uçtan uca çalışıyor mu?                                          |
 
 Sayfa aşağıda önce **Unit**, sonra **E2E** için ayrılmıştır.
 
@@ -165,6 +165,58 @@ test.describe('room list @smoke', () => {
 - Implementation detayları (internal component state, private function).
 - CSS class adlarına lock — `getByRole` / `getByLabel` / `getByText` kullan.
 - HA'ya gerçek bağlantı — aşağıya bak.
+
+## Runtime a11y (axe-core)
+
+Storybook `addon-a11y` component'i izole ederken axe koşar; E2E katmanı ise **render edilmiş sayfanın tamamını** — routing + state + compose edilmiş ağaç dahil — kontrol eder. İki katman birbirinin yerini almaz; Storybook component tasarım hatalarını, E2E ise integration-level regresyonları yakalar.
+
+### Helper
+
+[`apps/web-e2e/tests/support/a11y.ts`](../apps/web-e2e/tests/support/a11y.ts) içinde `assertA11y(page, options?)` tek fonksiyon ihraç eder. Smoke içinde DOM ready olduktan sonra çağrılır:
+
+```ts
+import { assertA11y } from './support/a11y';
+
+test('renders dashboard @smoke', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+  await assertA11y(page);
+});
+```
+
+### Fail eşiği
+
+- **Fatal (test fail):** `serious` + `critical` impact seviyeleri. CI PR'ı kırmız yapar, ayrıntılı violations listesi `a11y-violations` adıyla Playwright raporuna attach edilir.
+- **Informational (fail yok):** `moderate` + `minor` impact. Rapora `a11y-informational` attachment olarak düşer — görünür ama merge'ü engellemez. Fikir: bu seviyeleri zamanla azaltmak için bir zemin; erken aşamada gürültü yapmasın.
+
+Eşik istersen çağrı başına override edilebilir:
+
+```ts
+await assertA11y(page, { failOn: ['moderate', 'serious', 'critical'] });
+```
+
+### Kuralı devre dışı bırakma (nadir)
+
+`disableRules` escape-hatch'i var ama **her kullanım call-site'ta yorumla gerekçelendirilmeli**. Kabul edilen durumlar:
+
+- Known upstream kütüphane bug'ı (issue + versiyon yaz).
+- Kasıtlı tasarım kararı (örn. tooltip-on-hover widget'ta `aria-hidden` paternine özel).
+
+Gerekçesiz `disableRules` = review'da kırmızı bayrak.
+
+```ts
+await assertA11y(page, {
+  // Untitled UI Combobox v3.2: `aria-activedescendant`'ı option'lar render olmadan
+  // set ediyor, upstream #1234. Fix edildiğinde kaldır.
+  disableRules: ['aria-valid-attr-value'],
+});
+```
+
+### İyi kullanım
+
+- Her `@smoke` testine en az bir `assertA11y(page)` çağrısı — sayfa son state'e oturduktan sonra.
+- Birden fazla screen'li smoke'ta her screen transition'ından sonra ayrı çağrı.
+- Ayrı bir "a11y smoke" dosyası **açma**. Bu katman smoke'ların üstüne koşar; ayrı dosya ikinci bir pass olur, değer katmaz.
 
 ## HA mocking
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
 
   apps/web-e2e:
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.2
+        version: 4.11.2(playwright-core@1.59.1)
       '@glaon/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -292,6 +295,11 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@axe-core/playwright@4.11.2':
+    resolution: {integrity: sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -6497,6 +6505,11 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@axe-core/playwright@4.11.2(playwright-core@1.59.1)':
+    dependencies:
+      axe-core: 4.11.3
+      playwright-core: 1.59.1
 
   '@babel/code-frame@7.29.0':
     dependencies:


### PR DESCRIPTION
Closes #100

## Summary

Adds `@axe-core/playwright` plus a small `assertA11y(page, options?)` helper in [apps/web-e2e/tests/support/a11y.ts](apps/web-e2e/tests/support/a11y.ts) and wires the first `@smoke` test to call it. Runtime a11y now covers the integration-level surface that Storybook `addon-a11y` can't see (routing, composed tree, real state).

- Fatal threshold: `serious` + `critical` → test fail + `a11y-violations` JSON attachment on the Playwright report.
- Informational: `moderate` + `minor` → attached as `a11y-informational` for visibility, non-gating.
- Call-site escape hatches: `failOn` to override threshold, `disableRules` with a required justification comment.

## Scope — In

- `@axe-core/playwright@^4.11.2` devDep added only to `apps/web-e2e`.
- `assertA11y` helper with impact-based fail threshold and report attachments.
- `tests/smoke.spec.ts` → first smoke calls `assertA11y(page)`.
- [docs/testing.md](docs/testing.md) gains a **Runtime a11y (axe-core)** section and the layers table is updated.

## Scope — Out

- axe inside Storybook test-runner / play functions (tracked separately, #101).
- Mobile (Expo) a11y — separate runner, future issue.
- Per-component axe context scoping in smokes — we assert full-page for now; scope narrowing can come per-call when needed.

## Test plan

- [ ] `pnpm --filter @glaon/web-e2e exec playwright test --project=chromium --grep @smoke` passes locally (both smokes green).
- [ ] `pnpm lint`, `pnpm type-check`, `pnpm knip`, `pnpm format:check` clean on CI.
- [ ] CI `e2e` job green — axe check runs against the real rendered page in chromium.
- [ ] A deliberately broken DOM (e.g. `<h1>` removed) would surface as a serious/critical violation (verified by helper design; not an automated regression in this PR).
- [ ] Playwright HTML report shows `a11y-informational` attachment when only minor/moderate violations are present (manual spot-check in trace viewer).

## Notes

- Helper is private to `apps/web-e2e`; no public export, no shared package. If a second consumer appears, promote it then.
- The docs section explicitly warns against creating a standalone "a11y smoke" file — runtime a11y is piggybacked on existing smokes to avoid a redundant second pass.