### PR TITLE
docs(brand): fill color palette rationale in brand-design skill

### DIFF
--- a/.claude/skills/brand-design/SKILL.md
+++ b/.claude/skills/brand-design/SKILL.md
@@ -36,11 +36,41 @@ Glaon's Brand Guideline Figma file is the canonical source for brand decisions �
 
 ### Color palette
 
-_TBD — first pass lands when Design System Figma gets its color variables. Until then, defer color questions to Figma._ Rationale captured here once published:
+Glaon's color system is split into two Figma Variable collections (see [`docs/design-system-bootstrap.md`](../../../docs/design-system-bootstrap.md#variables--koleksiyonlar-ve-modes)):
 
-- Base palette + semantic roles (brand, surface, text, state).
-- Light/dark mode mapping (Figma Variables `Theme` mode).
-- Accessibility contrast floors per role.
+- **Primitives** — the raw palette inherited from the Brand Guideline (neutrals, brand hue, accents). Components never reference these directly.
+- **Semantics** — the contract components consume. Each semantic binds to a primitive via `Theme: light` / `Theme: dark` modes.
+
+Two non-negotiable rules:
+
+- Components reference semantics, never primitives. A swap of the brand hue must cascade through one rebinding, not a codebase sweep.
+- Light and dark are designed together, not retrofitted. Until #140 lands, dark bindings fall back to the Light primitive but the binding slot exists from day one — semantic _names_ are stable forever; only the values move.
+
+Semantic roles, with what each one means and when to reach for it:
+
+- **`surface/default`** — the canvas a screen sits on. Most layouts default to this. Calm, low chrome.
+- **`surface/muted`** — a recessed surface inside `surface/default`: form rows, list groups, secondary panels. Signals "still part of the page, but a step back".
+- **`surface/raised`** — an elevated surface above the canvas: cards, popovers, modals. Pairs with shadow tokens; never carry depth in color alone. Final binding lands with #139.
+- **`text/primary`** — body and heading text on `surface/default` / `surface/muted`. Must clear WCAG AA 4.5:1 against both.
+- **`text/muted`** — secondary text: captions, helper, timestamps. Same 4.5:1 floor — `muted` is a hue/weight choice, not a contrast escape hatch.
+- **`text/inverse`** — text on dark or saturated surfaces (e.g. label on `brand/primary`). "Inverse" is relative to the surface beneath it, not a literal theme inversion.
+- **`border/subtle`** — quiet dividers, inputs at rest, list separators. 3:1 against the adjacent surface (non-text UI floor).
+- **`border/strong`** — focus rings, selected state, emphatic dividers. 3:1 minimum; design intent typically clears it comfortably.
+- **`brand/primary`** — primary CTAs and the few places Glaon "speaks" with brand color. Use sparingly: density of brand color is inversely proportional to the trust it conveys.
+- **`brand/hover` / `brand/pressed`** — interactive shifts on `brand/primary`. Don't invent ad-hoc darkening; the tokens encode the brand's preferred curve. Lands with #138.
+- **`state/success`** — confirmation, healthy device. Greenish but inherits the brand's temperature; we don't ship a generic semaphore green.
+- **`state/warning`** — caution, non-blocking attention. Amber/yellow family; always paired with a glyph because hue alone fails colorblind users.
+- **`state/danger`** — destructive affirmation, fault state. The most restrained role on the list — overuse desensitizes, so it's reserved for actions or states that genuinely cannot be undone or ignored. Hue locked in #137.
+
+Light/dark mapping lives in Figma Variables `Theme` mode. Both modes share the same semantic name and diverge only in which primitive they bind to — that's what lets a component written against `text/primary` swap automatically when the theme flips, with no per-component dark variant.
+
+Accessibility floors (record per role; don't ask the developer to recompute):
+
+- Text on its surface — WCAG AA 4.5:1 minimum; aim for AAA 7:1 on body text in long-session contexts (wall tablet) where eye fatigue compounds.
+- Non-text UI (borders, focus rings, state glyphs) — 3:1 against the adjacent surface.
+- Brand color is not exempt: `brand/primary` over `surface/default` must clear 3:1 as a UI element, and 4.5:1 if text rides on it.
+
+Hex values, gradients, and exact alpha stops live in the Brand Guideline Figma file and the published Design System library. Don't restate them here — the skill points; Figma defines.
 
 ### Typography
 


### PR DESCRIPTION
## Summary

Closes #132 (code-side slice). Replaces the Color palette TBD in [.claude/skills/brand-design/SKILL.md](.claude/skills/brand-design/SKILL.md) with concrete semantic role definitions and rationale, so brand-design questions ("which token should this card background use?", "warning vs danger?") can route to named semantics instead of "defer to Figma".

## Scope — In

- `.claude/skills/brand-design/SKILL.md` Color palette section: primitive vs semantic split, full semantic taxonomy (`surface/*`, `text/*`, `border/*`, `brand/*`, `state/*`) with purpose + when-to-use guidance, light/dark mapping rationale via Figma Variables `Theme` mode, per-role WCAG contrast floors.
- Cross-references to [docs/design-system-bootstrap.md](docs/design-system-bootstrap.md) and the Brand-decision follow-up issues (#137 danger, #138 hover/pressed, #139 surface/raised, #140 dark bindings).

## Scope — Out

- Hex values, gradients, alpha stops — explicit skill rule: skill points, Figma defines.
- Figma-side acceptance criteria from the issue (Color page, primitive/semantic collection split, Theme modes, do/don't swatches) — done in Figma directly, not in this PR.
- A separate `docs/brand/colors.md` summary — issue says "bias toward not adding if skill already covers". The skill now covers it, so skipping per the issue's own guidance.
- Token export / Style Dictionary wiring (deferred per `docs/figma.md` follow-ups).
- Typography, spacing, radii, shadow — separate brand-decision issues.
- Component code consuming tokens — phase-3 (#15).

## Test plan

- [ ] Read the Color palette section end-to-end and confirm: no hex codes, every semantic group has a "what / when" line, light/dark and a11y floors are explicit.
- [ ] Verify the cross-link to `docs/design-system-bootstrap.md#variables--koleksiyonlar-ve-modes` resolves.
- [ ] Verify the four pending-binding follow-up references (#137, #138, #139, #140) are intact.
- [ ] CI green: commitlint, lint, type-check, Chromatic (no UI changes expected — docs-only).
- [ ] Confirm Figma-side ACs are tracked separately on the issue (Color page, Theme modes, do/don't swatches) and won't block this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)