### PR TITLE
chore(security): enable OSSF Scorecard supply-chain score

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: OSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 30
+
+      - name: Upload SARIF to GitHub code-scanning
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        with:
+          sarif_file: results.sarif

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -126,6 +126,50 @@ pinact run .github/workflows/
 
 Yeni bir third-party action'ı workflow'a eklerken pin'siz bir `uses:` commit'lemek kural ihlalidir — PR review'unda bloklanır.
 
+## OSSF Scorecard
+
+[OpenSSF Scorecard](https://github.com/ossf/scorecard) repo'yu ~20 supply-chain sinyaline göre (branch protection, SAST, token permissions, pinned-dependencies, signed-releases, code-review, vb.) puanlar. Kendi kurallarımızın ne kadarının makineye öğretildiğini dışarıdan bir gözle görmek için.
+
+Konum: [`.github/workflows/scorecard.yml`](../.github/workflows/scorecard.yml).
+
+### Tetikleme
+
+- **Haftalık schedule** — Pazartesi 01:30 UTC (CI trafiği en düşük pencere).
+- **`push` → `main`** — release-please PR'ı merge olduktan sonra baseline güncellenir.
+- **`branch_protection_rule`** — ruleset değişince Scorecard'ın branch-protection skoru anında refresh olur.
+
+### Token disiplini
+
+Top-level `permissions: read-all`; analysis job'u sadece ihtiyacı olan dört yazma/okuma hakkını (`security-events: write`, `id-token: write`, `contents: read`, `actions: read`) alır. `Token-Permissions` check'i bu minimal-principle kalıbı arar — top-level'da default verilseydi skor düşerdi.
+
+### Sonuçları nerede okurum?
+
+- **GitHub Security → Code scanning** — SARIF upload buraya düşer, findings "Scorecard" kaynağıyla etiketli.
+- **Workflow artifact** — `scorecard-sarif`, 30 gün tutulur; lokalde `sarif-fmt` veya VS Code SARIF Viewer ile açılır.
+- **Scorecard public API** — `publish_results: true` sayesinde `https://api.securityscorecards.dev/projects/github.com/toss-cengiz/glaon` endpoint'inde JSON.
+
+### Baseline
+
+İlk haftalık koşumdan sonra baseline ve her sinyalin durumu Security → Code scanning sekmesinde görünür. Badge README'ye eklenmez — skor ≥ 7.0 olmadan baseline reklamı yapmak ters tepki yaratır.
+
+### Düşük puanlı sinyallerin takibi
+
+Scorecard'ın her check'i kendi başına bir iyileştirme vektörü. Zaten kapatılmış Phase 0 işleri birkaç sinyali hazır hale getiriyor:
+
+| Scorecard check        | Neredeyiz?                          | Bağlı iş                           |
+| ---------------------- | ----------------------------------- | ---------------------------------- |
+| Branch-Protection      | development + main ruleset'lenmiş   | #69 (initial) + bu doküman         |
+| Pinned-Dependencies    | tüm GitHub Actions SHA'ya pinlenmiş | #94 (SHA pinning)                  |
+| Code-Review            | PR + linear history zorunlu         | #69 (initial)                      |
+| Dependency-Update-Tool | Renovate aktif                      | Renovate setup (tamamlanmış)       |
+| SAST                   | CodeQL koşuyor                      | #91 (CodeQL)                       |
+| Security-Policy        | `SECURITY.md` var                   | [docs/SECURITY.md](./SECURITY.md)  |
+| License                | LICENSE henüz yok                   | Follow-up (Phase 0 "Out of scope") |
+| Signed-Releases        | release-please henüz imzalamıyor    | Future (release infra genişlemesi) |
+| Fuzzing                | yok                                 | Future                             |
+
+İlk koşumdan sonra skor < 7.0 ise eksik sinyallerin her biri için gerektiğinde yeni issue açılır; Scorecard tek başına aksiyon üretmez, veri verir.
+
 ## CODEOWNERS
 
 [`.github/CODEOWNERS`](../.github/CODEOWNERS) her dosya path'ini en az bir sahibe bağlar. Tek maintainer (`@toss-cengiz`) olduğu için pratik etkisi henüz yok ama yapı hazır — yeni bir katılımcı geldiğinde path-based owner ataması tek commit.
@@ -198,4 +242,4 @@ Done.
 - [CODEOWNERS syntax](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
 - [pinact](https://github.com/suzuki-shunsuke/pinact) — GitHub Action SHA pinning aracı.
 - [OpenSSF Scorecard — Pinned-Dependencies](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) — SHA pinning kontrolünün gerekçesi.
-- İlgili issue: #69 (initial setup), #75 (merge method policy), #91 (CodeQL SAST), #92 (dependency review), #94 (SHA pinning).
+- İlgili issue: #69 (initial setup), #75 (merge method policy), #91 (CodeQL SAST), #92 (dependency review), #94 (SHA pinning), #98 (OSSF Scorecard).


### PR DESCRIPTION
## Summary

Adds [OpenSSF Scorecard](https://github.com/ossf/scorecard) as a weekly + on-push + on-ruleset-change analysis workflow. Gives us an outside-in score on ~20 supply-chain signals (branch protection, SAST, pinned-dependencies, token permissions, signed-releases, code-review, etc.) so we can see which of our own rules the machine has learned.

Findings land in GitHub Security → Code scanning and the public Scorecard API. Baseline + signal-to-issue mapping documented in `docs/governance.md`.

## Scope

**In**
- `.github/workflows/scorecard.yml` — triggers: weekly Monday 01:30 UTC, push to `main`, `branch_protection_rule`. Token discipline: top-level `permissions: read-all`; job holds only `security-events: write`, `id-token: write`, `contents: read`, `actions: read`.
- All third-party actions SHA-pinned with trailing version comment (`checkout` v4.3.1, `scorecard-action` v2.4.3, `upload-artifact` v4.6.2, `codeql-action/upload-sarif` v3).
- SARIF upload: 30-day workflow artifact + GitHub code-scanning ingestion.
- `publish_results: true` → results appear on `api.securityscorecards.dev`.
- `docs/governance.md` new "OSSF Scorecard" section documenting triggers, token discipline, result locations, baseline expectations, and the Scorecard-check → existing-issue mapping. `#98` added to the reference list.

**Out**
- Adding Scorecard to the required-status-checks list on `development`/`main` rulesets. Becomes required only after the first baseline score is observed and noise is measured — separate decision.
- README badge. Per the doc: no badge until score ≥ 7.0.
- Addressing individual low-scoring signals (License, Signed-Releases, Fuzzing). Tracked as follow-ups after the first run.

## Test plan

- [ ] `pnpm lint` green (no source change, but governance-level sanity).
- [ ] `pnpm knip` clean.
- [ ] `gh pr checks --watch` — all required checks green: `type-check · lint · audit`, `conventional-commits`, `gitleaks`, `review`, `visual regression`.
- [ ] Workflow file parses as valid YAML (validated via GitHub Actions schema — CI shows no parse error on the Actions tab).
- [ ] After merge: trigger one manual run (`gh workflow run "OSSF Scorecard"` on `main` after next release-please cycle) or wait for Monday 01:30 UTC schedule; confirm SARIF appears in Security → Code scanning and artifact `scorecard-sarif` is retained. (User action — post-merge verification; not part of this PR's green-CI gate.)

## User action

Post-merge, after the first Scorecard run completes: open Security → Code scanning, confirm the "Scorecard" source shows findings, note the overall score. If score < 7.0 on any check we control (Token-Permissions, Pinned-Dependencies, Branch-Protection, Code-Review, SAST), open follow-up issues per the table in `docs/governance.md`.

Closes #98