### PR TITLE
chore(dev): add VSCode Dev Container config for reproducible dev env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
+  "name": "Glaon",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "corepack enable && pnpm install --frozen-lockfile",
+  "forwardPorts": [5173, 6006, 8099],
+  "portsAttributes": {
+    "5173": { "label": "Vite dev (web)", "onAutoForward": "notify" },
+    "6006": { "label": "Storybook", "onAutoForward": "notify" },
+    "8099": { "label": "HA add-on (nginx)", "onAutoForward": "silent" }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-playwright.playwright",
+        "vitest.explorer",
+        "ms-azuretools.vscode-docker",
+        "github.vscode-pull-request-github"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "typescript.tsdk": "node_modules/typescript/lib"
+      }
+    }
+  },
+  "remoteUser": "node"
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ docs/       — Mimari, güvenlik, yol haritası (Türkçe)
 
 ## Geliştirme
 
+Tek komutla reproducible ortam için [Dev Container](docs/devcontainer.md) kullanabilirsin — VS Code'da "Reopen in Container" yeterli.
+
+Lokal kurulum:
+
 ```bash
 # Node 22 LTS gerekir; .nvmrc dosyasındaki sürümü kullan.
 corepack enable
@@ -58,6 +62,7 @@ pnpm lint
 - [Mimari](docs/ARCHITECTURE.md)
 - [Güvenlik](docs/SECURITY.md)
 - [Yol Haritası](docs/ROADMAP.md)
+- [Dev Container](docs/devcontainer.md)
 - [HA Add-on](addon/README.md)
 
 ## Lisans

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,0 +1,78 @@
+# Dev Container
+
+Glaon'un lokal geliştirme ortamı `.devcontainer/devcontainer.json` ile pinlenmiştir. Amaç: yeni bir katkıcı clone'dan ilk `pnpm dev`'e kadar sadece **iki komut** uzakta olsun (reopen-in-container + onay) — Node/pnpm sürüm uyuşmazlığı, eksik Docker, unutulmuş `gh` CLI gibi "benim makinemde çalışıyor" sınıfı problemler ortadan kalksın.
+
+## Hızlı başlangıç
+
+### VS Code (lokal) ile
+
+1. **Dev Containers** eklentisini kur: `ms-vscode-remote.remote-containers`.
+2. Repo'yu klonla ve VS Code'da aç.
+3. Command Palette → **Dev Containers: Reopen in Container**.
+4. Container inşa olur; `postCreateCommand` `pnpm install --frozen-lockfile` koşar.
+5. Hazır: `pnpm dev`, `pnpm test`, `pnpm --filter @glaon/ui storybook`.
+
+### GitHub Codespaces ile
+
+1. Repo sayfasında **Code → Codespaces → Create codespace on development**.
+2. Container aynı `devcontainer.json`'ı kullanır; extension'lar ve post-create aynı akışı izler.
+3. Forwarded port'ları (5173, 6006, 8099) Codespaces UI otomatik expose eder.
+
+## İçinde ne var?
+
+| Bileşen            | Nereden                                                         | Niye                                                                                                |
+| ------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| Node 22 LTS        | `mcr.microsoft.com/devcontainers/typescript-node:22` base image | `.nvmrc` ile aynı major; TypeScript + Node dev tooling pre-installed                                |
+| pnpm 9.15.0        | `corepack enable` (post-create)                                 | `package.json`'daki `packageManager` alanına göre pin — versiyon sürüklenmesi yok                   |
+| Docker (dış motor) | `ghcr.io/devcontainers/features/docker-outside-of-docker`       | `addon/` HA Add-on build'inde `docker buildx` host daemon'ını kullanır — container-in-container yok |
+| GitHub CLI         | `ghcr.io/devcontainers/features/github-cli`                     | `gh pr create`, `gh issue`, `gh run` akışları CLAUDE.md'deki issue-first iş akışının parçası        |
+
+## Port'lar
+
+| Port | Ne için?                                   | Auto-forward |
+| ---- | ------------------------------------------ | ------------ |
+| 5173 | Vite dev server (web)                      | notify       |
+| 6006 | Storybook                                  | notify       |
+| 8099 | HA add-on nginx (lokal add-on test'i için) | silent       |
+
+Codespaces otomatik HTTPS proxy URL'si üretir; lokal container'da `localhost:<port>` ile erişilir.
+
+## VS Code extension'ları
+
+Container açıldığında otomatik önerilen extension'lar:
+
+- **ESLint** (`dbaeumer.vscode-eslint`) — `@glaon/config`'tan gelen flat config'i okur.
+- **Prettier** (`esbenp.prettier-vscode`) — `.prettierrc` + format-on-save aktif.
+- **Playwright** (`ms-playwright.playwright`) — E2E test'lerini VS Code içinden koş/debug et.
+- **Vitest Explorer** (`vitest.explorer`) — unit + story test'lerini tree view'la çalıştır.
+- **Docker** (`ms-azuretools.vscode-docker`) — add-on Dockerfile'ları + host daemon bağlantısı.
+- **GitHub Pull Requests** (`github.vscode-pull-request-github`) — `gh` CLI'ye ek olarak review ve PR akışı.
+
+Settings katmanı: `formatOnSave: true`, Prettier default formatter, TypeScript SDK'sı `node_modules/typescript/lib`'ten (workspace sürümüyle uyumlu).
+
+## Doğrulama akışı
+
+Container ilk açıldığında aşağıdakilerin geçmesi beklenir — geçmiyorsa container kurulumu bozuk demektir:
+
+```bash
+pnpm install --frozen-lockfile  # post-create zaten koşmuş olmalı, tekrar çalışmalı
+pnpm type-check
+pnpm lint
+pnpm build
+```
+
+## Neden "outside of docker"?
+
+Add-on build'i için `docker buildx` gerekli. Container-in-container (DinD) çok daha ağır ve permissions hassas; host daemon'a socket mount etmek hem hızlı hem açık. Güvenlik notu: bu şemada container host daemon üzerinde tam yetkiyle konuşur — shared/CI ortamlarda DinD tercih edilebilir, ama tek developer'ın kendi Codespaces/laptop'unda tipik akış "outside".
+
+## Kapsam dışı
+
+- Expo / React Native **emulator** container-içi desteği — hâlâ host-side: simulator (iOS) ve Android emulator macOS/Linux host üzerinde koşar. `apps/mobile` için `pnpm --filter @glaon/mobile dev` container dışında çalıştırılır. Bu tutarlı bir follow-up: mobile build container'ı ayrı bir iş (ayrı issue).
+- GHCR'ye push edilmiş pre-built image — startup time bir problem olana kadar plain `devcontainer.json` yeterli. İleride `devcontainer.image.ref` ile bu dosyada tek satır değişecek.
+
+## Sorun giderme
+
+- **`corepack: not found`** → Base image Node 22 ile geliyor, corepack yerleşik olmalı. Image versiyonunu doğrula: `cat /etc/os-release` + `node --version`.
+- **`pnpm install` lockfile'ı reddediyor** → Host'ta `pnpm install` yapmışsan `node_modules/` ve `pnpm-lock.yaml` eşleşmeyebilir; container rebuild → `pnpm install --frozen-lockfile` temiz koşmalı.
+- **Docker daemon erişimi yok** → `docker-outside-of-docker` feature'ı host socket'i mount ediyor; Codespaces'te bu otomatik, lokalde Docker Desktop'un "Use the WSL 2 based engine" veya equivalent ayarı açık olmalı.
+- **Port 5173/6006 forward olmuyor** → VS Code **Ports** tab'inde manuel ekleyebilirsin; `forwardPorts` sadece default listesi.


### PR DESCRIPTION
Closes #103

## Summary

Pin the dev env via [.devcontainer/devcontainer.json](.devcontainer/devcontainer.json). Same config drives local VS Code **Reopen in Container** and GitHub Codespaces — single source of truth. No more chasing Node/pnpm version skew, missing Docker, or absent `gh` CLI.

- **Base**: `mcr.microsoft.com/devcontainers/typescript-node:22` (mirrors `.nvmrc`).
- **Features**: `docker-outside-of-docker` (host daemon via socket mount — faster than DinD and enough for single-dev add-on builds), `github-cli` (required by the issue-first workflow in CLAUDE.md).
- **pnpm**: `corepack enable` against `package.json#packageManager` pin (9.15.0) — no drift.
- **postCreateCommand**: `corepack enable && pnpm install --frozen-lockfile`.
- **Forwarded ports**: 5173 (Vite), 6006 (Storybook), 8099 (HA add-on nginx).
- **Recommended extensions**: ESLint, Prettier, Playwright, Vitest Explorer, Docker, GitHub Pull Requests. Settings layer enables format-on-save and points TS SDK at the workspace `node_modules/typescript/lib`.

