### PR TITLE
fix(figma-plugin): use 'Semi Bold' for Inter weight names

### DIFF
--- a/tools/figma-plugin/scripts/02-text-styles.js
+++ b/tools/figma-plugin/scripts/02-text-styles.js
@@ -28,10 +28,16 @@ const FONT = {
     family: 'Inter',
     regular: 'Regular',
     medium: 'Medium',
-    semibold: 'SemiBold',
+    semibold: 'Semi Bold',
     bold: 'Bold',
   },
-  rn: { family: 'Inter', regular: 'Regular', medium: 'Medium', semibold: 'SemiBold', bold: 'Bold' },
+  rn: {
+    family: 'Inter',
+    regular: 'Regular',
+    medium: 'Medium',
+    semibold: 'Semi Bold',
+    bold: 'Bold',
+  },
 };
 
 // Scale (px / line-height multiplier / weight). Mirrors a typical 1.25

--- a/tools/figma-plugin/scripts/04-color-palette-rebuild.js
+++ b/tools/figma-plugin/scripts/04-color-palette-rebuild.js
@@ -129,7 +129,7 @@ const PADDING = 32;
     }
 
     await figma.loadFontAsync({ family: 'Inter', style: 'Regular' });
-    await figma.loadFontAsync({ family: 'Inter', style: 'SemiBold' });
+    await figma.loadFontAsync({ family: 'Inter', style: 'Semi Bold' });
 
     if (legacy && legacy.type === 'FRAME' && !legacy.name.includes('legacy')) {
       legacy.name = `${legacy.name} ${LEGACY_SUFFIX}`.trim();
@@ -209,7 +209,7 @@ function buildSection(title, swatchNodes) {
 
   const heading = figma.createText();
   heading.name = `heading/${title.toLowerCase()}`;
-  heading.fontName = { family: 'Inter', style: 'SemiBold' };
+  heading.fontName = { family: 'Inter', style: 'Semi Bold' };
   heading.fontSize = 24;
   heading.characters = title;
   section.appendChild(heading);
@@ -258,7 +258,7 @@ function buildSwatch({ label, sub, variable }) {
 
   const labelNode = figma.createText();
   labelNode.name = `label/${label}`;
-  labelNode.fontName = { family: 'Inter', style: 'SemiBold' };
+  labelNode.fontName = { family: 'Inter', style: 'Semi Bold' };
   labelNode.fontSize = 12;
   labelNode.characters = label;
   wrapper.appendChild(labelNode);


### PR DESCRIPTION
## Summary

Closes #170. Figma's bundled Inter lists the medium-bold weight as `"Semi Bold"` (with the space). `"SemiBold"` (no space) is the PostScript name and doesn't resolve via `figma.loadFontAsync`, throwing:

\`\`\`
unhandled promise rejection: Throw: The font "Inter SemiBold" could not be loaded
\`\`\`

[02-text-styles.js](tools/figma-plugin/scripts/02-text-styles.js) hit it directly; [04-color-palette-rebuild.js](tools/figma-plugin/scripts/04-color-palette-rebuild.js) had the same bug at three more sites that hadn't fired yet.

## Scope — In

- [02-text-styles.js](tools/figma-plugin/scripts/02-text-styles.js) — `FONT.web.semibold` and `FONT.rn.semibold` (2 sites).
- [04-color-palette-rebuild.js](tools/figma-plugin/scripts/04-color-palette-rebuild.js) — `loadFontAsync` call + heading + label `fontName` (3 sites).

## Scope — Out

- Other Inter weight names (Regular / Medium / Bold) — single-word, already correct.
- Inter alternative families (Brand Guideline #133 outcome).
- Linting rule that forbids `'SemiBold'` literal in plugin scripts — worth opening as a follow-up issue alongside the optional-chaining lint discussed on #168 / #169.

## Test plan

- [ ] `grep -nE "'SemiBold'" tools/figma-plugin/scripts/*.js` returns empty.
- [ ] Copy `02-text-styles.js` content into `tools/figma-plugin/code.js`; run plugin in Figma desktop with `CONFIRM = true`; no `loadFontAsync` rejection; styles created with the Semi Bold weight where the scale calls for it.
- [ ] Copy `04-color-palette-rebuild.js`; run with `CONFIRM = true`; section headings + swatch labels render in Inter Semi Bold without runtime rejection.
- [ ] CI green: lint, type-check, audit, unit, playwright, Chromatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)