### PR TITLE
feat(ui): Select primitive + stories

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,5 +16,6 @@ pnpm-lock.yaml
 **/src/components/foundations/**
 **/src/components/shared-assets/**
 **/src/components/marketing/**
+**/src/hooks/**
 **/src/utils/cx.ts
 **/src/utils/is-react-component.ts

--- a/packages/config/eslint.config.js
+++ b/packages/config/eslint.config.js
@@ -29,6 +29,7 @@ export default tseslint.config(
       '**/src/components/foundations/**',
       '**/src/components/shared-assets/**',
       '**/src/components/marketing/**',
+      '**/src/hooks/**',
       '**/src/utils/cx.ts',
       '**/src/utils/is-react-component.ts',
     ],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -64,7 +64,10 @@
   "type": "module",
   "types": "./src/index.ts",
   "dependencies": {
+    "@react-types/shared": "^3.34.0",
     "@untitledui/icons": "^0.0.22",
-    "react-aria-components": "^1.17.0"
+    "react-aria": "^3.48.0",
+    "react-aria-components": "^1.17.0",
+    "react-stately": "^3.46.0"
   }
 }

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -1,0 +1,222 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import {
+  ComboBox,
+  MultiSelect,
+  NativeSelect,
+  Select,
+  SelectItem,
+  type SelectItemType,
+} from './Select';
+
+// Explicit `Meta<typeof Select>` annotation (rather than `satisfies`)
+// keeps the kit's deep RAC generic chains (`AriaSelectProps<SelectItemType>`
+// etc.) out of the exported `meta` signature — `tsc --noEmit` runs with
+// `declaration: true`.
+const meta: Meta<typeof Select> = {
+  title: 'Web Primitives/Select',
+  component: Select,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-select',
+    },
+  },
+  args: {
+    label: 'Country',
+    placeholder: 'Select a country',
+    size: 'md',
+    isDisabled: false,
+  },
+  argTypes: {
+    label: { control: 'text' },
+    hint: { control: 'text' },
+    placeholder: { control: 'text' },
+    tooltip: { control: 'text' },
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    isDisabled: { control: 'boolean' },
+    isInvalid: { control: 'boolean' },
+    isRequired: { control: 'boolean' },
+    hideRequiredIndicator: { control: 'boolean' },
+    selectedKey: { control: 'text' },
+    defaultSelectedKey: { control: 'text' },
+    name: { control: 'text' },
+    onSelectionChange: { control: false, action: 'selection-changed' },
+    onOpenChange: { control: false, action: 'open-changed' },
+    onBlur: { control: false, action: 'blurred' },
+    onFocus: { control: false, action: 'focused' },
+    items: { control: false, table: { disable: true } },
+    children: { control: false, table: { disable: true } },
+    icon: { control: false, table: { disable: true } },
+    className: { control: false, table: { disable: true } },
+    popoverClassName: { control: false, table: { disable: true } },
+    ref: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+// RAC-forwarded props that aren't useful as Storybook knobs but flow
+// through type-checking; covered by the F6 prop-coverage gate.
+export const excludeFromArgs = [
+  'autoFocus',
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'aria-errormessage',
+  'excludeFromTabOrder',
+  'form',
+  'translate',
+  'slot',
+  'data-rac',
+  'menuTrigger',
+  'shouldFlip',
+  'disabledKeys',
+  'validate',
+  'validationBehavior',
+  'isOpen',
+  'defaultOpen',
+  'autoComplete',
+  // Kit popover surface — not knobs.
+  'key',
+  'children',
+  'items',
+];
+
+const COUNTRIES: SelectItemType[] = [
+  { id: 'tr', label: 'Türkiye' },
+  { id: 'us', label: 'United States' },
+  { id: 'gb', label: 'United Kingdom' },
+  { id: 'de', label: 'Germany' },
+  { id: 'fr', label: 'France' },
+  { id: 'es', label: 'Spain' },
+  { id: 'it', label: 'Italy' },
+  { id: 'jp', label: 'Japan' },
+  { id: 'br', label: 'Brazil' },
+  { id: 'in', label: 'India' },
+];
+
+const renderItem = (item: SelectItemType) => (
+  <SelectItem key={item.id} id={item.id} label={item.label ?? ''} />
+);
+
+export const Default: Story = {
+  args: { items: COUNTRIES, children: renderItem },
+};
+
+export const WithDefaultValue: Story = {
+  args: {
+    items: COUNTRIES,
+    children: renderItem,
+    defaultSelectedKey: 'tr',
+  },
+};
+
+export const WithHint: Story = {
+  args: {
+    items: COUNTRIES,
+    children: renderItem,
+    hint: 'Select your billing country.',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    items: COUNTRIES,
+    children: renderItem,
+    isInvalid: true,
+    hint: 'Country is required.',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    items: COUNTRIES,
+    children: renderItem,
+    isDisabled: true,
+    defaultSelectedKey: 'tr',
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {(['sm', 'md', 'lg'] as const).map((size) => (
+        <Select key={size} {...args} size={size} label={`Size: ${size}`} items={COUNTRIES}>
+          {renderItem}
+        </Select>
+      ))}
+    </div>
+  ),
+};
+
+const LONG_LIST: SelectItemType[] = Array.from({ length: 200 }, (_, i) => ({
+  id: `item-${i.toString()}`,
+  label: `Option ${(i + 1).toString().padStart(3, '0')}`,
+}));
+
+export const LongList: Story = {
+  args: {
+    items: LONG_LIST,
+    children: renderItem,
+    label: 'Pick one of 200',
+    placeholder: 'Scroll for more',
+  },
+};
+
+// `ComboBox` is a sibling kit primitive; demonstrate it inline so the
+// search / filter affordance is reachable from the Select story
+// catalogue without a separate `Combobox.stories.tsx` file.
+export const WithSearch: Story = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <ComboBox label="Country (searchable)" placeholder="Type to filter" items={COUNTRIES}>
+        {renderItem}
+      </ComboBox>
+    </div>
+  ),
+};
+
+export const Multi: Story = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <MultiSelect
+        label="Languages"
+        placeholder="Pick one or more"
+        items={[
+          { id: 'tr', label: 'Türkçe' },
+          { id: 'en', label: 'English' },
+          { id: 'de', label: 'Deutsch' },
+          { id: 'fr', label: 'Français' },
+          { id: 'es', label: 'Español' },
+        ]}
+      >
+        {renderItem}
+      </MultiSelect>
+    </div>
+  ),
+};
+
+export const Native: Story = {
+  render: () => (
+    <div style={{ width: 360 }}>
+      <NativeSelect
+        label="Country (native)"
+        options={COUNTRIES.map((c) => ({
+          label: c.label ?? '',
+          value: c.id.toString(),
+        }))}
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -1,0 +1,34 @@
+// Glaon Select — thin wrap around the Untitled UI kit Select family
+// under `packages/ui/src/components/base/select/`. Per CLAUDE.md's
+// UUI Source Rule, the structural HTML/CSS, popover positioning,
+// keyboard navigation (arrow / typeahead / escape), and
+// invalid / disabled state matrix come from the kit (built on
+// react-aria-components `<Select>` + `<ComboBox>` + `<ListBox>`).
+// Glaon's contribution is the wrap layer (token override via
+// `theme.css` + `glaon-overrides.css`, prop API consistency, Figma
+// `parameters.design` mapping in the story).
+//
+// The kit ships several siblings — re-export them all so consumers
+// can reach the full catalogue via a single `@glaon/ui` import:
+//
+// - `Select` — single-value popover-based picker.
+// - `ComboBox` — search-as-you-type version.
+// - `MultiSelect` — multi-value popover with checkmarks.
+// - `TagSelect` — tag/chip multi-select.
+// - `NativeSelect` — HTML `<select>` for forms that want native UI.
+// - `SelectItem` — list-item helper used by every variant.
+// - `SelectContext`, `sizes`, types — escape hatches for custom
+//   compositions.
+
+export { Select, type SelectProps } from '../base/select/select';
+export { ComboBox } from '../base/select/combobox';
+export { MultiSelect } from '../base/select/multi-select';
+export { TagSelect, TagSelectBase, TagSelectTagsValue } from '../base/select/tag-select';
+export { NativeSelect } from '../base/select/select-native';
+export { SelectItem } from '../base/select/select-item';
+export {
+  SelectContext,
+  sizes as selectSizes,
+  type CommonProps as SelectCommonProps,
+  type SelectItemType,
+} from '../base/select/select-shared';

--- a/packages/ui/src/components/Select/index.ts
+++ b/packages/ui/src/components/Select/index.ts
@@ -1,0 +1,15 @@
+export {
+  ComboBox,
+  MultiSelect,
+  NativeSelect,
+  Select,
+  SelectContext,
+  SelectItem,
+  TagSelect,
+  TagSelectBase,
+  TagSelectTagsValue,
+  selectSizes,
+  type SelectCommonProps,
+  type SelectItemType,
+  type SelectProps,
+} from './Select';

--- a/packages/ui/src/components/base/select/combobox.tsx
+++ b/packages/ui/src/components/base/select/combobox.tsx
@@ -1,0 +1,180 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import type { FC, FocusEventHandler, PointerEventHandler, ReactNode, RefAttributes, RefObject } from "react";
+import { isValidElement, useCallback, useContext, useRef, useState } from "react";
+import { SearchLg } from "@untitledui/icons";
+import type { ComboBoxProps as AriaComboBoxProps, GroupProps as AriaGroupProps, ListBoxProps as AriaListBoxProps } from "react-aria-components";
+import { ComboBox as AriaComboBox, Group as AriaGroup, Input as AriaInput, ListBox as AriaListBox, ComboBoxStateContext } from "react-aria-components";
+import { HintText } from "@/components/base/input/hint-text";
+import { Label } from "@/components/base/input/label";
+import { Popover } from "@/components/base/select/popover";
+import { type CommonProps, SelectContext, type SelectItemType, sizes } from "@/components/base/select/select-shared";
+import { useResizeObserver } from "@/hooks/use-resize-observer";
+import { cx } from "@/utils/cx";
+import { isReactComponent } from "@/utils/is-react-component";
+
+interface ComboBoxProps extends Omit<AriaComboBoxProps<SelectItemType>, "children" | "items">, RefAttributes<HTMLDivElement>, CommonProps {
+    shortcut?: boolean;
+    items?: SelectItemType[];
+    popoverClassName?: string;
+    shortcutClassName?: string;
+    /** Leading icon component displayed before the input. */
+    icon?: FC | ReactNode;
+    children: AriaListBoxProps<SelectItemType>["children"];
+}
+
+interface ComboBoxValueProps extends AriaGroupProps {
+    size: "sm" | "md" | "lg";
+    shortcut: boolean;
+    placeholder?: string;
+    shortcutClassName?: string;
+    icon?: FC | ReactNode;
+    onFocus?: FocusEventHandler;
+    onPointerEnter?: PointerEventHandler;
+    ref?: RefObject<HTMLDivElement | null>;
+}
+
+const ComboBoxValue = ({ size, shortcut, placeholder, shortcutClassName, icon: IconProp, ...otherProps }: ComboBoxValueProps) => {
+    const state = useContext(ComboBoxStateContext);
+
+    const value = state?.selectedItem?.value || null;
+    const inputValue = state?.inputValue || null;
+
+    const first = inputValue?.split(value?.supportingText)?.[0] || "";
+    const last = inputValue?.split(first)[1];
+
+    return (
+        <AriaGroup
+            {...otherProps}
+            className={({ isFocusWithin, isDisabled }) =>
+                cx(
+                    "relative flex w-full items-center gap-2 rounded-lg bg-primary shadow-xs ring-1 ring-primary outline-hidden transition-shadow duration-100 ease-linear ring-inset",
+                    isDisabled && "cursor-not-allowed opacity-50",
+                    isFocusWithin && "ring-2 ring-brand",
+
+                    // Icon styles
+                    "*:data-icon:shrink-0 *:data-icon:text-fg-quaternary",
+
+                    sizes[size].root,
+                )
+            }
+        >
+            {isReactComponent(IconProp) ? (
+                <IconProp data-icon className="pointer-events-none" aria-hidden="true" />
+            ) : isValidElement(IconProp) ? (
+                IconProp
+            ) : (
+                <SearchLg data-icon className="pointer-events-none" aria-hidden="true" />
+            )}
+
+            <div className="relative flex w-full items-center">
+                {inputValue && (
+                    <span className={cx("absolute top-1/2 z-0 inline-flex w-full -translate-y-1/2 truncate", sizes[size].textContainer)} aria-hidden="true">
+                        <p className={cx("font-medium text-primary", sizes[size].text)}>{first}</p>
+                        {last && <p className={cx("-ml-0.75 text-tertiary", sizes[size].text)}>{last}</p>}
+                    </span>
+                )}
+
+                <AriaInput
+                    placeholder={placeholder}
+                    className={cx(
+                        "z-10 w-full appearance-none bg-transparent text-transparent caret-alpha-black/90 placeholder:text-placeholder focus:outline-hidden disabled:cursor-not-allowed",
+                        sizes[size].text,
+                    )}
+                />
+            </div>
+
+            {shortcut && (
+                <div
+                    className={cx(
+                        "absolute inset-y-0.5 right-0.5 z-10 hidden items-center rounded-r-[inherit] bg-linear-to-r from-transparent to-bg-primary to-40% pl-8 md:flex",
+                        sizes[size].shortcut,
+                        shortcutClassName,
+                    )}
+                >
+                    <span
+                        className="pointer-events-none rounded px-1 py-px text-xs font-medium text-quaternary ring-1 ring-secondary select-none ring-inset"
+                        aria-hidden="true"
+                    >
+                        ⌘K
+                    </span>
+                </div>
+            )}
+        </AriaGroup>
+    );
+};
+
+export const ComboBox = ({
+    placeholder = "Search",
+    shortcut = true,
+    size = "md",
+    children,
+    items,
+    shortcutClassName,
+    icon,
+    hideRequiredIndicator,
+    ...otherProps
+}: ComboBoxProps) => {
+    const placeholderRef = useRef<HTMLDivElement>(null);
+    const [popoverWidth, setPopoverWidth] = useState("");
+
+    // Resize observer for popover width
+    const onResize = useCallback(() => {
+        if (!placeholderRef.current) return;
+
+        const divRect = placeholderRef.current?.getBoundingClientRect();
+
+        setPopoverWidth(divRect.width + "px");
+    }, [placeholderRef, setPopoverWidth]);
+
+    useResizeObserver({
+        ref: placeholderRef,
+        box: "border-box",
+        onResize,
+    });
+
+    return (
+        <SelectContext.Provider value={{ size }}>
+            <AriaComboBox menuTrigger="focus" {...otherProps}>
+                {(state) => (
+                    <div className="flex flex-col gap-1.5">
+                        {otherProps.label && (
+                            <Label isRequired={hideRequiredIndicator ? false : state.isRequired} tooltip={otherProps.tooltip}>
+                                {otherProps.label}
+                            </Label>
+                        )}
+
+                        <ComboBoxValue
+                            ref={placeholderRef}
+                            placeholder={placeholder}
+                            shortcut={shortcut}
+                            shortcutClassName={shortcutClassName}
+                            icon={icon}
+                            size={size}
+                            // This is a workaround to correctly calculating the trigger width
+                            // while using ResizeObserver wasn't 100% reliable.
+                            onFocus={onResize}
+                            onPointerEnter={onResize}
+                        />
+
+                        <Popover size={size} triggerRef={placeholderRef} style={{ width: popoverWidth }} className={otherProps.popoverClassName}>
+                            <AriaListBox items={items} className="size-full outline-hidden">
+                                {children}
+                            </AriaListBox>
+                        </Popover>
+
+                        {otherProps.hint && (
+                            <HintText isInvalid={state.isInvalid} className={cx(size === "sm" && "text-xs")}>
+                                {otherProps.hint}
+                            </HintText>
+                        )}
+                    </div>
+                )}
+            </AriaComboBox>
+        </SelectContext.Provider>
+    );
+};

--- a/packages/ui/src/components/base/select/multi-select.tsx
+++ b/packages/ui/src/components/base/select/multi-select.tsx
@@ -1,0 +1,333 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import type { ReactNode, RefAttributes } from "react";
+import { useCallback, useRef, useState } from "react";
+import { ChevronDown, SearchLg } from "@untitledui/icons";
+import { useFilter } from "react-aria";
+import type { Selection } from "react-aria-components";
+import {
+    Autocomplete as AriaAutocomplete,
+    Button as AriaButton,
+    Dialog as AriaDialog,
+    DialogTrigger as AriaDialogTrigger,
+    Input as AriaInput,
+    ListBox as AriaListBox,
+    Popover as AriaPopover,
+    SearchField as AriaSearchField,
+} from "react-aria-components";
+import { Button } from "@/components/base/buttons/button";
+import { HintText } from "@/components/base/input/hint-text";
+import { Label } from "@/components/base/input/label";
+import { FeaturedIcon } from "@/components/foundations/featured-icon/featured-icon";
+import { cx } from "@/utils/cx";
+import { SelectItem } from "./select-item";
+import { type CommonProps, SelectContext, type SelectItemType, sizes } from "./select-shared";
+
+const searchSizes = {
+    sm: { wrapper: "py-1", root: "px-3 py-2 gap-2 *:data-icon:size-4 *:data-icon:stroke-[2.25px]", text: "text-sm" },
+    md: { wrapper: "py-0.5", root: "px-3 py-2 gap-2 *:data-icon:size-5", text: "text-md" },
+    lg: { wrapper: "py-0.5", root: "px-3.5 py-2.5 gap-2 *:data-icon:size-5", text: "text-md" },
+};
+
+const footerButtonSize = {
+    sm: "xs" as const,
+    md: "sm" as const,
+    lg: "sm" as const,
+};
+
+const popoverMaxHeights = {
+    sm: "max-h-68",
+    md: "max-h-76",
+    lg: "max-h-92",
+};
+
+interface MultiSelectFooterProps {
+    /**
+     * The size of the footer buttons.
+     * @default "sm"
+     */
+    size?: "sm" | "md" | "lg";
+    /** Handler that is called when the reset button is clicked. */
+    onReset?: () => void;
+    /** Handler that is called when the select all button is clicked. */
+    onSelectAll?: () => void;
+    /** Additional class name. */
+    className?: string;
+}
+
+const MultiSelectFooter = ({ size = "sm", onReset, onSelectAll, className }: MultiSelectFooterProps) => {
+    const btnSize = footerButtonSize[size];
+
+    return (
+        <div className={cx("flex items-center justify-between border-t border-secondary p-3", className)}>
+            <Button size={btnSize} color="secondary" onClick={onReset}>
+                Reset
+            </Button>
+            <Button size={btnSize} color="secondary" onClick={onSelectAll}>
+                Select all
+            </Button>
+        </div>
+    );
+};
+
+interface MultiSelectEmptyStateProps {
+    /**
+     * The title to display.
+     * @default "No results found"
+     */
+    title?: string;
+    /**
+     * The description to display.
+     * @default "Please try a different search term."
+     */
+    description?: string;
+    /** Handler that is called when the clear search button is clicked. */
+    onClearSearch?: () => void;
+    /** Additional class name. */
+    className?: string;
+}
+
+const MultiSelectEmptyState = ({
+    title = "No results found",
+    description = "Please try a different search term.",
+    onClearSearch,
+    className,
+}: MultiSelectEmptyStateProps) => (
+    <div className={cx("flex flex-col items-center gap-3 px-4 py-4", className)}>
+        <div className="flex flex-col items-center gap-3">
+            <FeaturedIcon icon={SearchLg} size="sm" color="gray" theme="modern" />
+            <div className="flex flex-col items-center gap-0.5 text-center text-sm">
+                <p className="font-semibold text-primary">{title}</p>
+                <p className="text-tertiary">{description}</p>
+            </div>
+        </div>
+        {onClearSearch && (
+            <Button size="sm" color="link-color" onClick={onClearSearch}>
+                Clear search
+            </Button>
+        )}
+    </div>
+);
+
+interface MultiSelectProps extends RefAttributes<HTMLDivElement>, CommonProps {
+    /** The items to display in the listbox. */
+    items?: SelectItemType[];
+    /** The children to render for each item. */
+    children: ReactNode | ((item: SelectItemType) => ReactNode);
+    /** The currently selected keys (controlled). */
+    selectedKeys?: Selection;
+    /** The initial selected keys (uncontrolled). */
+    defaultSelectedKeys?: Selection;
+    /** Handler that is called when the selection changes. */
+    onSelectionChange?: (keys: Selection) => void;
+    /** Whether the select is disabled. */
+    isDisabled?: boolean;
+    /** Whether the select is required. */
+    isRequired?: boolean;
+    /** Whether the select is in an invalid state. */
+    isInvalid?: boolean;
+    /** Additional class name for the popover. */
+    popoverClassName?: string;
+    /** Additional class name for the root element. */
+    className?: string;
+    /** Handler that is called when the reset button is clicked. */
+    onReset?: () => void;
+    /** Handler that is called when the select all button is clicked. */
+    onSelectAll?: () => void;
+    /**
+     * Whether to show the footer with reset and select all buttons.
+     * @default true
+     */
+    showFooter?: boolean;
+    /**
+     * Whether to show the search input in the popover.
+     * @default true
+     */
+    showSearch?: boolean;
+    /** The title to display when no items match the search. */
+    emptyStateTitle?: string;
+    /** The description to display when no items match the search. */
+    emptyStateDescription?: string;
+    /** Custom formatter for the selected count text in the trigger. */
+    selectedCountFormatter?: (count: number) => ReactNode;
+    /** Supporting text displayed next to the selected count in the trigger. */
+    supportingText?: ReactNode;
+}
+
+const MultiSelectRoot = ({
+    items,
+    children,
+    size = "md",
+    selectedKeys,
+    defaultSelectedKeys,
+    onSelectionChange,
+    isDisabled,
+    isRequired,
+    isInvalid,
+    placeholder = "Select",
+    label,
+    hint,
+    tooltip,
+    hideRequiredIndicator,
+    popoverClassName,
+    className,
+    onReset,
+    onSelectAll,
+    showFooter = true,
+    showSearch = true,
+    emptyStateTitle,
+    emptyStateDescription,
+    selectedCountFormatter,
+    supportingText,
+}: MultiSelectProps) => {
+    const { contains } = useFilter({ sensitivity: "base" });
+    const [searchValue, setSearchValue] = useState("");
+
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const [popoverWidth, setPopoverWidth] = useState("");
+
+    const onResize = useCallback(() => {
+        if (!triggerRef.current) return;
+        const rect = triggerRef.current.getBoundingClientRect();
+        setPopoverWidth(rect.width + "px");
+    }, []);
+
+    const selectedCount = selectedKeys instanceof Set ? selectedKeys.size : selectedKeys === "all" ? (items?.length ?? 0) : 0;
+    const hasSelection = selectedCount > 0;
+
+    const handleClearSearch = useCallback(() => {
+        setSearchValue("");
+    }, []);
+
+    return (
+        <SelectContext.Provider value={{ size }}>
+            <div className={cx("flex flex-col gap-1.5", className)}>
+                {label && (
+                    <Label isRequired={hideRequiredIndicator ? false : isRequired} isInvalid={isInvalid} tooltip={tooltip}>
+                        {label}
+                    </Label>
+                )}
+
+                <AriaDialogTrigger>
+                    <AriaButton
+                        ref={triggerRef}
+                        isDisabled={isDisabled}
+                        onClick={onResize}
+                        className={(state) =>
+                            cx(
+                                "relative flex w-full cursor-pointer items-center rounded-lg bg-primary shadow-xs ring-1 ring-primary outline-hidden transition duration-100 ease-linear ring-inset",
+                                (state.isFocusVisible || state.isPressed) && "ring-2 ring-brand",
+                                state.isDisabled && "cursor-not-allowed opacity-50",
+                            )
+                        }
+                    >
+                        <span
+                            className={cx(
+                                "flex w-full items-center truncate text-left",
+                                sizes[size].root,
+                                "*:data-icon:shrink-0 *:data-icon:text-fg-quaternary",
+                            )}
+                        >
+                            {hasSelection ? (
+                                <span className={cx("flex items-center", sizes[size].textContainer)}>
+                                    <span className={cx("font-medium text-primary", sizes[size].text)}>
+                                        {selectedCountFormatter ? selectedCountFormatter(selectedCount) : `${selectedCount} selected`}
+                                    </span>
+                                    {supportingText && <span className={cx("text-tertiary", sizes[size].text)}>{supportingText}</span>}
+                                </span>
+                            ) : (
+                                <span className={cx("text-placeholder", sizes[size].text)}>{placeholder}</span>
+                            )}
+
+                            <ChevronDown
+                                aria-hidden="true"
+                                className={cx("ml-auto shrink-0 text-fg-quaternary", size === "lg" ? "size-5" : "size-4 stroke-[2.25px]")}
+                            />
+                        </span>
+                    </AriaButton>
+
+                    <AriaPopover
+                        placement="bottom"
+                        offset={4}
+                        containerPadding={0}
+                        style={{ width: popoverWidth || undefined }}
+                        className={(state) =>
+                            cx(
+                                "w-(--trigger-width) origin-(--trigger-anchor-point) overflow-hidden rounded-lg bg-primary shadow-lg ring-1 ring-secondary_alt outline-hidden will-change-transform",
+                                state.isEntering &&
+                                    "duration-150 ease-out animate-in fade-in placement-top:slide-in-from-bottom-0.5 placement-bottom:slide-in-from-top-0.5",
+                                state.isExiting &&
+                                    "duration-100 ease-in animate-out fade-out placement-top:slide-out-to-bottom-0.5 placement-bottom:slide-out-to-top-0.5",
+                                popoverClassName,
+                            )
+                        }
+                    >
+                        <AriaDialog className="outline-hidden">
+                            <AriaAutocomplete filter={contains} inputValue={searchValue} onInputChange={setSearchValue}>
+                                {showSearch && (
+                                    <div className={cx("border-b border-secondary", searchSizes[size].wrapper)}>
+                                        <AriaSearchField aria-label="Search" value={searchValue} onChange={setSearchValue} autoFocus>
+                                            <div className={cx("flex items-center", searchSizes[size].root)}>
+                                                <SearchLg data-icon aria-hidden="true" className="shrink-0 text-fg-quaternary" />
+                                                <AriaInput
+                                                    placeholder="Search"
+                                                    className={cx(
+                                                        "w-full appearance-none bg-transparent text-primary caret-alpha-black/90 outline-hidden placeholder:text-placeholder",
+                                                        searchSizes[size].text,
+                                                    )}
+                                                />
+                                            </div>
+                                        </AriaSearchField>
+                                    </div>
+                                )}
+
+                                <AriaListBox
+                                    aria-label={label || "Options"}
+                                    items={items}
+                                    selectionMode="multiple"
+                                    selectedKeys={selectedKeys}
+                                    defaultSelectedKeys={defaultSelectedKeys}
+                                    onSelectionChange={onSelectionChange}
+                                    renderEmptyState={() => (
+                                        <MultiSelectEmptyState
+                                            title={emptyStateTitle}
+                                            description={emptyStateDescription}
+                                            onClearSearch={searchValue ? handleClearSearch : undefined}
+                                        />
+                                    )}
+                                    className={cx("overflow-y-auto py-1 outline-hidden", popoverMaxHeights[size])}
+                                >
+                                    {children}
+                                </AriaListBox>
+                            </AriaAutocomplete>
+
+                            {showFooter && <MultiSelectFooter size={size} onReset={onReset} onSelectAll={onSelectAll} />}
+                        </AriaDialog>
+                    </AriaPopover>
+                </AriaDialogTrigger>
+
+                {hint && (
+                    <HintText isInvalid={isInvalid} className={cx(size === "sm" && "text-xs")}>
+                        {hint}
+                    </HintText>
+                )}
+            </div>
+        </SelectContext.Provider>
+    );
+};
+
+const MultiSelect = MultiSelectRoot as typeof MultiSelectRoot & {
+    Item: typeof SelectItem;
+    Footer: typeof MultiSelectFooter;
+    EmptyState: typeof MultiSelectEmptyState;
+};
+
+MultiSelect.Item = SelectItem;
+MultiSelect.Footer = MultiSelectFooter;
+MultiSelect.EmptyState = MultiSelectEmptyState;
+
+export { MultiSelect };

--- a/packages/ui/src/components/base/select/multi-select.tsx
+++ b/packages/ui/src/components/base/select/multi-select.tsx
@@ -2,6 +2,16 @@
 // UUI kit source — pulled via `npx untitledui add`. Suppress
 // type-check so `untitledui upgrade` stays a clean replace operation.
 // Re-apply after every kit upgrade until UUI tightens types.
+//
+// GLAON PATCH (re-apply on upgrade): the upstream `MultiSelectRoot`
+// reads `selectedKeys` from its props to compute the trigger label
+// ("3 selected"). When the consumer doesn't pass a controlled
+// `selectedKeys` + `onSelectionChange` pair, the inner `<ListBox>`
+// still toggles its own internal selection — but the trigger's count
+// never updates because `selectedKeys` stays `undefined`. We fall back
+// to a `useState` pair when neither prop is set, so uncontrolled
+// usage works out of the box. Track upstream fix; once the kit fixes
+// this, drop the patch.
 "use client";
 
 import type { ReactNode, RefAttributes } from "react";
@@ -196,7 +206,25 @@ const MultiSelectRoot = ({
         setPopoverWidth(rect.width + "px");
     }, []);
 
-    const selectedCount = selectedKeys instanceof Set ? selectedKeys.size : selectedKeys === "all" ? (items?.length ?? 0) : 0;
+    // GLAON PATCH: fall back to internal state when neither
+    // `selectedKeys` nor `onSelectionChange` is provided so the
+    // trigger label updates on click in uncontrolled usage.
+    const isControlled = selectedKeys !== undefined;
+    const [internalKeys, setInternalKeys] = useState<Selection>(defaultSelectedKeys ?? new Set());
+    const effectiveSelectedKeys = isControlled ? selectedKeys : internalKeys;
+    const effectiveOnSelectionChange = isControlled
+        ? onSelectionChange
+        : (keys: Selection) => {
+              setInternalKeys(keys);
+              onSelectionChange?.(keys);
+          };
+
+    const selectedCount =
+        effectiveSelectedKeys instanceof Set
+            ? effectiveSelectedKeys.size
+            : effectiveSelectedKeys === "all"
+              ? (items?.length ?? 0)
+              : 0;
     const hasSelection = selectedCount > 0;
 
     const handleClearSearch = useCallback(() => {
@@ -289,9 +317,11 @@ const MultiSelectRoot = ({
                                     aria-label={label || "Options"}
                                     items={items}
                                     selectionMode="multiple"
-                                    selectedKeys={selectedKeys}
-                                    defaultSelectedKeys={defaultSelectedKeys}
-                                    onSelectionChange={onSelectionChange}
+                                    // GLAON PATCH: use the effective state so the ListBox
+                                    // is fully controlled by the kit's internal fallback
+                                    // when no external state is supplied.
+                                    selectedKeys={effectiveSelectedKeys}
+                                    onSelectionChange={effectiveOnSelectionChange}
                                     renderEmptyState={() => (
                                         <MultiSelectEmptyState
                                             title={emptyStateTitle}

--- a/packages/ui/src/components/base/select/popover.tsx
+++ b/packages/ui/src/components/base/select/popover.tsx
@@ -1,0 +1,41 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import type { RefAttributes } from "react";
+import type { PopoverProps as AriaPopoverProps } from "react-aria-components";
+import { Popover as AriaPopover } from "react-aria-components";
+import { cx } from "@/utils/cx";
+
+interface PopoverProps extends AriaPopoverProps, RefAttributes<HTMLElement> {
+    size: "sm" | "md" | "lg";
+}
+
+export const Popover = (props: PopoverProps) => {
+    return (
+        <AriaPopover
+            placement="bottom"
+            containerPadding={0}
+            offset={4}
+            {...props}
+            className={(state) =>
+                cx(
+                    "w-(--trigger-width) origin-(--trigger-anchor-point) overflow-x-hidden overflow-y-auto rounded-lg bg-primary py-1 shadow-lg ring-1 ring-secondary_alt outline-hidden will-change-transform",
+
+                    state.isEntering &&
+                        "duration-150 ease-out animate-in fade-in placement-right:slide-in-from-left-0.5 placement-top:slide-in-from-bottom-0.5 placement-bottom:slide-in-from-top-0.5",
+                    state.isExiting &&
+                        "duration-100 ease-in animate-out fade-out placement-right:slide-out-to-left-0.5 placement-top:slide-out-to-bottom-0.5 placement-bottom:slide-out-to-top-0.5",
+
+                    props.size === "sm" && "max-h-56!",
+                    props.size === "md" && "max-h-64!",
+                    props.size === "lg" && "max-h-80!",
+
+                    typeof props.className === "function" ? props.className(state) : props.className,
+                )
+            }
+        />
+    );
+};

--- a/packages/ui/src/components/base/select/select-item.tsx
+++ b/packages/ui/src/components/base/select/select-item.tsx
@@ -1,0 +1,139 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import { isValidElement, useContext } from "react";
+import { Check } from "@untitledui/icons";
+import type { ListBoxItemProps as AriaListBoxItemProps } from "react-aria-components";
+import { ListBoxItem as AriaListBoxItem, Text as AriaText } from "react-aria-components";
+import { Avatar } from "@/components/base/avatar/avatar";
+import { CheckboxBase } from "@/components/base/checkbox/checkbox";
+import { cx } from "@/utils/cx";
+import { isReactComponent } from "@/utils/is-react-component";
+import type { SelectItemType } from "./select-shared";
+import { SelectContext } from "./select-shared";
+
+const sizes = {
+    sm: {
+        root: "p-2 pr-2.5 gap-2 *:data-icon:size-4 *:data-icon:stroke-[2.25px]",
+        text: "text-sm",
+        textContainer: "gap-x-1.5",
+        check: "size-4 stroke-[2.25px]",
+        checkbox: "sm" as const,
+    },
+    md: {
+        root: "p-2 pr-2.5 gap-2 *:data-icon:size-5",
+        text: "text-md",
+        textContainer: "gap-x-2",
+        check: "size-5",
+        checkbox: "sm" as const,
+    },
+    lg: {
+        root: "p-2.5 pl-2 gap-2 *:data-icon:size-5",
+        text: "text-md",
+        textContainer: "gap-x-2",
+        check: "size-5",
+        checkbox: "md" as const,
+    },
+};
+
+interface SelectItemProps extends Omit<AriaListBoxItemProps<SelectItemType>, "id">, SelectItemType {
+    /** The selection indicator to be displayed on the item. */
+    selectionIndicator?: "checkmark" | "checkbox" | "none";
+    /** The alignment of the selection indicator. */
+    selectionIndicatorAlign?: "left" | "right";
+}
+
+export const SelectItem = ({
+    label,
+    id,
+    value,
+    avatarUrl,
+    supportingText,
+    isDisabled,
+    icon: Icon,
+    className,
+    children,
+    selectionIndicator = "checkmark",
+    selectionIndicatorAlign = "right",
+    ...props
+}: SelectItemProps) => {
+    const { size } = useContext(SelectContext);
+
+    const labelOrChildren = label || (typeof children === "string" ? children : "");
+    const textValue = supportingText ? labelOrChildren + " " + supportingText : labelOrChildren;
+
+    const isLeft = selectionIndicatorAlign === "left";
+
+    return (
+        <AriaListBoxItem
+            id={id}
+            value={
+                value ?? {
+                    id,
+                    label: labelOrChildren,
+                    avatarUrl,
+                    supportingText,
+                    isDisabled,
+                    icon: Icon,
+                }
+            }
+            textValue={textValue}
+            isDisabled={isDisabled}
+            {...props}
+            className={(state) =>
+                cx("w-full py-px outline-hidden", size === "sm" ? "px-1" : "px-1.5", typeof className === "function" ? className(state) : className)
+            }
+        >
+            {(state) => (
+                <div
+                    className={cx(
+                        "flex cursor-pointer items-center rounded-md outline-hidden select-none",
+                        (state.isFocused || state.isHovered || (state.isSelected && selectionIndicator !== "checkbox")) && "bg-primary_hover",
+                        state.isDisabled && "cursor-not-allowed opacity-50",
+                        state.isFocusVisible && "ring-2 ring-focus-ring ring-inset",
+
+                        // Icon styles
+                        "*:data-icon:shrink-0 *:data-icon:text-fg-quaternary",
+
+                        sizes[size].root,
+                    )}
+                >
+                    {isLeft && selectionIndicator === "checkbox" && (
+                        <CheckboxBase size={sizes[size].checkbox} isSelected={state.isSelected} isDisabled={state.isDisabled} />
+                    )}
+
+                    {avatarUrl ? (
+                        <Avatar aria-hidden="true" size="xs" src={avatarUrl} alt={label} className={cx(size === "sm" && "size-5")} />
+                    ) : isReactComponent(Icon) ? (
+                        <Icon data-icon aria-hidden="true" />
+                    ) : isValidElement(Icon) ? (
+                        Icon
+                    ) : null}
+
+                    <div className={cx("flex w-full min-w-0 flex-1 flex-wrap", sizes[size].textContainer)}>
+                        <AriaText slot="label" className={cx("truncate font-medium whitespace-nowrap text-primary", sizes[size].text)}>
+                            {label || (typeof children === "function" ? children(state) : children)}
+                        </AriaText>
+
+                        {supportingText && (
+                            <AriaText slot="description" className={cx("whitespace-nowrap text-tertiary", sizes[size].text)}>
+                                {supportingText}
+                            </AriaText>
+                        )}
+                    </div>
+
+                    {state.isSelected && selectionIndicator === "checkmark" && (
+                        <Check aria-hidden="true" className={cx("ml-auto text-fg-brand-primary", sizes[size].check)} />
+                    )}
+
+                    {!isLeft && selectionIndicator === "checkbox" && (
+                        <CheckboxBase size={sizes[size].checkbox} isSelected={state.isSelected} isDisabled={state.isDisabled} className="ml-auto" />
+                    )}
+                </div>
+            )}
+        </AriaListBoxItem>
+    );
+};

--- a/packages/ui/src/components/base/select/select-native.tsx
+++ b/packages/ui/src/components/base/select/select-native.tsx
@@ -1,0 +1,101 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import { type SelectHTMLAttributes, useId } from "react";
+import { ChevronDown } from "@untitledui/icons";
+import { HintText } from "@/components/base/input/hint-text";
+import { Label } from "@/components/base/input/label";
+import { cx } from "@/utils/cx";
+
+interface NativeSelectProps extends Omit<SelectHTMLAttributes<HTMLSelectElement>, "size"> {
+    label?: string;
+    hint?: string;
+    selectClassName?: string;
+    size?: "sm" | "md" | "lg";
+    options: { label: string; value: string; disabled?: boolean }[];
+}
+
+const styles = {
+    sm: {
+        root: "py-2 pl-3 text-sm",
+        icon: "size-4 right-2.5 stroke-[2.25px]",
+    },
+    md: {
+        root: "py-2 pl-3 text-md",
+        icon: "size-4 stroke-[2.25px] right-3",
+    },
+    lg: {
+        root: "py-2.5 px-3.5 text-md",
+        icon: "size-5 right-3",
+    },
+};
+
+export const NativeSelect = ({ label, hint, options, className, selectClassName, size = "md", ...props }: NativeSelectProps) => {
+    const id = useId();
+    const selectId = `select-native-${id}`;
+    const hintId = `select-native-hint-${id}`;
+
+    return (
+        <div className={cx("w-full in-data-input-wrapper:w-max", className)}>
+            {label && (
+                <Label htmlFor={selectId} id={selectId} className="mb-1.5">
+                    {label}
+                </Label>
+            )}
+
+            <div className="relative grid w-full items-center">
+                <select
+                    {...props}
+                    id={selectId}
+                    aria-describedby={hintId}
+                    aria-labelledby={selectId}
+                    className={cx(
+                        "appearance-none rounded-lg bg-primary font-medium text-primary shadow-xs ring-1 ring-primary outline-hidden transition duration-100 ease-linear ring-inset placeholder:text-fg-quaternary focus-visible:ring-2 focus-visible:ring-brand disabled:cursor-not-allowed disabled:opacity-50",
+
+                        styles[size].root,
+
+                        // Styles when the select is within an `InputGroup`
+                        "in-data-input-wrapper:flex in-data-input-wrapper:h-full in-data-input-wrapper:gap-1 in-data-input-wrapper:bg-inherit in-data-input-wrapper:px-3 in-data-input-wrapper:py-2 in-data-input-wrapper:font-normal in-data-input-wrapper:text-tertiary in-data-input-wrapper:shadow-none in-data-input-wrapper:ring-transparent in-data-input-wrapper:in-data-[size=sm]:text-sm",
+                        // Styles for the select when `TextField` is disabled
+                        "in-data-input-wrapper:group-disabled:pointer-events-none in-data-input-wrapper:group-disabled:cursor-not-allowed in-data-input-wrapper:group-disabled:bg-transparent",
+                        // Common styles for sizes and border radius within `InputGroup`
+                        "in-data-input-wrapper:in-data-leading:rounded-r-none in-data-input-wrapper:in-data-trailing:rounded-l-none in-data-input-wrapper:in-data-[input-size=lg]:py-2.5 in-data-input-wrapper:in-data-[input-size=md]:py-2 in-data-input-wrapper:in-data-[input-size=md]:pl-3 in-data-input-wrapper:in-data-[input-size=sm]:text-sm",
+                        // For "leading" dropdown within `InputGroup`
+                        "in-data-input-wrapper:in-data-leading:pr-4.5 in-data-input-wrapper:in-data-leading:in-data-[input-size=lg]:pl-3.5 in-data-input-wrapper:in-data-leading:in-data-[input-size=md]:pr-4.5 in-data-input-wrapper:in-data-leading:in-data-[input-size=md]:pl-3 in-data-input-wrapper:in-data-leading:in-data-[input-size=sm]:pr-3.5",
+                        // For "trailing" dropdown within `InputGroup`
+                        "in-data-input-wrapper:in-data-trailing:in-data-[input-size=lg]:pr-8 in-data-input-wrapper:in-data-trailing:in-data-[input-size=md]:pr-7.5 in-data-input-wrapper:in-data-trailing:in-data-[input-size=sm]:pr-6.5",
+                        selectClassName,
+                    )}
+                >
+                    {options.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                        </option>
+                    ))}
+                </select>
+
+                <ChevronDown
+                    aria-hidden="true"
+                    className={cx(
+                        "pointer-events-none absolute text-fg-quaternary",
+
+                        styles[size].icon,
+                        // Styles for the icon when the select is within an `InputGroup`
+                        "in-data-input-wrapper:right-0 in-data-input-wrapper:size-4 in-data-input-wrapper:stroke-[2.625px]",
+                        // For "trailing" dropdown within `InputGroup`
+                        "in-data-input-wrapper:in-data-trailing:in-data-[input-size=md]:right-3 in-data-input-wrapper:in-data-trailing:in-data-[input-size=sm]:right-3",
+                    )}
+                />
+            </div>
+
+            {hint && (
+                <HintText className="mt-2" id={hintId}>
+                    {hint}
+                </HintText>
+            )}
+        </div>
+    );
+};

--- a/packages/ui/src/components/base/select/select-shared.tsx
+++ b/packages/ui/src/components/base/select/select-shared.tsx
@@ -1,0 +1,55 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import type { FC, ReactNode } from "react";
+import { createContext } from "react";
+
+export type SelectItemType = {
+    /** Unique identifier for the item. */
+    id: string | number;
+    /** The primary display text. */
+    label?: string;
+    /** Avatar image URL. */
+    avatarUrl?: string;
+    /** Whether the item is disabled. */
+    isDisabled?: boolean;
+    /** Secondary text displayed alongside the label. */
+    supportingText?: string;
+    /** Leading icon component or element. */
+    icon?: FC | ReactNode;
+};
+
+export interface CommonProps {
+    /** Helper text displayed below the input. */
+    hint?: string;
+    /** Field label displayed above the input. */
+    label?: string;
+    /** Tooltip text for the help icon next to the label. */
+    tooltip?: string;
+    /**
+     * The size of the component.
+     * @default "md"
+     */
+    size?: "sm" | "md" | "lg";
+    /** Placeholder text when no value is selected. */
+    placeholder?: string;
+    /** Whether to hide the required indicator from the label. */
+    hideRequiredIndicator?: boolean;
+}
+
+export const sizes = {
+    sm: {
+        root: "py-2 pl-3 pr-2.5 gap-2 *:data-icon:size-4 *:data-icon:stroke-[2.25px]",
+        withIcon: "",
+        text: "text-sm",
+        textContainer: "gap-x-1.5",
+        shortcut: "pr-2.5",
+    },
+    md: { root: "py-2 px-3 gap-2 *:data-icon:size-5", withIcon: "", text: "text-md", textContainer: "gap-x-1.5", shortcut: "pr-2.5" },
+    lg: { root: "py-2.5 px-3.5 gap-2 *:data-icon:size-5", withIcon: "", text: "text-md", textContainer: "gap-x-1.5", shortcut: "pr-3" },
+};
+
+export const SelectContext = createContext<{ size: "sm" | "md" | "lg" }>({ size: "md" });

--- a/packages/ui/src/components/base/select/select.tsx
+++ b/packages/ui/src/components/base/select/select.tsx
@@ -1,0 +1,140 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import type { FC, ReactNode, Ref, RefAttributes } from "react";
+import { isValidElement } from "react";
+import { ChevronDown } from "@untitledui/icons";
+import type { SelectProps as AriaSelectProps } from "react-aria-components";
+import { Button as AriaButton, ListBox as AriaListBox, Select as AriaSelect, SelectValue as AriaSelectValue } from "react-aria-components";
+import { Avatar } from "@/components/base/avatar/avatar";
+import { HintText } from "@/components/base/input/hint-text";
+import { Label } from "@/components/base/input/label";
+import { cx } from "@/utils/cx";
+import { isReactComponent } from "@/utils/is-react-component";
+import { ComboBox } from "./combobox";
+import { Popover } from "./popover";
+import { SelectItem } from "./select-item";
+import { type CommonProps, SelectContext, type SelectItemType, sizes } from "./select-shared";
+
+export { SelectContext, sizes, type CommonProps, type SelectItemType } from "./select-shared";
+
+export interface SelectProps extends Omit<AriaSelectProps<SelectItemType>, "children" | "items">, RefAttributes<HTMLDivElement>, CommonProps {
+    items?: SelectItemType[];
+    popoverClassName?: string;
+    icon?: FC | ReactNode;
+    children: ReactNode | ((item: SelectItemType) => ReactNode);
+}
+
+interface SelectValueProps {
+    isOpen: boolean;
+    size: "sm" | "md" | "lg";
+    isFocused: boolean;
+    isDisabled: boolean;
+    placeholder?: string;
+    ref?: Ref<HTMLButtonElement>;
+    icon?: FC | ReactNode;
+}
+
+const SelectValue = ({ isOpen, isFocused, isDisabled, size, placeholder, icon, ref }: SelectValueProps) => {
+    return (
+        <AriaButton
+            ref={ref}
+            className={cx(
+                "relative flex w-full cursor-pointer items-center rounded-lg bg-primary shadow-xs ring-1 ring-primary outline-hidden transition duration-100 ease-linear ring-inset",
+                (isFocused || isOpen) && "ring-2 ring-brand",
+                isDisabled && "cursor-not-allowed opacity-50",
+            )}
+        >
+            <AriaSelectValue<SelectItemType>
+                className={(state) =>
+                    cx(
+                        "flex h-max w-full items-center justify-start truncate text-left align-middle",
+
+                        sizes[size].root,
+
+                        // With icon
+                        (state.selectedItems[0]?.icon || icon) && sizes[size].withIcon,
+
+                        // Icon styles
+                        "*:data-icon:shrink-0 *:data-icon:text-fg-quaternary",
+                    )
+                }
+            >
+                {(state) => {
+                    const selectedItem = state.selectedItems[0];
+                    const Icon = selectedItem?.icon || icon;
+
+                    return (
+                        <>
+                            {selectedItem?.avatarUrl ? (
+                                <Avatar size="xs" src={selectedItem.avatarUrl} alt={selectedItem.label} className={cx(size === "sm" && "size-5")} />
+                            ) : isReactComponent(Icon) ? (
+                                <Icon data-icon aria-hidden="true" />
+                            ) : isValidElement(Icon) ? (
+                                Icon
+                            ) : null}
+
+                            {selectedItem ? (
+                                <section className={cx("flex w-full truncate", sizes[size].textContainer)}>
+                                    <p className={cx("truncate font-medium text-primary", sizes[size].text)}>{selectedItem?.label}</p>
+                                    {selectedItem?.supportingText && <p className={cx("text-tertiary", sizes[size].text)}>{selectedItem?.supportingText}</p>}
+                                </section>
+                            ) : (
+                                <p className={cx("text-placeholder", sizes[size].text)}>{placeholder}</p>
+                            )}
+
+                            <ChevronDown
+                                aria-hidden="true"
+                                className={cx("ml-auto shrink-0 text-fg-quaternary", size === "lg" ? "size-5" : "size-4 stroke-[2.25px]")}
+                            />
+                        </>
+                    );
+                }}
+            </AriaSelectValue>
+        </AriaButton>
+    );
+};
+
+const Select = ({ placeholder = "Select", icon, size = "md", children, items, label, hint, tooltip, hideRequiredIndicator, className, ...rest }: SelectProps) => {
+    return (
+        <SelectContext.Provider value={{ size }}>
+            <AriaSelect {...rest} className={(state) => cx("flex flex-col gap-1.5", typeof className === "function" ? className(state) : className)}>
+                {(state) => (
+                    <>
+                        {label && (
+                            <Label isRequired={hideRequiredIndicator ? false : state.isRequired} tooltip={tooltip}>
+                                {label}
+                            </Label>
+                        )}
+
+                        <SelectValue {...state} {...{ size, placeholder }} icon={icon} />
+
+                        <Popover size={size} className={rest.popoverClassName}>
+                            <AriaListBox items={items} className="size-full outline-hidden">
+                                {children}
+                            </AriaListBox>
+                        </Popover>
+
+                        {hint && (
+                            <HintText isInvalid={state.isInvalid} className={cx(size === "sm" && "text-xs")}>
+                                {hint}
+                            </HintText>
+                        )}
+                    </>
+                )}
+            </AriaSelect>
+        </SelectContext.Provider>
+    );
+};
+
+const _Select = Select as typeof Select & {
+    ComboBox: typeof ComboBox;
+    Item: typeof SelectItem;
+};
+_Select.ComboBox = ComboBox;
+_Select.Item = SelectItem;
+
+export { _Select as Select };

--- a/packages/ui/src/components/base/select/tag-select.tsx
+++ b/packages/ui/src/components/base/select/tag-select.tsx
@@ -1,0 +1,407 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import type { FocusEventHandler, KeyboardEvent, PointerEventHandler, RefAttributes, RefObject } from "react";
+import React, { createContext, useCallback, useContext, useRef, useState } from "react";
+import { SearchLg } from "@untitledui/icons";
+import { FocusScope, useFilter, useFocusManager } from "react-aria";
+import type { ComboBoxProps as AriaComboBoxProps, GroupProps as AriaGroupProps, ListBoxProps as AriaListBoxProps, Key } from "react-aria-components";
+import { ComboBox as AriaComboBox, Group as AriaGroup, Input as AriaInput, ListBox as AriaListBox, ComboBoxStateContext } from "react-aria-components";
+import type { ListData } from "react-stately";
+import { useListData } from "react-stately";
+import { Avatar } from "@/components/base/avatar/avatar";
+import type { IconComponentType } from "@/components/base/badges/badge-types";
+import { HintText } from "@/components/base/input/hint-text";
+import { Label } from "@/components/base/input/label";
+import { Popover } from "@/components/base/select/popover";
+import { type SelectItemType, sizes } from "@/components/base/select/select-shared";
+import { TagCloseX } from "@/components/base/tags/base-components/tag-close-x";
+import { useResizeObserver } from "@/hooks/use-resize-observer";
+import { cx } from "@/utils/cx";
+import { SelectItem } from "./select-item";
+
+interface TagSelectValueProps extends AriaGroupProps {
+    size: "sm" | "md" | "lg";
+    shortcut?: boolean;
+    isDisabled?: boolean;
+    placeholder?: string;
+    shortcutClassName?: string;
+    icon?: IconComponentType | null;
+    ref?: RefObject<HTMLDivElement | null>;
+    onFocus?: FocusEventHandler;
+    onPointerEnter?: PointerEventHandler;
+}
+
+const TagSelectContext = createContext<{
+    size: "sm" | "md" | "lg";
+    selectedKeys: Key[];
+    selectedItems: ListData<SelectItemType>;
+    onRemove: (keys: Set<Key>) => void;
+    onInputChange: (value: string) => void;
+    valueFormatter?: (item: SelectItemType) => string;
+}>({
+    size: "sm",
+    selectedKeys: [],
+    selectedItems: {} as ListData<SelectItemType>,
+    onRemove: () => {},
+    onInputChange: () => {},
+});
+
+interface TagSelectProps extends Omit<AriaComboBoxProps<SelectItemType>, "children" | "items">, RefAttributes<HTMLDivElement> {
+    hint?: string;
+    label?: string;
+    tooltip?: string;
+    size?: "sm" | "md" | "lg";
+    placeholder?: string;
+    shortcut?: boolean;
+    items?: SelectItemType[];
+    popoverClassName?: string;
+    shortcutClassName?: string;
+    selectedItems: ListData<SelectItemType>;
+    icon?: IconComponentType | null;
+    children: AriaListBoxProps<SelectItemType>["children"];
+    onItemCleared?: (key: Key) => void;
+    onItemInserted?: (key: Key) => void;
+    valueFormatter?: (item: SelectItemType) => string;
+}
+
+export const TagSelectBase = ({
+    items,
+    children,
+    size = "sm",
+    selectedItems,
+    onItemCleared,
+    onItemInserted,
+    valueFormatter,
+    shortcut,
+    placeholder = "Search",
+    icon,
+    // Omit name to avoid conflicts with the `Select` component
+    name: _name,
+    className,
+    ...props
+}: TagSelectProps) => {
+    const { contains } = useFilter({ sensitivity: "base" });
+    const selectedKeys = selectedItems.items.map((item) => item.id);
+
+    const filter = useCallback(
+        (item: SelectItemType, filterText: string) => {
+            return !selectedKeys.includes(item.id) && contains(item.label || item.supportingText || "", filterText);
+        },
+        [contains, selectedKeys],
+    );
+
+    const accessibleList = useListData({
+        initialItems: items,
+        filter,
+    });
+
+    const onRemove = useCallback(
+        (keys: Set<Key>) => {
+            const key = keys.values().next().value;
+
+            if (!key) return;
+
+            selectedItems.remove(key);
+            onItemCleared?.(key);
+        },
+        [selectedItems, onItemCleared],
+    );
+
+    const onSelectionChange = (id: Key | null) => {
+        if (!id) {
+            return;
+        }
+
+        const item = accessibleList.getItem(id);
+
+        if (!item) {
+            return;
+        }
+
+        if (!selectedKeys.includes(id as string)) {
+            selectedItems.append(item);
+            onItemInserted?.(id);
+        }
+
+        accessibleList.setFilterText("");
+    };
+
+    const onInputChange = (value: string) => {
+        accessibleList.setFilterText(value);
+    };
+
+    const placeholderRef = useRef<HTMLDivElement>(null);
+    const [popoverWidth, setPopoverWidth] = useState("");
+
+    // Resize observer for popover width
+    const onResize = useCallback(() => {
+        if (!placeholderRef.current) return;
+        let divRect = placeholderRef.current?.getBoundingClientRect();
+        setPopoverWidth(divRect.width + "px");
+    }, [placeholderRef, setPopoverWidth]);
+
+    useResizeObserver({
+        ref: placeholderRef,
+        onResize: onResize,
+        box: "border-box",
+    });
+
+    return (
+        <TagSelectContext.Provider
+            value={{
+                size,
+                selectedKeys,
+                selectedItems,
+                onInputChange,
+                onRemove,
+                valueFormatter,
+            }}
+        >
+            <AriaComboBox
+                allowsEmptyCollection
+                menuTrigger="focus"
+                items={accessibleList.items}
+                onInputChange={onInputChange}
+                inputValue={accessibleList.filterText}
+                // This keeps the combobox popover open and the input value unchanged when an item is selected.
+                value={null}
+                onChange={onSelectionChange}
+                className={(state) => cx("flex flex-col gap-1.5", typeof className === "function" ? className(state) : className)}
+                {...props}
+            >
+                {(state) => (
+                    <>
+                        {props.label && (
+                            <Label isRequired={state.isRequired} tooltip={props.tooltip}>
+                                {props.label}
+                            </Label>
+                        )}
+
+                        <TagSelectTagsValue
+                            size={size}
+                            shortcut={shortcut}
+                            ref={placeholderRef}
+                            placeholder={placeholder}
+                            icon={icon}
+                            // This is a workaround to correctly calculating the trigger width
+                            // while using ResizeObserver wasn't 100% reliable.
+                            onFocus={onResize}
+                            onPointerEnter={onResize}
+                        />
+
+                        <Popover size={size} triggerRef={placeholderRef} style={{ width: popoverWidth }} className={props?.popoverClassName}>
+                            <AriaListBox selectionMode="multiple" className="size-full outline-hidden">
+                                {children}
+                            </AriaListBox>
+                        </Popover>
+
+                        {props.hint && (
+                            <HintText isInvalid={state.isInvalid} className={cx(size === "sm" && "text-xs")}>
+                                {props.hint}
+                            </HintText>
+                        )}
+                    </>
+                )}
+            </AriaComboBox>
+        </TagSelectContext.Provider>
+    );
+};
+
+const InnerTagSelect = ({ isDisabled, shortcut, shortcutClassName, placeholder, size = "sm" }: Omit<TagSelectProps, "selectedItems" | "children">) => {
+    const focusManager = useFocusManager();
+    const tagSelectContext = useContext(TagSelectContext);
+    const comboBoxStateContext = useContext(ComboBoxStateContext);
+
+    const handleInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+        const isCaretAtStart = event.currentTarget.selectionStart === 0 && event.currentTarget.selectionEnd === 0;
+
+        if (!isCaretAtStart && event.currentTarget.value !== "") {
+            return;
+        }
+
+        switch (event.key) {
+            case "Backspace":
+            case "ArrowLeft":
+                focusManager?.focusPrevious({ wrap: false, tabbable: false });
+                break;
+            case "ArrowRight":
+                focusManager?.focusNext({ wrap: false, tabbable: false });
+                break;
+        }
+    };
+
+    // Ensure dropdown opens on click even if input is already focused
+    const handleInputMouseDown = (_event: React.MouseEvent<HTMLInputElement>) => {
+        if (comboBoxStateContext && !comboBoxStateContext.isOpen) {
+            comboBoxStateContext.open();
+        }
+    };
+
+    const handleTagKeyDown = (event: KeyboardEvent<HTMLButtonElement>, value: Key) => {
+        // Do nothing when tab is clicked to move focus from the tag to the input element.
+        if (event.key === "Tab") {
+            return;
+        }
+
+        event.preventDefault();
+
+        const isFirstTag = tagSelectContext?.selectedItems?.items?.[0]?.id === value;
+
+        switch (event.key) {
+            case " ":
+            case "Enter":
+            case "Backspace":
+                if (isFirstTag) {
+                    focusManager?.focusNext({ wrap: false, tabbable: false });
+                } else {
+                    focusManager?.focusPrevious({ wrap: false, tabbable: false });
+                }
+
+                tagSelectContext.onRemove(new Set([value]));
+                break;
+
+            case "ArrowLeft":
+                focusManager?.focusPrevious({ wrap: false, tabbable: false });
+                break;
+            case "ArrowRight":
+                focusManager?.focusNext({ wrap: false, tabbable: false });
+                break;
+            case "Escape":
+                comboBoxStateContext?.close();
+                break;
+        }
+    };
+
+    const isSelectionEmpty = tagSelectContext?.selectedItems?.items?.length === 0;
+
+    return (
+        <div className="relative flex w-full min-w-0 flex-1 flex-row flex-wrap items-center justify-start gap-1.5">
+            {!isSelectionEmpty &&
+                tagSelectContext?.selectedItems?.items?.map((value) => (
+                    <span
+                        key={value.id}
+                        className={cx(
+                            "flex min-w-0 items-center rounded-md bg-primary ring-1 ring-primary ring-inset",
+                            size === "sm" ? "px-1 py-0.75" : "py-0.5 pr-1 pl-1.25",
+                        )}
+                    >
+                        <Avatar size="xs" alt={value?.label} src={value?.avatarUrl} className="size-4" />
+
+                        <p
+                            className={cx(
+                                "truncate font-medium whitespace-nowrap text-secondary select-none",
+                                size === "sm" ? "ml-1 text-xs" : "ml-1.25 text-sm",
+                            )}
+                        >
+                            {tagSelectContext.valueFormatter ? tagSelectContext.valueFormatter(value) : value?.label}
+                        </p>
+
+                        <TagCloseX
+                            size={size === "sm" ? "sm" : "md"}
+                            isDisabled={isDisabled}
+                            className="ml-0.75"
+                            // For workaround, onKeyDown is added to the button
+                            onKeyDown={(event) => handleTagKeyDown(event, value.id)}
+                            onPress={() => tagSelectContext.onRemove(new Set([value.id]))}
+                        />
+                    </span>
+                ))}
+
+            <div className={cx("relative flex min-w-12 flex-1 flex-row items-center", !isSelectionEmpty && "ml-0.5", shortcut && "min-w-[30%]")}>
+                <AriaInput
+                    placeholder={placeholder}
+                    onKeyDown={handleInputKeyDown}
+                    onMouseDown={handleInputMouseDown}
+                    className={cx(
+                        "w-full flex-[1_0_0] appearance-none bg-transparent text-ellipsis text-primary caret-alpha-black/90 outline-hidden placeholder:text-placeholder focus:outline-hidden disabled:cursor-not-allowed",
+                        sizes[size].text,
+                    )}
+                />
+
+                {shortcut && (
+                    <div
+                        aria-hidden="true"
+                        className={cx(
+                            "absolute inset-y-0.5 right-0.5 z-10 hidden items-center rounded-r-[inherit] bg-linear-to-r from-transparent to-bg-primary to-40% pl-8 md:flex",
+                            shortcutClassName,
+                            sizes[size].shortcut,
+                        )}
+                    >
+                        <span
+                            className={cx(
+                                "pointer-events-none rounded px-1 py-px text-xs font-medium text-quaternary ring-1 ring-secondary select-none ring-inset",
+                                isDisabled && "bg-transparent",
+                            )}
+                        >
+                            ⌘K
+                        </span>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export const TagSelectTagsValue = ({
+    size = "sm",
+    shortcut,
+    placeholder,
+    shortcutClassName,
+    icon: Icon = SearchLg,
+    // Omit this prop to avoid invalid HTML attribute warning
+    isDisabled: _isDisabled,
+    ...otherProps
+}: TagSelectValueProps) => {
+    const tagSelectContext = useContext(TagSelectContext);
+
+    const selectedItemsCount = tagSelectContext.selectedKeys.length;
+
+    return (
+        <AriaGroup
+            {...otherProps}
+            className={({ isFocusWithin, isDisabled }) =>
+                cx(
+                    "relative flex w-full items-center rounded-lg bg-primary shadow-xs ring-1 ring-primary outline-hidden transition duration-100 ease-linear ring-inset",
+                    isDisabled && "cursor-not-allowed opacity-50",
+                    isFocusWithin && "ring-2 ring-brand",
+
+                    // Icon styles
+                    "*:data-icon:shrink-0 *:data-icon:text-fg-quaternary",
+
+                    sizes[size].root,
+
+                    // Overwrite vertical padding for small size when there are selected items
+                    // to prevent height jump because the tags are taller than the input text.
+                    size === "sm" && selectedItemsCount > 0 && "py-1.5",
+                )
+            }
+        >
+            {({ isDisabled }) => (
+                <>
+                    {Icon && <Icon data-icon className="pointer-events-none" />}
+                    <FocusScope contain={false} autoFocus={false} restoreFocus={false}>
+                        <InnerTagSelect
+                            isDisabled={isDisabled}
+                            size={size}
+                            shortcut={shortcut}
+                            shortcutClassName={shortcutClassName}
+                            placeholder={placeholder}
+                        />
+                    </FocusScope>
+                </>
+            )}
+        </AriaGroup>
+    );
+};
+
+const TagSelect = TagSelectBase as typeof TagSelectBase & {
+    Item: typeof SelectItem;
+};
+
+TagSelect.Item = SelectItem;
+
+export { TagSelect };

--- a/packages/ui/src/components/base/tags/base-components/tag-close-x.tsx
+++ b/packages/ui/src/components/base/tags/base-components/tag-close-x.tsx
@@ -1,0 +1,38 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import type { RefAttributes } from "react";
+import { XClose } from "@untitledui/icons";
+import { Button as AriaButton, type ButtonProps as AriaButtonProps } from "react-aria-components";
+import { cx } from "@/utils/cx";
+
+interface TagCloseXProps extends AriaButtonProps, RefAttributes<HTMLButtonElement> {
+    size?: "sm" | "md" | "lg";
+    className?: string;
+}
+
+const styles = {
+    sm: { root: "p-0.5", icon: "size-2.5 stroke-[3.6px]" },
+    md: { root: "p-0.5", icon: "size-3 stroke-[2.86px]" },
+    lg: { root: "p-0.75", icon: "size-3.5 stroke-3" },
+};
+
+export const TagCloseX = ({ size = "md", className, ...otherProps }: TagCloseXProps) => {
+    return (
+        <AriaButton
+            slot="remove"
+            aria-label="Remove this tag"
+            className={cx(
+                "flex cursor-pointer rounded-[3px] text-fg-quaternary outline-transparent transition duration-100 ease-linear hover:bg-primary_hover hover:text-fg-quaternary_hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring disabled:cursor-not-allowed",
+                styles[size].root,
+                className,
+            )}
+            {...otherProps}
+        >
+            <XClose className={cx("transition-inherit-all", styles[size].icon)} />
+        </AriaButton>
+    );
+};

--- a/packages/ui/src/components/foundations/featured-icon/featured-icon.tsx
+++ b/packages/ui/src/components/foundations/featured-icon/featured-icon.tsx
@@ -1,0 +1,158 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+import type { FC, ReactNode, Ref } from "react";
+import { isValidElement } from "react";
+import { cx, sortCx } from "@/utils/cx";
+import { isReactComponent } from "@/utils/is-react-component";
+
+const iconsSizes = {
+    sm: "*:data-icon:size-4 *:data-icon:stroke-[2.25px]",
+    md: "*:data-icon:size-5",
+    lg: "*:data-icon:size-6",
+    xl: "*:data-icon:size-7",
+};
+
+const styles = sortCx({
+    light: {
+        base: "rounded-full",
+        sizes: {
+            sm: "size-8",
+            md: "size-10",
+            lg: "size-12",
+            xl: "size-14",
+        },
+        colors: {
+            brand: "bg-brand-secondary text-featured-icon-light-fg-brand",
+            gray: "bg-tertiary text-featured-icon-light-fg-gray",
+            error: "bg-error-secondary text-featured-icon-light-fg-error",
+            warning: "bg-warning-secondary text-featured-icon-light-fg-warning",
+            success: "bg-success-secondary text-featured-icon-light-fg-success",
+        },
+    },
+
+    gradient: {
+        base: "rounded-full text-fg-white before:absolute before:inset-0 before:size-full before:rounded-full before:border before:mask-b-from-0% after:absolute after:block after:rounded-full",
+        sizes: {
+            sm: "size-8 after:size-6 *:data-icon:size-4",
+            md: "size-10 after:size-7 *:data-icon:size-4",
+            lg: "size-12 after:size-8 *:data-icon:size-5",
+            xl: "size-14 after:size-10 *:data-icon:size-5",
+        },
+        colors: {
+            brand: "before:border-utility-brand-200 before:bg-utility-brand-50 after:bg-brand-solid",
+            gray: "before:border-utility-neutral-200 before:bg-utility-neutral-50 after:bg-secondary-solid",
+            error: "before:border-utility-red-200 before:bg-utility-red-50 after:bg-error-solid",
+            warning: "before:border-utility-yellow-200 before:bg-utility-yellow-50 after:bg-warning-solid",
+            success: "before:border-utility-green-200 before:bg-utility-green-50 after:bg-success-solid",
+        },
+    },
+
+    dark: {
+        base: "text-fg-white shadow-xs-skeuomorphic before:absolute before:inset-px before:border before:border-white/12 before:mask-b-from-0%",
+        sizes: {
+            sm: "size-8 rounded-md before:rounded-[5px]",
+            md: "size-10 rounded-lg before:rounded-[7px]",
+            lg: "size-12 rounded-[10px] before:rounded-[9px]",
+            xl: "size-14 rounded-xl before:rounded-[11px]",
+        },
+        colors: {
+            brand: "bg-brand-solid before:border-utility-brand-200/12",
+            gray: "bg-secondary-solid before:border-utility-neutral-200/12",
+            error: "bg-error-solid before:border-utility-red-200/12",
+            warning: "bg-warning-solid before:border-utility-yellow-200/12",
+            success: "bg-success-solid before:border-utility-green-200/12",
+        },
+    },
+
+    modern: {
+        base: "bg-primary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset",
+        sizes: {
+            sm: "size-8 rounded-md",
+            md: "size-10 rounded-lg",
+            lg: "size-12 rounded-[10px]",
+            xl: "size-14 rounded-xl",
+        },
+        colors: {
+            brand: "text-fg-brand-primary",
+            gray: "text-fg-secondary",
+            error: "text-fg-error-primary",
+            warning: "text-fg-warning-primary",
+            success: "text-fg-success-primary",
+        },
+    },
+    "modern-neue": {
+        base: [
+            "bg-primary_alt ring-1 ring-inset before:absolute before:inset-1",
+            // Shadow
+            "before:shadow-[0px_1px_2px_0px_rgba(0,0,0,0.1),0px_3px_3px_0px_rgba(0,0,0,0.09),1px_8px_5px_0px_rgba(0,0,0,0.05),2px_21px_6px_0px_rgba(0,0,0,0),0px_0px_0px_1px_rgba(0,0,0,0.08),1px_13px_5px_0px_rgba(0,0,0,0.01),0px_-2px_2px_0px_rgba(0,0,0,0.13)_inset] before:ring-1 before:ring-secondary_alt",
+        ].join(" "),
+        sizes: {
+            sm: "size-8 rounded-[8px] before:rounded-[4px]",
+            md: "size-10 rounded-[10px] before:rounded-[6px]",
+            lg: "size-12 rounded-[12px] before:rounded-[8px]",
+            xl: "size-14 rounded-[14px] before:rounded-[10px]",
+        },
+        colors: {
+            brand: "",
+            gray: "text-fg-secondary ring-primary",
+            error: "",
+            warning: "",
+            success: "",
+        },
+    },
+
+    outline: {
+        base: "before:absolute before:rounded-full before:border-2 after:absolute after:rounded-full after:border-2",
+        sizes: {
+            sm: "size-4 before:size-6 after:size-8.5",
+            md: "size-5 before:size-7 after:size-9.5",
+            lg: "size-6 before:size-8 after:size-10.5",
+            xl: "size-7 before:size-9 after:size-11.5",
+        },
+        colors: {
+            brand: "text-fg-brand-primary before:border-fg-brand-primary/30 after:border-fg-brand-primary/10",
+            gray: "text-fg-tertiary before:border-fg-tertiary/30 after:border-fg-tertiary/10",
+            error: "text-fg-error-primary before:border-fg-error-primary/30 after:border-fg-error-primary/10",
+            warning: "text-fg-warning-primary before:border-fg-warning-primary/30 after:border-fg-warning-primary/10",
+            success: "text-fg-success-primary before:border-fg-success-primary/30 after:border-fg-success-primary/10",
+        },
+    },
+});
+
+interface FeaturedIconProps {
+    ref?: Ref<HTMLDivElement>;
+    children?: ReactNode;
+    className?: string;
+    icon?: FC<{ className?: string }> | ReactNode;
+    size?: "sm" | "md" | "lg" | "xl";
+    color: "brand" | "gray" | "success" | "warning" | "error";
+    theme?: "light" | "gradient" | "dark" | "outline" | "modern" | "modern-neue";
+}
+
+export const FeaturedIcon = (props: FeaturedIconProps) => {
+    const { size = "sm", theme: variant = "light", color = "brand", icon: Icon, ...otherProps } = props;
+
+    return (
+        <div
+            {...otherProps}
+            data-featured-icon
+            className={cx(
+                "relative flex shrink-0 items-center justify-center",
+
+                iconsSizes[size],
+                styles[variant].base,
+                styles[variant].sizes[size],
+                styles[variant].colors[color],
+
+                props.className,
+            )}
+        >
+            {isReactComponent(Icon) && <Icon data-icon className="z-1" />}
+            {isValidElement(Icon) && <div className="z-1">{Icon}</div>}
+
+            {props.children}
+        </div>
+    );
+};

--- a/packages/ui/src/hooks/use-resize-observer.ts
+++ b/packages/ui/src/hooks/use-resize-observer.ts
@@ -1,0 +1,71 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+import { useEffect } from "react";
+import type { RefObject } from "@react-types/shared";
+
+/**
+ * Checks if the ResizeObserver API is supported.
+ * @returns True if the ResizeObserver API is supported, false otherwise.
+ */
+function hasResizeObserver() {
+    return typeof window.ResizeObserver !== "undefined";
+}
+
+/**
+ * The options for the useResizeObserver hook.
+ */
+type useResizeObserverOptionsType<T> = {
+    /**
+     * The ref to the element to observe.
+     */
+    ref: RefObject<T | undefined | null> | undefined;
+    /**
+     * The box to observe.
+     */
+    box?: ResizeObserverBoxOptions;
+    /**
+     * The callback function to call when the size changes.
+     */
+    onResize: () => void;
+};
+
+/**
+ * A hook that observes the size of an element and calls a callback function when the size changes.
+ * @param options - The options for the hook.
+ */
+export function useResizeObserver<T extends Element>(options: useResizeObserverOptionsType<T>) {
+    const { ref, box, onResize } = options;
+
+    useEffect(() => {
+        const element = ref?.current;
+        if (!element) {
+            return;
+        }
+
+        if (!hasResizeObserver()) {
+            window.addEventListener("resize", onResize, false);
+
+            return () => {
+                window.removeEventListener("resize", onResize, false);
+            };
+        } else {
+            const resizeObserverInstance = new window.ResizeObserver((entries) => {
+                if (!entries.length) {
+                    return;
+                }
+
+                onResize();
+            });
+
+            resizeObserverInstance.observe(element, { box });
+
+            return () => {
+                if (element) {
+                    resizeObserverInstance.unobserve(element);
+                }
+            };
+        }
+    }, [onResize, ref, box]);
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,7 @@ export * from './components/Input';
 export * from './components/PressableButton';
 export * from './components/ProgressBar';
 export * from './components/Radio';
+export * from './components/Select';
 export * from './components/Spinner';
 export * from './components/Stat';
 export * from './components/Switch';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,12 +205,21 @@ importers:
 
   packages/ui:
     dependencies:
+      '@react-types/shared':
+        specifier: ^3.34.0
+        version: 3.34.0(react@19.2.5)
       '@untitledui/icons':
         specifier: ^0.0.22
         version: 0.0.22(react@19.2.5)
+      react-aria:
+        specifier: ^3.48.0
+        version: 3.48.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-aria-components:
         specifier: ^1.17.0
         version: 1.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-stately:
+        specifier: ^3.46.0
+        version: 3.46.0(react@19.2.5)
     devDependencies:
       '@glaon/config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Seventh Phase 1 primitive group (P7) — the form-input portal-based picker. The kit ships a full Select family — \`Select\` (single popover-based picker), \`ComboBox\` (search-as-you-type), \`MultiSelect\` (multi-value popover), \`TagSelect\` (tag/chip multi), \`NativeSelect\` (HTML \`<select>\`), plus the \`SelectItem\` helper — all parameterized base primitives built on react-aria-components. The Glaon wrap re-exports them verbatim (same shape as Input / Textarea / form controls).

The kit's RAC + react-stately foundation handles the full a11y contract: keyboard navigation (arrow / typeahead / escape), proper roles (\`combobox\` / \`listbox\` / \`option\`), ARIA wiring, popover positioning + flip, and focus management on open / close.

## Surface

- \`Select\` — single popover-based picker with \`SelectItemType[]\` items + render-prop children.
- \`ComboBox\` — Select with search-as-you-type filter.
- \`MultiSelect\` — multi-value popover with checkmark indicators.
- \`TagSelect\`, \`TagSelectBase\`, \`TagSelectTagsValue\` — tag/chip multi-select.
- \`NativeSelect\` — HTML \`<select>\` for forms that want native UI.
- \`SelectItem\` — list-item helper consumed by every variant.
- \`SelectContext\`, \`selectSizes\`, \`SelectCommonProps\`, \`SelectItemType\` — escape hatches for custom compositions.

## Scope (In)

- \`components/Select/{Select.tsx,Select.stories.tsx,index.ts}\` — wrap + 10 stories (Default, WithDefaultValue, WithHint, WithError, Disabled, Sizes, LongList, WithSearch, Multi, Native).
- Kit sources placed under \`base/select/*.tsx\` (8 files) plus new transitive deps:
  - \`base/tags/base-components/tag-close-x.tsx\`
  - \`foundations/featured-icon/featured-icon.tsx\`
  - \`hooks/use-resize-observer.ts\`
  Each carries \`@ts-nocheck\`.
- \`packages/ui/package.json\` adds \`react-aria\`, \`react-stately\`, and \`@react-types/shared\` as direct dependencies — the kit's deeper imports reach beyond \`react-aria-components\`.
- \`.prettierignore\` / \`eslint.config.js\` extend their ignore lists with \`**/src/hooks/**\` (new tier from this kit pull).

## Scope (Out)

- **Async option loading** (Phase 2).
- **Tag/chip multi-select UI customization** (Phase 2 — Application).
- **Combobox standalone primitive** — surfaced as \`ComboBox\` from \`@glaon/ui\`, not a separate primitive directory.
- **RN \`*.native.tsx\`** — UUI is web-only; deferred to follow-up.

## F6 prop-coverage gate

Story file declares an \`excludeFromArgs\` allowlist for RAC-forwarded props (\`menuTrigger\`, \`shouldFlip\`, \`disabledKeys\`, \`validate\`, \`isOpen\` / \`defaultOpen\`, \`aria-*\`, etc.) and kit-internal props (\`children\`, \`items\`, \`icon\`, \`popoverClassName\`).

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui test --run\` — 51 passing (was 48; +3 for Select × 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\` severity
- [ ] Storybook spot-check: light + dark; arrow-key + typeahead navigation, escape closes
- [ ] Chromatic snapshots accepted (intentional new-component diffs, both closed + open states)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)