### PR TITLE
feat(ui): Tabs primitive + stories

### DIFF
--- a/packages/ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,215 @@
+import type { ReactNode } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { storybookIcons } from '../../icons/storybook';
+import { Tabs } from './Tabs';
+
+// Explicit `Meta<typeof Tabs>` annotation (rather than `satisfies`)
+// keeps the kit's deep RAC generic chains out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+const meta: Meta<typeof Tabs> = {
+  title: 'Web Primitives/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-tabs',
+    },
+  },
+  args: {
+    defaultSelectedKey: 'overview',
+    orientation: 'horizontal',
+    keyboardActivation: 'manual',
+  },
+  argTypes: {
+    defaultSelectedKey: { control: 'text' },
+    selectedKey: { control: 'text' },
+    orientation: { control: 'inline-radio', options: ['horizontal', 'vertical'] },
+    keyboardActivation: { control: 'inline-radio', options: ['automatic', 'manual'] },
+    isDisabled: { control: 'boolean' },
+    onSelectionChange: { control: false, action: 'selection-changed' },
+    children: { control: false, table: { disable: true } },
+    className: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 640 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+// `react-docgen-typescript` walks the static-property namespace on
+// `Tabs` (Tabs.List, Tabs.Trigger, Tabs.Content) and surfaces their
+// own props on the root signature too. The TabList-only props
+// (`size`, `type`, `items`, `fullWidth`) belong on `<Tabs.List>` per
+// the Glaon API; expose them via the sub-component story rather than
+// the root meta.
+export const excludeFromArgs = [
+  // TabList-only props (set on `<Tabs.List type=… size=… fullWidth>`).
+  'size',
+  'type',
+  'items',
+  'fullWidth',
+  // RAC-forwarded props not useful as Storybook knobs.
+  'autoFocus',
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'translate',
+  'slot',
+  'data-rac',
+  'ref',
+  'id',
+  'style',
+  'dir',
+];
+
+const samplePanel = (text: string): ReactNode => (
+  <div className="p-4 text-sm text-secondary">{text}</div>
+);
+
+export const Default: Story = {
+  render: (args) => (
+    <Tabs {...args}>
+      <Tabs.List type="button-brand">
+        <Tabs.Trigger id="overview" label="Overview" />
+        <Tabs.Trigger id="settings" label="Settings" />
+        <Tabs.Trigger id="billing" label="Billing" />
+      </Tabs.List>
+      <Tabs.Content id="overview">{samplePanel('Overview content lives here.')}</Tabs.Content>
+      <Tabs.Content id="settings">{samplePanel('Settings content lives here.')}</Tabs.Content>
+      <Tabs.Content id="billing">{samplePanel('Billing content lives here.')}</Tabs.Content>
+    </Tabs>
+  ),
+};
+
+export const Underline: Story = {
+  render: (args) => (
+    <Tabs {...args}>
+      <Tabs.List type="underline">
+        <Tabs.Trigger id="overview" label="Overview" />
+        <Tabs.Trigger id="settings" label="Settings" />
+        <Tabs.Trigger id="billing" label="Billing" />
+      </Tabs.List>
+      <Tabs.Content id="overview">{samplePanel('Overview.')}</Tabs.Content>
+      <Tabs.Content id="settings">{samplePanel('Settings.')}</Tabs.Content>
+      <Tabs.Content id="billing">{samplePanel('Billing.')}</Tabs.Content>
+    </Tabs>
+  ),
+};
+
+export const ButtonGray: Story = {
+  render: (args) => (
+    <Tabs {...args}>
+      <Tabs.List type="button-gray">
+        <Tabs.Trigger id="day" label="Day" />
+        <Tabs.Trigger id="week" label="Week" />
+        <Tabs.Trigger id="month" label="Month" />
+        <Tabs.Trigger id="year" label="Year" />
+      </Tabs.List>
+      <Tabs.Content id="day">{samplePanel('Day view.')}</Tabs.Content>
+      <Tabs.Content id="week">{samplePanel('Week view.')}</Tabs.Content>
+      <Tabs.Content id="month">{samplePanel('Month view.')}</Tabs.Content>
+      <Tabs.Content id="year">{samplePanel('Year view.')}</Tabs.Content>
+    </Tabs>
+  ),
+  args: { defaultSelectedKey: 'day' },
+};
+
+export const WithIcons: Story = {
+  render: (args) => (
+    <Tabs {...args}>
+      <Tabs.List type="button-brand">
+        <Tabs.Trigger id="home" label="Home" icon={storybookIcons.user} />
+        <Tabs.Trigger id="settings" label="Settings" icon={storybookIcons.settings} />
+        <Tabs.Trigger id="bell" label="Notifications" icon={storybookIcons.bell} />
+      </Tabs.List>
+      <Tabs.Content id="home">{samplePanel('Home.')}</Tabs.Content>
+      <Tabs.Content id="settings">{samplePanel('Settings.')}</Tabs.Content>
+      <Tabs.Content id="bell">{samplePanel('Notifications.')}</Tabs.Content>
+    </Tabs>
+  ),
+  args: { defaultSelectedKey: 'home' },
+};
+
+export const WithBadges: Story = {
+  render: (args) => (
+    <Tabs {...args}>
+      <Tabs.List type="button-brand">
+        <Tabs.Trigger id="inbox" label="Inbox" badge={12} />
+        <Tabs.Trigger id="archive" label="Archive" badge={3} />
+        <Tabs.Trigger id="spam" label="Spam" />
+      </Tabs.List>
+      <Tabs.Content id="inbox">{samplePanel('Inbox (12).')}</Tabs.Content>
+      <Tabs.Content id="archive">{samplePanel('Archive (3).')}</Tabs.Content>
+      <Tabs.Content id="spam">{samplePanel('Spam.')}</Tabs.Content>
+    </Tabs>
+  ),
+  args: { defaultSelectedKey: 'inbox' },
+};
+
+export const DisabledTab: Story = {
+  render: (args) => (
+    <Tabs {...args}>
+      <Tabs.List type="button-brand">
+        <Tabs.Trigger id="active" label="Active" />
+        <Tabs.Trigger id="paused" label="Paused" isDisabled />
+        <Tabs.Trigger id="archived" label="Archived" />
+      </Tabs.List>
+      <Tabs.Content id="active">{samplePanel('Active items.')}</Tabs.Content>
+      <Tabs.Content id="paused">{samplePanel('Paused items.')}</Tabs.Content>
+      <Tabs.Content id="archived">{samplePanel('Archived items.')}</Tabs.Content>
+    </Tabs>
+  ),
+  args: { defaultSelectedKey: 'active' },
+};
+
+export const Vertical: Story = {
+  args: { orientation: 'vertical', defaultSelectedKey: 'profile' },
+  render: (args) => (
+    <Tabs {...args}>
+      <div style={{ display: 'flex', gap: 24 }}>
+        <Tabs.List type="line">
+          <Tabs.Trigger id="profile" label="Profile" />
+          <Tabs.Trigger id="security" label="Security" />
+          <Tabs.Trigger id="notifications" label="Notifications" />
+          <Tabs.Trigger id="billing" label="Billing" />
+        </Tabs.List>
+        <div style={{ flex: 1 }}>
+          <Tabs.Content id="profile">{samplePanel('Profile settings.')}</Tabs.Content>
+          <Tabs.Content id="security">{samplePanel('Security settings.')}</Tabs.Content>
+          <Tabs.Content id="notifications">{samplePanel('Notification preferences.')}</Tabs.Content>
+          <Tabs.Content id="billing">{samplePanel('Billing details.')}</Tabs.Content>
+        </div>
+      </div>
+    </Tabs>
+  ),
+};
+
+export const ManyTabs: Story = {
+  args: { defaultSelectedKey: 'tab-1' },
+  render: (args) => (
+    <Tabs {...args}>
+      <div style={{ overflowX: 'auto' }}>
+        <Tabs.List type="underline">
+          {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+            <Tabs.Trigger key={n} id={`tab-${n.toString()}`} label={`Tab ${n.toString()}`} />
+          ))}
+        </Tabs.List>
+      </div>
+      {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+        <Tabs.Content key={n} id={`tab-${n.toString()}`}>
+          {samplePanel(`Content for tab ${n.toString()}.`)}
+        </Tabs.Content>
+      ))}
+    </Tabs>
+  ),
+};

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,57 @@
+// Glaon Tabs — thin wrap around the Untitled UI kit `Tabs` family
+// under `packages/ui/src/components/application/tabs/tabs.tsx`. Per
+// CLAUDE.md's UUI Source Rule, the structural HTML/CSS, focus / hover
+// state matrix, and orientation handling come from the kit (built on
+// react-aria-components `<Tabs>` + `<TabList>` + `<Tab>` +
+// `<TabPanel>`); Glaon's contribution is the wrap layer (token
+// override via `theme.css` + `glaon-overrides.css`, prop API
+// consistency, Figma `parameters.design` mapping in the story).
+//
+// Sub-components are exposed via the static-property pattern so
+// consumers compose tabs inline:
+//
+//   <Tabs defaultSelectedKey="overview">
+//     <Tabs.List>
+//       <Tabs.Trigger id="overview" label="Overview" />
+//       <Tabs.Trigger id="settings" label="Settings" />
+//     </Tabs.List>
+//     <Tabs.Content id="overview">…</Tabs.Content>
+//     <Tabs.Content id="settings">…</Tabs.Content>
+//   </Tabs>
+//
+// We use the Radix-style names (`Trigger` / `Content`) on the namespace
+// to match application-team expectations while still re-exporting the
+// kit's RAC-aligned names (`Tab` / `TabPanel`) for direct use.
+
+import {
+  Tab as KitTab,
+  TabList as KitTabList,
+  TabPanel as KitTabPanel,
+  Tabs as KitTabs,
+} from '../application/tabs/tabs';
+
+// Direct re-exports for kit-aligned consumers.
+export { KitTabList as TabList, KitTab as Tab, KitTabPanel as TabPanel };
+
+// Static-property namespace so consumers can compose tabs inline:
+//
+//   <Tabs defaultSelectedKey="x">
+//     <Tabs.List>…<Tabs.Trigger /></Tabs.List>
+//     <Tabs.Content id="x">…</Tabs.Content>
+//   </Tabs>
+//
+// We pin the exported type explicitly rather than letting
+// `Object.assign` infer it — the kit's `TabComponentProps` /
+// `TabListComponentProps` aren't exported, and the inferred shape
+// trips TS4023 under `declaration: true`.
+type TabsNamespace = typeof KitTabs & {
+  List: typeof KitTabList;
+  Trigger: typeof KitTab;
+  Content: typeof KitTabPanel;
+};
+
+export const Tabs: TabsNamespace = Object.assign(KitTabs, {
+  List: KitTabList,
+  Trigger: KitTab,
+  Content: KitTabPanel,
+});

