### PR TITLE
chore(mcp): add Figma Remote MCP entry to repo-scoped .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,10 @@
       "headers": {
         "X-Client-Id": "cdf3737dff9d485485968e50b63fd8b4"
       }
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 - Skip list: `dependabot/**` and `release-please--**`. Other bot branches should not be added without discussion.
 - `CHROMATIC_PROJECT_TOKEN` secret is user-managed; see [docs/chromatic.md](docs/chromatic.md). Branch protection for `development` and `main` is codified as ruleset JSON — see [docs/governance.md](docs/governance.md).
 - Chromatic MCP: after the first successful publish, the remote endpoint exposes only `docs` tools. Dev/test tools stay on the local Storybook server — don't try to replicate them remotely.
-- The Chromatic MCP entry in `.mcp.json` is part of the repo contract — don't edit or remove it as a drive-by. New MCP servers get their own entry and their own issue; breaking changes to the existing Chromatic URL require a tracked migration PR.
+- The MCP entries in `.mcp.json` (Chromatic, Figma) are part of the repo contract — don't edit or remove them as a drive-by. New MCP servers get their own entry and their own issue; breaking changes to existing URLs require a tracked migration PR. Auth tokens for OAuth-based MCPs (Figma) live per-user in Claude Code config and are never committed; see [docs/figma.md](docs/figma.md#per-developer-kurulum) for the per-developer authenticate flow.
 - Chromatic also runs a Figma design-code diff on each build. Every Storybook story is mapped to its Figma counterpart via the `storybook-id: <kebab-case>` string in the Figma component description (see [docs/figma.md](docs/figma.md#component-description--storybook-id)). When a build shows `Not implemented` or `Design changed`, treat it as a signal to coordinate a follow-up with design, not as a Chromatic config glitch.
 
 ## PR Scope & Test Plan Sync (MANDATORY)

--- a/docs/figma.md
+++ b/docs/figma.md
@@ -72,36 +72,38 @@ Token isimlendirmesi: `color.brand.primary`, `space.4`, `radius.md`, `shadow.car
 
 ## Figma Remote MCP
 
-Claude Code ve diğer agent'lar Figma Remote MCP üzerinden tasarım dosyalarını okur (component listesi, frame'ler, variable'lar). Lokal Figma desktop app'inin MCP server'ı (dev-mode) ayrı bir kanaldır; Glaon için remote MCP kullanılır çünkü takımın tümü aynı endpoint'e bağlanır.
+Claude Code ve diğer agent'lar Figma Remote MCP üzerinden tasarım dosyalarını okur (component listesi, frame'ler, variable'lar). Lokal Figma desktop app'inin MCP server'ı (dev-mode) ayrı bir kanaldır; Glaon için **hosted Remote MCP** (`https://mcp.figma.com/mcp`) kullanılır çünkü takımın tümü aynı endpoint'e bağlanır.
 
-### Kurulum
+### Konfigürasyon
 
-1. Figma hesabı ile giriş yap → Team'de **Dev mode** ve MCP enabled.
-2. Claude Code → Figma MCP authenticate tool'u tetikle; browser OAuth flow'u açılır.
-3. Onaylanan scope: file read (component, variable, frame metadata). **Write scope istenmez.**
-4. Repo kökündeki [`.mcp.json`](../.mcp.json)'a Figma entry'si eklenir (_yazma sırası: OAuth başarıyla döndükten sonra, ayrı commit_). Beklenen şekil:
+Repo-scoped: [`.mcp.json`](../.mcp.json)'da `figma` server'ı tanımlı. Header gerekmiyor — auth OAuth ile out-of-band yürüyor; token Figma tarafında "Connected apps" altında, Claude Code tarafında ise kullanıcı config'inde (lokal, repo'ya yazılmaz) tutulur.
 
-   ```jsonc
-   {
-     "mcpServers": {
-       "chromatic": { "...mevcut...": true },
-       "figma": {
-         "type": "http",
-         "url": "https://<figma-remote-endpoint>",
-         "headers": { "...auth metadata...": "" },
-       },
-     },
-   }
-   ```
+```jsonc
+{
+  "mcpServers": {
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp",
+    },
+  },
+}
+```
 
-   > Gerçek URL ve auth header'lar Figma tarafından OAuth callback'inde sağlanır; şu an placeholder. `.mcp.json` güncellemesi OAuth başarıyla tamamlanana kadar ertelenir.
+### Per-developer kurulum
 
-5. `claude mcp list` → `figma` status **connected**.
+Repo entry'si paylaşılan, ama OAuth her makinede ayrı yürür. Yeni geliştirici:
+
+1. Figma hesabı ile giriş yap → Team'de **Dev mode** + MCP enabled (admin ayarı).
+2. Claude Code session'ında `/mcp` slash command'ını çalıştır → server listesinde `figma` görünür, status **needs authentication**.
+3. `figma` üzerinde **Authenticate** seçeneğini tetikle → tarayıcıda Figma OAuth ekranı açılır.
+4. Onaylanan scope: file read (component, variable, frame metadata). **Write scope istenmez.**
+5. Onay → Claude Code'a geri dön → `claude mcp list` → `figma` status **connected**.
 
 ### Kullanım sınırları
 
-- Read-only. Agent Figma'da değişiklik yapmaz; tasarım değişiklikleri insan aksiyonudur.
+- Read-only. Agent Figma'da değişiklik yapmaz; tasarım değişiklikleri insan aksiyonudur (bkz. `tools/figma-plugin/`).
 - Büyük dosyalarda frame sayısı MCP response boyutunu şişirir; spesifik component/page sorgula.
+- CI'da Figma MCP bağlanmaz — interactive OAuth flow CI'da çalışmaz, ihtiyaç da yok (CI Storybook + Chromatic üzerinden gidiyor).
 
 ## Naming convention (Figma ⇄ kod)
 
@@ -190,7 +192,7 @@ Skill ve plugin loop'u _kendisi_ kapatmaz — önerir ve devretir.
 | Konu                                             | Durum                                                           |
 | ------------------------------------------------ | --------------------------------------------------------------- |
 | Figma Tokens plugin + Style Dictionary generator | ayrı issue açılacak (dosyalar + ilk token set'i olduktan sonra) |
-| Figma MCP `.mcp.json` entry                      | OAuth başarılı olunca küçük PR                                  |
+| Figma MCP `.mcp.json` entry                      | #156 ile eklendi                                                |
 | Chromatic ⇄ Figma design-code diff               | #53                                                             |
 | Figma branching + design review Slack bot        | ayrı issue                                                      |
 | REST `file:write` scope değerlendirmesi          | plugin akışı yetersiz kalırsa ayrı issue                        |


### PR DESCRIPTION
## Summary

- Add `figma` server to repo-scoped `.mcp.json` with URL `https://mcp.figma.com/mcp`. No headers — Figma's hosted MCP authenticates via OAuth out-of-band; tokens stay per-user in Claude Code config and are never committed.
- Replace the placeholder MCP section in `docs/figma.md` with the real configuration + a per-developer `/mcp` authenticate walkthrough.
- Mark the "Figma MCP `.mcp.json` entry" follow-up row as done (#156).
- Extend the `CLAUDE.md` "MCP entry is repo contract" note from Chromatic-only to cover both servers; link to the per-developer setup section.

## Scope — In

- `.mcp.json` — one new server entry.
- `docs/figma.md` — replace placeholder block; update follow-up table.
- `CLAUDE.md` — generalize the MCP repo-contract note.

## Scope — Out

- PAT-based fallback (`X-Figma-Token: ${FIGMA_PAT}`) — OAuth flow works; gerekirse ayrı issue.
- CI integration — interactive OAuth doesn't run in CI; Figma MCP stays Claude-Code-session-only.
- Migrating any per-user `claude mcp add` config — developers can `claude mcp remove "figma" -s local` after this lands and the repo-scoped entry takes over.

## Test plan

- [x] `pnpm prettier --check` passes for changed files.
- [x] CI green.
- [ ] After merge, on a developer machine: open Claude Code → `/mcp` → `figma` listed → Authenticate → browser OAuth → status `connected`. (User has confirmed OAuth was completed once already on per-user scope; this PR just promotes the entry to repo-scoped.)
- [ ] After merge, in a fresh sandbox session, the entry is automatically available (auth still per-user).

## Related

Closes #156
Refs #141 (epic), #145

https://claude.ai/code/session_01YVYgnn3dZAubfzJbXoBZia

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVYgnn3dZAubfzJbXoBZia)_