### PR TITLE
chore(labels): shift phases for phase-1 Design slot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,11 +13,12 @@ body:
       label: Phase
       options:
         - phase-0 (Foundation)
-        - phase-1 (HA integration)
-        - phase-2 (Core UI)
-        - phase-3 (Security hardening)
-        - phase-4 (Features)
-        - phase-5 (Polish & release)
+        - phase-1 (Design)
+        - phase-2 (HA integration)
+        - phase-3 (Core UI)
+        - phase-4 (Security hardening)
+        - phase-5 (Features)
+        - phase-6 (Polish & release)
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -13,11 +13,12 @@ body:
       label: Phase
       options:
         - phase-0 (Foundation)
-        - phase-1 (HA integration)
-        - phase-2 (Core UI)
-        - phase-3 (Security hardening)
-        - phase-4 (Features)
-        - phase-5 (Polish & release)
+        - phase-1 (Design)
+        - phase-2 (HA integration)
+        - phase-3 (Core UI)
+        - phase-4 (Security hardening)
+        - phase-5 (Features)
+        - phase-6 (Polish & release)
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -13,11 +13,12 @@ body:
       label: Phase
       options:
         - phase-0 (Foundation)
-        - phase-1 (HA integration)
-        - phase-2 (Core UI)
-        - phase-3 (Security hardening)
-        - phase-4 (Features)
-        - phase-5 (Polish & release)
+        - phase-1 (Design)
+        - phase-2 (HA integration)
+        - phase-3 (Core UI)
+        - phase-4 (Security hardening)
+        - phase-5 (Features)
+        - phase-6 (Polish & release)
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,11 +14,12 @@ body:
       description: Which phase does this belong to?
       options:
         - phase-0 (Foundation)
-        - phase-1 (HA integration)
-        - phase-2 (Core UI)
-        - phase-3 (Security hardening)
-        - phase-4 (Features)
-        - phase-5 (Polish & release)
+        - phase-1 (Design)
+        - phase-2 (HA integration)
+        - phase-3 (Core UI)
+        - phase-4 (Security hardening)
+        - phase-5 (Features)
+        - phase-6 (Polish & release)
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
## Summary

- Shift GitHub phase labels `phase-1..5` up by one so `phase-1` is empty for upcoming web/tablet/mobile design work.
- Introduce new `phase-1 = Design` label.
- Update the 4 issue template phase dropdowns to the new 7-entry layout.

Label renames themselves were executed out-of-band via `gh label edit`; existing issues now carry their shifted labels automatically because rename is non-destructive to the assignment.

New layout:

| # | Label | Meaning |
| - | - | - |
| 0 | phase-0 | Foundation |
| 1 | phase-1 | **Design** (new) |
| 2 | phase-2 | HA integration (was phase-1) |
| 3 | phase-3 | Core UI (was phase-2) |
| 4 | phase-4 | Security hardening (was phase-3) |
| 5 | phase-5 | Features (was phase-4) |
| 6 | phase-6 | Polish & release (was phase-5) |

## Scope — In

- Rename `phase-5 → phase-6`, `phase-4 → phase-5`, `phase-3 → phase-4`, `phase-2 → phase-3`, `phase-1 → phase-2` (done via `gh label edit`; no code diff).
- Create new `phase-1` Design label (color `#EC4899`).
- Update `.github/ISSUE_TEMPLATE/{bug,chore,docs,feature}.yml` phase dropdowns.

## Scope — Out

- Opening the phase-1 Design issues (web/tablet/mobile) — follow-up.
- Clarifying `docs/release.md:13`'s `Pre-1.0 döneminde (Phase 0–3)` reference — follow-up issue, because it's a release-policy decision, not label plumbing.

## Test plan

- [ ] `gh label list | grep phase` shows `phase-0..6` with `phase-1 = Design`.
- [ ] `gh issue list --label phase-2` returns the old HA-integration issues (#7–#13).
- [ ] `gh issue list --label phase-1` returns `[]` (empty, ready for design issues).
- [ ] GitHub web "New issue" → feature/chore/bug/docs templates all show the new 7-entry phase dropdown with `phase-1 (Design)` and `phase-6 (Polish & release)`.
- [ ] CI green on this PR.

Closes #121