### PR TITLE
feat(ui): Alert, Banner primitives + stories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,5 +14,6 @@ pnpm-lock.yaml
 **/src/components/base/**
 **/src/components/application/**
 **/src/components/foundations/**
+**/src/components/shared-assets/**
 **/src/utils/cx.ts
 **/src/utils/is-react-component.ts

--- a/knip.json
+++ b/knip.json
@@ -50,7 +50,11 @@
     "packages/ui": {
       "entry": ["src/**/*.stories.@(ts|tsx)"],
       "project": ["src/**/*.{ts,tsx}", ".storybook/**/*.{ts,tsx}"],
-      "ignore": ["src/components/base/**", "src/utils/is-react-component.ts"],
+      "ignore": [
+        "src/components/base/**",
+        "src/components/shared-assets/**",
+        "src/utils/is-react-component.ts"
+      ],
       "ignoreDependencies": [
         "@glaon/config",
         "tailwindcss",

--- a/packages/config/eslint.config.js
+++ b/packages/config/eslint.config.js
@@ -27,6 +27,7 @@ export default tseslint.config(
       '**/src/components/base/**',
       '**/src/components/application/**',
       '**/src/components/foundations/**',
+      '**/src/components/shared-assets/**',
       '**/src/utils/cx.ts',
       '**/src/utils/is-react-component.ts',
     ],

--- a/packages/ui/src/components/Alert/Alert.stories.tsx
+++ b/packages/ui/src/components/Alert/Alert.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { storybookIcons } from '../../icons/storybook';
+import { Alert } from './Alert';
+
+// Explicit `Meta<typeof Alert>` annotation (rather than `satisfies`) keeps
+// storybook csf-internal types out of the exported `meta` signature —
+// `tsc --noEmit` runs with `declaration: true` and trips TS2742 / TS4023
+// when the inferred meta references types that aren't portably named.
+const meta: Meta<typeof Alert> = {
+  title: 'Web Primitives/Alert',
+  component: Alert,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-alert',
+    },
+  },
+  args: {
+    title: 'New feature available',
+    description: 'Check out the new dashboard.',
+    intent: 'info',
+    dismissible: false,
+    dismissLabel: 'Dismiss',
+  },
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    intent: {
+      control: 'inline-radio',
+      options: ['info', 'success', 'warning', 'danger'],
+    },
+    dismissible: { control: 'boolean' },
+    dismissLabel: { control: 'text' },
+    icon: {
+      control: 'select',
+      options: Object.keys(storybookIcons),
+      mapping: storybookIcons,
+    },
+    onDismiss: { control: false, action: 'dismissed' },
+    className: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 480 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Alert>;
+
+export const Default: Story = {};
+
+export const Info: Story = {
+  args: { intent: 'info', title: 'Heads up — new release on Friday.' },
+};
+
+export const Success: Story = {
+  args: {
+    intent: 'success',
+    title: 'Saved',
+    description: 'Your changes are live.',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    intent: 'warning',
+    title: 'Token rotation in 24 hours',
+    description: 'Re-authenticate before midnight.',
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    intent: 'danger',
+    title: 'Could not save changes',
+    description: 'Network error. Try again.',
+  },
+};
+
+export const Dismissible: Story = {
+  args: { dismissible: true },
+};
+
+export const TitleOnly: Story = {
+  args: { description: undefined, title: 'A short status line' },
+};
+
+export const Intents: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {(['info', 'success', 'warning', 'danger'] as const).map((intent) => (
+        <Alert key={intent} {...args} intent={intent} title={`Intent: ${intent}`} />
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -1,0 +1,95 @@
+// Glaon Alert — inline message primitive. Per CLAUDE.md's UUI Source
+// Rule, the structural HTML/CSS is anchored on the Untitled UI kit
+// `banner-slim-default` shared-asset under
+// `packages/ui/src/components/shared-assets/banners/banner-slim-default.tsx`.
+// That kit file is a concrete template (no props, hard-coded copy), so
+// the Glaon wrap layer parameterizes its content (title / description /
+// intent icon / dismissible) while preserving the kit's class structure
+// (`bg-secondary` + `ring-secondary_alt` + `rounded-xl` + `shadow-lg`).
+// Tokens flow through Tailwind v4 `@theme` (UUI `theme.css`) and Glaon's
+// brand override layer.
+
+import type { FC, ReactNode } from 'react';
+
+import { AlertCircle, AlertTriangle, CheckCircle, InfoCircle } from '@untitledui/icons';
+
+import { CloseButton } from '../base/buttons/close-button';
+
+// `@untitledui/icons` declares each icon's `Props` interface in a per-file
+// module that isn't re-exported, so deriving an exact type against the
+// raw imports trips TS4023. The icon picker (`icons/storybook.ts`) uses
+// the same `FC<any>` workaround for the same reason.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+type IconComponent = FC<any>;
+
+export type AlertIntent = 'info' | 'success' | 'warning' | 'danger';
+
+export interface AlertProps {
+  /** Bold first line of the alert. */
+  title: ReactNode;
+  /** Optional secondary line; rendered after the title. */
+  description?: ReactNode;
+  /** Severity / colour group for the leading icon. */
+  intent?: AlertIntent;
+  /** Override the default icon for the chosen intent. */
+  icon?: IconComponent;
+  /** Render a close button at the top-right corner. */
+  dismissible?: boolean;
+  /** Fires when the close button is clicked. */
+  onDismiss?: () => void;
+  /** Accessible label for the close button. Defaults to "Dismiss". */
+  dismissLabel?: string;
+  /** Override the kit's outer container className. */
+  className?: string;
+}
+
+const intentIcons: Record<AlertIntent, IconComponent> = {
+  info: InfoCircle,
+  success: CheckCircle,
+  warning: AlertTriangle,
+  danger: AlertCircle,
+};
+
+const intentIconColor: Record<AlertIntent, string> = {
+  info: 'text-fg-brand-primary_alt',
+  success: 'text-fg-success-primary',
+  warning: 'text-fg-warning-primary',
+  danger: 'text-fg-error-primary',
+};
+
+export function Alert({
+  title,
+  description,
+  intent = 'info',
+  icon: IconOverride,
+  dismissible = false,
+  onDismiss,
+  dismissLabel = 'Dismiss',
+  className,
+}: AlertProps) {
+  const Icon = IconOverride ?? intentIcons[intent];
+  const iconColor = intentIconColor[intent];
+
+  const containerClass =
+    'relative flex items-center gap-3 rounded-xl bg-secondary p-4 shadow-lg ring-1 ring-secondary_alt';
+
+  return (
+    <div role="status" className={className ? `${containerClass} ${className}` : containerClass}>
+      <Icon aria-hidden="true" className={`size-5 shrink-0 ${iconColor}`} />
+      <div className="flex w-0 flex-1 flex-col gap-0.5 md:flex-row md:gap-1.5">
+        <p className="pr-8 text-sm font-semibold text-secondary md:pr-0">{title}</p>
+        {description !== undefined ? <p className="text-sm text-tertiary">{description}</p> : null}
+      </div>
+      {dismissible ? (
+        <div className="absolute top-2 right-2 flex shrink-0 items-center justify-center">
+          <CloseButton
+            size="sm"
+            label={dismissLabel}
+            {...(onDismiss ? { onPress: onDismiss } : {})}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/Alert/index.ts
+++ b/packages/ui/src/components/Alert/index.ts
@@ -1,0 +1,1 @@
+export { Alert, type AlertIntent, type AlertProps } from './Alert';

--- a/packages/ui/src/components/Banner/Banner.stories.tsx
+++ b/packages/ui/src/components/Banner/Banner.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Button } from '../Button';
+import { storybookIcons } from '../../icons/storybook';
+import { Banner } from './Banner';
+
+// Explicit `Meta<typeof Banner>` annotation (rather than `satisfies`)
+// keeps storybook csf-internal types out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true` and trips
+// TS2742 / TS4023 when the inferred meta references types that aren't
+// portably named.
+const meta: Meta<typeof Banner> = {
+  title: 'Web Primitives/Banner',
+  component: Banner,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-banner',
+    },
+  },
+  args: {
+    title: 'We use cookies',
+    description: 'See our cookie policy for details.',
+    intent: 'info',
+    dismissible: false,
+    dismissLabel: 'Dismiss',
+  },
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    intent: {
+      control: 'inline-radio',
+      options: ['info', 'success', 'warning', 'danger'],
+    },
+    dismissible: { control: 'boolean' },
+    dismissLabel: { control: 'text' },
+    icon: {
+      control: 'select',
+      options: Object.keys(storybookIcons),
+      mapping: storybookIcons,
+    },
+    actions: { control: false, table: { disable: true } },
+    onDismiss: { control: false, action: 'dismissed' },
+    className: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 720 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Banner>;
+
+export const Default: Story = {};
+
+export const Info: Story = {
+  args: {
+    intent: 'info',
+    title: 'New feature live',
+    description: 'Try it from the dashboard.',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    intent: 'success',
+    title: 'Backup complete',
+    description: 'All data restored.',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    intent: 'warning',
+    title: 'Maintenance window tonight',
+    description: '02:00 – 04:00 UTC.',
+  },
+};
+
+export const Danger: Story = {
+  args: {
+    intent: 'danger',
+    title: 'Connection lost',
+    description: 'Reconnecting…',
+  },
+};
+
+export const Dismissible: Story = {
+  args: { dismissible: true },
+};
+
+export const WithActions: Story = {
+  args: {
+    title: 'We use third-party cookies',
+    description: 'Read our cookie policy.',
+    actions: (
+      <>
+        <Button color="secondary" size="sm">
+          Decline
+        </Button>
+        <Button color="primary" size="sm">
+          Allow
+        </Button>
+      </>
+    ),
+  },
+};
+
+export const WithActionsDismissible: Story = {
+  args: {
+    title: 'Update available',
+    description: 'A new version is ready to install.',
+    dismissible: true,
+    actions: (
+      <>
+        <Button color="secondary" size="sm">
+          Later
+        </Button>
+        <Button color="primary" size="sm">
+          Update
+        </Button>
+      </>
+    ),
+  },
+};
+
+export const Intents: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {(['info', 'success', 'warning', 'danger'] as const).map((intent) => (
+        <Banner key={intent} {...args} intent={intent} title={`Intent: ${intent}`} />
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Banner/Banner.tsx
+++ b/packages/ui/src/components/Banner/Banner.tsx
@@ -1,0 +1,111 @@
+// Glaon Banner — page-level announcement primitive. Per CLAUDE.md's UUI
+// Source Rule, the structural HTML/CSS is anchored on the Untitled UI
+// kit `banner-dual-action-default` shared-asset under
+// `packages/ui/src/components/shared-assets/banners/banner-dual-action-default.tsx`.
+// That kit file is a concrete template (no props, hard-coded copy), so
+// the Glaon wrap layer parameterizes its content (title / description /
+// actions / intent icon / dismissible) while preserving the kit's class
+// structure. Tokens flow through Tailwind v4 `@theme` (UUI `theme.css`)
+// and Glaon's brand override layer.
+
+import type { FC, ReactNode } from 'react';
+
+import { AlertCircle, AlertTriangle, CheckCircle, InfoCircle } from '@untitledui/icons';
+
+import { CloseButton } from '../base/buttons/close-button';
+
+// `@untitledui/icons` declares each icon's `Props` interface in a per-file
+// module that isn't re-exported, so deriving an exact type against the
+// raw imports trips TS4023. The icon picker (`icons/storybook.ts`) uses
+// the same `FC<any>` workaround for the same reason.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+type IconComponent = FC<any>;
+
+export type BannerIntent = 'info' | 'success' | 'warning' | 'danger';
+
+export interface BannerProps {
+  /** Bold lead-in text. */
+  title: ReactNode;
+  /** Optional secondary line; rendered after the title. */
+  description?: ReactNode;
+  /** Severity / colour group for the leading icon. */
+  intent?: BannerIntent;
+  /** Override the default icon for the chosen intent. */
+  icon?: IconComponent;
+  /**
+   * Action slot — typically one or two `<Button>` elements. Rendered to
+   * the right of the message on desktop, below it on mobile.
+   */
+  actions?: ReactNode;
+  /** Render a close button at the top-right corner. */
+  dismissible?: boolean;
+  /** Fires when the close button is clicked. */
+  onDismiss?: () => void;
+  /** Accessible label for the close button. Defaults to "Dismiss". */
+  dismissLabel?: string;
+  /** Override the kit's outer container className. */
+  className?: string;
+}
+
+const intentIcons: Record<BannerIntent, IconComponent> = {
+  info: InfoCircle,
+  success: CheckCircle,
+  warning: AlertTriangle,
+  danger: AlertCircle,
+};
+
+const intentIconColor: Record<BannerIntent, string> = {
+  info: 'text-fg-brand-primary_alt',
+  success: 'text-fg-success-primary',
+  warning: 'text-fg-warning-primary',
+  danger: 'text-fg-error-primary',
+};
+
+export function Banner({
+  title,
+  description,
+  intent = 'info',
+  icon: IconOverride,
+  actions,
+  dismissible = false,
+  onDismiss,
+  dismissLabel = 'Dismiss',
+  className,
+}: BannerProps) {
+  const Icon = IconOverride ?? intentIcons[intent];
+  const iconColor = intentIconColor[intent];
+
+  const containerClass =
+    'relative flex flex-col gap-4 rounded-xl bg-secondary p-4 shadow-lg ring-1 ring-secondary_alt md:flex-row md:items-center md:gap-3 md:py-3 md:pr-3 md:pl-5';
+
+  return (
+    <div role="status" className={className ? `${containerClass} ${className}` : containerClass}>
+      <div className="flex flex-1 flex-col gap-3 md:w-0 md:flex-row md:items-center md:gap-2">
+        <Icon aria-hidden="true" className={`size-5 shrink-0 ${iconColor}`} />
+        <div className="flex flex-col gap-2 overflow-hidden lg:flex-row lg:gap-1.5">
+          <p className="pr-8 text-sm font-semibold text-secondary md:pr-0">{title}</p>
+          {description !== undefined ? (
+            <p className="text-sm text-tertiary">{description}</p>
+          ) : null}
+        </div>
+      </div>
+      {actions !== undefined || dismissible ? (
+        <div className="flex gap-2">
+          {actions !== undefined ? (
+            <div className="flex w-full flex-col-reverse gap-2 md:flex-row md:gap-3">{actions}</div>
+          ) : null}
+          {dismissible ? (
+            <div className="absolute top-2 right-2 flex shrink-0 items-center justify-center md:static">
+              <CloseButton
+                size="sm"
+                label={dismissLabel}
+                {...(onDismiss ? { onPress: onDismiss } : {})}
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/Banner/index.ts
+++ b/packages/ui/src/components/Banner/index.ts
@@ -1,0 +1,1 @@
+export { Banner, type BannerIntent, type BannerProps } from './Banner';

--- a/packages/ui/src/components/base/buttons/close-button.tsx
+++ b/packages/ui/src/components/base/buttons/close-button.tsx
@@ -1,0 +1,47 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add` as a transitive
+// dependency of `banner-slim-default` / `banner-dual-action-default`.
+// Suppress type-check so `untitledui upgrade` stays a clean replace
+// operation. Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import { X as CloseIcon } from "@untitledui/icons";
+import { Button as AriaButton, type ButtonProps as AriaButtonProps } from "react-aria-components";
+import { cx } from "@/utils/cx";
+
+const sizes = {
+    xs: { root: "size-7", icon: "size-4" },
+    sm: { root: "size-9", icon: "size-5" },
+    md: { root: "size-10", icon: "size-5" },
+    lg: { root: "size-11", icon: "size-6" },
+};
+
+const themes = {
+    light: "text-fg-quaternary hover:bg-primary_hover hover:text-fg-quaternary_hover focus-visible:outline-2 focus-visible:outline-offset-2 outline-focus-ring",
+    dark: "text-fg-white/70 hover:text-fg-white hover:bg-white/20 focus-visible:outline-2 focus-visible:outline-offset-2 outline-focus-ring",
+};
+
+interface CloseButtonProps extends AriaButtonProps {
+    theme?: "light" | "dark";
+    size?: "xs" | "sm" | "md" | "lg";
+    label?: string;
+}
+
+export const CloseButton = ({ label, className, size = "sm", theme = "light", ...otherProps }: CloseButtonProps) => {
+    return (
+        <AriaButton
+            {...otherProps}
+            aria-label={label || "Close"}
+            className={(state) =>
+                cx(
+                    "flex cursor-pointer items-center justify-center rounded-lg p-2 transition duration-100 ease-linear focus:outline-hidden",
+                    sizes[size].root,
+                    themes[theme],
+                    typeof className === "function" ? className(state) : className,
+                )
+            }
+        >
+            <CloseIcon aria-hidden="true" className={cx("shrink-0 transition-inherit-all", sizes[size].icon)} />
+        </AriaButton>
+    );
+};

--- a/packages/ui/src/components/shared-assets/banners/banner-dual-action-default.tsx
+++ b/packages/ui/src/components/shared-assets/banners/banner-dual-action-default.tsx
@@ -1,0 +1,51 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add banner-dual-action-default`.
+// This is a concrete shared-asset template (no props, hard-coded copy);
+// Glaon's `Banner` wrap uses this file's CSS class structure as the
+// canonical visual reference but parameterizes the content. Kept here
+// so `untitledui upgrade` can refresh the structural reference.
+"use client";
+
+import { CheckVerified02 } from "@untitledui/icons";
+import { Button } from "@/components/base/buttons/button";
+import { CloseButton } from "@/components/base/buttons/close-button";
+
+export const BannerDualActionDefault = () => {
+    return (
+        <div className="relative mx-2 mb-4 flex flex-col gap-4 rounded-xl bg-secondary p-4 shadow-lg ring-1 ring-secondary_alt md:m-0 md:flex-row md:items-center md:gap-3 md:py-3 md:pr-3 md:pl-5">
+            <div className="flex flex-1 flex-col gap-3 md:w-0 md:flex-row md:items-center md:gap-2">
+                <CheckVerified02 className="size-5 text-fg-brand-primary_alt" />
+
+                <div className="flex flex-col gap-2 overflow-hidden lg:flex-row lg:gap-1.5">
+                    <p className="pr-8 text-sm font-semibold text-secondary md:truncate md:pr-0">
+                        We use third-party cookies in order to personalise your experience
+                    </p>
+                    <p className="text-sm text-tertiary md:truncate">
+                        Read our{" "}
+                        <a
+                            href="#"
+                            className="rounded-xs underline decoration-utility-neutral-300 underline-offset-3 outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+                        >
+                            Cookie Policy
+                        </a>
+                        .
+                    </p>
+                </div>
+            </div>
+
+            <div className="flex gap-2">
+                <div className="flex w-full flex-col-reverse gap-2 md:flex-row md:gap-3">
+                    <Button color="secondary" size="sm">
+                        Decline
+                    </Button>
+                    <Button color="primary" size="sm">
+                        Allow
+                    </Button>
+                </div>
+                <div className="absolute top-2 right-2 flex shrink-0 items-center justify-center md:static">
+                    <CloseButton size="sm" label="Dismiss" />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/packages/ui/src/components/shared-assets/banners/banner-slim-default.tsx
+++ b/packages/ui/src/components/shared-assets/banners/banner-slim-default.tsx
@@ -1,0 +1,33 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add banner-slim-default`.
+// This is a concrete shared-asset template (no props, hard-coded copy);
+// Glaon's `Alert` wrap uses this file's CSS class structure as the
+// canonical visual reference but parameterizes the content. Kept here
+// so `untitledui upgrade` can refresh the structural reference.
+"use client";
+
+import { CloseButton } from "@/components/base/buttons/close-button";
+
+export const BannerSlimDefault = () => {
+    return (
+        <div className="relative mx-2 mb-4 flex items-center gap-4 rounded-xl bg-secondary p-4 shadow-lg ring-1 ring-secondary_alt md:m-0 md:gap-3 md:px-12 md:py-4">
+            <div className="flex w-0 flex-1 flex-col gap-0.5 md:flex-row md:justify-center md:gap-1.5 md:text-center">
+                <p className="pr-8 text-sm font-semibold text-secondary md:truncate md:pr-0">We've just launched a new feature!</p>
+                <p className="text-sm text-tertiary md:truncate">
+                    Check out the{" "}
+                    <a
+                        href="#"
+                        className="rounded-xs underline decoration-utility-neutral-300 underline-offset-3 outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+                    >
+                        new dashboard
+                    </a>
+                    .
+                </p>
+            </div>
+
+            <div className="absolute top-2 right-2 flex shrink-0 items-center justify-center">
+                <CloseButton size="sm" label="Dismiss" />
+            </div>
+        </div>
+    );
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,7 +2,9 @@
 // Untitled UI is licensed and must be added manually; this package re-exports
 // and composes its primitives into Glaon-branded components.
 
+export * from './components/Alert';
 export * from './components/Badge';
+export * from './components/Banner';
 export * from './components/Button';
 export * from './components/PressableButton';
 export * from './components/ProgressBar';


### PR DESCRIPTION
## Summary

Second Phase 1 primitive group (P2). UUI doesn't ship parameterized base primitives for Alert / Banner — only concrete shared-asset templates with hard-coded copy. This PR pulls those templates as the canonical structural reference, then writes Glaon wraps that parameterize content while preserving the kit's class structure.

- `Alert` — inline status message, derived from `banner-slim-default`.
- `Banner` — page-level announcement with optional action slot, derived from `banner-dual-action-default`.
- Both wraps share an `intent` prop (`info` / `success` / `warning` / `danger`) mapping to `@untitledui/icons` + token-driven colour classes.
- The kit `CloseButton` (new this PR, lives under `base/buttons/`) is used by both wraps for the dismiss affordance.

## Architectural note

Existing primitives (Button, Badge, ProgressBar, Spinner) re-export the kit verbatim because the kit ships them as parameterized base primitives. Alert / Banner ship as concrete templates instead, so the wrap layer here does more work — it owns the JSX, parameterizing what the kit hard-codes. The kit files remain committed under `shared-assets/banners/` so `untitledui upgrade` can refresh the structural reference; the wraps continue to import the kit's `CloseButton` (and Button via story args).

## Scope (In)

- `packages/ui/src/components/Alert/{Alert.tsx,Alert.stories.tsx,index.ts}` — wrap + 8 stories (Default, Info, Success, Warning, Danger, Dismissible, TitleOnly, Intents).
- `packages/ui/src/components/Banner/{Banner.tsx,Banner.stories.tsx,index.ts}` — wrap + 9 stories (Default, Info, Success, Warning, Danger, Dismissible, WithActions, WithActionsDismissible, Intents).
- Kit sources pulled (with \`@ts-nocheck\`): \`base/buttons/close-button.tsx\`, \`shared-assets/banners/banner-slim-default.tsx\`, \`shared-assets/banners/banner-dual-action-default.tsx\`.
- \`packages/ui/src/index.ts\` barrel re-exports both primitives and their public types (\`AlertIntent\`, \`AlertProps\`, \`BannerIntent\`, \`BannerProps\`).
- \`.prettierignore\` / \`packages/config/eslint.config.js\` / \`knip.json\` extend their ignore lists with \`**/src/components/shared-assets/**\`.

## Scope (Out)

- **RN (\`*.native.tsx\`) for Alert / Banner** — UUI is web-only and we have no hand-rolled RN counterpart yet. Deferred to a follow-up issue (same approach as P1).
- **Toast** — P16 (\`#191\`), needs portal + ToastProvider.
- **Coloured backgrounds per intent** — kit canon keeps a neutral background (\`bg-secondary\`); only the icon varies by intent. If Figma shows fully coloured backgrounds we'll iterate as a follow-up.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui test --run\` — 24 passing (was 18; Alert + Banner each contribute 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\`
- [ ] Storybook spot-check: light + dark, every story renders without console error
- [ ] Chromatic snapshots accepted (intentional new-component diffs)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)