## Scope — In

- `.devcontainer/devcontainer.json` committed.
- [docs/devcontainer.md](docs/devcontainer.md) (Turkish) — setup, ports, extensions, validation flow, Codespaces path, troubleshooting, explicit out-of-scope items.
- README gets a one-liner pointer + a **Dev Container** entry under Dokümantasyon.

## Scope — Out

- **Expo / React Native emulator** inside the container — host-side (macOS/Linux simulator + Android emulator). Mobile build container is a future, separate issue.
- **Pre-baked image on GHCR** — plain `devcontainer.json` is sufficient until cold-start time becomes a pain point. When it does, swap in `image.ref` with a single-line change.

## Test plan

- [ ] `python3 -c "import json; json.load(open('.devcontainer/devcontainer.json'))"` → valid JSON.
- [ ] `pnpm format:check` on touched files — clean.
- [ ] `pnpm knip` — clean.
- [ ] Manual: "Reopen in Container" in VS Code → `pnpm install --frozen-lockfile` runs via postCreateCommand → `pnpm type-check && pnpm lint && pnpm build` green inside container.
- [ ] Manual: Forwarded ports 5173 / 6006 reachable from host when `pnpm dev` / `pnpm --filter @glaon/ui storybook` runs inside container.
- [ ] Manual: GitHub Codespaces launch on `103-dev-container` → same flow works without additional setup.
- [ ] CI unaffected — this is a dev-env change, not a CI or runtime change; all existing checks should be green.

## Notes

- The feature pins use the `:1` major tag (e.g. `docker-outside-of-docker:1`) — the devcontainer features registry is stable on majors and Renovate can bump within that range if needed.
- Settings are intentionally minimal; per-user preferences (keybindings, themes) stay out of the shared config.