### PR TITLE
fix(figma-plugin): drop optional chaining + nullish coalescing in 01-variables-bootstrap

### DIFF
--- a/tools/figma-plugin/scripts/01-variables-bootstrap.js
+++ b/tools/figma-plugin/scripts/01-variables-bootstrap.js
@@ -95,9 +95,10 @@ const SEMANTIC_BINDINGS = {
     const primitiveVarsByName = new Map();
     for (const [name, value] of Object.entries(BRAND_REF)) {
       let v = allVars.find(
-        (x) => x.name === name && x.variableCollectionId === (primitivesCol?.id ?? null),
+        (x) =>
+          x.name === name && x.variableCollectionId === (primitivesCol ? primitivesCol.id : null),
       );
-      const concreteValue = value ?? PLACEHOLDER;
+      const concreteValue = value !== null ? value : PLACEHOLDER;
       if (!v) {
         if (CONFIRM && primitivesCol) {
           v = figma.variables.createVariable(name, primitivesCol, 'COLOR');
@@ -120,7 +121,9 @@ const SEMANTIC_BINDINGS = {
     // --- Semantic variables ---
     for (const [semanticName, primitiveName] of Object.entries(SEMANTIC_BINDINGS)) {
       let v = allVars.find(
-        (x) => x.name === semanticName && x.variableCollectionId === (semanticCol?.id ?? null),
+        (x) =>
+          x.name === semanticName &&
+          x.variableCollectionId === (semanticCol ? semanticCol.id : null),
       );
       if (!v) {
         if (CONFIRM && semanticCol) {
@@ -179,5 +182,8 @@ function ensureThemeModes(collection, confirm, created) {
     }
     created.push(`mode: ${collection.name}/Dark`);
   }
-  return { light: lightMode?.modeId, dark: darkMode?.modeId };
+  return {
+    light: lightMode ? lightMode.modeId : null,
+    dark: darkMode ? darkMode.modeId : null,
+  };
 }


### PR DESCRIPTION
## Summary

- Replace optional chaining (`?.`) and nullish coalescing (`??`) in `01-variables-bootstrap.js` with classic equivalents — Figma plugin `api: 1.0.0` runtime threw `Syntax error on line 98: Unexpected token .` before any mutation could run, blocking #145.
- `02-text-styles.js` and `03-button-import-reskin.js` are clean (verified by `grep -E '\?\.|\?\?'`).

## Scope — In

- 4 line edits in `tools/figma-plugin/scripts/01-variables-bootstrap.js`.

## Scope — Out

- Manifest `api` upgrade.
- Automated script-syntax CI check.

## Test plan

- [x] `grep -E '\?\.|\?\?' tools/figma-plugin/scripts/*.js` is empty.
- [x] `node --check 01-variables-bootstrap.js` passes.
- [x] `pnpm prettier --check` passes for the file.
- [ ] User runs the script in the Design System Figma file → no syntax error → dry-run notification appears.
- [ ] CI green.

## Related

Closes #154
Refs #141 (epic), #145

https://claude.ai/code/session_01YVYgnn3dZAubfzJbXoBZia

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVYgnn3dZAubfzJbXoBZia)_