--- a/packages/ui/src/components/Tabs/index.ts
+++ b/packages/ui/src/components/Tabs/index.ts
@@ -1,0 +1,1 @@
+export { Tab, TabList, TabPanel, Tabs } from './Tabs';

--- a/packages/ui/src/components/application/tabs/tabs.tsx
+++ b/packages/ui/src/components/application/tabs/tabs.tsx
@@ -1,0 +1,242 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add tabs`. Suppress
+// type-check so `untitledui upgrade` stays a clean replace operation.
+// Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import type { ComponentPropsWithRef, FC, ReactNode } from "react";
+import { createContext, isValidElement, useContext } from "react";
+import type { TabListProps as AriaTabListProps, TabProps as AriaTabProps, TabRenderProps as AriaTabRenderProps } from "react-aria-components";
+import { Tab as AriaTab, TabList as AriaTabList, TabPanel as AriaTabPanel, Tabs as AriaTabs, TabsContext, useSlottedContext } from "react-aria-components";
+import { Badge } from "@/components/base/badges/badges";
+import { cx } from "@/utils/cx";
+import { isReactComponent } from "@/utils/is-react-component";
+
+type Orientation = "horizontal" | "vertical";
+
+// Types for different orientations
+type HorizontalTypes = "button-brand" | "button-gray" | "button-border" | "button-minimal" | "underline";
+type VerticalTypes = "button-brand" | "button-gray" | "button-border" | "button-minimal" | "line";
+type TabTypeColors<T> = T extends "horizontal" ? HorizontalTypes : VerticalTypes;
+
+// Styles for different types of tab
+const getTabStyles = ({ isFocusVisible, isSelected, isHovered }: AriaTabRenderProps) => ({
+    "button-brand": cx(
+        "outline-focus-ring *:data-icon:text-fg-quaternary",
+        isFocusVisible && "outline-2 -outline-offset-2",
+        (isSelected || isHovered) && "bg-brand-primary_alt text-brand-secondary *:data-icon:text-fg-brand-secondary_hover",
+    ),
+    "button-gray": cx(
+        "outline-focus-ring *:data-icon:text-fg-quaternary",
+        isHovered && "bg-primary_hover text-secondary *:data-icon:text-fg-secondary_hover",
+        isFocusVisible && "outline-2 -outline-offset-2",
+        isSelected && "bg-primary_hover text-secondary *:data-icon:text-fg-secondary_hover",
+    ),
+    "button-border": cx(
+        "outline-focus-ring *:data-icon:text-fg-quaternary",
+        isFocusVisible && "outline-2 -outline-offset-2",
+        (isSelected || isHovered) && "bg-primary_alt text-secondary shadow-sm *:data-icon:text-fg-secondary_hover",
+    ),
+    "button-minimal": cx(
+        "rounded-lg outline-focus-ring *:data-icon:text-fg-quaternary",
+        isFocusVisible && "outline-2 -outline-offset-2",
+        (isSelected || isHovered) && "bg-primary_alt text-secondary shadow-xs ring-1 ring-primary ring-inset *:data-icon:text-fg-secondary_hover",
+    ),
+    underline: cx(
+        "rounded-none border-b-2 border-transparent outline-focus-ring *:data-icon:text-fg-quaternary",
+        isFocusVisible && "outline-2 -outline-offset-2",
+        (isSelected || isHovered) && "border-fg-brand-primary_alt text-brand-secondary *:data-icon:text-fg-brand-secondary_hover",
+    ),
+    line: cx(
+        "rounded-none border-l-2 border-transparent outline-focus-ring *:data-icon:text-fg-quaternary",
+        isFocusVisible && "outline-2 -outline-offset-2",
+        (isSelected || isHovered) && "border-fg-brand-primary_alt text-brand-secondary *:data-icon:text-fg-brand-secondary_hover",
+    ),
+});
+
+const sizes = {
+    sm: {
+        base: "text-sm font-semibold gap-1 *:data-icon:size-4",
+        "button-brand": "py-2 px-2.5",
+        "button-gray": "py-2 px-2.5",
+        "button-border": "py-2 px-2.5",
+        "button-minimal": "py-2 px-2.5",
+        underline: "px-0.5 pb-2.5 pt-0",
+        line: "pl-2.5 pr-3 py-0.5",
+    },
+    md: {
+        base: "text-md font-semibold gap-1.5 *:data-icon:size-5",
+        "button-brand": "py-2.5 px-2.5",
+        "button-gray": "py-2.5 px-2.5",
+        "button-border": "py-2.5 px-2.5",
+        "button-minimal": "py-2.5 px-2.5",
+        underline: "px-0.5 pb-2.5 pt-0",
+        line: "pr-3.5 pl-3 py-1",
+    },
+};
+
+// Styles for different types of horizontal tabs
+const getHorizontalStyles = ({ size, fullWidth }: { size?: "sm" | "md"; fullWidth?: boolean }) => ({
+    "button-brand": "gap-1",
+    "button-gray": "gap-1",
+    "button-border": cx("gap-1 rounded-[10px] bg-secondary_alt p-1 ring-1 ring-secondary ring-inset", size === "md" && "rounded-xl p-1.5"),
+    "button-minimal": "gap-0.5 rounded-lg bg-secondary_alt ring-1 ring-inset ring-secondary",
+    underline: cx("gap-3", fullWidth && "w-full gap-4"),
+    line: "gap-2",
+});
+
+const getColorStyles = ({ isSelected, isHovered }: Partial<AriaTabRenderProps>) => ({
+    "button-brand": isSelected || isHovered ? "brand" : "gray",
+    "button-gray": "gray",
+    "button-border": "gray",
+    "button-minimal": "gray",
+    underline: isSelected || isHovered ? "brand" : "gray",
+    line: isSelected || isHovered ? "brand" : "gray",
+});
+
+interface TabListComponentProps<T extends object, K extends Orientation> extends Omit<AriaTabListProps<T>, "items"> {
+    /** The size of the tab list. */
+    size?: keyof typeof sizes;
+    /** The type of the tab list. */
+    type?: TabTypeColors<K>;
+    /** The orientation of the tab list. */
+    orientation?: K;
+    /** The items of the tab list. When provided, tabs are rendered automatically via the render function in children. */
+    items?: T[];
+    /** Whether the tab list is full width. */
+    fullWidth?: boolean;
+}
+
+const TabListContext = createContext<Omit<TabListComponentProps<TabComponentProps, Orientation>, "items">>({
+    size: "sm",
+    type: "button-brand",
+});
+
+export const TabList = <T extends Orientation>({
+    size = "sm",
+    type = "button-brand",
+    orientation: orientationProp,
+    fullWidth,
+    className,
+    children,
+    ...otherProps
+}: TabListComponentProps<TabComponentProps, T>) => {
+    const context = useSlottedContext(TabsContext);
+
+    const orientation = orientationProp ?? context?.orientation ?? "horizontal";
+
+    return (
+        <TabListContext.Provider value={{ size, type, orientation, fullWidth }}>
+            <AriaTabList
+                {...otherProps}
+                className={(state) =>
+                    cx(
+                        "group flex",
+
+                        getHorizontalStyles({
+                            size,
+                            fullWidth,
+                        })[type as HorizontalTypes],
+
+                        orientation === "vertical" && "w-max flex-col",
+
+                        // Only horizontal tabs with underline type have bottom border
+                        orientation === "horizontal" &&
+                            type === "underline" &&
+                            "relative before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-border-secondary",
+
+                        typeof className === "function" ? className(state) : className,
+                    )
+                }
+            >
+                {children ?? (otherProps.items ? (item) => <Tab {...item}>{item.children}</Tab> : undefined)}
+            </AriaTabList>
+        </TabListContext.Provider>
+    );
+};
+
+export const TabPanel = (props: ComponentPropsWithRef<typeof AriaTabPanel>) => {
+    return (
+        <AriaTabPanel
+            {...props}
+            className={(state) =>
+                cx(
+                    "outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2",
+                    typeof props.className === "function" ? props.className(state) : props.className,
+                )
+            }
+        />
+    );
+};
+
+interface TabComponentProps extends AriaTabProps {
+    /** The label of the tab. */
+    label?: ReactNode;
+    /** The children of the tab. */
+    children?: ReactNode | ((props: AriaTabRenderProps) => ReactNode);
+    /** Icon component or element to show before the text */
+    icon?: FC<{ className?: string }> | ReactNode;
+    /** The badge displayed next to the label. */
+    badge?: number | string;
+}
+
+export const Tab = ({ label, children, badge, icon: Icon, className, ...otherProps }: TabComponentProps) => {
+    const { size = "sm", type = "button-brand", fullWidth } = useContext(TabListContext);
+
+    const showPillColorBadge = type === "underline" || type === "line" || type === "button-brand";
+
+    return (
+        <AriaTab
+            {...otherProps}
+            className={(prop) =>
+                cx(
+                    "z-10 flex h-max cursor-pointer items-center justify-center gap-2 rounded-md whitespace-nowrap text-quaternary transition duration-100 ease-linear",
+                    "group-orientation-vertical:justify-start",
+                    fullWidth && "w-full flex-1",
+                    sizes[size].base,
+                    sizes[size][type],
+                    getTabStyles(prop)[type],
+                    typeof className === "function" ? className(prop) : className,
+                )
+            }
+        >
+            {(state) => (
+                <>
+                    {/* Icon */}
+                    {isValidElement(Icon) && Icon}
+                    {isReactComponent(Icon) && <Icon data-icon className="transition-inherit-all" />}
+
+                    <span className={cx("flex items-center gap-1.5", type !== "line" && "px-0.5")}>
+                        {typeof children === "function" ? children(state) : children || label}
+
+                        {/* Badge */}
+                        {badge && (
+                            <Badge
+                                size="sm"
+                                type={showPillColorBadge ? "pill-color" : "modern"}
+                                color={showPillColorBadge && (state.isHovered || state.isSelected) ? "brand" : "gray"}
+                                className={cx("hidden transition-inherit-all md:flex", size === "sm" && "-my-px")}
+                            >
+                                {badge}
+                            </Badge>
+                        )}
+                    </span>
+                </>
+            )}
+        </AriaTab>
+    );
+};
+
+export const Tabs = ({ className, ...props }: ComponentPropsWithRef<typeof AriaTabs>) => {
+    return (
+        <AriaTabs
+            keyboardActivation="manual"
+            {...props}
+            className={(state) => cx("flex w-full flex-col", typeof className === "function" ? className(state) : className)}
+        />
+    );
+};
+
+Tabs.Panel = TabPanel;
+Tabs.List = TabList;
+Tabs.Item = Tab;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,5 +17,6 @@ export * from './components/Select';
 export * from './components/Spinner';
 export * from './components/Stat';
 export * from './components/Switch';
+export * from './components/Tabs';
 export * from './components/Textarea';
 export * from './theme';


### PR DESCRIPTION
## Summary

Eighth Phase 1 primitive group (P8). The kit ships \`Tabs\` + \`TabList\` + \`Tab\` + \`TabPanel\` as parameterized base primitives built on react-aria-components, so the Glaon wrap re-exports them verbatim. The kit's RAC foundation handles the full a11y contract: keyboard navigation (arrow keys for cycle, Home / End, Enter for activation when \`keyboardActivation: 'manual'\`), proper roles, ARIA wiring, and orientation-aware focus management.

## Surface

- \`Tabs\` — root container; static-property namespace exposes \`Tabs.List\`, \`Tabs.Trigger\`, \`Tabs.Content\` (Radix-style names consumers expect).
- \`TabList\`, \`Tab\`, \`TabPanel\` — also re-exported directly for kit-aligned consumers.
- \`Tabs.List\` accepts \`type\` (\`button-brand\` / \`button-gray\` / \`button-border\` / \`button-minimal\` / \`underline\` for horizontal; \`line\` for vertical), \`size\` (\`sm\` / \`md\`), \`fullWidth\`.
- \`Tabs.Trigger\` accepts \`label\`, \`icon\`, \`badge\` (number or string), and the full RAC \`<Tab>\` prop surface.

## Scope (In)

- \`components/Tabs/{Tabs.tsx,Tabs.stories.tsx,index.ts}\` — wrap + 8 stories (Default, Underline, ButtonGray, WithIcons, WithBadges, DisabledTab, Vertical, ManyTabs).
- Kit source placed under \`application/tabs/tabs.tsx\` with \`@ts-nocheck\`.
- \`packages/ui/src/index.ts\` barrel re-exports \`Tabs\` plus \`TabList\` / \`Tab\` / \`TabPanel\`.

## Scope (Out)

- **Lazy panel content loading helpers** (Phase 2 if needed).
- **Routed tabs** (URL sync — Phase 2).
- **RN \`*.native.tsx\`** — UUI is web-only; deferred to follow-up.

## Notable details

- The exported \`Tabs\` namespace is pinned to an explicit \`typeof KitTabs & { List; Trigger; Content }\` intersection rather than letting \`Object.assign\` infer the shape — the kit's internal \`TabComponentProps\` / \`TabListComponentProps\` aren't exported, and the inferred type would trip TS4023 under \`declaration: true\`.
- F6 prop-coverage gate's \`excludeFromArgs\` allowlist surfaces TabList-only props (\`size\`, \`type\`, \`items\`, \`fullWidth\`) on the root meta — \`react-docgen-typescript\` walks the static-property namespace and picks up sub-component props on the merged shape, but in practice consumers set them on \`<Tabs.List …>\`.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui test --run\` — 54 passing (was 51; +3 for Tabs × 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\` severity
- [ ] Storybook spot-check: light + dark; arrow-key cycle, Home / End, Enter activation
- [ ] Chromatic snapshots accepted (intentional new-component diffs)

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)