### PR TITLE
docs(design-system): bootstrap spec, plugin scripts, pinned Figma URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,14 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 ## Design Source of Truth (MANDATORY)
 
 - Figma is the canonical source for Glaon's design: colors, spacing, typography, shadow, component visuals, and screen mockups all live there. Code **references** this source — it does not invent parallel values.
+- Three canonical Figma files (always reachable; pinned here so they never drift out of context):
+  - **Brand Guideline** — color rationale, typography, spacing/radii/shadow, logo, do/don't. Brand decisions live here. <https://www.figma.com/design/JLbLmCMDdhxOisbVYiAo5C/Brand-Guidelines>
+  - **Design System** — Glaon's published primitive library. Variables + text styles + re-skinned primitives. <https://www.figma.com/design/KP0SVNxQEjT0gotajwc9I0/Design-System>
+  - **Untitled UI** — licensed third-party kit. Used as the source we **detach + re-skin** primitives from; never consumed directly by Components/Screens. <https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/UntitledUI>
 - Design tokens are not hand-typed. They are exported from Figma Variables via the Figma Tokens plugin, committed as JSON, and transformed by Style Dictionary into per-platform outputs. Hex codes and raw spacing numbers don't appear in component code; token references do.
 - New primitives are designed in Figma first. A code-only primitive without a Figma counterpart is not mergeable — design review gate applies before the Storybook story is written.
 - Figma component descriptions carry the Storybook component ID in the form `storybook-id: <kebab-case>`. This is the contract that Chromatic's Figma plugin (#53) relies on; don't change the format without coordinating that integration.
-- Setup and workflow details: [docs/figma.md](docs/figma.md).
+- Setup and workflow details: [docs/figma.md](docs/figma.md). Design System bootstrap spec: [docs/design-system-bootstrap.md](docs/design-system-bootstrap.md).
 
 ## Storybook Rule (MANDATORY)
 

