### PR TITLE
docs(rules): mandate untitled ui source for base primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,15 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 - Figma component descriptions carry the Storybook component ID in the form `storybook-id: <kebab-case>`. This is the contract that Chromatic's Figma plugin (#53) relies on; don't change the format without coordinating that integration.
 - Setup and workflow details: [docs/figma.md](docs/figma.md). Design System bootstrap spec: [docs/design-system-bootstrap.md](docs/design-system-bootstrap.md).
 
+## UUI Source Rule (MANDATORY)
+
+- Every base primitive in `@glaon/ui` (web side) **must wrap an Untitled UI source pulled via `npx untitledui add`**. Hand-rolling a primitive's structural HTML/CSS or rolling your own variant matrix from scratch is forbidden — Glaon's contribution is the wrap layer (token override, `<ThemeProvider>` integration, prop API consistency, Figma `parameters.design` mapping), not the kit's source itself.
+- Workflow: `npx untitledui add <component-name> --yes` to fetch the kit source into `packages/ui/src/components/...`, then write `<Name>.tsx` (Glaon wrap) that imports the kit Button/Input/etc. and re-exports under the Glaon prop contract. Token overrides land in `packages/ui/src/styles/` (UUI `theme.css` + Glaon F2 brand override layer), never inside individual component files.
+- Exceptions:
+  - **RN-side primitives** (e.g. `PressableButton`) when no UUI source ships for React Native — hand-roll is allowed but must mirror the web wrap's prop contract and consume tokens through `useTheme()`.
+  - **Application primitives** (Phase 2: `AppShell`, `DataTable`, `FormField`, …) compose multiple base primitives and may add orchestration logic. Their structural pieces still come from UUI when available.
+- Setup decisions: [ADR 0011](docs/adr/0011-untitled-ui-react-kit.md), [ADR 0013](docs/adr/0013-tailwind-v4-uui-theme.md). Per-developer + CI runbook: [packages/ui/README.md](packages/ui/README.md).
+
 ## Storybook Rule (MANDATORY)
 
 - Every new UI component (web or mobile) ships in the same PR with at least one Storybook story. No story, no merge.

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -73,16 +73,28 @@ pnpm --filter @glaon/ui exec vitest --project=storybook src/components/Button/Bu
 
 ## Story yazım kuralları
 
+### Yeni primitive nereden başlar
+
+Web tarafındaki her base primitive **Untitled UI source'undan başlar** — bkz. [CLAUDE.md "UUI Source Rule"](../CLAUDE.md#uui-source-rule-mandatory). Akış:
+
+1. `npx untitledui add <component> --yes` → kit source `packages/ui/src/components/...` altına yazılır.
+2. Glaon wrap'i (`<Name>.tsx`) kit primitive'ini import edip Glaon prop kontratı + `<ThemeProvider>` entegrasyonuyla yeniden export eder.
+3. Story dosyası kit'in expose ettiği tam variant matrix'i kullanır + `parameters.design` Figma URL'ini set eder.
+
+Hand-rolled primitive (sıfırdan elle yazma) yasak. RN-side primitive'leri için (`PressableButton` benzeri) UUI yoksa hand-roll yapılır; web wrap'inin prop kontratını yansıtmak zorunda.
+
 ### Dosya yerleşimi
 
 Her component kendi klasöründe ve story'siyle birlikte tutulur:
 
 ```
 packages/ui/src/components/Button/
-├── Button.tsx            # component
+├── Button.tsx            # Glaon wrap (kit'i import eder)
 ├── Button.stories.tsx    # story (zorunlu)
 └── index.ts              # barrel export
 ```
+
+Kit source dosyaları CLI'ın kendi default path'inde (`packages/ui/src/components/base/...`) yaşar — `untitledui upgrade` doğrudan oraya yazar; Glaon wrap onları import eder.
 
 ### CSF 3.0 format
 


### PR DESCRIPTION
## Summary

- The kit-vs-hand-rolled debate resurfaced across PR #214 (tokenize-only attempt that lost design fidelity), PR #217 (Tailwind v3), and PR #220 (v4 + theme.css). ADR 0011 + ADR 0013 pin the technical foundation, but neither explicitly forbids hand-rolled primitives — and #214 proved the gap is easy to slip through.
- Codifies the rule in CLAUDE.md so every P1–P18 primitive PR starts from `npx untitledui add` instead of from scratch.

## Scope (In)

- **`CLAUDE.md`** — new "UUI Source Rule (MANDATORY)" section right before the Storybook Rule:
  - Web base primitives must wrap a UUI source pulled via the CLI; hand-rolling structural HTML/CSS or variant matrices is forbidden.
  - Glaon's contribution is the wrap layer (token override, `<ThemeProvider>` integration, prop API consistency, Figma `parameters.design` mapping).
  - Tokens live in `packages/ui/src/styles/` (UUI theme.css + Glaon F2 brand override layer), never inline in component files.
  - Two carve-outs: (1) RN-side primitives when no UUI source exists, must mirror the web wrap's prop contract; (2) Application primitives in Phase 2 may compose multiple base primitives but their structural pieces still come from UUI when available.
  - Cross-references ADR 0011, ADR 0013, packages/ui/README.md.
- **`docs/storybook.md`** — "Story yazım kuralları" gains a "Yeni primitive nereden başlar" subsection that points at the CLI workflow up front and notes the hand-roll exception for RN-side. The dosya yerleşimi diagram annotates `Button.tsx` as the Glaon wrap and explains kit source lives under `components/base/...` per the CLI's default path.

## Scope (Out)

- Converting the existing hand-rolled Button + PressableButton — that's #215, which lands the actual UUI Button source on top of the now-merged v4 + theme.css foundation.
- Duplicating the rule in `packages/ui/README.md` or `docs/design-system-bootstrap.md`. CLAUDE.md + docs/storybook.md are the load-bearing surfaces; the rest cross-link back.

## Test plan

- [x] `pnpm exec prettier --check` clean on the touched files.
- [x] Pre-commit hook passed (gitleaks + lint-staged).
- [x] CI green on this branch (markdown-only changes).
- [ ] Reviewer: the new MANDATORY rule reads as a hard rule, not a recommendation; the carve-outs are honest about RN-side and Application-tier exceptions.
- [ ] Reviewer: docs/storybook.md primitive workflow now starts with the CLI and matches CLAUDE.md's directive.

Closes #221
Refs #14, #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)