### PR TITLE
feat(ui): Card primitive + stories

### DIFF
--- a/packages/ui/src/components/Card/Card.stories.tsx
+++ b/packages/ui/src/components/Card/Card.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Button } from '../Button';
+import { Card } from './Card';
+
+// Explicit `Meta<typeof Card>` annotation (rather than `satisfies`)
+// keeps storybook csf-internal types out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+const meta: Meta<typeof Card> = {
+  title: 'Web Primitives/Card',
+  component: Card,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-card',
+    },
+  },
+  args: {
+    variant: 'default',
+    interactive: false,
+  },
+  argTypes: {
+    variant: { control: 'inline-radio', options: ['default', 'elevated', 'muted'] },
+    interactive: { control: 'boolean' },
+    onPress: { control: false, action: 'pressed' },
+    children: { control: false, table: { disable: true } },
+    className: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 480 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+const sampleBody = (
+  <Card.Body>
+    <p className="text-sm text-secondary">
+      Cards group related content into a single tappable surface. They can host any combination of
+      headers, bodies, and footers.
+    </p>
+  </Card.Body>
+);
+
+export const Default: Story = {
+  args: { children: sampleBody },
+};
+
+export const Elevated: Story = {
+  args: {
+    variant: 'elevated',
+    children: sampleBody,
+  },
+};
+
+export const Muted: Story = {
+  args: {
+    variant: 'muted',
+    children: sampleBody,
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    interactive: true,
+    children: sampleBody,
+  },
+};
+
+export const WithHeaderFooter: Story = {
+  args: {
+    children: (
+      <>
+        <Card.Header>
+          <h3 className="text-lg font-semibold text-primary">Project Glaon</h3>
+          <p className="text-sm text-tertiary">Updated 2 hours ago</p>
+        </Card.Header>
+        <Card.Body>
+          <p className="text-sm text-secondary">
+            Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a single
+            monorepo.
+          </p>
+        </Card.Body>
+        <Card.Footer>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+            <Button color="secondary" size="sm">
+              Cancel
+            </Button>
+            <Button color="primary" size="sm">
+              Open
+            </Button>
+          </div>
+        </Card.Footer>
+      </>
+    ),
+  },
+};
+
+export const InteractiveTile: Story = {
+  args: {
+    interactive: true,
+    children: (
+      <Card.Body>
+        <h3 className="text-base font-semibold text-primary">Activate scene</h3>
+        <p className="mt-1 text-sm text-tertiary">Living room — Movie night</p>
+      </Card.Body>
+    ),
+  },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {(['default', 'elevated', 'muted'] as const).map((variant) => (
+        <Card key={variant} variant={variant}>
+          <Card.Body>
+            <p className="text-sm font-medium text-primary">
+              variant: <span className="font-mono">{variant}</span>
+            </p>
+          </Card.Body>
+        </Card>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -1,0 +1,125 @@
+// Glaon Card — surface primitive that hosts other content. UUI doesn't
+// ship a generic `Card` base primitive; only marketing hero / CTA cards
+// (e.g. `metrics-card-gray-light` pulled in P3). Glaon hand-rolls a
+// parameterized Card using the kit's canonical surface vocabulary —
+// `bg-primary` (or `bg-secondary` for the `muted` variant) +
+// `ring-1 ring-secondary_alt` + `rounded-xl` + `shadow-{xs,lg}` — that
+// every UUI surface in the catalogue uses. Tokens flow through
+// Tailwind v4 `@theme` (UUI `theme.css`) and Glaon's brand override.
+//
+// Sub-components are exposed via the static-property pattern
+// (`Card.Header` / `Card.Body` / `Card.Footer`) so consumers compose
+// the regions inline without needing extra named imports.
+
+import type { ReactNode } from 'react';
+
+import { Button as AriaButton } from 'react-aria-components';
+
+export type CardVariant = 'default' | 'elevated' | 'muted';
+
+export interface CardProps {
+  /**
+   * Visual style of the surface.
+   * - `default` — neutral background + subtle border + thin shadow.
+   * - `elevated` — same background, dropped shadow for emphasis.
+   * - `muted` — tinted background; useful for nested cards.
+   * @default 'default'
+   */
+  variant?: CardVariant;
+  /**
+   * Render the card as a clickable surface (hover + keyboard focus +
+   * `role="button"`). Use this for navigation tiles, selectable
+   * options, etc.
+   */
+  interactive?: boolean;
+  /** Fires when an interactive card is activated. */
+  onPress?: () => void;
+  /** Override the kit's outer container className. */
+  className?: string;
+  /** Card content. Compose with `Card.Header` / `Card.Body` / `Card.Footer`. */
+  children: ReactNode;
+}
+
+export interface CardHeaderProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export interface CardBodyProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export interface CardFooterProps {
+  className?: string;
+  children: ReactNode;
+}
+
+const baseStyles = 'block rounded-xl overflow-hidden text-left';
+
+const variantStyles: Record<CardVariant, string> = {
+  default: 'bg-primary ring-1 ring-secondary_alt shadow-xs',
+  elevated: 'bg-primary ring-1 ring-secondary_alt shadow-lg',
+  muted: 'bg-secondary ring-1 ring-secondary_alt shadow-xs',
+};
+
+// `cursor-pointer` + `transition-shadow` for the affordance, plus
+// `outline-focus-ring` to opt into the kit's focus-visible token. The
+// underlying RAC `<Button>` handles keyboard activation + the
+// `role="button"` ARIA contract on its own.
+const interactiveStyles =
+  'cursor-pointer transition-shadow duration-150 hover:shadow-md outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2';
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+function CardRoot({
+  variant = 'default',
+  interactive = false,
+  onPress,
+  className,
+  children,
+}: CardProps) {
+  const containerClass = joinClasses(
+    baseStyles,
+    variantStyles[variant],
+    interactive && interactiveStyles,
+    className,
+  );
+
+  if (interactive) {
+    return (
+      <AriaButton className={containerClass} {...(onPress ? { onPress } : {})}>
+        {children}
+      </AriaButton>
+    );
+  }
+  return <div className={containerClass}>{children}</div>;
+}
+
+function CardHeader({ className, children }: CardHeaderProps) {
+  return (
+    <div className={joinClasses('px-6 pt-6 pb-4 border-b border-secondary_alt', className)}>
+      {children}
+    </div>
+  );
+}
+
+function CardBody({ className, children }: CardBodyProps) {
+  return <div className={joinClasses('px-6 py-6', className)}>{children}</div>;
+}
+
+function CardFooter({ className, children }: CardFooterProps) {
+  return (
+    <div className={joinClasses('px-6 pt-4 pb-6 border-t border-secondary_alt', className)}>
+      {children}
+    </div>
+  );
+}
+
+export const Card = Object.assign(CardRoot, {
+  Header: CardHeader,
+  Body: CardBody,
+  Footer: CardFooter,
+});

--- a/packages/ui/src/components/Card/index.ts
+++ b/packages/ui/src/components/Card/index.ts
@@ -1,0 +1,8 @@
+export {
+  Card,
+  type CardBodyProps,
+  type CardFooterProps,
+  type CardHeaderProps,
+  type CardProps,
+  type CardVariant,
+} from './Card';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,6 +7,7 @@ export * from './components/Avatar';
 export * from './components/Badge';
 export * from './components/Banner';
 export * from './components/Button';
+export * from './components/Card';
 export * from './components/PressableButton';
 export * from './components/ProgressBar';
 export * from './components/Spinner';


### PR DESCRIPTION
## Summary

Fourth Phase 1 primitive group (P4). UUI doesn't ship a generic Card base — only marketing hero/CTA cards, none of which are parameterized as a hosting surface. This PR hand-rolls a Glaon Card using the kit's canonical surface vocabulary (`bg-primary` or `bg-secondary` + `ring-1 ring-secondary_alt` + `rounded-xl` + `shadow-{xs,lg}`), the same pattern every UUI surface in the catalogue uses. Same wrap-pattern ladder as P2 Alert / Banner and P3 Stat — kit token CSS as canonical reference, content fully parameterized.

## Surface

- `Card` root: `variant` (`default` / `elevated` / `muted`), `interactive`, `onPress`, `className`, `children`.
- `Card.Header` / `Card.Body` / `Card.Footer` attached as static properties for inline composition. Header / Footer add `border-{b,t} border-secondary_alt` dividers so multi-slot cards read as distinct regions.
- Interactive variant wraps the surface in react-aria-components `<Button>` for keyboard activation + `role="button"` ARIA contract; hover/focus styling via tokens.

## Scope (In)

- `components/Card/{Card.tsx,Card.stories.tsx,index.ts}` — wrap + 7 stories (Default, Elevated, Muted, Interactive, WithHeaderFooter, InteractiveTile, Variants).
- `packages/ui/src/index.ts` barrel re-exports `Card`, `CardProps`, `CardVariant`, `CardHeaderProps`, `CardBodyProps`, `CardFooterProps`.

## Scope (Out)

- **RN \`Card.native.tsx\`** — UUI is web-only; deferred to a follow-up issue (same pattern as P1 / P2 / P3).
- **Other Surface primitives** — Modal / Drawer / Popover / Tooltip ship in P12–P15.
- **Card-internal data fetching** — forbidden by CLAUDE.md's Component Data-Fetching Boundary; consumers pass content as children.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui test --run\` — 33 passing (was 30; +3 for Card × 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\`
- [ ] Storybook spot-check: light + dark, interactive variant keyboard focus + hover
- [ ] Chromatic snapshots accepted (intentional new-component diffs)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)