### PR TITLE
feat(ui): SideNav primitive + stories

### DIFF
--- a/packages/ui/src/components/SideNav/SideNav.stories.tsx
+++ b/packages/ui/src/components/SideNav/SideNav.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import type { FC } from 'react';
+
+import { Avatar } from '../Avatar';
+import { storybookIcons } from '../../icons/storybook';
+import { SideNav } from './SideNav';
+
+// Pull a few icons from the curated picker so stories share the
+// same icon-typing workaround as Button / Alert / TopBar etc. The
+// picker types entries as `IconComponent | undefined` (so its `none`
+// option resolves to `undefined`), but `SideNav.Item.icon` requires
+// non-undefined under `exactOptionalPropertyTypes`. Cast through a
+// helper so stories stay readable.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+const icon = (key: keyof typeof storybookIcons): FC<any> =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+  storybookIcons[key] as FC<any>;
+
+const bell = icon('bell');
+const heart = icon('heart');
+const settings = icon('settings');
+const star = icon('star');
+const user = icon('user');
+
+// Explicit `Meta<typeof SideNav>` annotation (rather than `satisfies`)
+// keeps the merged static-property shape out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+const meta: Meta<typeof SideNav> = {
+  title: 'Web Primitives/SideNav',
+  component: SideNav,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-sidenav',
+    },
+  },
+  args: {
+    collapsed: false,
+  },
+  argTypes: {
+    collapsed: { control: 'boolean' },
+    children: { control: false, table: { disable: true } },
+    className: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: 'flex', height: 560 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SideNav>;
+
+const SampleBrand = () => <span className="text-base font-semibold text-primary">Glaon</span>;
+
+export const Default: Story = {
+  render: (args) => (
+    <SideNav {...args}>
+      <SideNav.Brand>
+        <SampleBrand />
+      </SideNav.Brand>
+      <SideNav.Group>
+        <SideNav.Item label="Devices" icon={user} href="#" current />
+        <SideNav.Item label="Scenes" icon={star} href="#" />
+        <SideNav.Item label="Favorites" icon={heart} href="#" />
+        <SideNav.Item label="Notifications" icon={bell} href="#" />
+      </SideNav.Group>
+      <SideNav.Footer>
+        <SideNav.Item label="Settings" icon={settings} href="#" />
+        <SideNav.Item label="Profile" icon={user} href="#" />
+      </SideNav.Footer>
+    </SideNav>
+  ),
+};
+
+export const Collapsed: Story = {
+  args: { collapsed: true },
+  render: (args) => (
+    <SideNav {...args}>
+      <SideNav.Brand>
+        <span className="text-base font-semibold text-primary">G</span>
+      </SideNav.Brand>
+      <SideNav.Group>
+        <SideNav.Item label="Devices" icon={user} href="#" current />
+        <SideNav.Item label="Scenes" icon={star} href="#" />
+        <SideNav.Item label="Notifications" icon={bell} href="#" />
+      </SideNav.Group>
+      <SideNav.Footer>
+        <SideNav.Item label="Settings" icon={settings} href="#" />
+      </SideNav.Footer>
+    </SideNav>
+  ),
+};
+
+export const WithGroups: Story = {
+  render: (args) => (
+    <SideNav {...args}>
+      <SideNav.Brand>
+        <SampleBrand />
+      </SideNav.Brand>
+      <SideNav.Group label="Workspace">
+        <SideNav.Item label="Devices" icon={user} href="#" current />
+        <SideNav.Item label="Scenes" icon={star} href="#" />
+      </SideNav.Group>
+      <SideNav.Group label="Activity">
+        <SideNav.Item label="Notifications" icon={bell} href="#" />
+        <SideNav.Item label="Favorites" icon={heart} href="#" />
+      </SideNav.Group>
+      <SideNav.Footer>
+        <SideNav.Item label="Settings" icon={settings} href="#" />
+      </SideNav.Footer>
+    </SideNav>
+  ),
+};
+
+export const WithBadges: Story = {
+  render: (args) => (
+    <SideNav {...args}>
+      <SideNav.Brand>
+        <SampleBrand />
+      </SideNav.Brand>
+      <SideNav.Group>
+        <SideNav.Item label="Devices" icon={user} href="#" current badge={12} />
+        <SideNav.Item label="Notifications" icon={bell} href="#" badge={3} />
+        <SideNav.Item label="Scenes" icon={star} href="#" />
+        <SideNav.Item label="Favorites" icon={heart} href="#" badge="New" />
+      </SideNav.Group>
+      <SideNav.Footer>
+        <SideNav.Item label="Settings" icon={settings} href="#" />
+      </SideNav.Footer>
+    </SideNav>
+  ),
+};
+
+export const WithFooterUserSection: Story = {
+  render: (args) => (
+    <SideNav {...args}>
+      <SideNav.Brand>
+        <SampleBrand />
+      </SideNav.Brand>
+      <SideNav.Group>
+        <SideNav.Item label="Devices" icon={user} href="#" current />
+        <SideNav.Item label="Scenes" icon={star} href="#" />
+      </SideNav.Group>
+      <SideNav.Footer>
+        <div className="flex items-center gap-3 rounded-md border border-secondary_alt p-3">
+          <Avatar size="sm" alt="Olivia Rhye" initials="OR" />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
+            <span className="truncate text-xs text-tertiary">olivia@glaon.app</span>
+          </div>
+        </div>
+      </SideNav.Footer>
+    </SideNav>
+  ),
+};

--- a/packages/ui/src/components/SideNav/SideNav.tsx
+++ b/packages/ui/src/components/SideNav/SideNav.tsx
@@ -1,0 +1,181 @@
+// Glaon SideNav — application-shell side navigation. UUI ships
+// `sidebar-simple` and a few siblings as concrete templates that
+// hard-code the logo, search input, and a "user account" card; the
+// only piece that's a clean parameterized primitive is `NavItemBase`
+// (the link / collapsible item rendering). Glaon hand-rolls the
+// outer shell using kit surface vocabulary as canonical reference
+// (`bg-primary` + `border-secondary` border-r + 280px desktop width)
+// and re-uses the kit `NavItemBase` for items, getting the kit's
+// hover / current / focus styling and `aria-current="page"` wiring
+// for free.
+//
+// Usage:
+//
+//   <SideNav>
+//     <SideNav.Brand>
+//       <Logo />
+//     </SideNav.Brand>
+//     <SideNav.Group label="Workspace">
+//       <SideNav.Item href="/devices" icon={Cpu01} current>Devices</SideNav.Item>
+//       <SideNav.Item href="/scenes" icon={Sun}>Scenes</SideNav.Item>
+//     </SideNav.Group>
+//     <SideNav.Footer>
+//       <SideNav.Item href="/settings" icon={Settings01}>Settings</SideNav.Item>
+//     </SideNav.Footer>
+//   </SideNav>
+
+import type { FC, MouseEventHandler, ReactNode } from 'react';
+import { createContext, useContext } from 'react';
+
+import { NavItemBase } from '../application/app-navigation/base-components/nav-item';
+
+// `@untitledui/icons` ships icons without standalone `.d.ts` files,
+// so importers see them as `error`-typed values under strict
+// type-check + the `no-unsafe-assignment` lint rule. Same workaround
+// as `icons/storybook.ts` and `Alert.tsx` — type the slot loosely so
+// consumers can pass `<Cpu01 />` etc. without per-call casts. The
+// kit's `NavItemBase` narrows the type back to `FC<HTMLAttributes>`
+// at the render site.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+type IconComponent = FC<any>;
+
+export interface SideNavProps {
+  /**
+   * Reduce the width to icon-only (`w-16`). Consumers can swap to
+   * collapsed at any breakpoint via their own state; this is just a
+   * visual toggle.
+   */
+  collapsed?: boolean;
+  /** Override the kit's outer container className. */
+  className?: string;
+  /**
+   * Composed content. Use `SideNav.Brand` (top), `SideNav.Group` /
+   * `SideNav.Item` (middle), and `SideNav.Footer` (bottom).
+   */
+  children: ReactNode;
+}
+
+export interface SideNavBrandProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export interface SideNavGroupProps {
+  /** Optional caption rendered above the items (uppercase eyebrow). */
+  label?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}
+
+export interface SideNavItemProps {
+  /** Link label (becomes children of the underlying `<a>`). */
+  label: ReactNode;
+  /** URL (omit for non-link items that handle clicks via `onClick`). */
+  href?: string;
+  /** Icon component rendered before the label. */
+  icon?: IconComponent;
+  /** Optional badge — number / string renders a kit Badge, ReactNode passes through. */
+  badge?: ReactNode;
+  /** Mark this item as the active route (drives `aria-current="page"`). */
+  current?: boolean;
+  /** Click handler (also fires for keyboard activation). */
+  onClick?: MouseEventHandler;
+}
+
+export interface SideNavFooterProps {
+  className?: string;
+  children: ReactNode;
+}
+
+const CollapsedContext = createContext(false);
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+function SideNavRoot({ collapsed = false, className, children }: SideNavProps) {
+  const containerClass = joinClasses(
+    'flex h-full flex-col gap-5 bg-primary border-r border-secondary py-5 transition-[width] duration-150',
+    collapsed ? 'w-16 px-2' : 'w-70 px-4',
+    className,
+  );
+  return (
+    <CollapsedContext.Provider value={collapsed}>
+      <aside className={containerClass}>
+        <nav aria-label="Sidebar" className="flex h-full w-full max-w-full flex-col gap-5">
+          {children}
+        </nav>
+      </aside>
+    </CollapsedContext.Provider>
+  );
+}
+
+function SideNavBrand({ className, children }: SideNavBrandProps) {
+  return (
+    <div className={joinClasses('flex shrink-0 items-center gap-2', className)}>{children}</div>
+  );
+}
+
+function SideNavGroup({ label, className, children }: SideNavGroupProps) {
+  const collapsed = useContext(CollapsedContext);
+  return (
+    <div className={joinClasses('flex flex-col gap-1', className)}>
+      {label && !collapsed ? (
+        <p className="px-2 pt-2 pb-1 text-xs font-semibold tracking-wide text-tertiary uppercase">
+          {label}
+        </p>
+      ) : null}
+      <ul className="flex flex-col gap-px">{children}</ul>
+    </div>
+  );
+}
+
+function SideNavItem({ label, href, icon, badge, current, onClick }: SideNavItemProps) {
+  const collapsed = useContext(CollapsedContext);
+  // `NavItemBase` declares its optional props without `| undefined`,
+  // so under `exactOptionalPropertyTypes` we have to omit-not-pass-
+  // undefined for each one we don't have. Spread only what's defined.
+  // The kit narrows `icon` to `FC<HTMLAttributes<HTMLOrSVGElement>>`;
+  // our wider `IconComponent` (`FC<any>`) is assignment-safe at
+  // runtime — cast at the boundary rather than tightening every
+  // story's icon prop.
+  return (
+    <li className="py-px">
+      <NavItemBase
+        type="link"
+        truncate={!collapsed}
+        {...(href !== undefined ? { href } : {})}
+        {...(icon !== undefined
+          ? {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- IconComponent → kit's narrower FC<HTMLAttributes>; safe at runtime
+              icon: icon as FC<any>,
+            }
+          : {})}
+        {...(current !== undefined ? { current } : {})}
+        {...(onClick !== undefined ? { onClick } : {})}
+        {...(!collapsed && badge !== undefined ? { badge } : {})}
+      >
+        {collapsed ? null : label}
+      </NavItemBase>
+    </li>
+  );
+}
+
+function SideNavFooter({ className, children }: SideNavFooterProps) {
+  return <div className={joinClasses('mt-auto flex flex-col gap-1', className)}>{children}</div>;
+}
+
+type SideNavNamespace = typeof SideNavRoot & {
+  Brand: typeof SideNavBrand;
+  Group: typeof SideNavGroup;
+  Item: typeof SideNavItem;
+  Footer: typeof SideNavFooter;
+};
+
+export const SideNav: SideNavNamespace = Object.assign(SideNavRoot, {
+  Brand: SideNavBrand,
+  Group: SideNavGroup,
+  Item: SideNavItem,
+  Footer: SideNavFooter,
+});

--- a/packages/ui/src/components/SideNav/SideNav.tsx
+++ b/packages/ui/src/components/SideNav/SideNav.tsx
@@ -90,6 +90,13 @@ export interface SideNavFooterProps {
 
 const CollapsedContext = createContext(false);
 
+// Marks the descendant tree as being inside a `<ul>` (set by
+// `SideNav.Group`). `SideNav.Item` reads it to decide whether to
+// render a `<li>` wrapper — wrapping is required for `listitem`
+// semantics inside `<ul>`, but a bare `<li>` outside a list trips
+// axe `listitem` rule. Footer leaves this context as `false`.
+const InListContext = createContext(false);
+
 function joinClasses(...parts: (string | undefined | false)[]): string {
   return parts.filter((p): p is string => Boolean(p)).join(' ');
 }
@@ -126,13 +133,17 @@ function SideNavGroup({ label, className, children }: SideNavGroupProps) {
           {label}
         </p>
       ) : null}
-      <ul className="flex flex-col gap-px">{children}</ul>
+      <InListContext.Provider value>
+        <ul className="flex flex-col gap-px">{children}</ul>
+      </InListContext.Provider>
     </div>
   );
 }
 
 function SideNavItem({ label, href, icon, badge, current, onClick }: SideNavItemProps) {
   const collapsed = useContext(CollapsedContext);
+  const inList = useContext(InListContext);
+
   // `NavItemBase` declares its optional props without `| undefined`,
   // so under `exactOptionalPropertyTypes` we have to omit-not-pass-
   // undefined for each one we don't have. Spread only what's defined.
@@ -140,32 +151,38 @@ function SideNavItem({ label, href, icon, badge, current, onClick }: SideNavItem
   // our wider `IconComponent` (`FC<any>`) is assignment-safe at
   // runtime — cast at the boundary rather than tightening every
   // story's icon prop.
-  return (
-    // `list-none` keeps the marker bullet from showing when an Item
-    // is rendered outside a styled list (e.g. inside `SideNav.Footer`,
-    // which is a `<div>` because the slot also supports non-item
-    // content like the user-card in WithFooterUserSection). Inside
-    // `SideNav.Group`'s `<ul>` the suppression is redundant but
-    // harmless.
-    <li className="list-none py-px">
-      <NavItemBase
-        type="link"
-        truncate={!collapsed}
-        {...(href !== undefined ? { href } : {})}
-        {...(icon !== undefined
-          ? {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- IconComponent → kit's narrower FC<HTMLAttributes>; safe at runtime
-              icon: icon as FC<any>,
-            }
-          : {})}
-        {...(current !== undefined ? { current } : {})}
-        {...(onClick !== undefined ? { onClick } : {})}
-        {...(!collapsed && badge !== undefined ? { badge } : {})}
-      >
-        {collapsed ? null : label}
-      </NavItemBase>
-    </li>
+  //
+  // In collapsed mode the visible label is hidden so the icon stands
+  // alone; render the label as `sr-only` text so screen readers and
+  // axe `link-name` still see an accessible name on the `<a>`.
+  const itemNode = (
+    <NavItemBase
+      type="link"
+      truncate={!collapsed}
+      {...(href !== undefined ? { href } : {})}
+      {...(icon !== undefined
+        ? {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment -- IconComponent → kit's narrower FC<HTMLAttributes>; safe at runtime
+            icon: icon as FC<any>,
+          }
+        : {})}
+      {...(current !== undefined ? { current } : {})}
+      {...(onClick !== undefined ? { onClick } : {})}
+      {...(!collapsed && badge !== undefined ? { badge } : {})}
+    >
+      {collapsed ? <span className="sr-only">{label}</span> : label}
+    </NavItemBase>
   );
+
+  // Inside `SideNav.Group`'s `<ul>` the item must be wrapped in
+  // `<li>` for `listitem` semantics. Outside a list (e.g. directly
+  // under `SideNav.Footer`'s `<div>`), wrapping in `<li>` would trip
+  // axe `listitem` ("must be in `<ul>` / `<ol>`") and render a
+  // browser-default bullet marker. Skip the wrapper in that case.
+  if (inList) {
+    return <li className="py-px">{itemNode}</li>;
+  }
+  return <div className="py-px">{itemNode}</div>;
 }
 
 function SideNavFooter({ className, children }: SideNavFooterProps) {

--- a/packages/ui/src/components/SideNav/SideNav.tsx
+++ b/packages/ui/src/components/SideNav/SideNav.tsx
@@ -141,7 +141,13 @@ function SideNavItem({ label, href, icon, badge, current, onClick }: SideNavItem
   // runtime — cast at the boundary rather than tightening every
   // story's icon prop.
   return (
-    <li className="py-px">
+    // `list-none` keeps the marker bullet from showing when an Item
+    // is rendered outside a styled list (e.g. inside `SideNav.Footer`,
+    // which is a `<div>` because the slot also supports non-item
+    // content like the user-card in WithFooterUserSection). Inside
+    // `SideNav.Group`'s `<ul>` the suppression is redundant but
+    // harmless.
+    <li className="list-none py-px">
       <NavItemBase
         type="link"
         truncate={!collapsed}

--- a/packages/ui/src/components/SideNav/index.ts
+++ b/packages/ui/src/components/SideNav/index.ts
@@ -1,0 +1,8 @@
+export {
+  SideNav,
+  type SideNavBrandProps,
+  type SideNavFooterProps,
+  type SideNavGroupProps,
+  type SideNavItemProps,
+  type SideNavProps,
+} from './SideNav';

--- a/packages/ui/src/components/application/app-navigation/base-components/nav-item.tsx
+++ b/packages/ui/src/components/application/app-navigation/base-components/nav-item.tsx
@@ -1,0 +1,125 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add sidebar-simple`.
+// Glaons SideNav imports `NavItemBase` directly; the rest of the
+// sidebar-simple package (sidebar shell, nav-list, account card,
+// mobile header, logo) is too opinionated for our app shell, so
+// we discard it and hand-roll the SideNav layout. Kept here so
+// `untitledui upgrade` can refresh the item visuals.
+"use client";
+
+import type { FC, HTMLAttributes, MouseEventHandler, ReactNode } from "react";
+import { ChevronDown, Share04 } from "@untitledui/icons";
+import { Link as AriaLink } from "react-aria-components";
+import { Badge } from "@/components/base/badges/badges";
+import { cx, sortCx } from "@/utils/cx";
+
+const styles = sortCx({
+    root: "group relative flex max-h-9 w-full cursor-pointer items-center rounded-md bg-primary outline-focus-ring transition duration-100 ease-linear select-none hover:bg-primary_hover focus-visible:z-10 focus-visible:outline-2 focus-visible:outline-offset-2",
+    rootSelected: "bg-secondary hover:bg-secondary_hover",
+});
+
+interface NavItemBaseProps {
+    /** Whether the nav item shows only an icon. */
+    iconOnly?: boolean;
+    /** Whether the collapsible nav item is open. */
+    open?: boolean;
+    /** URL to navigate to when the nav item is clicked. */
+    href?: string;
+    /** Type of the nav item. */
+    type: "link" | "collapsible" | "collapsible-child";
+    /** Icon component to display. */
+    icon?: FC<HTMLAttributes<HTMLOrSVGElement>>;
+    /** Badge to display. */
+    badge?: ReactNode;
+    /** Whether the nav item is currently active. */
+    current?: boolean;
+    /** Whether to truncate the label text. */
+    truncate?: boolean;
+    /** Handler for click events. */
+    onClick?: MouseEventHandler;
+    /** Content to display. */
+    children?: ReactNode;
+}
+
+export const NavItemBase = ({ current, type, badge, href, icon: Icon, children, truncate = true, onClick }: NavItemBaseProps) => {
+    const iconElement = Icon && (
+        <Icon
+            aria-hidden="true"
+            className={cx(
+                "mr-2 size-5 shrink-0 text-fg-quaternary transition-inherit-all group-hover/item:text-fg-quaternary_hover",
+                current && "text-fg-quaternary_hover",
+            )}
+        />
+    );
+
+    const badgeElement =
+        badge && (typeof badge === "string" || typeof badge === "number") ? (
+            <Badge className="ml-3" color="gray" type="pill-color" size="sm">
+                {badge}
+            </Badge>
+        ) : (
+            badge
+        );
+
+    const labelElement = (
+        <span
+            className={cx(
+                "flex-1 text-sm font-semibold text-secondary transition-inherit-all group-hover/item:text-secondary_hover",
+                truncate && "truncate",
+                current && "text-secondary_hover",
+            )}
+        >
+            {children}
+        </span>
+    );
+
+    const isExternal = href && href.startsWith("http");
+    const externalIcon = isExternal && <Share04 className="size-4 stroke-[2.5px] text-fg-quaternary" />;
+
+    if (type === "collapsible") {
+        return (
+            <summary className={cx("p-2", styles.root, current && styles.rootSelected)} onClick={onClick}>
+                {iconElement}
+
+                {labelElement}
+
+                {badgeElement}
+
+                <ChevronDown aria-hidden="true" className="ml-3 size-4 shrink-0 stroke-[2.5px] text-fg-quaternary in-open:-scale-y-100" />
+            </summary>
+        );
+    }
+
+    if (type === "collapsible-child") {
+        return (
+            <AriaLink
+                href={href!}
+                target={isExternal ? "_blank" : "_self"}
+                rel="noopener noreferrer"
+                className={cx("py-2 pr-3 pl-10", styles.root, current && styles.rootSelected)}
+                onClick={onClick}
+                aria-current={current ? "page" : undefined}
+            >
+                {labelElement}
+                {externalIcon}
+                {badgeElement}
+            </AriaLink>
+        );
+    }
+
+    return (
+        <AriaLink
+            href={href!}
+            target={isExternal ? "_blank" : "_self"}
+            rel="noopener noreferrer"
+            className={cx("group/item p-2", styles.root, current && styles.rootSelected)}
+            onClick={onClick}
+            aria-current={current ? "page" : undefined}
+        >
+            {iconElement}
+            {labelElement}
+            {externalIcon}
+            {badgeElement}
+        </AriaLink>
+    );
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,6 +15,7 @@ export * from './components/PressableButton';
 export * from './components/ProgressBar';
 export * from './components/Radio';
 export * from './components/Select';
+export * from './components/SideNav';
 export * from './components/Spinner';
 export * from './components/Stat';
 export * from './components/Switch';


### PR DESCRIPTION
## Summary

Eleventh Phase 1 primitive group (P11) — application-shell side navigation. UUI ships \`sidebar-simple\` and siblings as concrete templates with hard-coded logo / search / account card; the only clean parameterized piece is \`NavItemBase\` (link + collapsible item rendering). Glaon hand-rolls the outer shell using kit surface vocabulary as canonical reference and re-uses the kit \`NavItemBase\` for items — hover / current / focus styling and \`aria-current="page"\` wiring come from the kit.

## Surface

- \`SideNav\` root: \`collapsed\` (icon-only \`w-16\` instead of \`w-70\`), \`className\`, \`children\`. Renders \`<aside>\` containing \`<nav aria-label="Sidebar">\`.
- \`SideNav.Brand\` — top slot for logo / wordmark.
- \`SideNav.Group\` — section with optional uppercase eyebrow \`label\`; hides label in collapsed mode.
- \`SideNav.Item\` — wrap of kit \`NavItemBase\`: \`label\` / \`href\` / \`icon\` / \`badge\` / \`current\` / \`onClick\`. Hides label + badge in collapsed mode (via React context shared from root).
- \`SideNav.Footer\` — bottom slot pinned with \`mt-auto\`.

## Scope (In)

- \`components/SideNav/{SideNav.tsx,SideNav.stories.tsx,index.ts}\` — wrap + 5 stories (Default, Collapsed, WithGroups, WithBadges, WithFooterUserSection).
- Kit source kept under \`application/app-navigation/base-components/nav-item.tsx\` (with \`@ts-nocheck\`); the rest of \`sidebar-simple\` (sidebar shell, nav-list, account card, mobile header, logo) is discarded — too opinionated for a Glaon layout primitive.
- \`packages/ui/src/index.ts\` barrel re-exports the new family.

## Scope (Out)

- **AppShell composition** — Phase 2 wires \`TopBar\` + \`SideNav\` + content into a single primitive.
- **Mobile drawer behaviour** — composes with \`Drawer\` (P15) in Phase 2.
- **Routed selection state** — URL sync is Phase 2.
- **RN \`SideNav.native.tsx\`** — UUI is web-only; deferred to follow-up.

## Notable details

- Icon prop on \`SideNav.Item\` typed loosely (\`FC<any>\`) so the kit's narrower \`FC<HTMLAttributes<HTMLOrSVGElement>>\` doesn't force per-call casts at story sites — same pattern as \`Alert.tsx\` / \`TopBar.tsx\`.
- Optional props are spread conditionally rather than forwarded with \`undefined\`, satisfying \`exactOptionalPropertyTypes\` at the kit's \`NavItemBase\` boundary.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui build\` clean (\`tsc -b\` strict mode)
- [x] \`pnpm --filter @glaon/ui test --run\` — 63 passing (was 60; +3 for SideNav × 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\` severity (\`<aside>\` + \`<nav aria-label="Sidebar">\` + \`aria-current="page"\` on the active item)
- [ ] Storybook spot-check: light + dark; collapsed mode toggle, item keyboard focus
- [ ] Chromatic snapshots accepted (intentional new-component diffs)

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)