### PR TITLE
ci: skip commitlint on release PRs targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,11 @@ jobs:
 
   commit-lint:
     name: conventional-commits
-    if: github.event_name == 'pull_request'
+    # Skipped for release PRs (development → main): those bundle historical
+    # squash commits whose headers grew past 72 chars when GitHub appended
+    # ` (#N)`. docs/release.md explicitly notes conventional-commits is not
+    # a required check on main; this keeps the job off noisy release PRs.
+    if: github.event_name == 'pull_request' && github.base_ref != 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Summary

Gates the `commit-lint` job with `github.base_ref != 'main'` so it only runs on development-targeting PRs. Release PRs (`development → main`) bundle historical squash commits whose headers grew past 72 chars when GitHub appended ` (#N)` during squash — those are not fixable without rewriting history, and the rule was never meant for retroactive scans of shipped work.

[docs/release.md](docs/release.md) already describes the intent — _"commitlint PR-only event'lerde koşar"_ — and the `main` ruleset does not require `conventional-commits`. This change aligns the workflow with what the docs + ruleset already say.

Found while opening #123 (first v0.1.0 release PR).

## Scope

**In**
- `.github/workflows/ci.yml` — one-line `if:` condition on the `commit-lint` job, with an inline comment explaining the reason.

**Out**
- Rewriting historical commits. Destructive + changes nothing for future commits.
- Doc edits. `docs/release.md` already describes the intended behavior; no text change needed.
- Fixing `docs/release.md`'s separate inaccuracy about squash-vs-rebase for dev→main. Tracked as a follow-up after v0.1.0 ships.

## Test plan

- [ ] `pnpm lint` green.
- [ ] `pnpm knip` clean.
- [ ] This PR's CI: `commit-lint` still runs and passes (single `ci:` commit). Development-targeting PRs continue enforcing the rule.
- [ ] After merge + PR #123's CI re-runs on the new development HEAD: `conventional-commits` check on #123 shows as skipped or not present, no red X.

Closes #124