### PR TITLE
docs(figma): add Brand Guideline as canonical brand source

### DIFF
--- a/.claude/skills/brand-design/SKILL.md
+++ b/.claude/skills/brand-design/SKILL.md
@@ -32,7 +32,7 @@ Out of scope (route elsewhere):
 
 ## Brand inputs
 
-Glaon's Design System Figma file is the canonical source. When the file is populated, the tokens and primitives land there first; this skill references them via the naming convention in `docs/figma.md`.
+Glaon's Brand Guideline Figma file is the canonical source for brand decisions — color rationale, typography scale, spacing/radii/shadow, logo usage, component personality. The Design System Figma file consumes those decisions later as published token primitives. Both files are tabled in [docs/figma.md](../../../docs/figma.md#dosya-yapısı).
 
 ### Color palette
 

--- a/docs/figma.md
+++ b/docs/figma.md
@@ -12,18 +12,24 @@ Bu sayfa:
 
 ## Dosya yapısı
 
-Üç ayrı Figma dosyası (aynı takım / workspace altında):
+Dört ayrı Figma dosyası (aynı takım / workspace altında):
 
-| Dosya             | İçerik                                                                               | URL                                                                 |
-| ----------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
-| **Design System** | Primitive'ler, color palette, type scale, spacing, radii, shadow — published library | <https://www.figma.com/design/KP0SVNxQEjT0gotajwc9I0/Design-System> |
-| **Components**    | Design System'i tüketen composite component'ler (Card, Dialog, DeviceTile…)          | <https://www.figma.com/design/auyB12SfWNs3eUho4UpI2k/Components>    |
-| **Screens**       | Web + mobile ekran mockup'ları (dashboard, detail, settings…)                        | <https://www.figma.com/design/JdUxahXzXwVAsjkgzIjIT9/Screens>       |
+| Dosya               | İçerik                                                                                                       | Faz      | URL                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------ | -------- | ------------------------------------------------------------------- |
+| **Brand Guideline** | Color rationale, typography, spacing/radii/shadow, logo usage, do/don't — brand kararlarının kanonik kaynağı | phase-1  | <https://www.figma.com/design/JLbLmCMDdhxOisbVYiAo5C/Glaon>         |
+| **Design System**   | Primitive'ler, color palette, type scale, spacing, radii, shadow — published library                         | phase-3+ | <https://www.figma.com/design/KP0SVNxQEjT0gotajwc9I0/Design-System> |
+| **Components**      | Design System'i tüketen composite component'ler (Card, Dialog, DeviceTile…)                                  | phase-3+ | <https://www.figma.com/design/auyB12SfWNs3eUho4UpI2k/Components>    |
+| **Screens**         | Web + mobile ekran mockup'ları (dashboard, detail, settings…)                                                | phase-3+ | <https://www.figma.com/design/JdUxahXzXwVAsjkgzIjIT9/Screens>       |
 
-Tüm takım üyeleri üçüne de en az "can view" seviyesinde erişime sahip olur.
+Tüm takım üyeleri dördüne de en az "can view" seviyesinde erişime sahip olur.
 
-### Neden üç dosya?
+### Faz eşlemesi
 
+Brand Guideline **phase-1**'de aktif olarak kullanılır; Glaon'un brand kararlarının (renk rationale'ı, tipografi, spacing/radii/shadow, logo kullanımı, do/don't) kanonik kaynağıdır. Design System library bu kararları token primitive'leri olarak **phase-3 ve sonrasında** yayınlar; Components ve Screens aynı fazlarda onu tüketir. Yani brand decisions önce Brand Guideline'da karara bağlanır, sonra Design System library'ye düşer — tek yönlü bir akış.
+
+### Neden dört dosya?
+
+- **Rationale vs published library**: Brand Guideline brand kararlarının ve do/don't'ların yaşadığı dosya; Design System bu kararları tüketen published token + primitive library. Rationale curated ve seyrek değişir; library versiyonlanır ve token değişiklikleri consumer dosyalara yayılır. Tek dosyada "rationale'ı neden değiştirmiyoruz?" ile "library'yi neden bump'lıyoruz?" aynı branch'te karışır.
 - **Library vs consumer ayrımı**: Design System published library olduğunda, Components ve Screens dosyaları onu tüketir (version pinning, instance override trace'i). Tek dosyada karışık olsa branch publish karmaşık hale gelir.
 - **Scope-based review**: Token değişikliği Design System PR'ında, yeni composite Components dosyasında, ekran mockup'ı Screens dosyasında tartışılır.
 - **Chromatic-Figma uyumu** (#53): Chromatic Figma plugin'i bir Storybook component'ini bir Figma component'ine map ederken, Design System dosyasındaki kanonik olanı işaret eder.


### PR DESCRIPTION
## Summary

- Adds the Brand Guideline Figma file (`JLbLmCMDdhxOisbVYiAo5C/Glaon`) to the canonical file table in `docs/figma.md` as the fourth file, slotted before Design System so the natural reading order follows the one-way flow (brand decisions → published token library → consumers).
- Introduces a "Faz" column on that table so phase-1 vs phase-3+ scope is visible at a glance; adds a short "Faz eşlemesi" paragraph below the table spelling out the flow.
- Renames the "Neden üç dosya?" rationale section to "Neden dört dosya?" and leads with a new *rationale-vs-published-library* bullet that justifies keeping brand-guideline and design-system files separate (rationale is stable and curated, library versions and propagates to consumers).
- Updates `.claude/skills/brand-design/SKILL.md` "Brand inputs" so brand-level questions route to the Brand Guideline file as the canonical source; the Design System file is now correctly described as the downstream consumer.

## Scope — In

- `docs/figma.md` (file table, section rename, phase-mapping paragraph)
- `.claude/skills/brand-design/SKILL.md` (Brand inputs pointer)

## Scope — Out

- Populating Figma variables (color, typography, spacing/radii/shadow, logo usage) — covered by the follow-up phase-1 issues #132 / #133 / #134 / #135.
- Touching the Design System / Components / Screens URLs — unchanged placeholders until those phases open.
- Token generator / Style Dictionary wiring — remains deferred per `docs/figma.md#follow-up-işler-bu-issue-kapsamı-dışı`.

## Test plan

- [x] `docs/figma.md` file table has a Brand Guideline row with the correct URL and the new Faz column.
- [x] "Faz eşlemesi" paragraph is present and references the 4-file model.
- [x] `.claude/skills/brand-design/SKILL.md` Brand inputs section points at the Brand Guideline file (with an anchor link to the `docs/figma.md#dosya-yapısı` section).
- [x] Prettier passes (pre-commit hook green).
- [ ] CI green on this PR.

Closes #131