### PR TITLE
chore(chromatic): pr-only signal, strict on dev/main

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -44,5 +44,10 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/ui
           onlyChanged: true
-          exitZeroOnChanges: false
+          # Pull requests treat Chromatic as a signal — diffs publish to the
+          # Chromatic UI for review but don't block merge. Pushes to the
+          # base branches (`development`, `main`) keep the strict gate so
+          # nothing slips into the baseline without an opportunity to fail.
+          # See CLAUDE.md "Chromatic Visual Regression" for the full policy.
+          exitZeroOnChanges: ${{ github.event_name == 'pull_request' }}
           autoAcceptChanges: development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,12 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 
 ## Chromatic Visual Regression (MANDATORY)
 
-- Every PR runs Chromatic as a required status check. The workflow is configured with `exitZeroOnChanges: false`, so any pixel-level change blocks merge until resolved.
-- When the check is red:
+- Every PR runs Chromatic as a required status check. The workflow uses `exitZeroOnChanges: ${{ github.event_name == 'pull_request' }}`, so PRs treat Chromatic as a **signal** (diffs publish to the Chromatic UI for review but don't block merge), while pushes to `development` and `main` stay strict — pixel-level regressions there fail the check until accepted in Chromatic.
+- When the PR check shows diffs:
+  - Open the Chromatic build, review the diff, accept anything intentional.
   - Unintended regression → fix in code, push again.
-  - Intentional visual change → open the Chromatic build, review the diff, click **Accept**. Never work around the check by tweaking `.github/workflows/chromatic.yml` or suppressing stories.
+  - The PR can still merge before the diffs are accepted, but unaccepted diffs flow into `development` and **will** fail the strict gate there. Reviewers should treat the Chromatic link as a required walkthrough, not optional.
+- Never work around the strict gate on `development`/`main` by tweaking `.github/workflows/chromatic.yml` or suppressing stories.
 - `development` is the baseline branch (`autoAcceptChanges: development`). Story changes merged into `development` become the new baseline automatically.
 - Skip list: `dependabot/**` and `release-please--**`. Other bot branches should not be added without discussion.
 - `CHROMATIC_PROJECT_TOKEN` secret is user-managed; see [docs/chromatic.md](docs/chromatic.md). Branch protection for `development` and `main` is codified as ruleset JSON — see [docs/governance.md](docs/governance.md).

--- a/docs/chromatic.md
+++ b/docs/chromatic.md
@@ -1,6 +1,6 @@
 # Chromatic
 
-Chromatic, Glaon Storybook'unun görsel regresyon altyapısıdır. Her PR'da zorunlu check olarak çalışır, beklenmeyen piksel farkı olduğunda merge'i engeller. Ayrıca remote MCP endpoint sağlar — AI agent'lar takımın Chromatic'teki component kataloguna uzaktan erişebilir.
+Chromatic, Glaon Storybook'unun görsel regresyon altyapısıdır. Her PR'da zorunlu check olarak çalışır; PR'larda **signal**, `development`/`main` push'larında **strict** policy uygular. Ayrıca remote MCP endpoint sağlar — AI agent'lar takımın Chromatic'teki component kataloguna uzaktan erişebilir.
 
 ## Nasıl çalışır?
 
@@ -10,8 +10,9 @@ Chromatic, Glaon Storybook'unun görsel regresyon altyapısıdır. Her PR'da zor
    - Storybook'u build eder (`packages/ui` altında).
    - Snapshot'ları Chromatic'e upload eder.
    - Baseline ile diff alır.
-   - Piksel farkı varsa check **kırılır** (`exitZeroOnChanges: false`) → PR merge edilemez.
-   - `development` branch'te (baseline branch) otomatik accept: `autoAcceptChanges: development`.
+   - **PR event'inde** `exitZeroOnChanges: true` → check yeşil kalır, diff'ler Chromatic UI'da review için yayınlanır, PR merge engellenmez.
+   - **Push event'inde (`development`, `main`)** `exitZeroOnChanges: false` → kabul edilmemiş diff varsa check **kırılır**, push reverse edilir veya Chromatic UI'da accept gerekir.
+   - `development` branch'te `autoAcceptChanges: development` ile diff'ler otomatik baseline'a alınır; bu sayede strict gate yalnızca `development → main` release flow'unda gerçek anlamda bloklayıcı olur.
 4. Development server çalışırken Chromatic MCP endpoint'i `http://localhost:6006/mcp` (lokal, dev + docs tools). Uzak Chromatic MCP ise Chromatic cloud'da host edilir; agent bağlandığında sadece docs tools'a erişir.
 
 ## İlk kurulum (kullanıcı aksiyonları)
@@ -49,12 +50,14 @@ Chromatic, Glaon Storybook'unun görsel regresyon altyapısıdır. Her PR'da zor
 
 1. PR açılır. Chromatic workflow çalışır.
 2. **Hiç görsel değişiklik yok** → check yeşil ✅, merge serbest.
-3. **Kasıtsız görsel değişiklik** (regresyon) → check kırmızı ❌. Kodda düzelt, tekrar push.
-4. **Kasıtlı görsel değişiklik** → check kırmızı. Chromatic UI'da build'i aç → "Review changes" → piksel diff'lerine bak → "Accept" → check yeşile döner. Merge serbest.
+3. **Görsel değişiklik var (kasıtlı veya kasıtsız)** → check yeşil ✅ (PR'larda signal-only) ama Chromatic UI'da diff bekliyor. Reviewer Chromatic build'ini açar:
+   - Kasıtlı değişiklik → "Accept" → diff baseline'a yazılır.
+   - Kasıtsız regresyon → kodda düzelt, tekrar push.
+   - PR mergeable kalır (CI block yok), ama unaccepted diff'ler `development`'a aktığında oradaki strict check kırılır → reviewer Chromatic link'ini ihmal etmemeli.
 
-### Neden `exitZeroOnChanges: false`?
+### `exitZeroOnChanges` neden conditional?
 
-Default opsiyonu seçersek (change'ler exit 0 ile geçer), reviewer'lar görsel değişikliği kaçırabilir. Mandatory check olarak tutmak = her görsel değişikliğin insan gözünden geçmesini garantiler. Glaon CLAUDE.md'nin "Chromatic Visual Regression (MANDATORY)" kuralı bu kararı somutlaştırır.
+PR'larda strict tutum (`exitZeroOnChanges: false`) her ufak intentional değişiklikte reviewer'ı Chromatic UI'a göndermek + merge'i bloklamak demekti. Phase 1 boyunca bu pattern Glaon'un asıl iş hızını yavaşlattı (her primitive PR'ında manuel accept turu). Pull request'lerde signal-only (`exitZeroOnChanges: true`) reviewer'a Chromatic'i tarama özgürlüğü verir, `development`/`main` push'larında strict tutum kalan koruma katmanı olarak iş görür. Glaon CLAUDE.md'nin "Chromatic Visual Regression (MANDATORY)" kuralı bu split policy'yi açıkça yazar.
 
 ### `onlyChanged: true` (TurboSnap)
 


### PR DESCRIPTION
## Summary

- Phase 1 PRs (#220, #213, #224, #228, …) all hit the same wall: `exitZeroOnChanges: false` blocks every PR until someone accepts the diffs in Chromatic UI. Appropriate for protecting the released baseline; painful for the high-cadence primitive PR work.
- This PR splits the policy: PRs treat Chromatic as a signal (CI green, diffs reviewable), pushes to `development`/`main` keep the strict gate. With `autoAcceptChanges: development` already in place, the strict gate effectively fires only when a regression slips past PR review.

## Scope (In)

- `.github/workflows/chromatic.yml` — `exitZeroOnChanges: ${{ github.event_name == 'pull_request' }}`. Inline comment summarizes the why.
- `CLAUDE.md` "Chromatic Visual Regression (MANDATORY)" — rewritten to describe the split policy, sets reviewer expectations (Chromatic link is a required walkthrough even though it no longer blocks the merge button).
- `docs/chromatic.md` — story flow + new "exitZeroOnChanges neden conditional?" section in line with the same policy.

## Scope (Out)

- ADR 0008 (Chromatic adoption) — superseded değil; bu PR yalnız parametre değişikliği.
- `autoAcceptChanges` patterns — mevcut `development` korunur.
- Branch protection ruleset (codified JSON in `docs/governance.md`) — required check name (`Chromatic / visual regression`) aynı kalıyor; ruleset file'ı değişmiyor.

## Test plan

- [x] `pnpm exec prettier --check` clean on the touched files.
- [x] Pre-commit hook passed (gitleaks + lint-staged).
- [ ] CI green on this branch (markdown + workflow change; type-check / lint / story-tests no-ops).
- [ ] **Verification on this PR's own Chromatic run**: with the new policy, the workflow should report green even if Chromatic surfaces diffs (this PR doesn't change any stories so probably no diffs anyway, but the conditional should now resolve to `true` for the `pull_request` event).
- [ ] **PR #228 follow-up**: rebase the icon-system branch, force-push, observe Chromatic check go green even though the icon swap stories will produce diffs that need acceptance in the Chromatic UI.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)