### PR TITLE
fix(figma-plugin): drop optional chaining for Figma runtime parser

### DIFF
--- a/tools/figma-plugin/scripts/01-variables-bootstrap.js
+++ b/tools/figma-plugin/scripts/01-variables-bootstrap.js
@@ -95,9 +95,11 @@ const SEMANTIC_BINDINGS = {
     const primitiveVarsByName = new Map();
     for (const [name, value] of Object.entries(BRAND_REF)) {
       let v = allVars.find(
-        (x) => x.name === name && x.variableCollectionId === (primitivesCol?.id ?? null),
+        (x) =>
+          x.name === name &&
+          x.variableCollectionId === (primitivesCol ? primitivesCol.id : null),
       );
-      const concreteValue = value ?? PLACEHOLDER;
+      const concreteValue = value !== null && value !== undefined ? value : PLACEHOLDER;
       if (!v) {
         if (CONFIRM && primitivesCol) {
           v = figma.variables.createVariable(name, primitivesCol, 'COLOR');
@@ -120,7 +122,9 @@ const SEMANTIC_BINDINGS = {
     // --- Semantic variables ---
     for (const [semanticName, primitiveName] of Object.entries(SEMANTIC_BINDINGS)) {
       let v = allVars.find(
-        (x) => x.name === semanticName && x.variableCollectionId === (semanticCol?.id ?? null),
+        (x) =>
+          x.name === semanticName &&
+          x.variableCollectionId === (semanticCol ? semanticCol.id : null),
       );
       if (!v) {
         if (CONFIRM && semanticCol) {
@@ -179,5 +183,8 @@ function ensureThemeModes(collection, confirm, created) {
     }
     created.push(`mode: ${collection.name}/Dark`);
   }
-  return { light: lightMode?.modeId, dark: darkMode?.modeId };
+  return {
+    light: lightMode ? lightMode.modeId : undefined,
+    dark: darkMode ? darkMode.modeId : undefined,
+  };
 }

--- a/tools/figma-plugin/scripts/04-color-palette-rebuild.js
+++ b/tools/figma-plugin/scripts/04-color-palette-rebuild.js
@@ -135,7 +135,7 @@ const PADDING = 32;
       legacy.name = `${legacy.name} ${LEGACY_SUFFIX}`.trim();
     }
 
-    const page = legacy?.parent ?? figma.currentPage;
+    const page = legacy && legacy.parent ? legacy.parent : figma.currentPage;
     let newFrame = page.children.find(
       (n) => n.type === 'FRAME' && n.name === NEW_FRAME_NAME,
     );


### PR DESCRIPTION
## Summary

Closes #168. Figma's plugin sandbox parser rejects ES2020 `?.` (optional chaining) and `??` (nullish coalescing) with `Syntax error: Unexpected token .`. The scripts parsed fine in Node and modern linters, so PR CI on #167 / #153 stayed green — but actually loading the script in Figma desktop threw before any code ran.

This fix rewrites every site as ternary / explicit null-undefined checks; semantics are bit-for-bit unchanged.

## Scope — In

- [tools/figma-plugin/scripts/01-variables-bootstrap.js](tools/figma-plugin/scripts/01-variables-bootstrap.js) — 4 sites: `primitivesCol?.id ?? null`, `value ?? PLACEHOLDER`, `semanticCol?.id ?? null`, and the `lightMode?.modeId / darkMode?.modeId` return.
- [tools/figma-plugin/scripts/04-color-palette-rebuild.js](tools/figma-plugin/scripts/04-color-palette-rebuild.js) — 1 site: `legacy?.parent ?? figma.currentPage`.
- Verification: `grep -nE '\?\.|\?\?' tools/figma-plugin/scripts/*.js` returns nothing.

## Scope — Out

- Linting rule to forbid `?.` / `??` in `tools/figma-plugin/scripts/*.js` going forward — worth adding later (separate issue), kept off this PR.
- 02-text-styles.js / 03-button-import-reskin.js — grep showed neither uses these operators; untouched.
- Manifest API version bump — tried no upgrades.
- Touching uncommitted [tools/figma-plugin/code.js](tools/figma-plugin/code.js) or [.mcp.json](.mcp.json) — those are local #145 / MCP playground state.

## Test plan

- [ ] `grep -nE '\?\.|\?\?' tools/figma-plugin/scripts/*.js` returns empty.
- [ ] In Figma desktop: copy `01-variables-bootstrap.js` content into `tools/figma-plugin/code.js`; **Plugins → Development → Glaon** loads without `Syntax error`; dry-run notification fires.
- [ ] Same test for `04-color-palette-rebuild.js`.
- [ ] CI green: lint, type-check, audit, unit, playwright, Chromatic (no UI changes — script-only).

## Why this slipped CI

Node's parser supports `?.` and `??` since 14.x; ESLint default rules don't forbid them. CI's `type-check + lint + audit` parses the scripts as JS but doesn't execute them under Figma's runtime. The defect only surfaces when a developer copies a script into `code.js` and runs it inside Figma desktop — a manual step that lives off the CI path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)