### PR TITLE
refactor(ui): re-skin button + pressablebutton on glaon tokens

### DIFF
--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -6,16 +6,28 @@ const meta = {
   title: 'Web Primitives/Button',
   component: Button,
   tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-button',
+    },
+  },
   args: {
     children: 'Click me',
-    variant: 'primary',
+    intent: 'primary',
     size: 'md',
     disabled: false,
+    loading: false,
   },
   argTypes: {
-    variant: { control: 'inline-radio', options: ['primary', 'secondary'] },
+    intent: {
+      control: 'inline-radio',
+      options: ['primary', 'secondary', 'tertiary', 'destructive'],
+    },
     size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
     disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    leadingIcon: { control: false },
     onClick: { action: 'clicked' },
   },
 } satisfies Meta<typeof Button>;
@@ -26,11 +38,41 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {};
 
 export const Secondary: Story = {
-  args: { variant: 'secondary' },
+  args: { intent: 'secondary' },
+};
+
+export const Tertiary: Story = {
+  args: { intent: 'tertiary' },
+};
+
+export const Destructive: Story = {
+  args: { intent: 'destructive' },
 };
 
 export const Disabled: Story = {
   args: { disabled: true },
+};
+
+export const Loading: Story = {
+  args: { loading: true, children: 'Saving' },
+};
+
+export const WithLeadingIcon: Story = {
+  args: {
+    leadingIcon: (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M12 5v14M5 12h14" strokeLinecap="round" />
+      </svg>
+    ),
+    children: 'Add item',
+  },
 };
 
 export const Sizes: Story = {

--- a/packages/ui/src/components/Button/Button.test.tsx
+++ b/packages/ui/src/components/Button/Button.test.tsx
@@ -22,9 +22,16 @@ describe('Button', () => {
     expect(screen.getByRole('button', { name: 'Save' })).toHaveAttribute('type', 'button');
   });
 
-  it('switches background color for the secondary variant', () => {
-    render(<Button variant="secondary">Cancel</Button>);
+  it('switches background color token for the secondary intent', () => {
+    render(<Button intent="secondary">Cancel</Button>);
     const button = screen.getByRole('button', { name: 'Cancel' });
-    expect(button.style.backgroundColor).toBe('rgb(255, 255, 255)');
+    expect(button.style.backgroundColor).toBe('var(--base-white)');
+  });
+
+  it('marks itself busy and disables the click handler when loading', () => {
+    render(<Button loading>Saving</Button>);
+    const button = screen.getByRole('button', { name: /Saving/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
   });
 });

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,63 +1,145 @@
-import type { ButtonHTMLAttributes, ReactNode } from 'react';
+// Web Button — inline style consumes the CSS custom properties emitted by
+// F2 (`packages/ui/dist/tokens/web.css`). Variant matrix mirrors the kit:
+// intent (primary | secondary | tertiary | destructive) × size (sm | md |
+// lg) × state (default | hover | active | disabled | loading).
+//
+// Token consumption is intentionally string-based — `var(--brand-500)`,
+// `var(--neutral-300)` — so a future `[data-theme='dark']` block in the
+// emitted CSS lights up dark colors without component code changes.
+//
+// `loading` shows the spinner and suppresses click handlers; `leadingIcon`
+// is hidden in that state to keep the affordance unambiguous.
 
-export type ButtonVariant = 'primary' | 'secondary';
-export type ButtonSize = 'sm' | 'md' | 'lg';
+import type { ButtonHTMLAttributes, CSSProperties, MouseEvent } from 'react';
 
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: ButtonVariant;
-  size?: ButtonSize;
-  children: ReactNode;
-}
+import { DEFAULT_BUTTON_INTENT, DEFAULT_BUTTON_SIZE, type ButtonBaseProps } from './Button.types';
 
-const baseStyle: React.CSSProperties = {
+export type { ButtonIntent, ButtonSize, ButtonBaseProps } from './Button.types';
+
+export interface ButtonProps
+  extends ButtonBaseProps, Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'disabled'> {}
+
+const baseStyle: CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
+  gap: 8,
   border: '1px solid transparent',
   borderRadius: 6,
   fontWeight: 600,
   cursor: 'pointer',
-  transition: 'background-color 120ms ease, border-color 120ms ease',
+  transition: 'background-color 120ms ease, border-color 120ms ease, color 120ms ease',
+  fontFamily: 'inherit',
 };
 
-const variantStyle: Record<ButtonVariant, React.CSSProperties> = {
+const intentStyle: Record<NonNullable<ButtonBaseProps['intent']>, CSSProperties> = {
   primary: {
-    backgroundColor: '#2563eb',
-    color: '#ffffff',
+    backgroundColor: 'var(--brand-500)',
+    color: 'var(--base-white)',
+    borderColor: 'var(--brand-500)',
   },
   secondary: {
-    backgroundColor: '#ffffff',
-    color: '#111827',
-    borderColor: '#d1d5db',
+    backgroundColor: 'var(--base-white)',
+    color: 'var(--neutral-900)',
+    borderColor: 'var(--neutral-300)',
+  },
+  tertiary: {
+    backgroundColor: 'transparent',
+    color: 'var(--brand-500)',
+    borderColor: 'transparent',
+  },
+  destructive: {
+    backgroundColor: 'var(--red-500)',
+    color: 'var(--base-white)',
+    borderColor: 'var(--red-500)',
   },
 };
 
-const sizeStyle: Record<ButtonSize, React.CSSProperties> = {
-  sm: { padding: '4px 10px', fontSize: 13 },
-  md: { padding: '8px 14px', fontSize: 14 },
-  lg: { padding: '12px 20px', fontSize: 16 },
+const sizeStyle: Record<NonNullable<ButtonBaseProps['size']>, CSSProperties> = {
+  sm: { padding: '4px 10px', fontSize: 13, minHeight: 28 },
+  md: { padding: '8px 14px', fontSize: 14, minHeight: 36 },
+  lg: { padding: '12px 20px', fontSize: 16, minHeight: 44 },
+};
+
+const inactiveStyle: CSSProperties = {
+  opacity: 0.5,
+  cursor: 'not-allowed',
 };
 
 export function Button({
-  variant = 'primary',
-  size = 'md',
-  disabled,
-  style,
+  intent = DEFAULT_BUTTON_INTENT,
+  size = DEFAULT_BUTTON_SIZE,
+  loading = false,
+  disabled = false,
+  leadingIcon,
   children,
+  style,
+  onClick,
   ...rest
 }: ButtonProps) {
-  const composedStyle: React.CSSProperties = {
+  const inactive = disabled || loading;
+  const composedStyle: CSSProperties = {
     ...baseStyle,
-    ...variantStyle[variant],
+    ...intentStyle[intent],
     ...sizeStyle[size],
-    opacity: disabled === true ? 0.5 : 1,
-    cursor: disabled === true ? 'not-allowed' : 'pointer',
+    ...(inactive ? inactiveStyle : null),
     ...style,
   };
-
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (inactive) return;
+    onClick?.(event);
+  };
   return (
-    <button type="button" disabled={disabled} style={composedStyle} {...rest}>
-      {children}
+    <button
+      type="button"
+      disabled={inactive}
+      aria-busy={loading || undefined}
+      style={composedStyle}
+      onClick={handleClick}
+      {...rest}
+    >
+      {loading ? (
+        <Spinner size={size} />
+      ) : leadingIcon !== undefined ? (
+        <span aria-hidden="true">{leadingIcon}</span>
+      ) : null}
+      <span>{children}</span>
     </button>
   );
+}
+
+const SPINNER_SIZE: Record<NonNullable<ButtonBaseProps['size']>, number> = {
+  sm: 12,
+  md: 14,
+  lg: 16,
+};
+
+function Spinner({ size }: { size: NonNullable<ButtonBaseProps['size']> }) {
+  const px = SPINNER_SIZE[size];
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        width: px,
+        height: px,
+        borderRadius: '50%',
+        border: '2px solid currentColor',
+        borderTopColor: 'transparent',
+        animation: 'glaon-button-spinner 720ms linear infinite',
+        display: 'inline-block',
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+if (typeof document !== 'undefined') {
+  const id = 'glaon-button-spinner-keyframes';
+  if (!document.getElementById(id)) {
+    const style = document.createElement('style');
+    style.id = id;
+    style.textContent =
+      '@keyframes glaon-button-spinner { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }';
+    document.head.appendChild(style);
+  }
 }

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -14,8 +14,6 @@ import type { ButtonHTMLAttributes, CSSProperties, MouseEvent } from 'react';
 
 import { DEFAULT_BUTTON_INTENT, DEFAULT_BUTTON_SIZE, type ButtonBaseProps } from './Button.types';
 
-export type { ButtonIntent, ButtonSize, ButtonBaseProps } from './Button.types';
-
 export interface ButtonProps
   extends ButtonBaseProps, Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'disabled'> {}
 
@@ -49,9 +47,9 @@ const intentStyle: Record<NonNullable<ButtonBaseProps['intent']>, CSSProperties>
     borderColor: 'transparent',
   },
   destructive: {
-    backgroundColor: 'var(--red-500)',
+    backgroundColor: 'var(--red-700)',
     color: 'var(--base-white)',
-    borderColor: 'var(--red-500)',
+    borderColor: 'var(--red-700)',
   },
 };
 

--- a/packages/ui/src/components/Button/Button.types.ts
+++ b/packages/ui/src/components/Button/Button.types.ts
@@ -1,0 +1,28 @@
+// Shared button contract. The DOM (`Button`) and RN (`PressableButton`)
+// implementations both extend this shape with platform-specific event
+// handlers and host props.
+
+import type { ReactNode } from 'react';
+
+export type ButtonIntent = 'primary' | 'secondary' | 'tertiary' | 'destructive';
+
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonBaseProps {
+  intent?: ButtonIntent;
+  size?: ButtonSize;
+  /** Show a spinner instead of (or alongside) the label. Disables interaction
+   * for the duration; the consumer's click/press handler is suppressed. */
+  loading?: boolean;
+  disabled?: boolean;
+  /** Decorative icon rendered before the label. Pass any node — emoji,
+   * inline SVG, or an icon component. Hidden during `loading`. */
+  leadingIcon?: ReactNode;
+  children: ReactNode;
+}
+
+/** Default intent applied when `intent` is omitted. */
+export const DEFAULT_BUTTON_INTENT: ButtonIntent = 'primary';
+
+/** Default size applied when `size` is omitted. */
+export const DEFAULT_BUTTON_SIZE: ButtonSize = 'md';

--- a/packages/ui/src/components/Button/index.ts
+++ b/packages/ui/src/components/Button/index.ts
@@ -1,2 +1,3 @@
 export { Button } from './Button';
-export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
+export type { ButtonProps } from './Button';
+export type { ButtonIntent, ButtonSize, ButtonBaseProps } from './Button.types';

--- a/packages/ui/src/components/PressableButton/PressableButton.stories.tsx
+++ b/packages/ui/src/components/PressableButton/PressableButton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import { View } from 'react-native';
+import { Text, View } from 'react-native';
 
 import { PressableButton } from './PressableButton';
 
@@ -7,16 +7,28 @@ const meta = {
   title: 'RN Primitives/PressableButton',
   component: PressableButton,
   tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=rn-primitives-pressable-button',
+    },
+  },
   args: {
     children: 'Press me',
-    variant: 'primary',
+    intent: 'primary',
     size: 'md',
     disabled: false,
+    loading: false,
   },
   argTypes: {
-    variant: { control: 'inline-radio', options: ['primary', 'secondary'] },
+    intent: {
+      control: 'inline-radio',
+      options: ['primary', 'secondary', 'tertiary', 'destructive'],
+    },
     size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
     disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    leadingIcon: { control: false },
     onPress: { action: 'pressed' },
   },
 } satisfies Meta<typeof PressableButton>;
@@ -27,11 +39,30 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {};
 
 export const Secondary: Story = {
-  args: { variant: 'secondary' },
+  args: { intent: 'secondary' },
+};
+
+export const Tertiary: Story = {
+  args: { intent: 'tertiary' },
+};
+
+export const Destructive: Story = {
+  args: { intent: 'destructive' },
 };
 
 export const Disabled: Story = {
   args: { disabled: true },
+};
+
+export const Loading: Story = {
+  args: { loading: true, children: 'Saving' },
+};
+
+export const WithLeadingIcon: Story = {
+  args: {
+    leadingIcon: <Text style={{ color: 'inherit', fontSize: 14 }}>+</Text>,
+    children: 'Add item',
+  },
 };
 
 export const Sizes: Story = {

--- a/packages/ui/src/components/PressableButton/PressableButton.tsx
+++ b/packages/ui/src/components/PressableButton/PressableButton.tsx
@@ -25,8 +25,6 @@ import {
   type ButtonSize,
 } from '../Button/Button.types';
 
-export type { ButtonIntent, ButtonSize, ButtonBaseProps } from '../Button/Button.types';
-
 export interface PressableButtonProps
   extends ButtonBaseProps, Omit<PressableProps, 'children' | 'style' | 'disabled'> {}
 
@@ -34,7 +32,7 @@ interface PaintTokens {
   base: { white: string };
   neutral: { '300': string; '900': string };
   brand: { '500': string };
-  red: { '500': string };
+  red: { '700': string };
 }
 
 interface IntentSurface {
@@ -65,8 +63,8 @@ function intentSurfaceFor(intent: ButtonIntent, tokens: PaintTokens): IntentSurf
       };
     case 'destructive':
       return {
-        background: tokens.red['500'],
-        border: tokens.red['500'],
+        background: tokens.red['700'],
+        border: tokens.red['700'],
         label: tokens.base.white,
       };
   }
@@ -120,7 +118,11 @@ export function PressableButton({
       {...rest}
     >
       {loading ? (
-        <ActivityIndicator size={sizing.spinner} color={surface.label} />
+        <ActivityIndicator
+          size={sizing.spinner}
+          color={surface.label}
+          accessibilityLabel="Loading"
+        />
       ) : leadingIcon !== undefined ? (
         <View accessibilityElementsHidden style={styles.icon}>
           {leadingIcon}

--- a/packages/ui/src/components/PressableButton/PressableButton.tsx
+++ b/packages/ui/src/components/PressableButton/PressableButton.tsx
@@ -1,64 +1,154 @@
-import type { ReactNode } from 'react';
-import { Pressable, StyleSheet, Text, type PressableProps } from 'react-native';
+// RN Button — `Pressable` + `View` + `Text` with a Glaon `useTheme()`-fed
+// design token object. Variant matrix mirrors the web `Button`:
+// intent (primary | secondary | tertiary | destructive) × size (sm | md |
+// lg) × state (default | pressed | disabled | loading).
+//
+// Tokens are read from the active `<ThemeProvider tokens={tokens}>` —
+// consumers import the generated tokens object from
+// `@glaon/ui/dist/tokens/rn` and pass it in once at the app shell.
 
-export type PressableButtonVariant = 'primary' | 'secondary';
-export type PressableButtonSize = 'sm' | 'md' | 'lg';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  type PressableProps,
+} from 'react-native';
 
-export interface PressableButtonProps extends Omit<PressableProps, 'children' | 'style'> {
-  variant?: PressableButtonVariant;
-  size?: PressableButtonSize;
-  children: ReactNode;
+import { useTheme } from '../../theme';
+import {
+  DEFAULT_BUTTON_INTENT,
+  DEFAULT_BUTTON_SIZE,
+  type ButtonBaseProps,
+  type ButtonIntent,
+  type ButtonSize,
+} from '../Button/Button.types';
+
+export type { ButtonIntent, ButtonSize, ButtonBaseProps } from '../Button/Button.types';
+
+export interface PressableButtonProps
+  extends ButtonBaseProps, Omit<PressableProps, 'children' | 'style' | 'disabled'> {}
+
+interface PaintTokens {
+  base: { white: string };
+  neutral: { '300': string; '900': string };
+  brand: { '500': string };
+  red: { '500': string };
 }
 
+interface IntentSurface {
+  background: string;
+  border: string;
+  label: string;
+}
+
+function intentSurfaceFor(intent: ButtonIntent, tokens: PaintTokens): IntentSurface {
+  switch (intent) {
+    case 'primary':
+      return {
+        background: tokens.brand['500'],
+        border: tokens.brand['500'],
+        label: tokens.base.white,
+      };
+    case 'secondary':
+      return {
+        background: tokens.base.white,
+        border: tokens.neutral['300'],
+        label: tokens.neutral['900'],
+      };
+    case 'tertiary':
+      return {
+        background: 'transparent',
+        border: 'transparent',
+        label: tokens.brand['500'],
+      };
+    case 'destructive':
+      return {
+        background: tokens.red['500'],
+        border: tokens.red['500'],
+        label: tokens.base.white,
+      };
+  }
+}
+
+const sizePadding: Record<
+  ButtonSize,
+  {
+    paddingVertical: number;
+    paddingHorizontal: number;
+    fontSize: number;
+    minHeight: number;
+    spinner: number;
+  }
+> = {
+  sm: { paddingVertical: 4, paddingHorizontal: 10, fontSize: 13, minHeight: 28, spinner: 12 },
+  md: { paddingVertical: 8, paddingHorizontal: 14, fontSize: 14, minHeight: 36, spinner: 14 },
+  lg: { paddingVertical: 12, paddingHorizontal: 20, fontSize: 16, minHeight: 44, spinner: 16 },
+};
+
 export function PressableButton({
-  variant = 'primary',
-  size = 'md',
-  disabled,
+  intent = DEFAULT_BUTTON_INTENT,
+  size = DEFAULT_BUTTON_SIZE,
+  loading = false,
+  disabled = false,
+  leadingIcon,
   children,
   ...rest
 }: PressableButtonProps) {
+  const { tokens } = useTheme<PaintTokens>();
+  const surface = intentSurfaceFor(intent, tokens);
+  const sizing = sizePadding[size];
+  const inactive = disabled || loading;
   return (
     <Pressable
       accessibilityRole="button"
-      disabled={disabled}
+      accessibilityState={{ disabled: inactive, busy: loading }}
+      disabled={inactive}
       style={({ pressed }) => [
         styles.base,
-        styles[variant],
-        styles[size],
-        disabled === true && styles.disabled,
-        pressed && !(disabled === true) && styles.pressed,
+        {
+          backgroundColor: surface.background,
+          borderColor: surface.border,
+          paddingVertical: sizing.paddingVertical,
+          paddingHorizontal: sizing.paddingHorizontal,
+          minHeight: sizing.minHeight,
+        },
+        inactive && styles.inactive,
+        pressed && !inactive && styles.pressed,
       ]}
       {...rest}
     >
-      <Text style={[styles.label, styles[`${variant}Label`]]}>{children}</Text>
+      {loading ? (
+        <ActivityIndicator size={sizing.spinner} color={surface.label} />
+      ) : leadingIcon !== undefined ? (
+        <View accessibilityElementsHidden style={styles.icon}>
+          {leadingIcon}
+        </View>
+      ) : null}
+      <Text style={[styles.label, { color: surface.label, fontSize: sizing.fontSize }]}>
+        {children}
+      </Text>
     </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
   base: {
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: 6,
     borderWidth: 1,
-    borderColor: 'transparent',
+    columnGap: 8,
   },
-  primary: {
-    backgroundColor: '#2563eb',
-  },
-  secondary: {
-    backgroundColor: '#ffffff',
-    borderColor: '#d1d5db',
-  },
-  sm: { paddingVertical: 4, paddingHorizontal: 10 },
-  md: { paddingVertical: 8, paddingHorizontal: 14 },
-  lg: { paddingVertical: 12, paddingHorizontal: 20 },
-  disabled: { opacity: 0.5 },
-  pressed: { opacity: 0.8 },
   label: {
     fontWeight: '600',
-    fontSize: 14,
   },
-  primaryLabel: { color: '#ffffff' },
-  secondaryLabel: { color: '#111827' },
+  icon: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  inactive: { opacity: 0.5 },
+  pressed: { opacity: 0.8 },
 });

--- a/packages/ui/src/components/PressableButton/index.ts
+++ b/packages/ui/src/components/PressableButton/index.ts
@@ -1,6 +1,2 @@
 export { PressableButton } from './PressableButton';
-export type {
-  PressableButtonProps,
-  PressableButtonVariant,
-  PressableButtonSize,
-} from './PressableButton';
+export type { PressableButtonProps } from './PressableButton';


### PR DESCRIPTION
## Summary

- F5 of the Phase 1 design-system code integration. Drops hard-coded hex values from the existing Button + PressableButton, threads F2 design tokens through them, and widens the variant matrix to the kit-aligned shape: intent (primary | secondary | tertiary | destructive) × size (sm | md | lg) × state (default | hover/pressed | disabled | loading).
- Sets the reference pattern every later primitive (P1–P18) copies: token-only styling, design-system Figma frame embed, complete props in Storybook controls, addon-a11y green at error level.

## Scope (In)

- `packages/ui/src/components/Button/Button.types.ts` — new shared base props (`ButtonIntent`, `ButtonSize`, `ButtonBaseProps`, defaults, `loading`, `leadingIcon`).
- `packages/ui/src/components/Button/Button.tsx` (web):
  - Inline style consumes CSS custom properties from `dist/tokens/web.css` (`var(--brand-500)`, `var(--base-white)`, `var(--neutral-300)`, `var(--neutral-900)`, `var(--red-500)`). Zero raw hex left.
  - `loading` renders a CSS-keyframe spinner, sets `aria-busy`, suppresses click handlers; `leadingIcon` is hidden in that state.
  - Spinner keyframes injected once via `document.head` (guarded for SSR).
- `packages/ui/src/components/PressableButton/PressableButton.tsx` (RN):
  - Reads tokens from `useTheme()` (F4). Requires `<ThemeProvider tokens={tokens}>` at app shell — Storybook preview already wires this.
  - Same intent / size / state matrix as web. Shared `Button.types.ts` powers both.
  - Loading uses `ActivityIndicator`, `accessibilityState` exposes `disabled` + `busy`.
- Story files for both:
  - `parameters.design` Figma URL keyed on `storybook-id: web-primitives-button` / `rn-primitives-pressable-button`.
  - New `Tertiary`, `Destructive`, `Loading`, `WithLeadingIcon` variants alongside the existing default + Sizes matrix.
  - Args/argTypes rebuilt around `intent` (legacy `variant` removed).
- `Button.test.tsx` — covers renamed prop, asserts CSS-var literal (jsdom doesn't resolve `var(...)`), new `loading` busy-state test.
- Index barrels (`Button/index.ts`, `PressableButton/index.ts`) re-export the new types.

## Scope (Out)

- Pulling the actual Untitled UI kit source via `npx untitledui add` — F5 keeps the existing hand-rolled implementations and tokenizes them. The first kit-source primitive lands in P1+ when a brand-new component is needed.
- Hover state styling on the web button. Inline styles can't drive `:hover`; the upcoming primitive PRs will move to scoped CSS classes (or CSS-in-JS) where hover/active states matter visually. F5 is an upgrade-in-place, not a rewrite of the styling layer.
- `[data-theme='dark']` overrides — source tokens are still single-mode (#140 follow-up).
- Wiring `build:tokens` into the global turbo `build` task. Storybook + test:stories already prefix it via package scripts; F6 / future primitive PRs can extend the chain when consumers need it during `pnpm build`.

## Test plan

- [x] `pnpm type-check` green across the monorepo.
- [x] `pnpm lint` green across the monorepo.
- [x] `pnpm exec prettier --check` clean on the touched files.
- [x] `pnpm --filter @glaon/ui test` (Vitest unit) passes — 5/5 including the new loading-state assertion.
- [x] `pnpm --filter @glaon/ui build-storybook` succeeds end-to-end.
- [x] Pre-commit hook passed (gitleaks + lint-staged).
- [ ] CI green (Vitest browser stories runs in CI; was blocked locally only because Playwright's chromium binary isn't installed on this machine).
- [ ] Reviewer (local): `pnpm --filter @glaon/ui storybook` → toolbar Theme toggle leaves the matrix readable in light; the four intents render distinct colors; Loading spinner animates; WithLeadingIcon renders the inline SVG / RN text node before the label.
- [ ] Reviewer: addon-a11y panel green at `error` level on Default + Disabled stories of both components.
- [ ] Reviewer: Chromatic visual diffs accepted (Glaon brand color flip + new spinner / icon slots are intentional).

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)