### PR TITLE
docs(brand): add 04-color-palette-rebuild plugin script for Brand Guideline parity

### DIFF
--- a/tools/figma-plugin/scripts/01-variables-bootstrap.js
+++ b/tools/figma-plugin/scripts/01-variables-bootstrap.js
@@ -28,7 +28,7 @@ const PLACEHOLDER = { r: 1, g: 0, b: 1, a: 1 };
 // Format: { r, g, b, a } with 0..1 channels, OR null.
 const BRAND_REF = {
   // Neutrals
-  'color/kirli-beyaz': null, // off-white surface base
+  'color/dirty-white': null, // off-white surface base
   'color/sand-100': null,
   'color/sand-300': null,
   'color/night-blue-500': null, // primary text
@@ -47,12 +47,12 @@ const BRAND_REF = {
 // they bind to (per spec). If the primitive is missing, the semantic gets
 // a placeholder fallback so consumers can still wire up.
 const SEMANTIC_BINDINGS = {
-  'surface/default': 'color/kirli-beyaz',
+  'surface/default': 'color/dirty-white',
   'surface/muted': 'color/sand-100',
-  'surface/raised': 'color/kirli-beyaz', // #139 follow-up may shift
+  'surface/raised': 'color/dirty-white', // #139 follow-up may shift
   'text/primary': 'color/night-blue-500',
   'text/muted': 'color/night-blue-700',
-  'text/inverse': 'color/kirli-beyaz',
+  'text/inverse': 'color/dirty-white',
   'border/subtle': 'color/sand-300',
   'border/strong': 'color/night-blue-500',
   'brand/primary': 'color/brand-primary',

--- a/tools/figma-plugin/scripts/04-color-palette-rebuild.js
+++ b/tools/figma-plugin/scripts/04-color-palette-rebuild.js
@@ -1,0 +1,276 @@
+// Glaon — 04 Color Palette Rebuild
+//
+// Rebuilds the `Color Palette` frame in the Brand Guideline Figma file
+// to match the primitive + semantic taxonomy decided in #132. The
+// existing 4-swatch layout (Dark Slate Blue / Coral Red / Muted Steel
+// Blue / Light Gray) is renamed and preserved as a legacy reference;
+// a fresh `Color Palette` frame is created next to it with a primitive
+// row + semantic row of swatches that bind to the file's Variables —
+// or fall back to placeholder magenta if the Variables aren't there yet.
+//
+// What this script intentionally *doesn't* do (visual judgment is left
+// to the designer): light/dark side-by-side preview, contrast
+// annotations, do/don't examples. Add those manually in Figma after the
+// scaffold is in place. The script preserves any non-`section/*` child
+// frames you add to the new `Color Palette` frame, so manual sections
+// survive re-runs.
+//
+// Usage:
+//   1. Copy this file's contents into tools/figma-plugin/code.js.
+//   2. Open the Brand Guideline Figma file (file key
+//      JLbLmCMDdhxOisbVYiAo5C).
+//   3. (Optional but recommended) Run 01-variables-bootstrap first in
+//      this file so swatch fills bind to real Variables instead of
+//      placeholder magenta.
+//   4. Run plugin (Plugins → Development → Glaon).
+//   5. Review the dry-run notification; flip CONFIRM = true; re-run.
+//   6. In Figma: hand-author contrast notes, light/dark preview, and
+//      do/don't examples (per #132 acceptance criteria).
+//   7. `git restore tools/figma-plugin/code.js` to scaffold.
+//
+// Idempotent: re-running only refreshes the `section/primitives` and
+// `section/semantic` frames inside `Color Palette`; everything else is
+// left untouched.
+
+const CONFIRM = false;
+
+const LEGACY_FRAME_ID = '17:521';
+const LEGACY_SUFFIX = '(legacy 2026-04-26)';
+const NEW_FRAME_NAME = 'Color Palette';
+const PLACEHOLDER = { r: 1, g: 0, b: 1 };
+
+const PRIMITIVES = [
+  { name: 'kirli-beyaz', note: 'off-white surface base' },
+  { name: 'sand-100', note: 'lighter neutral' },
+  { name: 'sand-300', note: 'mid neutral border' },
+  { name: 'night-blue-500', note: 'primary text / strong border' },
+  { name: 'night-blue-700', note: 'muted text shift' },
+  { name: 'brand-primary', note: 'primary CTA hue' },
+  { name: 'brand-primary-hover', note: '#138 follow-up' },
+  { name: 'brand-primary-pressed', note: '#138 follow-up' },
+  { name: 'state-success', note: 'confirmation' },
+  { name: 'state-warning', note: 'caution' },
+  { name: 'state-danger', note: '#137 follow-up' },
+];
+
+const SEMANTICS = [
+  { name: 'surface/default', binding: 'kirli-beyaz' },
+  { name: 'surface/muted', binding: 'sand-100' },
+  { name: 'surface/raised', binding: 'kirli-beyaz' },
+  { name: 'text/primary', binding: 'night-blue-500' },
+  { name: 'text/muted', binding: 'night-blue-700' },
+  { name: 'text/inverse', binding: 'kirli-beyaz' },
+  { name: 'border/subtle', binding: 'sand-300' },
+  { name: 'border/strong', binding: 'night-blue-500' },
+  { name: 'brand/primary', binding: 'brand-primary' },
+  { name: 'brand/hover', binding: 'brand-primary-hover' },
+  { name: 'brand/pressed', binding: 'brand-primary-pressed' },
+  { name: 'state/success', binding: 'state-success' },
+  { name: 'state/warning', binding: 'state-warning' },
+  { name: 'state/danger', binding: 'state-danger' },
+];
+
+const SWATCH_W = 120;
+const SWATCH_H = 120;
+const SWATCH_GAP = 16;
+const ROW_GAP = 32;
+const SECTION_GAP = 48;
+const PER_ROW = 6;
+const PADDING = 32;
+
+(async () => {
+  try {
+    const allVars = await figma.variables.getLocalVariablesAsync('COLOR');
+    const primitiveVars = new Map();
+    const semanticVars = new Map();
+    const missingPrimitives = [];
+    const missingSemantics = [];
+
+    for (const p of PRIMITIVES) {
+      const v = allVars.find((x) => x.name === `color/${p.name}`);
+      if (v) primitiveVars.set(p.name, v);
+      else missingPrimitives.push(p.name);
+    }
+    for (const s of SEMANTICS) {
+      const v = allVars.find((x) => x.name === s.name);
+      if (v) semanticVars.set(s.name, v);
+      else missingSemantics.push(s.name);
+    }
+
+    const actions = [];
+    const legacy = await figma.getNodeByIdAsync(LEGACY_FRAME_ID);
+    if (legacy && legacy.type === 'FRAME') {
+      if (legacy.name.includes('legacy')) {
+        actions.push(`legacy frame already renamed: "${legacy.name}"`);
+      } else {
+        actions.push(`rename legacy: "${legacy.name}" → "${legacy.name} ${LEGACY_SUFFIX}"`);
+      }
+    } else {
+      actions.push(`legacy frame ${LEGACY_FRAME_ID} not found — creating fresh ${NEW_FRAME_NAME}`);
+    }
+    actions.push(
+      `refresh "${NEW_FRAME_NAME}" with ${PRIMITIVES.length} primitives + ${SEMANTICS.length} semantics`,
+    );
+
+    if (!CONFIRM) {
+      const summary = [
+        '🔍 DRY-RUN',
+        `actions: ${actions.length}`,
+        `primitives missing: ${missingPrimitives.length}`,
+        `semantics missing: ${missingSemantics.length}`,
+      ].join(' · ');
+      figma.notify(summary, { timeout: 8000 });
+      console.log('[Glaon color-palette-rebuild] Plan:');
+      for (const a of actions) console.log('  •', a);
+      if (missingPrimitives.length) console.log('Missing primitives:', missingPrimitives);
+      if (missingSemantics.length) console.log('Missing semantics:', missingSemantics);
+      figma.closePlugin();
+      return;
+    }
+
+    await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
+    await figma.loadFontAsync({ family: 'Inter', style: 'SemiBold' });
+
+    if (legacy && legacy.type === 'FRAME' && !legacy.name.includes('legacy')) {
+      legacy.name = `${legacy.name} ${LEGACY_SUFFIX}`.trim();
+    }
+
+    const page = legacy?.parent ?? figma.currentPage;
+    let newFrame = page.children.find(
+      (n) => n.type === 'FRAME' && n.name === NEW_FRAME_NAME,
+    );
+    if (!newFrame) {
+      newFrame = figma.createFrame();
+      newFrame.name = NEW_FRAME_NAME;
+      newFrame.layoutMode = 'VERTICAL';
+      newFrame.primaryAxisSizingMode = 'AUTO';
+      newFrame.counterAxisSizingMode = 'AUTO';
+      newFrame.itemSpacing = SECTION_GAP;
+      newFrame.paddingLeft = PADDING;
+      newFrame.paddingRight = PADDING;
+      newFrame.paddingTop = PADDING;
+      newFrame.paddingBottom = PADDING;
+      newFrame.fills = [{ type: 'SOLID', color: { r: 1, g: 1, b: 1 } }];
+      page.appendChild(newFrame);
+      if (legacy && 'absoluteBoundingBox' in legacy && legacy.absoluteBoundingBox) {
+        newFrame.x = legacy.x;
+        newFrame.y = legacy.y + (legacy.height || 0) + 80;
+      }
+    }
+
+    for (const child of [...newFrame.children]) {
+      if (child.name.startsWith('section/')) child.remove();
+    }
+
+    const primitivesSection = buildSection(
+      'Primitives',
+      PRIMITIVES.map((p) =>
+        buildSwatch({ label: p.name, sub: p.note, variable: primitiveVars.get(p.name) }),
+      ),
+    );
+    newFrame.appendChild(primitivesSection);
+
+    const semanticsSection = buildSection(
+      'Semantic',
+      SEMANTICS.map((s) =>
+        buildSwatch({ label: s.name, sub: `→ ${s.binding}`, variable: semanticVars.get(s.name) }),
+      ),
+    );
+    newFrame.appendChild(semanticsSection);
+
+    const summary = [
+      '✅ APPLIED',
+      `primitives: ${PRIMITIVES.length}`,
+      `semantics: ${SEMANTICS.length}`,
+      `placeholders: ${missingPrimitives.length + missingSemantics.length}`,
+    ].join(' · ');
+    figma.notify(summary, { timeout: 8000 });
+    if (missingPrimitives.length || missingSemantics.length) {
+      console.log('[Glaon color-palette-rebuild] Placeholder swatches (Variables missing):');
+      if (missingPrimitives.length) console.log('  primitives:', missingPrimitives);
+      if (missingSemantics.length) console.log('  semantics:', missingSemantics);
+    }
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();
+
+function buildSection(title, swatchNodes) {
+  const section = figma.createFrame();
+  section.name = `section/${title.toLowerCase()}`;
+  section.layoutMode = 'VERTICAL';
+  section.primaryAxisSizingMode = 'AUTO';
+  section.counterAxisSizingMode = 'AUTO';
+  section.itemSpacing = ROW_GAP;
+  section.fills = [];
+
+  const heading = figma.createText();
+  heading.name = `heading/${title.toLowerCase()}`;
+  heading.fontName = { family: 'Inter', style: 'SemiBold' };
+  heading.fontSize = 24;
+  heading.characters = title;
+  section.appendChild(heading);
+
+  for (let i = 0; i < swatchNodes.length; i += PER_ROW) {
+    const row = figma.createFrame();
+    row.name = `row/${title.toLowerCase()}/${i / PER_ROW}`;
+    row.layoutMode = 'HORIZONTAL';
+    row.primaryAxisSizingMode = 'AUTO';
+    row.counterAxisSizingMode = 'AUTO';
+    row.itemSpacing = SWATCH_GAP;
+    row.fills = [];
+    for (const node of swatchNodes.slice(i, i + PER_ROW)) {
+      row.appendChild(node);
+    }
+    section.appendChild(row);
+  }
+
+  return section;
+}
+
+function buildSwatch({ label, sub, variable }) {
+  const wrapper = figma.createFrame();
+  wrapper.name = `swatch/${label}`;
+  wrapper.layoutMode = 'VERTICAL';
+  wrapper.primaryAxisSizingMode = 'AUTO';
+  wrapper.counterAxisSizingMode = 'AUTO';
+  wrapper.itemSpacing = 8;
+  wrapper.fills = [];
+
+  const tile = figma.createRectangle();
+  tile.name = `tile/${label}`;
+  tile.resize(SWATCH_W, SWATCH_H);
+  tile.cornerRadius = 8;
+  if (variable) {
+    const fill = figma.variables.setBoundVariableForPaint(
+      { type: 'SOLID', color: { r: 1, g: 0, b: 1 } },
+      'color',
+      variable,
+    );
+    tile.fills = [fill];
+  } else {
+    tile.fills = [{ type: 'SOLID', color: PLACEHOLDER }];
+  }
+  wrapper.appendChild(tile);
+
+  const labelNode = figma.createText();
+  labelNode.name = `label/${label}`;
+  labelNode.fontName = { family: 'Inter', style: 'SemiBold' };
+  labelNode.fontSize = 12;
+  labelNode.characters = label;
+  wrapper.appendChild(labelNode);
+
+  if (sub) {
+    const subNode = figma.createText();
+    subNode.name = `sub/${label}`;
+    subNode.fontName = { family: 'Inter', style: 'Regular' };
+    subNode.fontSize = 11;
+    subNode.characters = sub;
+    wrapper.appendChild(subNode);
+  }
+
+  return wrapper;
+}

--- a/tools/figma-plugin/scripts/04-color-palette-rebuild.js
+++ b/tools/figma-plugin/scripts/04-color-palette-rebuild.js
@@ -40,7 +40,7 @@ const NEW_FRAME_NAME = 'Color Palette';
 const PLACEHOLDER = { r: 1, g: 0, b: 1 };
 
 const PRIMITIVES = [
-  { name: 'kirli-beyaz', note: 'off-white surface base' },
+  { name: 'dirty-white', note: 'off-white surface base' },
   { name: 'sand-100', note: 'lighter neutral' },
   { name: 'sand-300', note: 'mid neutral border' },
   { name: 'night-blue-500', note: 'primary text / strong border' },
@@ -54,12 +54,12 @@ const PRIMITIVES = [
 ];
 
 const SEMANTICS = [
-  { name: 'surface/default', binding: 'kirli-beyaz' },
+  { name: 'surface/default', binding: 'dirty-white' },
   { name: 'surface/muted', binding: 'sand-100' },
-  { name: 'surface/raised', binding: 'kirli-beyaz' },
+  { name: 'surface/raised', binding: 'dirty-white' },
   { name: 'text/primary', binding: 'night-blue-500' },
   { name: 'text/muted', binding: 'night-blue-700' },
-  { name: 'text/inverse', binding: 'kirli-beyaz' },
+  { name: 'text/inverse', binding: 'dirty-white' },
   { name: 'border/subtle', binding: 'sand-300' },
   { name: 'border/strong', binding: 'night-blue-500' },
   { name: 'brand/primary', binding: 'brand-primary' },


### PR DESCRIPTION
## Summary

Closes #160 (code-side scaffold). Adds [tools/figma-plugin/scripts/04-color-palette-rebuild.js](tools/figma-plugin/scripts/04-color-palette-rebuild.js) — an idempotent, dry-run-by-default Figma Plugin script that rebuilds the Brand Guideline `Color Palette` frame to match the primitive + semantic taxonomy decided in #132 / [.claude/skills/brand-design/SKILL.md](.claude/skills/brand-design/SKILL.md). Also renames the `kirli-beyaz` primitive token to `dirty-white` across the plugin scripts so token names are consistently English. The remaining acceptance criteria (contrast annotations, light/dark side-by-side preview, do/don't examples) are visual judgment work and stay in Figma — the script preserves any non-`section/*` frames you add so manual content survives re-runs.

## Scope — In

- `tools/figma-plugin/scripts/04-color-palette-rebuild.js`. Same shape as 01–03: BRAND_REF-style lists at top, dry-run summary via `figma.notify` + console, `CONFIRM = false` flag, full guardrails per [.claude/skills/brand-design/SKILL.md](.claude/skills/brand-design/SKILL.md) (no network, single review step, always closePlugin).
- Behaviour:
  - Renames the legacy 4-swatch frame (id `17:521`, current name `Color Palette`) → `Color Palette (legacy 2026-04-26)`. Doesn't delete; you can compare side-by-side or remove later.
  - Creates a fresh `Color Palette` auto-layout frame with `section/primitives` (11 primitive swatches: dirty-white, sand-100/300, night-blue-500/700, brand-primary + hover/pressed, state-success/warning/danger) and `section/semantic` (14 semantic swatches mapped to roles per the skill).
  - Each swatch tile binds its fill to a local Color Variable when present (`color/<name>` for primitives, `<role>` for semantics). Missing variables get a magenta placeholder + a console list so you know what to bootstrap next.
  - Idempotent: re-runs only refresh `section/*` children inside the new frame — manual sections (`do-dont/...`, `light-dark-preview/...`, contrast notes) you author by hand are left intact.
- Token rename `kirli-beyaz` → `dirty-white` in [01-variables-bootstrap.js](tools/figma-plugin/scripts/01-variables-bootstrap.js) and [04-color-palette-rebuild.js](tools/figma-plugin/scripts/04-color-palette-rebuild.js); drops the matching TODO comment in 01 since it's now done.

## Scope — Out

- Contrast annotations per role — visual layout decision, designer in Figma.
- Light / dark side-by-side preview — visual layout, designer.
- Do/Don't 4–6 example mini-vignettes — visual layout, designer.
- Variables collection bootstrap inside the Brand Guideline file — that's #163 (B4). Run [tools/figma-plugin/scripts/01-variables-bootstrap.js](tools/figma-plugin/scripts/01-variables-bootstrap.js) in this file first if you want bound swatches instead of placeholders; the script reports missing variables either way.
- Skill / docs updates — [.claude/skills/brand-design/SKILL.md](.claude/skills/brand-design/SKILL.md) Color palette section already matches the taxonomy this script writes (PR #158); no changes needed here. Adding a deep-link to the new frame's node ID is best done after Figma publishes (separate tiny PR if useful).
- `Kirli Beyaz` mentions in [docs/design-system-bootstrap.md](docs/design-system-bootstrap.md) Turkish prose — kept as-is per `docs/` Turkish language policy; only the technical token names were renamed.
- Touching [tools/figma-plugin/code.js](tools/figma-plugin/code.js) or [.mcp.json](.mcp.json) — those have local uncommitted changes (related to #145 / MCP work) and stay out of this PR.

## Test plan

- [ ] Open Brand Guideline in Figma desktop; copy `04-color-palette-rebuild.js` into `tools/figma-plugin/code.js`; run plugin.
- [ ] Dry-run notification reads `🔍 DRY-RUN · actions: 2 · primitives missing: N · semantics missing: M` (counts depend on whether Variables exist yet).
- [ ] Console logs the action plan + missing-variables list, including `dirty-white` (not `kirli-beyaz`) as the first primitive.
- [ ] Flip `CONFIRM = true`, re-run; notification reads `✅ APPLIED · primitives: 11 · semantics: 14 · placeholders: K`.
- [ ] Verify in Figma: legacy frame renamed, new `Color Palette` frame sits below it, two sections (`section/primitives`, `section/semantic`) populated with correctly-named swatches; the off-white tile is labelled `dirty-white`.
- [ ] Add a manual `manual/do-dont` frame inside the new `Color Palette` frame; re-run the script with `CONFIRM = true`; verify the manual frame survives (idempotency test).
- [ ] Sanity-check 01-variables-bootstrap.js still runs cleanly — `BRAND_REF` and `SEMANTIC_BINDINGS` reference `color/dirty-white`; no leftover `kirli-beyaz`.
- [ ] `git restore tools/figma-plugin/code.js` returns the entry to scaffold.
- [ ] CI green: lint, type-check, audit, unit, playwright, Chromatic (no UI changes — script-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)