### PR TITLE
chore(labels): add area:design to issue template dropdowns

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -31,6 +31,7 @@ body:
         - area:mobile
         - area:core
         - area:ui
+        - area:design
         - area:addon
         - area:ci
         - area:security

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -31,6 +31,7 @@ body:
         - area:mobile
         - area:core
         - area:ui
+        - area:design
         - area:addon
         - area:ci
         - area:security

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -31,6 +31,7 @@ body:
         - area:mobile
         - area:core
         - area:ui
+        - area:design
         - area:addon
         - area:ci
         - area:security

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -33,6 +33,7 @@ body:
         - area:mobile
         - area:core
         - area:ui
+        - area:design
         - area:addon
         - area:ci
         - area:security


### PR DESCRIPTION
## Summary

- Creates `area:design` label out-of-band via `gh label create area:design --color FBCFE8` (pastel pink, thematically aligned with `phase-1 Design = #EC4899`).
- Adds `area:design` to the `areas` multi-select in all four issue templates (bug, chore, docs, feature), slotted between `area:ui` and `area:addon` so visual-surface categories stay adjacent.

Follows the precedent set in #122: label metadata lives in GitHub, not in a repo-side YAML; the dropdown wiring is the only code diff.

## Scope — In

- `.github/ISSUE_TEMPLATE/bug.yml`
- `.github/ISSUE_TEMPLATE/chore.yml`
- `.github/ISSUE_TEMPLATE/docs.yml`
- `.github/ISSUE_TEMPLATE/feature.yml`

## Scope — Out

- Opening the phase-1 brand-guideline issues (docs baseline, color, typography, spacing/radii/shadow, logo usage) — follow-ups after this lands.
- Relabelling existing issues — none of the current open issues are brand-guideline work.

## Test plan

- [x] `gh label list | grep area:design` shows the new label with color `#FBCFE8`.
- [ ] GitHub web "New issue" → feature/chore/bug/docs templates all show `area:design` in the area multi-select, between `area:ui` and `area:addon`.
- [ ] CI green on this PR.

Closes #129