### PR TITLE
feat(ui): adopt @untitledui/icons + storybook icon picker

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -64,6 +64,7 @@
   "type": "module",
   "types": "./src/index.ts",
   "dependencies": {
+    "@untitledui/icons": "^0.0.22",
     "react-aria-components": "^1.17.0"
   }
 }

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -1,37 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { storybookIcons } from '../../icons/storybook';
 import { Button } from './Button';
-
-// Placeholder icons used in stories until the Untitled UI icon set lands as
-// its own primitive PR. Once that issue ships, the `iconLeading` /
-// `iconTrailing` controls switch to a real picker keyed off the kit's icon
-// catalog.
-const PlusIcon = ({ className }: { className?: string }) => (
-  <svg
-    aria-hidden="true"
-    className={className}
-    viewBox="0 0 20 20"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-  >
-    <path d="M10 4v12M4 10h12" strokeLinecap="round" />
-  </svg>
-);
-const ArrowRightIcon = ({ className }: { className?: string }) => (
-  <svg
-    aria-hidden="true"
-    className={className}
-    viewBox="0 0 20 20"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-  >
-    <path d="M4 10h12M10 4l6 6-6 6" strokeLinecap="round" strokeLinejoin="round" />
-  </svg>
-);
-
-const ICONS = { none: undefined, plus: PlusIcon, arrowRight: ArrowRightIcon } as const;
 
 const meta = {
   title: 'Web Primitives/Button',
@@ -74,13 +44,13 @@ const meta = {
     noTextPadding: { control: 'boolean' },
     iconLeading: {
       control: 'select',
-      options: Object.keys(ICONS),
-      mapping: ICONS,
+      options: Object.keys(storybookIcons),
+      mapping: storybookIcons,
     },
     iconTrailing: {
       control: 'select',
-      options: Object.keys(ICONS),
-      mapping: ICONS,
+      options: Object.keys(storybookIcons),
+      mapping: storybookIcons,
     },
     onClick: { action: 'clicked' },
   },
@@ -147,11 +117,17 @@ export const LoadingWithText: Story = {
 };
 
 export const WithLeadingIcon: Story = {
-  args: { iconLeading: PlusIcon, children: 'Add item' },
+  args: {
+    iconLeading: 'search',
+    children: 'Add item',
+    iconTrailing: 'upload',
+    routerOptions: {},
+    slot: {},
+  },
 };
 
 export const WithTrailingIcon: Story = {
-  args: { iconTrailing: ArrowRightIcon, children: 'Continue' },
+  args: { iconTrailing: storybookIcons.arrowRight, children: 'Continue' },
 };
 
 export const Sizes: Story = {

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -117,13 +117,7 @@ export const LoadingWithText: Story = {
 };
 
 export const WithLeadingIcon: Story = {
-  args: {
-    iconLeading: 'search',
-    children: 'Add item',
-    iconTrailing: 'upload',
-    routerOptions: {},
-    slot: {},
-  },
+  args: { iconLeading: storybookIcons.plus, children: 'Add item' },
 };
 
 export const WithTrailingIcon: Story = {

--- a/packages/ui/src/components/PressableButton/PressableButton.stories.tsx
+++ b/packages/ui/src/components/PressableButton/PressableButton.stories.tsx
@@ -1,20 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
-import type { FC } from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 
+import { storybookIcons } from '../../icons/storybook';
 import { PressableButton } from './PressableButton';
-
-// Placeholder icons keep parity with the web Button stories until the
-// shared Untitled UI icon catalog lands as its own primitive PR.
-const PlusIcon: FC<{ color?: string; size?: number }> = ({ color = 'currentColor', size = 16 }) => (
-  <Text style={{ color, fontSize: size, lineHeight: size, fontWeight: '600' }}>＋</Text>
-);
-const ArrowRightIcon: FC<{ color?: string; size?: number }> = ({
-  color = 'currentColor',
-  size = 16,
-}) => <Text style={{ color, fontSize: size, lineHeight: size, fontWeight: '600' }}>→</Text>;
-
-const ICONS = { none: undefined, plus: PlusIcon, arrowRight: ArrowRightIcon } as const;
 
 const meta = {
   title: 'RN Primitives/PressableButton',
@@ -57,13 +45,13 @@ const meta = {
     noTextPadding: { control: 'boolean' },
     iconLeading: {
       control: 'select',
-      options: Object.keys(ICONS),
-      mapping: ICONS,
+      options: Object.keys(storybookIcons),
+      mapping: storybookIcons,
     },
     iconTrailing: {
       control: 'select',
-      options: Object.keys(ICONS),
-      mapping: ICONS,
+      options: Object.keys(storybookIcons),
+      mapping: storybookIcons,
     },
     onPress: { action: 'pressed' },
   },
@@ -111,11 +99,11 @@ export const LoadingWithText: Story = {
 };
 
 export const WithLeadingIcon: Story = {
-  args: { iconLeading: PlusIcon, children: 'Add item' },
+  args: { iconLeading: storybookIcons.plus, children: 'Add item' },
 };
 
 export const WithTrailingIcon: Story = {
-  args: { iconTrailing: ArrowRightIcon, children: 'Continue' },
+  args: { iconTrailing: storybookIcons.arrowRight, children: 'Continue' },
 };
 
 export const Sizes: Story = {

--- a/packages/ui/src/components/PressableButton/PressableButton.tsx
+++ b/packages/ui/src/components/PressableButton/PressableButton.tsx
@@ -10,7 +10,7 @@
 // tokens come from F2's `dist/tokens/rn.ts` build output, brand colors
 // override UUI defaults the same way the web glaon-overrides.css does.
 
-import { useMemo, type FC, type ReactNode } from 'react';
+import { useMemo, type ComponentType, type ReactNode, type SVGProps } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -35,6 +35,17 @@ export type PressableButtonColor =
 
 export type PressableButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
+// Mirrors `@untitledui/icons` Props (SVGProps widened with color/size).
+// PressableButton renders icons via `<Icon color={surface.label}
+// size={sizing.iconSize} />`, so any UUI icon — or a hand-rolled one
+// with the same shape — slots in.
+type IconLeadingComponent = ComponentType<
+  SVGProps<SVGSVGElement> & {
+    color?: string;
+    size?: number;
+  }
+>;
+
 export interface PressableButtonProps extends Omit<
   PressableProps,
   'children' | 'style' | 'disabled'
@@ -43,10 +54,11 @@ export interface PressableButtonProps extends Omit<
   color?: PressableButtonColor;
   /** Size variant — mirrors the kit web `Button` `size` prop. */
   size?: PressableButtonSize;
-  /** Icon component or element rendered before the label. */
-  iconLeading?: FC<{ color?: string; size?: number }> | ReactNode;
+  /** Icon component or element rendered before the label. Accepts the
+   * kit's `@untitledui/icons` shape (`SVGProps` + `color?` + `size?`). */
+  iconLeading?: IconLeadingComponent | ReactNode;
   /** Icon component or element rendered after the label. */
-  iconTrailing?: FC<{ color?: string; size?: number }> | ReactNode;
+  iconTrailing?: IconLeadingComponent | ReactNode;
   /** Disables the button and shows a disabled state. */
   isDisabled?: boolean;
   /** Shows a loading spinner and disables the button. */
@@ -202,9 +214,7 @@ const SIZE_SPECS: Record<PressableButtonSize, SizeSpec> = {
   },
 };
 
-function isComponent(
-  value: PressableButtonProps['iconLeading'],
-): value is FC<{ color?: string; size?: number }> {
+function isComponent(value: PressableButtonProps['iconLeading']): value is IconLeadingComponent {
   return typeof value === 'function';
 }
 

--- a/packages/ui/src/icons/storybook.ts
+++ b/packages/ui/src/icons/storybook.ts
@@ -1,0 +1,100 @@
+// Curated icon picker for Storybook controls.
+//
+// Untitled UI's `@untitledui/icons` package ships ~1,179 React icons.
+// Surfacing all of them as a Storybook `select` control would be useless
+// noise; the map below is a small, opinionated subset that covers the
+// 80 % of cases primitive PRs will need (button leading/trailing icons,
+// alert affordances, input adornments). Stories opt into the full set by
+// importing directly from `@untitledui/icons`.
+//
+// Usage in a story:
+//
+//   import { storybookIcons } from '@/icons/storybook';
+//   ...
+//   argTypes: {
+//     iconLeading: { control: 'select', options: Object.keys(storybookIcons), mapping: storybookIcons },
+//   }
+//
+// Adding a new entry: pick a token-aware name from `@untitledui/icons`,
+// import it here, and append it under a sensible group (don't bloat).
+
+import type { FC } from 'react';
+
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Bell01,
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Copy01,
+  Download01,
+  Edit01,
+  Eye,
+  FilterFunnel01,
+  Heart,
+  Link01,
+  Mail01,
+  Plus,
+  SearchSm,
+  Settings01,
+  Star01,
+  Trash01,
+  Upload01,
+  User01,
+  X,
+} from '@untitledui/icons';
+
+// `@untitledui/icons` declares each icon's `Props` interface in a per-file
+// module that isn't re-exported, so deriving `typeof storybookIcons`
+// against the raw imports trips TS4023.
+//
+// The map needs to be assignment-compatible with two different
+// `iconLeading` prop shapes:
+//   - the kit Button (`FC<{ className?: string }>`) — narrow
+//   - PressableButton (`ComponentType<SVGProps + { color?, size? }>`) — wide
+//
+// Function parameter types are contravariant, so no single non-`any`
+// component shape satisfies both at the same time. `ComponentType<any>`
+// keeps the Storybook `mapping` consumable by both wraps without forcing
+// callers to cast at every story site.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+type IconComponent = FC<any>;
+
+export const storybookIcons: Record<string, IconComponent | undefined> = {
+  none: undefined,
+  // Movement / chevrons
+  arrowLeft: ArrowLeft,
+  arrowRight: ArrowRight,
+  arrowUp: ArrowUp,
+  arrowDown: ArrowDown,
+  chevronLeft: ChevronLeft,
+  chevronRight: ChevronRight,
+  chevronUp: ChevronUp,
+  chevronDown: ChevronDown,
+  // Universal actions
+  plus: Plus,
+  check: Check,
+  x: X,
+  edit: Edit01,
+  trash: Trash01,
+  copy: Copy01,
+  link: Link01,
+  search: SearchSm,
+  filter: FilterFunnel01,
+  download: Download01,
+  upload: Upload01,
+  // Surface affordances
+  mail: Mail01,
+  bell: Bell01,
+  user: User01,
+  settings: Settings01,
+  eye: Eye,
+  heart: Heart,
+  star: Star01,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@untitledui/icons':
+        specifier: ^0.0.22
+        version: 0.0.22(react@19.2.5)
       react-aria-components:
         specifier: ^1.17.0
         version: 1.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2656,6 +2659,11 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@untitledui/icons@0.0.22':
+    resolution: {integrity: sha512-lEUdk2Ni7SocXMjIokJDoBeECzmZO1qAIuZc+91rAqwSMln0CKRnk+r2dC2TJ9ccION/1ZFed2fIeKvAEAs0lQ==}
+    peerDependencies:
+      react: '>= 16'
 
   '@valibot/to-json-schema@1.6.0':
     resolution: {integrity: sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==}
@@ -9286,6 +9294,10 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@untitledui/icons@0.0.22(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
 
   '@valibot/to-json-schema@1.6.0(valibot@1.2.0(typescript@5.7.3))':
     dependencies:


### PR DESCRIPTION
## Summary

- PR #224 left Button + PressableButton stories on inline SVG placeholders (`Plus`, `ArrowRight`) with a note that the real picker would land alongside the kit's icon set.
- Untitled UI ships exactly that — `@untitledui/icons` v0.0.22, public npm, MIT-licensed, 1,179 icons, no deps, ~2.7 MB unpacked. This PR adopts it as a runtime dep on `@glaon/ui`, exposes a curated 26-icon picker through Storybook controls, and updates the existing stories to consume the map.
- Unblocks P1+ primitive PRs from needing per-PR icon scaffolding.

## Scope (In)

- `@untitledui/icons` runtime dep on `@glaon/ui`. Version locked, no auth setup needed (public registry).
- `packages/ui/src/icons/storybook.ts` — curated icon map.
  - 26 entries: chevrons (left/right/up/down), arrows (left/right/up/down), universal actions (plus, check, x, edit, trash, copy, link, search, filter, download, upload), surface affordances (mail, bell, user, settings, eye, heart, star), plus the `none` sentinel.
  - Stories consume it via `argTypes.iconLeading.mapping` so reviewers swap icons live from the controls panel.
  - Map element type is `FC<any>` with an inline `eslint-disable` + rationale comment. Function parameter types are contravariant, so no single non-`any` shape is assignment-compatible with both the kit Button's narrow `FC<{className?}>` and `PressableButton`'s wider `IconLeadingComponent` at once.
- `Button.stories.tsx` + `PressableButton.stories.tsx` drop their inline SVG placeholders and read from `storybookIcons`. `WithLeadingIcon` / `WithTrailingIcon` story args switch to `storybookIcons.plus` / `storybookIcons.arrowRight`.
- `PressableButton.tsx` widens `iconLeading` / `iconTrailing` from `FC<{color?, size?}>` to `IconLeadingComponent` (`ComponentType<SVGProps + color + size>`) so any UUI icon — and any hand-rolled icon with the same shape — slots in. The matching `isComponent` type guard is updated.

## Scope (Out)

- A Glaon icon primitive wrap. UUI's icons render as plain `FC<SVGProps>`, the kit Button + PressableButton accept that directly, and no Glaon-specific affordances are needed today.
- Exposing every UUI icon to Storybook. The curated subset keeps the picker fast and signals which icons primitive PRs should reach for first; consumers can `import { Foo } from '@untitledui/icons'` directly when needed.
- Touching the prop-coverage gate (#175). New `iconLeading` / `iconTrailing` types stay reachable through the existing argTypes entries — no `excludeFromArgs` change required.

## Test plan

- [x] `pnpm type-check` green across the monorepo.
- [x] `pnpm lint` green across the monorepo.
- [x] `pnpm knip` clean.
- [x] `pnpm exec prettier --check` clean on the touched files.
- [x] `pnpm --filter @glaon/ui test` — 9/9 tests pass (smoke + the prop-coverage gate from F6).
- [x] `pnpm --filter @glaon/ui build-storybook` succeeds.
- [x] Pre-commit hook passed (gitleaks + lint-staged).
- [ ] CI green on this branch.
- [ ] Reviewer (local): `pnpm --filter @glaon/ui storybook` → **Web Primitives / Button** and **RN Primitives / PressableButton** stories now show the curated icon picker; switching icons in the controls panel re-renders Button with the chosen UUI glyph at the right color and size.
- [ ] Reviewer: Chromatic visual diffs reviewed and accepted (Button + PressableButton's `WithLeadingIcon` / `WithTrailingIcon` swap from inline SVG to UUI icons; the rest are byte-identical).

Closes #227
Refs #14, #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)