### PR TITLE
feat(release): attach SPDX SBOM artifacts to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,112 @@ jobs:
   release-please:
     name: release-please
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - id: release
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+  workspace-sbom:
+    name: workspace SBOM
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          persist-credentials: false
+
+      - name: Generate workspace SBOM (SPDX JSON)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: glaon-sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attach SBOM to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" glaon-sbom.spdx.json --clobber --repo "${{ github.repository }}"
+
+  addon-sbom:
+    name: add-on image SBOM (${{ matrix.arch }})
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            build_from: ghcr.io/home-assistant/amd64-base:3.21
+            platform: linux/amd64
+          - arch: aarch64
+            build_from: ghcr.io/home-assistant/aarch64-base:3.21
+            platform: linux/arm64
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build web + stage add-on context
+        run: pnpm build:addon
+
+      - name: Set up QEMU
+        if: matrix.arch != 'amd64'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build add-on image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: ./addon
+          file: ./addon/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            BUILD_FROM=${{ matrix.build_from }}
+          push: false
+          load: true
+          tags: glaon-addon:${{ matrix.arch }}
+
+      - name: Generate image SBOM (SPDX JSON)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: glaon-addon:${{ matrix.arch }}
+          format: spdx-json
+          output-file: glaon-addon-${{ matrix.arch }}-sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attach SBOM to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" "glaon-addon-${{ matrix.arch }}-sbom.spdx.json" --clobber --repo "${{ github.repository }}"

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -156,17 +156,17 @@ Top-level `permissions: read-all`; analysis job'u sadece ihtiyacı olan dört ya
 
 Scorecard'ın her check'i kendi başına bir iyileştirme vektörü. Zaten kapatılmış Phase 0 işleri birkaç sinyali hazır hale getiriyor:
 
-| Scorecard check        | Neredeyiz?                          | Bağlı iş                           |
-| ---------------------- | ----------------------------------- | ---------------------------------- |
-| Branch-Protection      | development + main ruleset'lenmiş   | #69 (initial) + bu doküman         |
-| Pinned-Dependencies    | tüm GitHub Actions SHA'ya pinlenmiş | #94 (SHA pinning)                  |
-| Code-Review            | PR + linear history zorunlu         | #69 (initial)                      |
-| Dependency-Update-Tool | Renovate aktif                      | Renovate setup (tamamlanmış)       |
-| SAST                   | CodeQL koşuyor                      | #91 (CodeQL)                       |
-| Security-Policy        | `SECURITY.md` var                   | [docs/SECURITY.md](./SECURITY.md)  |
-| License                | LICENSE henüz yok                   | Follow-up (Phase 0 "Out of scope") |
-| Signed-Releases        | release-please henüz imzalamıyor    | Future (release infra genişlemesi) |
-| Fuzzing                | yok                                 | Future                             |
+| Scorecard check        | Neredeyiz?                                 | Bağlı iş                           |
+| ---------------------- | ------------------------------------------ | ---------------------------------- |
+| Branch-Protection      | development + main ruleset'lenmiş          | #69 (initial) + bu doküman         |
+| Pinned-Dependencies    | tüm GitHub Actions SHA'ya pinlenmiş        | #94 (SHA pinning)                  |
+| Code-Review            | PR + linear history zorunlu                | #69 (initial)                      |
+| Dependency-Update-Tool | Renovate aktif                             | Renovate setup (tamamlanmış)       |
+| SAST                   | CodeQL koşuyor                             | #91 (CodeQL)                       |
+| Security-Policy        | `SECURITY.md` var                          | [docs/SECURITY.md](./SECURITY.md)  |
+| License                | LICENSE henüz yok                          | Follow-up (Phase 0 "Out of scope") |
+| Signed-Releases        | SBOM release'e ekleniyor, cosign henüz yok | #99 (SBOM), follow-up (cosign)     |
+| Fuzzing                | yok                                        | Future                             |
 
 İlk koşumdan sonra skor < 7.0 ise eksik sinyallerin her biri için gerektiğinde yeni issue açılır; Scorecard tek başına aksiyon üretmez, veri verir.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -56,6 +56,53 @@ Sen yalnızca Release PR'ı merge edersin; kalanı otomatik.
 
 **Neden squash commit başlığı kritik:** `development → main` merge edildiğinde release-please, `main`'e düşen her commit'in başlığını `@commitlint/config-conventional` kurallarına göre parse eder. Squash title PR_TITLE (bkz. `scripts/apply-repo-settings.sh`) olduğu için PR başlıkları zaten commitlint'ten geçmiş olur; ama release PR'ını açarken de aynı disiplin geçerli. Başlık `feat:`/`fix:`/`perf:`/`refactor:` ile başlamıyorsa release-please o commit'i CHANGELOG'da göstermez ve versiyon bump'ı üretmez.
 
