### PR TITLE
docs(ui): adopt untitled ui react kit via github packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,11 @@ android/
 .env.*
 !.env.example
 
+# Per-developer npm registry auth (GitHub Packages PAT) — token never commits.
+# Repo-scoped `.npmrc` (registry mapping only, no token) IS committed when needed.
+.npmrc
+!.npmrc.example
+
 # Claude Code local overrides (per-developer)
 .claude/settings.local.json
 

--- a/docs/adr/0011-untitled-ui-react-kit.md
+++ b/docs/adr/0011-untitled-ui-react-kit.md
@@ -1,0 +1,80 @@
+# ADR 0011 — Untitled UI React kit'i `@glaon/ui` paketinin tabanı + GitHub Packages private registry üzerinden delivery
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-27
+- **Karar verenler:** @cengizdoyran
+- **İlgili konular:** issue #14, [docs/figma.md](../figma.md), [packages/ui/README.md](../../packages/ui/README.md), [docs/design-system-bootstrap.md](../design-system-bootstrap.md)
+
+## Bağlam
+
+Glaon'un `@glaon/ui` paketi, web ve mobil consumer'ların tükettiği primitive component katmanını barındırır. Phase 1 boyunca on'a yakın primitive (Button, Input, Modal, Drawer, Popover, Tooltip, Select, Tabs vs.) kod tarafına gelir; her birinin a11y, focus-trap, portal ve keyboard kontrolü ciddi yatırım gerektirir.
+
+Kararı şekillendiren kısıtlar:
+
+- **Lisans gerçeği**: Untitled UI React kit ücretli, kapalı kaynak bir kit. Source code'u public bir repoya commit etmek lisans ihlali. Glaon repo'su (`toss-cengiz/glaon`) public.
+- **CI ihtiyacı**: Storybook build, Chromatic visual regression, Vitest browser tests her PR'da koşar — kit her CI run'unda erişilebilir olmalı.
+- **Onboarding eşiği**: Yeni geliştirici lokal'de Storybook'u 5 dakikada çalıştırabilmeli; auth/registry adımı dokümante ve mekanik olmalı.
+- **Versioning + güvenlik**: Kit güncellemeleri trace edilebilir olmalı (Renovate dashboard'da görünmeli, breaking change'ler PR review'dan geçmeli, security advisory'leri yakalansın).
+- **Phase 1 plan**: F3 (#14) "Untitled UI React kit'i `@glaon/ui`'ye entegre et"; F5+ primitive PR'ları kit'in sağladığı headless layer'ı tüketir.
+
+Göz önünde bulundurulan alternatifler:
+
+- **Seçenek A — Source vendor (`packages/ui/vendor/untitled-ui/`)**: Kit'i source olarak commit et. Lisans ihlali; public repo'da yayımlanmış olur. Eleminate.
+- **Seçenek B — Public npm clone**: Kit'i public bir npm paketi olarak yeniden yayınla. Lisans açıkça yasaklıyor. Eleminate.
+- **Seçenek C — Private Git submodule**: Org altında private bir `glaon-uui-vendor` repo'sunda kit'i tut, ana repo'da submodule olarak çek. Çalışır; deploy key ile CI auth basit. Ama: kit upgrade'i manuel iki commit (vendor repo + submodule pointer), Renovate native submodule update'i sınırlı, iki repo bakımı yükü.
+- **Seçenek D — GitHub Packages private npm registry (seçilen)**: Kit'i `toss-cengiz` org'una private GitHub package olarak publish. `npm install` ile çek; `.npmrc` registry mapping repo'ya commit; auth token (PAT lokal'de, `GITHUB_TOKEN` CI'da) commit edilmez. Karar bölümünde detay.
+
+## Karar
+
+`@glaon/ui` Untitled UI React kit'i bir devDependency olarak tüketir. Kit, `toss-cengiz` org'unun private GitHub Packages npm registry'sine paketlenmiş haliyle yüklenir; ne `node_modules` ne de source kit'in hiçbir parçası ana repo'ya commit edilmez. Component implementasyonları kit primitive'lerini wrap eder, Glaon design token'larıyla yeniden temalar.
+
+Kararın teknik detayları:
+
+- **Paket adı**: `@<org>/<kit-paket-adi>` (kesin isim F3-B PR'ında, yayın anında belirlenir; bu ADR pattern'i belgelendirir).
+- **Registry**: `https://npm.pkg.github.com` — GitHub Packages npm endpoint'i.
+- **`.npmrc`**: Repo-scoped, scope → registry mapping satırı içerir; auth token içermez. Per-developer PAT `~/.npmrc`'de yaşar.
+- **Per-developer kurulum**: README runbook'unda dokümante. PAT scope: `read:packages`.
+- **CI auth**: Workflow'lar `actions/setup-node` adımında `registry-url: https://npm.pkg.github.com` set eder; `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` env var ile authenticate. `GITHUB_TOKEN` zaten her workflow'da otomatik mevcut, ek secret gerekmez.
+- **Versioning**: Kit semver pinning; major bump'lar Renovate dashboard'unda manuel approval; minor + patch otomatik PR (CI yeşil + auto-merge dependency policy'sine tabi).
+- **Lisans attribution**: `packages/ui/README.md` ve Brand Guideline Cover sayfasında atıf paragrafı.
+- **`@glaon/ui` boundary**: Sadece bu paket Untitled UI primitive'lerini import edebilir; diğer paketler ve apps `@glaon/ui` üzerinden tüketir. CLAUDE.md "Package Boundaries" kuralı korunur.
+
+## Sonuçlar
+
+### Olumlu
+
+- **Versioning native**: pnpm + Renovate kit upgrade'lerini ücretsiz handle eder; CI yeşil + auto-merge politikası uygulanabilir.
+- **Tek ekosistem**: pnpm install hep bir akış, ek `git submodule update`, vendor folder veya manuel kopya yok.
+- **CI auth basit**: GitHub Action otomatik `GITHUB_TOKEN` ile auth; ek secret yönetimi yok.
+- **Source kontrol**: Tüm geliştiriciler ve CI tek registry'den aynı paket sürümüne erişir; lokal "vendor klasörünü unuttum" sınıfı sorun yok.
+- **Lisans uyumlu**: Kit yalnızca org-internal package olarak yaşar, public registry'de değil.
+- **Eski kararla uyumlu**: ADR 0001 (Turborepo + pnpm) ve ADR 0004 (`@glaon/core` boundary) ile çakışmaz; `@glaon/ui` tek consumer.
+
+### Olumsuz / ödenecek bedel
+
+- **Onboarding ekstra adım**: Yeni geliştirici GitHub PAT (read:packages scope) oluşturup `~/.npmrc`'ye eklemek zorunda. README runbook'u şart; otherwise `pnpm install` 401 ile patlıyor.
+- **GitHub Packages quota**: Org'un private package storage + bandwidth quota'sına bağımlı. Glaon mevcut kullanım seviyesinde yeterli; takım büyürse takip edilmeli.
+- **Auth troubleshooting**: PAT expiry, scope yanlışlığı veya `.npmrc` ordering sıkıntıları "neden install çalışmıyor" tipli destek isteği yaratabilir. Runbook bunu hafifletir.
+- **Kit yayın akışı**: Kullanıcının kit'i her güncellemede `npm publish` etmesi gerekir; GitHub Action otomasyonu için ayrı bir release workflow kurulabilir (bu ADR kapsamı dışı).
+
+### Etkileri
+
+- **Kod organizasyonu**: `packages/ui/src/components/<Primitive>/` altında her primitive Untitled UI'nin headless karşılığını import eder; token'larla skin'lenir. Direct kit import sadece bu paketin içinde.
+- **CI süresi**: pnpm cache'lenmiş `~/.pnpm-store` ile kit ek bir resolve zamanı eklemez; ilk install'da yalnızca download süresi devreye girer.
+- **Göç**: Kitten vazgeçilirse yalnızca `@glaon/ui` içindeki wrap'lar değişir; consumer'lar (web, mobile, addon) etkilenmez. Lock-in component-API seviyesinde değil, paket seviyesinde.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Untitled UI'nin lisans modeli değişir (örn. open source'a geçer veya source vendor'ı kabul eder).
+- GitHub Packages quota tutmuyor / fiyatlama değişir.
+- Phase 1 sonunda kit kullanım yüzeyi çok ince kalırsa (sadece 2-3 primitive faydalanıyorsa) hand-roll daha düşük maliyet olabilir.
+- Glaon repo'su private'a geçerse source vendor seçeneği yeniden açılır.
+
+## Referanslar
+
+- Issue #14 — `feat(ui): integrate Untitled UI React kit into @glaon/ui` (relabel: phase-3 → phase-1; bu ADR onun decision parçası).
+- ADR 0001 — Turborepo + pnpm workspaces (paket yönetimi temeli).
+- ADR 0010 — Figma tasarım kaynağı + plugin bridge (UUI'nin Figma tarafı tek dosya, source-of-truth).
+- GitHub Packages npm docs: <https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-npm-registry>
+- Untitled UI lisans bilgisi: lokal kayıtta (üye satın alma sayfası).
+- `packages/ui/README.md` — per-developer ve CI kurulum runbook'u.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,7 @@ Deprecated durumu, kararı yapılacak işin dışına çıkarttığımızda kull
 | 0008 | [Chromatic tek görsel regresyon aracı](0008-chromatic-visual-regression.md)             | Accepted | 2026-04-21 |
 | 0009 | [HA Add-on + Ingress teslim kanalı](0009-ha-addon-ingress-delivery.md)                  | Accepted | 2026-04-20 |
 | 0010 | [Figma tasarım kaynağı + plugin bridge](0010-figma-source-of-truth.md)                  | Accepted | 2026-04-22 |
+| 0011 | [Untitled UI React kit + GitHub Packages delivery](0011-untitled-ui-react-kit.md)       | Accepted | 2026-04-27 |
 
 ## Konvansiyonlar
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,11 +1,81 @@
 # @glaon/ui
 
-Untitled UI React kit sarmalayıcısı. Kit lisanslı olduğu için kaynak dosyalar depoya dahil değildir.
+Glaon'un primitive component kütüphanesi. Web (Vite/React 19) ve mobil (Expo/RN) consumer'ların tükettiği Storybook-tabanlı paket. Lisanslı **Untitled UI React kit**'in headless layer'ını wrap eder ve Figma'dan export edilen Glaon design token'larıyla yeniden temalar.
 
-## Kurulum
+Kararın gerekçesi: [ADR 0011 — Untitled UI React kit + GitHub Packages delivery](../../docs/adr/0011-untitled-ui-react-kit.md).
 
-1. Untitled UI React kaynaklarını `packages/ui/src/untitled/` altına kopyala (bu dizin `.gitignore` içinde tutulacak).
-2. `src/index.ts` içinden Glaon'a uyarlanmış sarmalayıcıları dışa aktar.
-3. Web ve mobil uygulamalar yalnızca `@glaon/ui` üzerinden import etsin — Untitled UI'ı doğrudan kullanmayın.
+## Untitled UI React kit — kurulum
 
-Temalama, tokenlar ve tipografi Faz 2'de ele alınacak.
+Kit lisanslı ve kapalı kaynak. Source code repo'ya commit **edilmez** (Glaon repo'su public). Kit, Glaon org'unun **GitHub Packages private npm registry**'sine paketlenir; `pnpm install` registry'den çeker.
+
+### Per-developer setup (yeni geliştirici onboarding)
+
+1. **GitHub Personal Access Token (PAT) oluştur**:
+   - <https://github.com/settings/tokens> → Fine-grained veya Classic.
+   - Scope: `read:packages` (yeterli; başka yetki gerekmez).
+   - Expiry: ekibin politikasına göre (90 gün önerilir).
+2. **`~/.npmrc`'ye ekle** (lokal, repo dışı):
+   ```ini
+   //npm.pkg.github.com/:_authToken=ghp_xxxxxxxxxxxxxxxxxxxx
+   ```
+   Bu satır yalnızca senin makinende kalır; **asla repo'ya commit etme**. Repo'nun root'undaki `.npmrc` (commit edilmiş) sadece scope → registry mapping'i içerir, token taşımaz.
+3. **`pnpm install`**: Kit otomatik olarak çekilir. 401 alıyorsan PAT scope'unu (`read:packages`) ve expiry'sini kontrol et.
+
+### CI auth (otomatik)
+
+`.github/workflows/*.yml` içinde `actions/setup-node` adımı `registry-url: https://npm.pkg.github.com` ile authenticate eder; `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` env var ile auth. `GITHUB_TOKEN` her workflow'da otomatik mevcut, ek secret kurulumu gerekmez.
+
+### Kit version bump'ları
+
+- Renovate `dependencies` dashboard'unda kit guncellemelerini izler. Patch + minor otomatik PR; major manuel approval.
+- Manuel bump'lar drive-by yapılmaz — Renovate dashboard'undaki entry tetikler.
+- Lokal'de güncelleme test edildiğinde `pnpm --filter @glaon/ui add @<scope>/<package>@latest` ile, ardından `pnpm install` lockfile'ı senkronlar.
+
+## Lisans / attribution
+
+`@glaon/ui`, Untitled UI'nin React kit'ini ticari lisans altında kullanır. Lisans şartları kit publisher'ı tarafından belirlenir; her release Brand Guideline Cover sayfasında ve bu README'de atıf paragrafıyla taşınır:
+
+> Bu paket, Untitled UI tarafından sağlanan licensed React component kit'ini barındırır. Kit'in source code'u Glaon org'unun GitHub Packages private registry'sinde tutulur, public dağıtım yapılmaz. Lisans şartları için Untitled UI'nin license belgesine bakınız.
+
+## Component yetiştirme akışı
+
+Yeni primitive eklenmesi:
+
+1. **Figma'da tasarla** (Design System dosyasında, [docs/design-system-bootstrap.md](../../docs/design-system-bootstrap.md)).
+2. **`packages/ui/src/components/<Name>/`** altında:
+   - `<Name>.tsx` — web (DOM-tabanlı) implementation.
+   - `<Name>.native.tsx` — RN implementation (gerekiyorsa).
+   - `<Name>.types.ts` — shared prop sözleşmesi.
+   - `<Name>.stories.tsx` — Storybook story'leri.
+   - `index.ts` — re-export.
+3. **Token tüket**: `dist/tokens/web.css` (CSS vars) veya `dist/tokens/rn.ts` (typed object). Hex / raw px yazmak yasak — [CLAUDE.md "Design Source of Truth"](../../CLAUDE.md#design-source-of-truth-mandatory).
+4. **Storybook**: addon-a11y (error level), addon-designs (Figma embed), addon-vitest (browser tests). Story coverage: default + en az bir edge case ([docs/storybook.md](../../docs/storybook.md)).
+5. **Barrel**: `packages/ui/src/index.ts`'i güncelle.
+
+## Komutlar
+
+```bash
+pnpm --filter @glaon/ui storybook        # localhost:6006
+pnpm --filter @glaon/ui build:tokens     # tokens/*.json → dist/tokens/{web.css,rn.ts}
+pnpm --filter @glaon/ui build            # tsc -b
+pnpm --filter @glaon/ui test             # Vitest unit
+pnpm --filter @glaon/ui test:stories     # Vitest browser (Playwright)
+pnpm --filter @glaon/ui chromatic        # visual regression upload
+pnpm --filter @glaon/ui type-check
+pnpm --filter @glaon/ui lint
+```
+
+## Sorun giderme
+
+- **`pnpm install` 401 / 404 (kit paketi)**: PAT eksik veya scope yanlış. `~/.npmrc`'de `//npm.pkg.github.com/:_authToken=...` satırı var mı; PAT'ın `read:packages` scope'u set mi.
+- **CI'da auth hatası**: Workflow'da `actions/setup-node`'un `registry-url` parametresi set mi; `NODE_AUTH_TOKEN` env var `GITHUB_TOKEN`'a bağlı mı.
+- **Hex/px literal lint hatası**: Component dosyasında token yerine raw değer var. F2 üretimi `dist/tokens/{web.css,rn.ts}`'dan ilgili token'ı tüket.
+- **Storybook a11y panel'i `error` veriyor**: `addon-a11y` `a11y.test: 'error'` ile aktif; merge için yeşil olmalı. İstisnai durumlarda inline doc + scope-narrow `parameters.a11y.config.rules`.
+
+## Referanslar
+
+- [ADR 0011 — Untitled UI React kit + GitHub Packages delivery](../../docs/adr/0011-untitled-ui-react-kit.md)
+- [docs/storybook.md](../../docs/storybook.md) — story conventions + addons.
+- [docs/figma.md](../../docs/figma.md) — tasarım kaynağı + plugin bridge.
+- [docs/design-system-bootstrap.md](../../docs/design-system-bootstrap.md) — Figma file yapısı + primitive yetiştirme.
+- [packages/ui/tokens/README.md](tokens/README.md) — design token export + schema.


### PR DESCRIPTION
## Summary

- F3-A of the Phase 1 design-system code integration. Captures the **delivery decision** for the licensed Untitled UI React kit before the kit publishes, so primitive PRs (F5+ and P1–P18) have a stable contract to compile against.
- Decision: kit ships as a private GitHub Packages npm registry artifact. Per-developer auth via PAT in `~/.npmrc`; CI auth via the workflow's auto-provided `GITHUB_TOKEN`.

## Scope (In)

- **`docs/adr/0011-untitled-ui-react-kit.md`** — frozen rationale, alternatives evaluated (source vendor, public npm clone, private git submodule), license posture, reassessment triggers.
- **`docs/adr/README.md`** — index entry for ADR-0011.
- **`packages/ui/README.md`** — replaces the legacy `src/untitled/` runbook with:
  - Per-developer onboarding (GitHub PAT with `read:packages` scope, `~/.npmrc` template, troubleshooting).
  - CI auth pattern (`actions/setup-node` + `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`).
  - Component growth flow + token consumption rules.
  - License attribution paragraph (carried verbatim to Brand Guideline Cover on each release).
- **`.gitignore`** — `.npmrc` ignored (block PAT leaks); `.npmrc.example` allow-listed for templating.

## Scope (Out)

The mechanical wiring waits until the kit actually publishes to GitHub Packages. F3-B (new follow-up issue) will deliver:

- Repo-scoped `.npmrc` with scope → registry mapping.
- `packages/ui/package.json` dependency declaration on the kit package (name pinned at publish time).
- CI workflow update wiring `NODE_AUTH_TOKEN`.
- Sample import smoke story that renders one kit primitive end-to-end through Storybook.
- `pnpm audit --audit-level high` re-run after the dep lands.

This split keeps F3-A reviewable today (decision-only, zero dependency surface change) and lets F3-B happen the moment the kit is publishable.

## Test plan

- [x] Pre-commit hook passed (gitleaks + lint-staged).
- [x] `pnpm exec prettier --check` passed on the touched files.
- [ ] CI green on this branch (markdown + .gitignore only — type-check / lint / story-tests no-ops).
- [ ] Reviewer: ADR captures the why convincingly; alternatives are honest, not strawmen.
- [ ] Reviewer: README runbook is reproducible by a fresh developer (PAT scope, `~/.npmrc` syntax, expected error modes).
- [ ] Reviewer: `.gitignore` blocks accidental PAT leaks but leaves room for a repo-scoped `.npmrc.example` template.

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)