### PR TITLE
docs(ui): adopt untitled ui react kit via cli source delivery

### DIFF
--- a/docs/adr/0011-untitled-ui-react-kit.md
+++ b/docs/adr/0011-untitled-ui-react-kit.md
@@ -1,0 +1,90 @@
+# ADR 0011 — Untitled UI React kit'i CLI ile source-based teslim et
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-04-27
+- **Karar verenler:** @cengizdoyran
+- **İlgili konular:** issue #14, [packages/ui/README.md](../../packages/ui/README.md), [docs/design-system-bootstrap.md](../design-system-bootstrap.md), [docs/figma.md](../figma.md)
+
+## Bağlam
+
+Glaon'un `@glaon/ui` paketi Phase 1 boyunca on'a yakın primitive'i (Button, Input, Modal, Drawer, Popover, Tooltip, Select, Tabs, vs.) kod tarafına getirir. Her primitive'in a11y, focus-trap, portal ve klavye davranışı ciddi yatırım gerektirir; lisanslı **Untitled UI React kit**'i bu yatırımın source materyali olarak kullanmak istiyoruz.
+
+Untitled UI'nin teslim modeli incelendi:
+
+- Kit **npm paketi olarak yayınlanmıyor**. Yayıncının resmi yolu `npx untitledui` CLI'dır. CLI iki yönde çalışır:
+  - `untitledui init` boş bir Vite veya Next.js projesi iskeleti yaratır.
+  - `untitledui add <component>` belirtilen component'in source code'unu projeye yazar (`--path` ile hedef dizin override edilebilir). License key (Pro hesap) gerekir.
+- Yani teslimat **source-based**: kit'in kodu projenize kopyalanır, harici bir runtime bağımlılığı kalmaz.
+- Resmi MCP server'ı (`https://www.untitledui.com/react/api/mcp`) bu CLI'nın yanında ek bir kanal olarak component metadata'sı ve search exposure'ı sunar; ayrı bir issue (#206) altında değerlendirilir.
+
+Bu durum kararı şekillendiren kısıtlar:
+
+- **Lisans gerçeği**: Kit Pro lisanslı, ücretli. Source code'un Glaon kod tabanına entegre edilmesi lisansın izin verdiği "embed in product source" senaryosuyla uyumlu görünüyor; ama yayıncının dokümantasyonu public-repo commit'i için açık bir hüküm içermiyor. Bu ADR'nin Sonuçlar bölümü ihtiyaten dokümantasyon takibini ve gerekirse repo private'a alma fallback'ını sıralar.
+- **CI ihtiyacı**: Storybook build, Chromatic visual regression, Vitest browser tests her PR'da koşar. Source committed olursa CI ek auth gerekmez; gitignored + regenerate olursa her CI run'unda CLI quota + ağ gecikmesi.
+- **Onboarding eşiği**: Kit'in source'u zaten repoda olursa yeni geliştiricinin tek yapması gereken `pnpm install` + Storybook çalıştırmak. Aksi halde Pro lisans key'i ve `untitledui login` adımı eklenir.
+- **Versioning**: Kit upgrade'leri `untitledui upgrade` komutuyla yapılır; sonuç diff PR review'dan geçer. Renovate entegrasyonu yok ama upgrade frequency düşük (kit minor bump'ları, manuel review zaten istenecek seviyede).
+
+Göz önünde bulundurulan alternatifler:
+
+- **Seçenek A — GitHub Packages private npm registry**: İlk önerimizdi (eski PR #205'te kaydedildi, kapanış sebebiyle hayata geçmedi). Kit'i org'un private GitHub Packages'a yayınlama. Sorun: kit npm package değil, yayınlanması için yayıncının "wrap-and-republish" iznini gerektirir, lisans şartlarında açık değil. Eleminate.
+- **Seçenek B — Private Git submodule**: Org altında private bir kit-vendor repo. Submodule auth, manuel versioning, Renovate entegrasyonu sınırlı. CLI tabanlı resmi yola karşı ek ekstra katman.
+- **Seçenek C — Source committed via CLI (seçilen)**: `npx untitledui add --path packages/ui/src/components/<Name>` ile component source'unu doğrudan projeye yaz; commit et. Karar bölümünde detay.
+- **Seçenek D — Gitignored + CI regenerate**: Source gitignored, CI `untitledui add` ile her run'da yeniden üretir. Lisans temiz olur ama CI runtime'a bağımlı: ağ kesilmesi, CLI quota, license key rotation hatalarının hepsi build'i blokluyor.
+
+## Karar
+
+Untitled UI React kit'i `npx untitledui add` CLI'sı üzerinden source-based teslim alıyoruz; üretilen source dosyaları Glaon repo'suna commit ediyoruz. `@glaon/ui` paketinin component implementasyonları kit source'unu wrap eder ve Glaon design token'larıyla yeniden temalar.
+
+Kararın teknik detayları:
+
+- **Init skip**: `untitledui init` Vite veya Next.js projesi sıfırdan kurar. Glaon zaten Turborepo + Vite + Storybook ile kurulu; init çalıştırmıyoruz, sadece `add` kullanıyoruz.
+- **Per-component add**: `npx untitledui add <component> --path packages/ui/src/components/<Name> --yes` ile component source'u projeye yazılır.
+- **Path konvansiyonu**: Tüm kit source'u `packages/ui/src/components/` altında, primitive başına klasör olarak yaşar. CLI'ın varsayılan path'i (örn. `src/components/...`) Glaon'un monorepo path'ine override edilir.
+- **Lisans key teslimi**: Yeni geliştirici `~/.config/untitledui/auth` (CLI default) veya `--license <key>` flag'i ile login olur. CI source kit'i regenerate etmiyor → CI'da key gerekmez. Ekip içinde key paylaşımı gerekiyorsa şifre yöneticisinde tutulur.
+- **Lisans attribution**: Kit'in lisans dosyası (yayıncının sağladığı) `LICENSE-untitledui.md` olarak repo'ya commit edilir; her commit'lenmiş component dosyasında CLI'ın eklediği license header korunur, ayrıca `packages/ui/README.md`'de attribution paragrafı.
+- **Glaon wrap pattern**: Kit'in primitive'i raw olarak değil, Glaon-spesifik wrapper component üzerinden export edilir. Wrap, token tüketimi + Glaon prop API contract'ı + storybook-id Figma mapping'ini garantiler. Direkt kit import sadece wrap'in içinde geçerli.
+- **Upgrade akışı**: Kit upgrade'leri `npx untitledui upgrade` komutuyla, yeni issue + PR olarak iner. Manuel review zorunlu (yayıncı breaking change'leri açıkça etiketler).
+- **Public repo tutumu**: Repo public; ADR yazıldığı tarihte yayıncının lisans dokümantasyonu commit-to-public-repo için açık hüküm içermiyor. İlk component'leri eklemeden önce yayıncı ile yazılı onay alınması veya repo private'a çekilmesi gerekirse, bu fallback Sonuçlar bölümündeki tetikleyiciye dahil. Şu an default tutumumuz commit etmek; lisans ihlali tespit edilirse gitignored + CI regenerate seçeneğine (Seçenek D) geçilir.
+
+## Sonuçlar
+
+### Olumlu
+
+- **CI sade**: Source repoda → her CI run'unda kit auth/regenerate adımı yok. Storybook build, Chromatic, Vitest browser tests gecikmesiz.
+- **Onboarding hızlı**: Yeni geliştirici `pnpm install` + Storybook ile çalışır hâle gelir, Pro lisans key'i upgrade/yeni component eklemek dışında gerekmez.
+- **PR review'da diff**: Kit upgrade'leri ve yeni primitive eklemeleri review edilebilir text diff'i olarak geçer; "ne değişti?" sorusu git history'de okunur.
+- **Lock-in component-API seviyesinde değil**: Glaon wrap'leri kit'i abstraction altında tutuyor; yarın kit değişirse yalnızca wrap'lerin internal'ı değişir, consumer'lar etkilenmez.
+- **Resmi yolla uyum**: Yayıncının önerdiği akış (CLI + add) kullanılıyor; topluluk + yayıncı destek için bu modelde örneklere bakar.
+
+### Olumsuz / ödenecek bedel
+
+- **Public repo lisans riski**: Kit Pro source code'unun public repoda görünür olması yayıncının lisans şartlarını açıkça karşılamayabilir. Yayıncı dokümantasyonu netleşmediği sürece bu bir potansiyel maddi risk; karar tarihinde kabul edildi, takibi açık kalmalı.
+- **Kit upgrade manuel**: Renovate native upgrade'i yok; `untitledui upgrade` her seferinde insan tetiklemeli + diff review gerektirir. Kit minor bump'ları ekibe yük olabilir.
+- **CLI bağımlılığı**: Yayıncı CLI'ı API'sini değiştirirse upgrade akışı bozulabilir. Yayıncının runtime'a değil, sadece publishing pipeline'a etkisi olduğu için risk sınırlı.
+- **Çift dosyalar**: Aynı primitive'in raw kit source'u + Glaon wrap'i ayrı ayrı dosyalarda yaşar; paket boyutu (Storybook bundle) iki katı satır artışı.
+
+### Etkileri
+
+- **Kod organizasyonu**: `packages/ui/src/components/<Primitive>/` altında her primitive iki katman: kit source (CLI tarafından yazılan) + Glaon wrap (`<Primitive>.tsx`/`.native.tsx`). Wrap'ler shared `<Primitive>.types.ts` üzerinden konuşur; kit source'a direct import sadece wrap içinde.
+- **CI süresi**: Ek bir CI step yok. Storybook build kit source'u mevcut olarak kabul eder.
+- **Göç yolu**: Kitten vazgeçilirse `untitledui` CLI çalıştırılmaz, mevcut source dosyaları repo'da kalır (snapshot olarak), yeni primitive'ler hand-roll yazılır. Lock-in component-API'nin ötesinde değil.
+- **Lisans dökümanı**: `LICENSE-untitledui.md` ve `packages/ui/README.md` attribution paragrafı her release'de güncel kalmalı; release-please workflow'una manuel kontrol eklemek pragmatik (otomatik kontrol kit'in license metadata'sına dayanır, henüz var değil).
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Untitled UI yayıncısı public-repo commit'i için yazılı/standart bir lisans hükmü yayınlar veya yasaklar (ihlal varsa Seçenek D'ye geçilir).
+- Glaon repo'su private'a geçer (kararı yeniden masaya yatırma ihtiyacı yok ama riskler değişir; ADR güncel kalır).
+- Kit minor bump frequency'si haftalıktan sıkılaşır ve manuel review yükü dayanılmaz olur — Renovate-tipi otomasyon araştırması gerekir.
+- Kit'in CLI'ı kullanım dışı bırakılır veya farklı bir resmi yöntem yayınlanır.
+- `@glaon/ui` kit kullanımı yüzeyi sadece 1-2 primitive'e iner — hand-roll daha düşük maliyetli olur.
+
+## Referanslar
+
+- Issue #14 — `feat(ui): integrate Untitled UI React kit into @glaon/ui`.
+- Issue #206 — `chore(mcp): add Untitled UI Remote MCP entry to .mcp.json` (paralel iz).
+- ADR 0001 — Turborepo + pnpm workspaces (paket yönetimi temeli).
+- ADR 0010 — Figma tasarım kaynağı + plugin bridge (UUI'nin tek Figma dosyası, source-of-truth).
+- Untitled UI CLI: `npx untitledui --help`.
+- Untitled UI MCP: <https://www.untitledui.com/react/integrations/mcp>.
+- Yayıncı lisans dokümantasyonu: lokal kayıtta (Pro hesap dashboard'u).
+- `packages/ui/README.md` — kit kurulum + per-developer + CI runbook'u.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,7 @@ Deprecated durumu, kararı yapılacak işin dışına çıkarttığımızda kull
 | 0008 | [Chromatic tek görsel regresyon aracı](0008-chromatic-visual-regression.md)             | Accepted | 2026-04-21 |
 | 0009 | [HA Add-on + Ingress teslim kanalı](0009-ha-addon-ingress-delivery.md)                  | Accepted | 2026-04-20 |
 | 0010 | [Figma tasarım kaynağı + plugin bridge](0010-figma-source-of-truth.md)                  | Accepted | 2026-04-22 |
+| 0011 | [Untitled UI React kit + CLI source-based delivery](0011-untitled-ui-react-kit.md)      | Accepted | 2026-04-27 |
 
 ## Konvansiyonlar
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,11 +1,93 @@
 # @glaon/ui
 
-Untitled UI React kit sarmalayıcısı. Kit lisanslı olduğu için kaynak dosyalar depoya dahil değildir.
+Glaon'un primitive component kütüphanesi. Web (Vite/React 19) ve mobil (Expo/RN) consumer'ların tükettiği Storybook-tabanlı paket. Lisanslı **Untitled UI React kit**'in source code'unu CLI üzerinden çekip Glaon design token'larıyla yeniden temalar.
 
-## Kurulum
+Kararın gerekçesi: [ADR 0011 — Untitled UI React kit + CLI source-based delivery](../../docs/adr/0011-untitled-ui-react-kit.md).
 
-1. Untitled UI React kaynaklarını `packages/ui/src/untitled/` altına kopyala (bu dizin `.gitignore` içinde tutulacak).
-2. `src/index.ts` içinden Glaon'a uyarlanmış sarmalayıcıları dışa aktar.
-3. Web ve mobil uygulamalar yalnızca `@glaon/ui` üzerinden import etsin — Untitled UI'ı doğrudan kullanmayın.
+## Untitled UI React kit — kurulum
 
-Temalama, tokenlar ve tipografi Faz 2'de ele alınacak.
+Kit lisanslı ve **npm paketi olarak yayınlanmaz**. Yayıncının resmi yolu `npx untitledui` CLI'sıdır; CLI component source'unu doğrudan projeye yazar (harici dep yok). Source dosyaları repo'ya commit edilir, böylece CI ek auth gerekmeden çalışır.
+
+### Per-developer setup (yeni geliştirici onboarding)
+
+1. **Pro lisans key edin**: <https://www.untitledui.com> → Pro hesap. Key dashboard'da görünür.
+2. **CLI'a login**:
+   ```bash
+   npx untitledui login
+   # alternatif: her komut için --license <key>
+   ```
+   Auth token CLI'ın local config'inde tutulur (`~/.config/untitledui/`); repo'ya commit edilmez.
+3. **`pnpm install`** + Storybook çalıştır. Kit source'u zaten repoda → ek adım yok.
+4. **Yeni primitive eklemek istiyorsan** ya da **kit upgrade** yapacaksan login state'i aktif kalmalı; aksi halde `untitledui add`/`upgrade` 401 verir.
+
+### Yeni primitive ekleme (manuel adım)
+
+`untitledui init` çalıştırılmaz — Glaon zaten Vite + Storybook ile kurulu. Sadece `add` kullanılır:
+
+```bash
+npx untitledui@latest add <component-name> \
+  --type base \
+  --path packages/ui/src/components/<Name> \
+  --yes
+```
+
+Sonra Glaon wrap'ini yaz:
+
+- `<Name>.tsx` (web) ve `<Name>.native.tsx` (RN, gerekiyorsa) kit primitive'ini import eder, Glaon design token'larıyla skin'ler.
+- `<Name>.types.ts` shared prop sözleşmesi.
+- `<Name>.stories.tsx` Storybook story'leri.
+- `index.ts` re-export.
+
+`packages/ui/src/index.ts` barrel'ı güncellemeyi unutma. CSF 3.0 + addon-a11y (error level) + `parameters.design` ile Figma frame embed zorunlu — bkz. [docs/storybook.md](../../docs/storybook.md), [docs/figma.md](../../docs/figma.md).
+
+### Kit upgrade
+
+Kit yeni sürümlerini takip etmek için yeni bir issue açıp ayrı bir branch'te:
+
+```bash
+npx untitledui upgrade
+```
+
+CLI etkilenen dosyaları yeniden yazar. Diff'i PR review'da incele — yayıncının breaking change'leri commit message'larında işaretlenir.
+
+### CI tarafı
+
+CI Storybook build, Chromatic, Vitest browser tests sırasında kit source'unu **mevcut olarak** kabul eder; `untitledui` CLI'sını çalıştırmaz, lisans key gerekmez. Workflow'larda ek auth setup yoktur.
+
+## Lisans / attribution
+
+`@glaon/ui`, Untitled UI React kit'inin Pro source code'unu Glaon proje deposuna gömerek kullanır. Yayıncının lisans şartlarının metni `LICENSE-untitledui.md` dosyasında repoda taşınır; her kit dosyasında CLI'ın eklediği header korunur.
+
+> Bu paket, Untitled UI tarafından sağlanan licensed React component kit'inin source code'unu içerir. Source'un üretimi CLI yoluyla, sahip olunan Pro lisans key'i ile yapılır. Lisans şartlarının tam metni `LICENSE-untitledui.md` dosyasında, ek bilgi <https://www.untitledui.com> üzerindedir.
+
+Brand Guideline Cover sayfasında da aynı paragraf release süresince güncel tutulur (bkz. #166).
+
+## Komutlar
+
+```bash
+pnpm --filter @glaon/ui storybook        # localhost:6006
+pnpm --filter @glaon/ui build:tokens     # tokens/*.json → dist/tokens/{web.css,rn.ts}
+pnpm --filter @glaon/ui build            # tsc -b
+pnpm --filter @glaon/ui test             # Vitest unit
+pnpm --filter @glaon/ui test:stories     # Vitest browser (Playwright)
+pnpm --filter @glaon/ui chromatic        # visual regression upload
+pnpm --filter @glaon/ui type-check
+pnpm --filter @glaon/ui lint
+```
+
+## Sorun giderme
+
+- **`untitledui add` 401 / 403**: `untitledui login` ile yeniden auth ol, ya da `--license <key>` flag'iyle çalıştır. Pro hesap aktif mi kontrol et.
+- **Kit source'unda CLI değişiklik yapmadığım dosyaya da dokundu**: `--overwrite` olmadan default davranış; review et, gerekirse `git restore` ile geri al, `--path` argümanını daralt.
+- **Storybook a11y panel'i `error` veriyor**: `addon-a11y` `a11y.test: 'error'` ile aktif; merge için yeşil olmalı. İstisnai durumlarda inline doc + scope-narrow `parameters.a11y.config.rules`.
+- **Hex/px literal lint hatası**: Component dosyasında token yerine raw değer var. F2 üretimi `dist/tokens/{web.css,rn.ts}`'dan ilgili token'ı tüket.
+
+## Referanslar
+
+- [ADR 0011 — Untitled UI React kit + CLI source-based delivery](../../docs/adr/0011-untitled-ui-react-kit.md)
+- [docs/storybook.md](../../docs/storybook.md) — story conventions + addons.
+- [docs/figma.md](../../docs/figma.md) — tasarım kaynağı + plugin bridge.
+- [docs/design-system-bootstrap.md](../../docs/design-system-bootstrap.md) — Figma file yapısı + primitive yetiştirme.
+- [packages/ui/tokens/README.md](tokens/README.md) — design token export + schema.
+- Untitled UI CLI: `npx untitledui --help`.
+- Untitled UI MCP: <https://www.untitledui.com/react/integrations/mcp> — issue #206 ile entegre edilecek.


### PR DESCRIPTION
## Summary

- Replaces the obsolete GitHub Packages registry decision (PR #205, closed). Untitled UI is **not** an npm package — the publisher's official tooling is the `npx untitledui` CLI, which writes component source directly into the consuming project.
- F3 of the Phase 1 design-system code integration: locks in the source-based delivery model, commits the kit code into Glaon, wraps every primitive behind a thin Glaon layer that consumes design tokens.

## Scope (In)

- **`docs/adr/0011-untitled-ui-react-kit.md`** — frozen rationale, alternatives evaluated (registry / submodule / source commit / CI regenerate), license posture, reassessment triggers.
- **`docs/adr/README.md`** — index entry for ADR-0011.
- **`packages/ui/README.md`** — onboarding runbook for the new flow:
  - Pro key acquisition + `untitledui login`.
  - Per-primitive `npx untitledui add` command (with `--type base --path packages/ui/src/components/<Name> --yes`).
  - Upgrade workflow (`npx untitledui upgrade` per issue + PR review).
  - CI implications (kit source committed → no auth needed in workflows).
  - License attribution paragraph (carried verbatim onto Brand Guideline Cover at each release).
  - Troubleshooting (login, overwrite scope, a11y, hex/px lint).

## Scope (Out)

- **First primitive source commit + Glaon wrap.** Lands in F5 (#174) when Button + PressableButton re-skin to consume tokens. The kit source for Button arrives there alongside the wrap.
- **Untitled UI Remote MCP entry** — separate issue (#206) per the CLAUDE.md "new MCP servers get their own issue" rule. PR will add the entry to `.mcp.json`.
- **`LICENSE-untitledui.md`** — will arrive alongside the first `untitledui add` commit so the publisher-supplied license text travels with the code.
- **Renovate-style upgrade automation** — none today; the ADR keeps it as a reassessment trigger if minor bump frequency becomes painful.

## Test plan

- [x] Pre-commit hook passed (gitleaks + lint-staged).
- [x] `pnpm exec prettier --check` passed on the touched files.
- [x] CI green on this branch (markdown-only changes — type-check / lint / story-tests no-ops).
- [ ] Reviewer: ADR captures the why convincingly; alternatives are honest, not strawmen. License risk is acknowledged with a concrete fallback.
- [ ] Reviewer: README runbook is reproducible by a fresh developer (Pro key, `untitledui login`, per-primitive add command, expected error modes).
- [x] Reviewer: ADR's "no `init` step" stance matches Glaon's existing Vite + Storybook setup — no risk of CLI-driven config files clobbering current tooling.

Refs #14, #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)