+## Release artifact'leri — SBOM
+
+Her GitHub Release, [SPDX JSON](https://spdx.github.io/spdx-spec/v2.3/SPDX-JSON/) formatında Software Bill of Materials dosyalarıyla birlikte yayınlanır. Release-please release'i yarattıktan sonra aynı workflow'ta iki follow-up job koşar ve çıktıları release asset olarak yükler.
+
+### Hangi dosyalar ekli?
+
+| Dosya                                | Kaynak                                   | Kapsam                                                                 |
+| ------------------------------------ | ---------------------------------------- | ---------------------------------------------------------------------- |
+| `glaon-sbom.spdx.json`               | syft, `path: .` ile workspace taraması   | Tüm `pnpm-lock.yaml` + `package.json` zinciri (apps + packages + root) |
+| `glaon-addon-amd64-sbom.spdx.json`   | syft, build edilmiş add-on image üstünde | `amd64` add-on container'ı (base image + nginx + web bundle)           |
+| `glaon-addon-aarch64-sbom.spdx.json` | syft, build edilmiş add-on image üstünde | `aarch64` add-on container'ı                                           |
+
+Workspace SBOM: Node.js tarafındaki tüm doğrudan + transitive bağımlılıkları listeler. Mobile (Expo) build'i şu an kapsam dışı — mobile release pipeline ayrı bir iş ([#99](https://github.com/toss-cengiz/glaon/issues/99)'un "Scope — Out" notu).
+
+Image SBOM (arch başına): HA add-on olarak dağıtılan container'ın her iki architecture'ı için ayrı üretilir. Base image (`ghcr.io/home-assistant/*-base:3.21`) içindeki alpine paketleri, çalışma zamanında yüklenen `nginx`, ve `COPY dist` ile gelen web asset'lerini kapsar.
+
+### Nasıl indirir ve doğrularım?
+
+Release sayfasından tek tek indirilir; komut satırından toplu indirme:
+
+```bash
+gh release download v0.1.0 \
+  --pattern 'glaon-sbom.spdx.json' \
+  --pattern 'glaon-addon-*-sbom.spdx.json'
+```
+
+Dosyalar SPDX 2.3 JSON spec'ine uyar; hızlı bir sanity check için:
+
+```bash
+jq '.spdxVersion, .name, (.packages | length)' glaon-sbom.spdx.json
+# "SPDX-2.3"
+# "glaon"  (veya repo adı)
+# 450+     (workspace dep sayısı)
+```
+
+Vulnerability taraması için SBOM'u [grype](https://github.com/anchore/grype) gibi bir tool'a besleyebilirsin:
+
+```bash
+grype sbom:glaon-addon-amd64-sbom.spdx.json
+```
+
+### Şu an kapsam dışı — takip eden işler
+
+- **Cosign / Sigstore imzalaması**: SBOM dosyaları henüz kriptografik olarak imzalanmıyor. [#99](https://github.com/toss-cengiz/glaon/issues/99)'un "Scope — Out" notu bu adımı bir sonraki güvenlik iterasyonuna bırakır. İmzalamadan sonra `glaon-sbom.spdx.json.sig` formatında ek asset'ler düşecek ve bu bölüm doğrulama komutuyla güncellenecek.
+- **VEX attestation'ları**: Hangi CVE'lerin aslında Glaon'un runtime'ında exploit edilemediğini tanımlayan VEX belgeleri henüz üretilmiyor. Grype çıktısındaki false-positive'ler için yakın gelecekte planlı.
+- **Mobile SBOM**: Expo prebuild + EAS build pipeline'ı mobile release issue'sunda ele alınacak; SBOM üretimi o akışa entegre edilir.
+
 ## Manuel tag — acil durum fallback
 
 release-please çalışmadığı durumda (workflow bozuk, API limit, vb.) manuel tag:


### PR DESCRIPTION
## Summary

Extends the release workflow so every `vX.Y.Z` GitHub Release ships with SPDX JSON Software Bills of Materials for both the Node workspace and the HA add-on container image (per-arch). Generation runs inside the same `release-please` workflow and only fires when release-please actually creates a release — no cost on release-PR churn.

## Scope

**In**
- `.github/workflows/release.yml`:
  - `release-please` job now exposes `release_created` and `tag_name` as outputs.
  - `workspace-sbom` job (gated on `release_created == 'true'`) — checks out the tagged ref, runs `anchore/sbom-action` against `path: .`, produces `glaon-sbom.spdx.json`, uploads it to the release via `gh release upload`.
  - `addon-sbom` matrix job (amd64 + aarch64) — reuses the build steps from `addon-build.yml` (pnpm install → `pnpm build:addon` → setup-qemu for aarch64 → buildx load), then scans the loaded `glaon-addon:<arch>` image with `anchore/sbom-action` and uploads `glaon-addon-<arch>-sbom.spdx.json` to the same release.
- New actions SHA-pinned: `anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0`. Existing pins (`actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/build-push-action`) reused.
- Token discipline: `release-please` retains `contents: write` + `pull-requests: write`; the SBOM jobs scope `contents: write` only (no `pull-requests`). Nothing else widens.
- `docs/release.md` — new "Release artifact'leri — SBOM" section: artifact table, retrieval + sanity check + grype example, Scope-Out list (cosign, VEX, mobile).
- `docs/governance.md` — Scorecard "Signed-Releases" row updated to reflect SBOM presence + pending cosign work.

**Out**
- **Cosign / Sigstore signing** of the SBOMs (and the release commit). Follow-up issue — noted in the `docs/release.md` "Scope-Out" list and in the Scorecard table.
- **VEX attestations** for false-positive CVEs from grype.
- **Mobile SBOM** (Expo / EAS). Belongs to the mobile release pipeline issue — explicitly out of #99's scope.
- **Adding the SBOM jobs to required status checks.** They only run on `push: main` when a release is created; there is no required-check semantics to add.

## Test plan

- [ ] `pnpm lint` green.
- [ ] `pnpm knip` clean.
- [ ] `gh pr checks --watch` — all required checks green: `type-check · lint · audit`, `conventional-commits`, `gitleaks`, `review`, `visual regression`.
- [ ] Workflow YAML parses — no error shown in the Actions tab for this PR.
- [ ] First real release after merge: Release PR (`chore(main): release vX.Y.Z`) is merged → on the resulting push to `main`, workflow runs; verify the release page shows three SPDX artifacts (`glaon-sbom.spdx.json`, `glaon-addon-amd64-sbom.spdx.json`, `glaon-addon-aarch64-sbom.spdx.json`). (User action — post-merge, gated on the first release cut.)
- [ ] Download one artifact and `jq '.spdxVersion' glaon-sbom.spdx.json` returns `"SPDX-2.3"`.

## User action

- Post-merge, at the first actual release cut: watch the Release workflow run; confirm the three SPDX assets attach successfully. If any of the SBOM jobs fail, the Release itself still exists — manually re-running the job (via **Re-run failed jobs**) is safe since the release tag already exists and `gh release upload --clobber` is idempotent.

Closes #99