--- a/docs/design-system-bootstrap.md
+++ b/docs/design-system-bootstrap.md
@@ -1,0 +1,128 @@
+# Design System Bootstrap
+
+Glaon Design System Figma dosyasını ([KP0SVNxQEjT0gotajwc9I0/Design-System](https://www.figma.com/design/KP0SVNxQEjT0gotajwc9I0/Design-System)) ilk çalışır hâle getirecek teknik runbook. Brand kararları Brand Guideline'da yaşıyor, kod tarafı henüz token'ları tüketmiyor; bu doc o ikisinin arasındaki katmanı tanımlar.
+
+Bu doc kanonik referans **rationale** değil — Brand-decision rationale'ı `.claude/skills/brand-design/SKILL.md` ve Brand Guideline Figma dosyasındadır. Burada **nasıl bootstrap'lenir** ve **dosya yapısı ne olmalı** sorularına cevap veriyoruz.
+
+## Yapı genel bakış
+
+Üç Figma dosyası, tek yönlü akış:
+
+```
+Brand Guideline   →   Design System   →   Components / Screens / Code
+(decisions)           (this doc)           (consumers)
+```
+
+Untitled UI ([cDLzPUkcsDJtvwqZLWRwrd/UntitledUI](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/UntitledUI)) Design System'in **kaynak materyali** — primitive'leri oradan **detach + re-skin** ederek Glaon Semantic variable'larına bağlıyoruz. Untitled UI kendisi consumer'lar tarafından doğrudan referans edilmez.
+
+## Sayfa yapısı
+
+Design System dosyası şu altı sayfayı, bu sırayla içerir:
+
+| Sayfa           | İçerik                                                                                                                                                                                                                                   |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Cover**       | Dosyanın rolü, sahibi, library publish durumu, Brand Guideline + Untitled UI dosyalarına link, Untitled UI lisans/attribution paragrafı, "nasıl tüketilir" not.                                                                          |
+| **Variables**   | `Primitives` ve `Semantic` koleksiyonlarının kanonik gösterimi (swatch'ler, scale tabloları). Variables Figma'nın sol panelinde yaşar; bu sayfa görsel referans + dokümantasyondur.                                                      |
+| **Foundations** | Text styles (Display/Heading/Body/Caption × Web/RN), spacing/radii/shadow scale örnekleri, color usage do/don't.                                                                                                                         |
+| **Components**  | Detach edilmiş + re-skin edilmiş primitive'ler. Her primitive bir frame; variants/sizes/states matrisi yan yana. Component description'ında `storybook-id: <kebab-case>` zorunlu.                                                        |
+| **Patterns**    | Birden çok primitive'in birlikte kullanıldığı kabul edilmiş örüntüler (form layout, card hierarchy, modal flow). Composite component değil — örnek, "böyle birleştirilebilir" demonstrasyonu. Composite'lar Components Figma dosyasında. |
+| **Changelog**   | Library publish'leri arası yapılan değişikliklerin manuel kaydı (Figma henüz bunu otomatikleştirmiyor). Her publish'te bir frame: tarih, değişen Variables/styles/components listesi, breaking change uyarısı.                           |
+
+## Variables — koleksiyonlar ve modes
+
+İki koleksiyon, iki mode ekseni:
+
+### Koleksiyonlar
+
+- **Primitives** — Brand Guideline'daki ham değerlerin Design System'deki yansıması. `color/sand/100`, `color/night-blue/500`, `space/4`, `radius/md`, `shadow/card` gibi. Brand Guideline kısmen dolu olduğu sürece bazı primitive'ler de eksik kalır; eksikler `null` veya placeholder olarak işaretlenir.
+- **Semantic** — Components'in tükettiği isimler. `surface/default`, `text/primary` vb. Her semantic variable bir primitive'e (ya da ileride: başka bir semantic'e) bind'lenir.
+
+### Modes
+
+- **Theme**: `light`, `dark`. Dark bindings #140 inene kadar Light primitive'lere fallback.
+- **Platform** Figma'da ayrı bir mode değil. Web ile mobile arasındaki farklar (RN spacing multiplier, font stack) **Style Dictionary transform katmanında** uygulanır — Figma sadece base değerleri tutar. Platform-spesifik bir token gerçekten gerekirse (örn. `font/family/web` vs. `font/family/rn`) bunu mode yerine variable name'inde kodlarız.
+
+### Semantic taksonomi
+
+Bu liste sabittir; yeni semantic eklemek için Brand-decision issue gerekir (#137 / #138 / #139 örnekleri). İlk slice'ta tanımlananlar:
+
+| Grup      | Variable                                             | Örnek Light binding (Brand Guideline ilerledikçe doğrulanır) |
+| --------- | ---------------------------------------------------- | ------------------------------------------------------------ |
+| `surface` | `surface/default`, `surface/muted`, `surface/raised` | Kirli Beyaz, Kirli Beyaz tint, beyaz veya alpha (#139)       |
+| `text`    | `text/primary`, `text/muted`, `text/inverse`         | Night Blue, Night Blue 60%, Kirli Beyaz                      |
+| `border`  | `border/subtle`, `border/strong`                     | Sand line, Night Blue 20%                                    |
+| `brand`   | `brand/primary`, `brand/hover`, `brand/pressed`      | Brand primary; hover/pressed #138 ile karara bağlanır        |
+| `state`   | `state/success`, `state/warning`, `state/danger`     | Brand palette içinden; danger #137 ile karara bağlanır       |
+
+Eksik kalanlar (`brand/hover`, `brand/pressed`, `state/danger`, `surface/raised`) Brand-decision issue'ları kapanana kadar Light primitive'e geçici fallback ile bind'lenir. Semantic _isimleri_ değişmez — yalnız değerler güncellenir.
+
+## Untitled UI: detach + re-skin
+
+Karar: **detach + re-skin** (subscribe ya da reference değil).
+
+### Akış
+
+1. **Kopyala**: Untitled UI dosyasında ihtiyacımız olan primitive'i seç → Cmd/Ctrl+C → Design System Components sayfasına yapıştır.
+2. **Detach**: Yapıştırılan instance'ı `Detach instance` ile master link'inden ayır. Artık yerel component'tir; Untitled UI'nin sonraki güncellemelerinden bağımsız.
+3. **Re-skin**: Plugin script (#147 pattern'i) fill/stroke/text bağlamalarını Glaon `Semantic` variable'larına yeniden bağlar. Hard-coded renk kalmaz; raw spacing/sayılar Glaon `Primitives` üzerinden ifade edilir.
+4. **Variants doğrula**: `intent / size / state` matrisi Components sayfasına serilir. Eksik state varsa o primitive'in issue'sında not düşülür.
+5. **Tag'le**: Component description'a `storybook-id: web-primitives-<name>` ekle. Chromatic Figma plugin'i (#53) bu etiketi okuyor.
+6. **Publish**: Library publish manuel adım. Variables → Publish; Components → Publish. Kullanıcı tetikler.
+
+### Lisans / attribution
+
+Untitled UI ücretli bir kit; lisans koşulları her publish'te Cover sayfasında atıf paragrafıyla taşınır. Re-skin'in lisans gereksinimini karşıladığından emin olmak Glaon ekibinin sorumluluğunda; ilk publish öncesi lisans paragrafının doldurulmuş olması zorunlu (placeholder ile başlanır, ilk publish'te tamamlanır).
+
+## Plugin script çalıştırma akışı
+
+Tüm bootstrap operasyonları `tools/figma-plugin/scripts/` altında commit edilir. Per-task akış (bkz. `tools/figma-plugin/README.md`):
+
+1. Çalıştırmak istediğin script'i seç (`01-variables-bootstrap.js`, `02-text-styles.js`, `03-button-import-reskin.js`).
+2. İçeriğini `tools/figma-plugin/code.js`'in üzerine yapıştır.
+3. Figma desktop'ta dosyayı aç → Plugins → Development → Glaon → çalıştır.
+4. **Dry-run (default)**: `CONFIRM = false` ile script ne yapacağının özetini `figma.notify` üzerinden gösterir, mutasyon yapmaz.
+5. Özeti onayladıysan script'in başındaki `CONFIRM = true` flag'ini aç → tekrar çalıştır.
+6. Figma'da değişiklikleri review et (Variables panel, Components sayfası).
+7. Memnunsan library'i publish et. Değilsen `Ctrl+Z` ile geri al.
+8. `code.js`'i scaffold haline döndür: `git restore tools/figma-plugin/code.js`.
+
+Idempotent olduğu için her script tekrar çalıştırılabilir — eksik mode/variable ekler, var olanı yeniden yaratmaz. Brand Guideline ilerledikçe `01-variables-bootstrap.js` yeniden çalıştırılır; eski değerler korunur, yenileri yamalanır.
+
+## storybook-id format
+
+Her customize edilen primitive'in component description'ında:
+
+```
+storybook-id: web-primitives-<kebab-case>
+```
+
+Format: Storybook CSF path'inin kebab-case çevirisi. Örnekler:
+
+| Primitive                       | storybook-id                     |
+| ------------------------------- | -------------------------------- |
+| `Web Primitives/Button`         | `web-primitives-button`          |
+| `Web Primitives/Input`          | `web-primitives-input`           |
+| `Web Primitives/Card`           | `web-primitives-card`            |
+| `RN Primitives/PressableButton` | `rn-primitives-pressable-button` |
+
+Detay: [docs/figma.md — Component description → Storybook ID](figma.md#component-description--storybook-id).
+
+## Sonra ne var?
+
+Bu doc bittiğinde sıra:
+
+1. **Foundation issue'ları** kapanır: #144 (file scaffold), #145 (Variables), #146 (typography).
+2. **Button issue'su** (#147) end-to-end pattern'i kurar.
+3. **Follow-up primitive grupları** (#148–#152) Button pattern'ini kopyalar.
+4. **Library publish edilir** → Components / Screens dosyaları subscribe edebilir.
+5. **Token JSON export** (deferred — `docs/figma.md` follow-ups) — design tokens kod tarafına bağlanır.
+6. **Phase-3 kod consumer'ları** başlar (#14, #15, #17).
+
+## Referanslar
+
+- Brand-decision skill: [.claude/skills/brand-design/SKILL.md](../.claude/skills/brand-design/SKILL.md)
+- Figma file ladder + naming + token akışı: [docs/figma.md](figma.md)
+- Plugin contract (guardrails): [tools/figma-plugin/README.md](../tools/figma-plugin/README.md)
+- Chromatic Figma plugin entegrasyonu: [docs/chromatic.md](chromatic.md#figma-entegrasyonu)
+- Brand-decision issue'ları: #132 (color), #133 (type), #134 (spacing/radii/shadow), #137 (state/danger), #138 (brand/hover-pressed), #139 (surface/raised), #140 (dark mode).
+- Design-system foundation issue'ları: #142, #143, #144, #145, #146, #147; follow-up primitive grupları: #148–#152.

--- a/docs/figma.md
+++ b/docs/figma.md
@@ -25,7 +25,7 @@ Tüm takım üyeleri dördüne de en az "can view" seviyesinde erişime sahip ol
 
 ### Faz eşlemesi
 
-Brand Guideline **phase-1**'de aktif olarak kullanılır; Glaon'un brand kararlarının (renk rationale'ı, tipografi, spacing/radii/shadow, logo kullanımı, do/don't) kanonik kaynağıdır. Design System library bu kararları token primitive'leri olarak **phase-3 ve sonrasında** yayınlar; Components ve Screens aynı fazlarda onu tüketir. Yani brand decisions önce Brand Guideline'da karara bağlanır, sonra Design System library'ye düşer — tek yönlü bir akış.
+Brand Guideline **phase-1**'de aktif olarak kullanılır; Glaon'un brand kararlarının (renk rationale'ı, tipografi, spacing/radii/shadow, logo kullanımı, do/don't) kanonik kaynağıdır. Design System library'nin foundation çalışması (Variables koleksiyonları, text styles, ilk primitive set) **phase-0** altında — bkz. [docs/design-system-bootstrap.md](design-system-bootstrap.md) ve epic #141. Components ve Screens dosyaları phase-3 ve sonrasında bu library'yi tüketir. Yani brand decisions önce Brand Guideline'da karara bağlanır, sonra Design System library'ye düşer, sonra Components/Screens onu tüketir — tek yönlü bir akış.
 
 ### Neden dört dosya?
 

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "ignore": ["tools/figma-plugin/code.js", ".lighthouserc.cjs", ".lighthouserc.mobile.cjs"],
+  "ignore": [
+    "tools/figma-plugin/code.js",
+    "tools/figma-plugin/scripts/**",
+    ".lighthouserc.cjs",
+    ".lighthouserc.mobile.cjs"
+  ],
   "ignoreBinaries": ["eslint"],
   "workspaces": {
     ".": {

--- a/tools/figma-plugin/README.md
+++ b/tools/figma-plugin/README.md
@@ -7,7 +7,8 @@ Detaylı workflow ve kurallar: [docs/figma.md](../../docs/figma.md#claude-author
 ## Dosyalar
 
 - `manifest.json` — Figma Plugin manifest (API 1.0). `editorType` hem `"figma"` hem `"dev"` içerir, yani plugin Design Mode ve Dev Mode'da import edilebilir. Network access kapalı; dynamic-page access açık (büyük dosyalarda page-by-page yükler).
-- `code.js` — plugin entry. Scaffold hali sadece notification gösterip kapanır. Her task için Claude bu dosyanın içeriğini yeniden yazar; commit etmeyiz, lokal kullanılır ve `git restore` ile scaffold'a dönülür.
+- `code.js` — plugin entry. Scaffold hali sadece notification gösterip kapanır. Her task için bu dosyanın içeriği yeniden yazılır; ad-hoc task'larda commit etmeyiz, lokal kullanılır ve `git restore` ile scaffold'a dönülür.
+- `scripts/` — yeniden kullanılabilir, commit'li script kütüphanesi. Bootstrap operasyonları (Variables yaratma, text styles ekleme, primitive re-skin) bu dizinde yaşar; per-task çalıştırmak için içeriği `code.js`'e kopyalanır.
 - `brand-design` skill (`.claude/skills/brand-design/SKILL.md`) — plugin script'i üretirken Claude'un uymak zorunda olduğu guardrail'leri tanımlar (dry-run default, `CONFIRM` flag, no network, notify+closePlugin).
 
 ## Figma'ya nasıl yüklenir?
@@ -22,12 +23,31 @@ Detaylı workflow ve kurallar: [docs/figma.md](../../docs/figma.md#claude-author
 
 ## Task akışı (Claude-authored script)
 
-1. İhtiyaç doğar: "bu variable'ları yeniden adlandır", "bu renk palette'ini ekle", vb.
+İki kanal var: `scripts/` altındaki yeniden kullanılabilir script'ler ve ad-hoc per-task script'ler. İkisi de aynı `code.js` entry'si üzerinden çalışır.
+
+### Scripts/ ile çalışmak (yeniden kullanılabilir)
+
+`scripts/` dizininde commit edilmiş bootstrap operasyonları için:
+
+1. İlgili dosyayı seç (örn. `scripts/01-variables-bootstrap.js`).
+2. Tüm içeriğini `tools/figma-plugin/code.js`'in üzerine kopyala.
+3. Figma desktop'ta hedef dosyayı aç → Plugins → Development → Glaon → çalıştır.
+4. Default `CONFIRM = false` → dry-run özeti `figma.notify` ile görünür, mutasyon yok.
+5. Özeti onayladıysan script'in başındaki `CONFIRM = true` flag'ini elle aç → tekrar çalıştır.
+6. Figma'da değişiklikleri review et → memnunsan library'yi publish et; değilse `Ctrl+Z`.
+7. `code.js`'i scaffold haline döndür: `git restore tools/figma-plugin/code.js`.
+
+`scripts/` dosyaları idempotent yazılır — yeniden çalıştırmak güvenlidir; var olan node'ları yeniden yaratmaz, eksikleri ekler.
+
+### Ad-hoc per-task script
+
+Yeniden kullanım planı olmayan tek-seferlik operasyonlar için:
+
+1. İhtiyaç doğar: "bu variable'ları yeniden adlandır", "bu rengi şu node'a ata", vb.
 2. Claude görevi `brand-design` skill'i üzerinden analiz eder ve `code.js`'e uygun script'i yazar.
-3. Script default **dry-run**: mutasyon yerine ne değişeceğinin özetini `figma.notify` ile gösterir.
-4. Dry-run çıktısını doğruladıktan sonra script'in başındaki `CONFIRM = true` flag'ini elle aç ve yeniden çalıştır.
-5. Figma'da değişiklikleri review et → tatmin ediciyse Design System dosyasını **publish** et (library bump); değilse `Ctrl+Z` / Figma history ile geri al.
-6. `code.js`'i scaffold haline döndür (`git restore tools/figma-plugin/code.js`) — task'a özel script'ler repo'ya commit edilmez. Yeniden kullanılabilir bir operasyon çıkarsa ayrı issue + düzgün bir script modülü olarak eklenir.
+3. Script default **dry-run**, `CONFIRM = true` ile mutasyona geçer.
+4. Figma'da review + publish veya undo.
+5. `code.js`'i scaffold haline döndür (`git restore tools/figma-plugin/code.js`) — ad-hoc script'ler repo'ya commit edilmez. Yeniden kullanılabilir olduğu ortaya çıkarsa ayrı issue açılıp `scripts/` altına taşınır.
 
 ## Neden plugin, neden REST değil?
 

--- a/tools/figma-plugin/scripts/01-variables-bootstrap.js
+++ b/tools/figma-plugin/scripts/01-variables-bootstrap.js
@@ -1,0 +1,183 @@
+// Glaon — 01 Variables Bootstrap
+//
+// Creates the `Primitives` and `Semantic` Variables collections in the
+// Design System Figma file with `Theme: Light / Dark` modes, and lays
+// down the canonical Semantic taxonomy from
+// docs/design-system-bootstrap.md.
+//
+// Usage:
+//   1. Copy this file's contents into tools/figma-plugin/code.js.
+//   2. Open the Design System Figma file.
+//   3. Edit the BRAND_REF map below to fill in any Brand Guideline
+//      values you have. Anything left as `null` is created as a visible
+//      placeholder (magenta) and listed in the dry-run summary.
+//   4. Run the plugin (Plugins → Development → Glaon).
+//   5. Review the dry-run notification; flip CONFIRM to true; re-run.
+//   6. After confirm, review Variables panel → publish library.
+//   7. `git restore tools/figma-plugin/code.js` to scaffold.
+//
+// Idempotent: re-running after Brand Guideline updates only adds the new
+// variables / modes; existing entries are kept.
+
+const CONFIRM = false;
+
+// Placeholder magenta — easy to spot in the file as "not yet defined".
+const PLACEHOLDER = { r: 1, g: 0, b: 1, a: 1 };
+
+// Brand Guideline values — fill in what's known, leave `null` for the rest.
+// Format: { r, g, b, a } with 0..1 channels, OR null.
+const BRAND_REF = {
+  // Neutrals
+  'color/kirli-beyaz': null, // off-white surface base
+  'color/sand-100': null,
+  'color/sand-300': null,
+  'color/night-blue-500': null, // primary text
+  'color/night-blue-700': null,
+  // Brand
+  'color/brand-primary': null,
+  'color/brand-primary-hover': null, // #138 follow-up
+  'color/brand-primary-pressed': null, // #138 follow-up
+  // States
+  'color/state-success': null,
+  'color/state-warning': null,
+  'color/state-danger': null, // #137 follow-up
+};
+
+// Semantic taxonomy. Keys are variable names; values are the Primitives
+// they bind to (per spec). If the primitive is missing, the semantic gets
+// a placeholder fallback so consumers can still wire up.
+const SEMANTIC_BINDINGS = {
+  'surface/default': 'color/kirli-beyaz',
+  'surface/muted': 'color/sand-100',
+  'surface/raised': 'color/kirli-beyaz', // #139 follow-up may shift
+  'text/primary': 'color/night-blue-500',
+  'text/muted': 'color/night-blue-700',
+  'text/inverse': 'color/kirli-beyaz',
+  'border/subtle': 'color/sand-300',
+  'border/strong': 'color/night-blue-500',
+  'brand/primary': 'color/brand-primary',
+  'brand/hover': 'color/brand-primary-hover',
+  'brand/pressed': 'color/brand-primary-pressed',
+  'state/success': 'color/state-success',
+  'state/warning': 'color/state-warning',
+  'state/danger': 'color/state-danger',
+};
+
+(async () => {
+  try {
+    const collections = await figma.variables.getLocalVariableCollectionsAsync();
+    const created = [];
+    const updated = [];
+    const missing = [];
+
+    // --- Primitives collection ---
+    let primitivesCol = collections.find((c) => c.name === 'Primitives');
+    if (!primitivesCol) {
+      if (CONFIRM) {
+        primitivesCol = figma.variables.createVariableCollection('Primitives');
+      }
+      created.push('collection: Primitives');
+    }
+    const primitivesModes = ensureThemeModes(primitivesCol, CONFIRM, created);
+
+    // --- Semantic collection ---
+    let semanticCol = collections.find((c) => c.name === 'Semantic');
+    if (!semanticCol) {
+      if (CONFIRM) {
+        semanticCol = figma.variables.createVariableCollection('Semantic');
+      }
+      created.push('collection: Semantic');
+    }
+    const semanticModes = ensureThemeModes(semanticCol, CONFIRM, created);
+
+    // --- Primitives variables ---
+    const allVars = await figma.variables.getLocalVariablesAsync('COLOR');
+    const primitiveVarsByName = new Map();
+    for (const [name, value] of Object.entries(BRAND_REF)) {
+      let v = allVars.find(
+        (x) => x.name === name && x.variableCollectionId === (primitivesCol?.id ?? null),
+      );
+      const concreteValue = value ?? PLACEHOLDER;
+      if (!v) {
+        if (CONFIRM && primitivesCol) {
+          v = figma.variables.createVariable(name, primitivesCol, 'COLOR');
+          v.setValueForMode(primitivesModes.light, concreteValue);
+          v.setValueForMode(primitivesModes.dark, concreteValue);
+        }
+        created.push(`primitive: ${name}${value ? '' : ' (placeholder)'}`);
+      } else if (CONFIRM) {
+        // Update placeholder if we now have a real value.
+        if (value) {
+          v.setValueForMode(primitivesModes.light, concreteValue);
+          v.setValueForMode(primitivesModes.dark, concreteValue);
+          updated.push(`primitive: ${name}`);
+        }
+      }
+      if (value === null) missing.push(name);
+      if (v) primitiveVarsByName.set(name, v);
+    }
+
+    // --- Semantic variables ---
+    for (const [semanticName, primitiveName] of Object.entries(SEMANTIC_BINDINGS)) {
+      let v = allVars.find(
+        (x) => x.name === semanticName && x.variableCollectionId === (semanticCol?.id ?? null),
+      );
+      if (!v) {
+        if (CONFIRM && semanticCol) {
+          v = figma.variables.createVariable(semanticName, semanticCol, 'COLOR');
+        }
+        created.push(`semantic: ${semanticName}`);
+      }
+      if (CONFIRM && v && primitiveVarsByName.has(primitiveName)) {
+        const target = primitiveVarsByName.get(primitiveName);
+        const alias = { type: 'VARIABLE_ALIAS', id: target.id };
+        v.setValueForMode(semanticModes.light, alias);
+        v.setValueForMode(semanticModes.dark, alias); // Dark fallback to Light until #140
+      }
+    }
+
+    const summary = [
+      CONFIRM ? '✅ APPLIED' : '🔍 DRY-RUN',
+      `created: ${created.length}`,
+      `updated: ${updated.length}`,
+      `missing brand values: ${missing.length}`,
+    ].join(' · ');
+    figma.notify(summary, { timeout: 8000 });
+    if (created.length || updated.length || missing.length) {
+      console.log('[Glaon variables-bootstrap]');
+      if (created.length) console.log('Created:', created);
+      if (updated.length) console.log('Updated:', updated);
+      if (missing.length) console.log('Missing (placeholder used):', missing);
+    }
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();
+
+function ensureThemeModes(collection, confirm, created) {
+  if (!collection) {
+    return { light: null, dark: null };
+  }
+  // Default mode named "Mode 1" or similar — rename to Light if there is only one.
+  let lightMode = collection.modes.find((m) => /light/i.test(m.name));
+  let darkMode = collection.modes.find((m) => /dark/i.test(m.name));
+  if (!lightMode) {
+    if (confirm) {
+      const target = collection.modes[0];
+      collection.renameMode(target.modeId, 'Light');
+      lightMode = collection.modes.find((m) => m.name === 'Light');
+    }
+    created.push(`mode: ${collection.name}/Light`);
+  }
+  if (!darkMode) {
+    if (confirm) {
+      const id = collection.addMode('Dark');
+      darkMode = { modeId: id, name: 'Dark' };
+    }
+    created.push(`mode: ${collection.name}/Dark`);
+  }
+  return { light: lightMode?.modeId, dark: darkMode?.modeId };
+}

--- a/tools/figma-plugin/scripts/02-text-styles.js
+++ b/tools/figma-plugin/scripts/02-text-styles.js
@@ -1,0 +1,104 @@
+// Glaon — 02 Text Styles
+//
+// Creates Glaon's canonical text style family (Display / Heading / Body /
+// Caption) in the Design System Figma file. Web and RN sets are created
+// in parallel namespaces. Numeric properties are hard-coded for the first
+// pass; once typography Variables land per #146, this script is updated
+// to bind to them.
+//
+// Usage:
+//   1. Copy this file's contents into tools/figma-plugin/code.js.
+//   2. Open the Design System Figma file. Run #145 first so collections
+//      exist (this script is independent of them but the order keeps the
+//      file tidy).
+//   3. Edit the FONT block below if Brand Guideline has a typography
+//      decision (#133); otherwise the placeholder Inter / Inter is used.
+//   4. Run plugin (Plugins → Development → Glaon).
+//   5. Review dry-run; flip CONFIRM; re-run; review styles in Figma.
+//
+// Idempotent: existing styles with the same name are skipped (not
+// overwritten). To force an update, delete the style first or extend the
+// script.
+
+const CONFIRM = false;
+
+// Replace these with Brand Guideline #133 outcome when available.
+const FONT = {
+  web: {
+    family: 'Inter',
+    regular: 'Regular',
+    medium: 'Medium',
+    semibold: 'SemiBold',
+    bold: 'Bold',
+  },
+  rn: { family: 'Inter', regular: 'Regular', medium: 'Medium', semibold: 'SemiBold', bold: 'Bold' },
+};
+
+// Scale (px / line-height multiplier / weight). Mirrors a typical 1.25
+// modular scale; replace with #133 outcome.
+const SCALE = [
+  { name: 'Display/XL', size: 56, line: 1.1, weight: 'bold' },
+  { name: 'Display/LG', size: 44, line: 1.15, weight: 'bold' },
+  { name: 'Display/MD', size: 36, line: 1.2, weight: 'semibold' },
+  { name: 'Heading/H1', size: 28, line: 1.25, weight: 'semibold' },
+  { name: 'Heading/H2', size: 24, line: 1.3, weight: 'semibold' },
+  { name: 'Heading/H3', size: 20, line: 1.35, weight: 'medium' },
+  { name: 'Heading/H4', size: 18, line: 1.4, weight: 'medium' },
+  { name: 'Body/LG', size: 18, line: 1.5, weight: 'regular' },
+  { name: 'Body/MD', size: 16, line: 1.5, weight: 'regular' },
+  { name: 'Body/SM', size: 14, line: 1.5, weight: 'regular' },
+  { name: 'Caption', size: 12, line: 1.4, weight: 'medium' },
+];
+
+(async () => {
+  try {
+    const existing = await figma.getLocalTextStylesAsync();
+    const created = [];
+    const skipped = [];
+
+    for (const platform of ['Web', 'RN']) {
+      const fontConfig = FONT[platform.toLowerCase()];
+      // Pre-load all weights we'll use across the scale.
+      if (CONFIRM) {
+        const weights = new Set(SCALE.map((s) => fontConfig[s.weight] || 'Regular'));
+        for (const style of weights) {
+          await figma.loadFontAsync({ family: fontConfig.family, style });
+        }
+      }
+
+      for (const entry of SCALE) {
+        const fullName = `${platform}/${entry.name}`;
+        const dup = existing.find((s) => s.name === fullName);
+        if (dup) {
+          skipped.push(fullName);
+          continue;
+        }
+        if (CONFIRM) {
+          const style = figma.createTextStyle();
+          style.name = fullName;
+          style.fontName = {
+            family: fontConfig.family,
+            style: fontConfig[entry.weight] || 'Regular',
+          };
+          style.fontSize = entry.size;
+          style.lineHeight = { value: entry.size * entry.line, unit: 'PIXELS' };
+        }
+        created.push(fullName);
+      }
+    }
+
+    const summary = [
+      CONFIRM ? '✅ APPLIED' : '🔍 DRY-RUN',
+      `created: ${created.length}`,
+      `skipped (existing): ${skipped.length}`,
+    ].join(' · ');
+    figma.notify(summary, { timeout: 8000 });
+    if (created.length) console.log('[Glaon text-styles] Created:', created);
+    if (skipped.length) console.log('[Glaon text-styles] Skipped:', skipped);
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();

--- a/tools/figma-plugin/scripts/03-button-import-reskin.js
+++ b/tools/figma-plugin/scripts/03-button-import-reskin.js
@@ -1,0 +1,180 @@
+// Glaon — 03 Button Import + Re-skin
+//
+// Re-binds an Untitled UI Button (already pasted + detached on the
+// Components page of the Design System file) to Glaon's Semantic
+// variables, and tags the component description with
+// `storybook-id: web-primitives-button`. Pattern: this is the template
+// every other primitive issue (#148–#152) copies.
+//
+// Prerequisites:
+//   - Variables collection `Semantic` exists (run 01-variables-bootstrap
+//     first).
+//   - The Untitled UI Button has been copied into the Design System
+//     file's `Components` page and `Detach instance`'d. The detached
+//     component (a COMPONENT_SET or COMPONENT node) is selected before
+//     running this plugin.
+//
+// What it does:
+//   - Walks the selection tree.
+//   - For each fill/stroke of every node, applies a heuristic mapping
+//     in BIND_MAP to assign a Semantic variable. Adjust BIND_MAP based
+//     on dry-run output before flipping CONFIRM.
+//   - Sets the component description to `storybook-id: web-primitives-button`.
+//
+// Usage:
+//   1. Run scripts/01-variables-bootstrap.js first.
+//   2. Paste the Untitled UI Button into Components page; Detach.
+//   3. Select the resulting component / component set node.
+//   4. Copy this script's contents into tools/figma-plugin/code.js.
+//   5. Run plugin → review dry-run summary (lists every fill found and
+//      what it would bind to).
+//   6. Adjust BIND_MAP if the heuristic missed something.
+//   7. Flip CONFIRM = true → re-run.
+
+const CONFIRM = false;
+
+const STORYBOOK_ID = 'web-primitives-button';
+
+// Heuristic: node-name substring → Semantic variable name.
+// Order matters; first match wins. Adjust based on the actual UUI Button
+// node tree (visible in the dry-run console output).
+const BIND_MAP = [
+  // intent: primary
+  { match: /primary.*background|fill.*primary/i, fill: 'brand/primary' },
+  { match: /primary.*hover/i, fill: 'brand/hover' },
+  { match: /primary.*pressed|primary.*active/i, fill: 'brand/pressed' },
+  { match: /primary.*label|primary.*text/i, fill: 'text/inverse' },
+  // intent: secondary / outline
+  { match: /secondary.*background|outline.*background/i, fill: 'surface/default' },
+  { match: /secondary.*border|outline.*border/i, fill: 'border/strong' },
+  { match: /secondary.*label|outline.*label|secondary.*text/i, fill: 'text/primary' },
+  // intent: ghost
+  { match: /ghost.*background/i, fill: 'surface/muted' },
+  { match: /ghost.*label|ghost.*text/i, fill: 'text/primary' },
+  // intent: destructive
+  { match: /destructive.*background|danger.*background/i, fill: 'state/danger' },
+  { match: /destructive.*label|destructive.*text/i, fill: 'text/inverse' },
+  // states
+  { match: /disabled.*background/i, fill: 'surface/muted' },
+  { match: /disabled.*label|disabled.*text/i, fill: 'text/muted' },
+  // generic fallbacks
+  { match: /label|text/i, fill: 'text/primary' },
+  { match: /background|fill/i, fill: 'surface/default' },
+];
+
+(async () => {
+  try {
+    const selection = figma.currentPage.selection;
+    if (selection.length !== 1) {
+      figma.notify('Select exactly one COMPONENT or COMPONENT_SET node first.', { error: true });
+      figma.closePlugin();
+      return;
+    }
+    const root = selection[0];
+    if (root.type !== 'COMPONENT' && root.type !== 'COMPONENT_SET') {
+      figma.notify(`Selected node is ${root.type}; expected COMPONENT or COMPONENT_SET.`, {
+        error: true,
+      });
+      figma.closePlugin();
+      return;
+    }
+
+    const semanticVars = (await figma.variables.getLocalVariablesAsync('COLOR')).filter((v) =>
+      v.name.includes('/'),
+    );
+    const semanticByName = new Map(semanticVars.map((v) => [v.name, v]));
+
+    const plan = [];
+    const skipped = [];
+    walk(root, (node) => {
+      if ('fills' in node && Array.isArray(node.fills)) {
+        for (let i = 0; i < node.fills.length; i++) {
+          const fill = node.fills[i];
+          if (fill.type !== 'SOLID') continue;
+          const target = pickBinding(node.name);
+          if (!target) {
+            skipped.push(`${node.name} fill[${i}] (no rule)`);
+            continue;
+          }
+          const variable = semanticByName.get(target);
+          if (!variable) {
+            skipped.push(
+              `${node.name} fill[${i}] → ${target} (variable missing — run 01-variables-bootstrap)`,
+            );
+            continue;
+          }
+          plan.push({ node, fillIndex: i, target, variable });
+        }
+      }
+    });
+
+    if (CONFIRM) {
+      for (const entry of plan) {
+        const fills = clone(entry.node.fills);
+        fills[entry.fillIndex] = figma.variables.setBoundVariableForPaint(
+          fills[entry.fillIndex],
+          'color',
+          entry.variable,
+        );
+        entry.node.fills = fills;
+      }
+      // Set storybook-id on the component description (or all variants).
+      if (root.type === 'COMPONENT') {
+        root.description = mergeStorybookId(root.description);
+      } else {
+        for (const child of root.children) {
+          if (child.type === 'COMPONENT') {
+            child.description = mergeStorybookId(child.description);
+          }
+        }
+        root.description = mergeStorybookId(root.description);
+      }
+    }
+
+    const summary = [
+      CONFIRM ? '✅ APPLIED' : '🔍 DRY-RUN',
+      `bindings: ${plan.length}`,
+      `skipped: ${skipped.length}`,
+    ].join(' · ');
+    figma.notify(summary, { timeout: 8000 });
+    console.log('[Glaon button-reskin] Plan:');
+    for (const entry of plan)
+      console.log(`  ${entry.node.name} fill[${entry.fillIndex}] → ${entry.target}`);
+    if (skipped.length) {
+      console.log('[Glaon button-reskin] Skipped:');
+      for (const s of skipped) console.log(`  ${s}`);
+    }
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();
+
+function walk(node, fn) {
+  fn(node);
+  if ('children' in node) {
+    for (const child of node.children) walk(child, fn);
+  }
+}
+
+function pickBinding(nodeName) {
+  for (const rule of BIND_MAP) {
+    if (rule.match.test(nodeName)) return rule.fill;
+  }
+  return null;
+}
+
+function mergeStorybookId(existing) {
+  const tag = `storybook-id: ${STORYBOOK_ID}`;
+  if (!existing) return tag;
+  if (existing.includes('storybook-id:')) {
+    return existing.replace(/storybook-id:\s*\S+/g, tag);
+  }
+  return `${existing}\n\n${tag}`;
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}


### PR DESCRIPTION
## Summary

- Pin three canonical Figma URLs (Brand Guideline, Design System, Untitled UI) into `CLAUDE.md` so they're always in context.
- Add `docs/design-system-bootstrap.md` — the technical spec for the Design System Figma file: page layout, Variables (`Primitives` + `Semantic` with `Theme` modes), detach + re-skin workflow over Untitled UI, license/attribution, per-script execution flow.
- Introduce `tools/figma-plugin/scripts/` for committed, idempotent bootstrap scripts; document the per-task copy-into-`code.js` flow alongside the existing ad-hoc workflow.
- Ship the first-slice scripts (Phase-0 foundation + Button end-to-end):
  - `01-variables-bootstrap.js` — `Primitives` + `Semantic` collections, Light/Dark modes, canonical taxonomy with placeholders for Brand Guideline gaps.
  - `02-text-styles.js` — Display / Heading / Body / Caption family for Web + RN.
  - `03-button-import-reskin.js` — re-binds an UUI Button copy on Components page to Semantic variables; tags `storybook-id: web-primitives-button`.
- Update `docs/figma.md` to point at the new bootstrap doc and clarify phase mapping.
- `knip.json` ignores `tools/figma-plugin/scripts/**` next to the existing `code.js` ignore.

## Scope — In

- Doc changes: `CLAUDE.md`, `docs/figma.md`, new `docs/design-system-bootstrap.md`, `tools/figma-plugin/README.md`.
- Build hygiene: `knip.json` ignore extension.
- Plugin scripts: three bootstrap scripts under `tools/figma-plugin/scripts/`.

## Scope — Out

- Running the plugin scripts in Figma — manual user action, tracked under #144 / #145 / #146 / #147.
- Code-side `@glaon/ui` Button refactor to consume Glaon tokens — phase-3 (#14, #15).
- Token JSON export / Style Dictionary — deferred per `docs/figma.md` follow-ups.
- Other primitive groups (Form, Surface+Overlay, Navigation, Feedback, Data Display) — separate phase-0 issues #148–#152.

## Test plan

- [x] `pnpm type-check` passes locally.
- [x] `pnpm lint` passes locally.
- [x] `pnpm prettier --check` passes for changed files.
- [x] `pnpm knip` passes locally.
- [x] `pnpm syncpack:lint` passes locally.
- [x] CI green on this PR (verify, package-contract, unit-tests, size-check, gitleaks, commitlint, Chromatic).
- [ ] User runs `01-variables-bootstrap.js` in Design System Figma → dry-run summary inspected → `CONFIRM=true` → re-run → Variables panel shows Primitives + Semantic.
- [ ] User runs `02-text-styles.js` → Web/* and RN/* style families visible in Local styles.
- [ ] User pastes + detaches an UUI Button on Components page, runs `03-button-import-reskin.js` → bindings list reviewed → confirm → component description carries `storybook-id: web-primitives-button`.
- [ ] Library publish (manual) recorded on Changelog page in the Design System file.

## Related

Closes #142
Closes #143
Refs #141 (epic), #144, #145, #146, #147, #148, #149, #150, #151, #152

https://claude.ai/code/session_01YVYgnn3dZAubfzJbXoBZia

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVYgnn3dZAubfzJbXoBZia)_