### PR TITLE
feat(ui): Tooltip primitive + stories

### DIFF
--- a/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,11 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 import { Button } from '../Button';
-import { Tooltip, TooltipTrigger } from './Tooltip';
+import { Tooltip } from './Tooltip';
 
 // Explicit `Meta<typeof Tooltip>` annotation (rather than `satisfies`)
 // keeps the kit's deep RAC generic chains out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// IMPORTANT: don't wrap the trigger element inside the kit's
+// `<TooltipTrigger>` *and* a Glaon `<Button>` — kit `TooltipTrigger`
+// already renders an `<AriaButton>`, so the combo produces
+// button-inside-button which fails axe `nested-interactive`. Pass
+// the Glaon `<Button>` (or any focusable element) directly as the
+// `<Tooltip>` child; RAC's `TooltipTrigger` context automatically
+// wires `aria-describedby` to whichever focusable child it finds.
 const meta: Meta<typeof Tooltip> = {
   title: 'Web Primitives/Tooltip',
   component: Tooltip,
@@ -95,11 +103,9 @@ export const excludeFromArgs = [
 export const Default: Story = {
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          Hover me
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        Hover me
+      </Button>
     </Tooltip>
   ),
 };
@@ -111,11 +117,9 @@ export const WithDescription: Story = {
   },
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          Hover me
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        Hover me
+      </Button>
     </Tooltip>
   ),
 };
@@ -124,11 +128,9 @@ export const WithArrow: Story = {
   args: { arrow: true },
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          With arrow
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        With arrow
+      </Button>
     </Tooltip>
   ),
 };
@@ -137,11 +139,9 @@ export const Top: Story = {
   args: { placement: 'top' },
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          Top
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        Top
+      </Button>
     </Tooltip>
   ),
 };
@@ -150,11 +150,9 @@ export const Bottom: Story = {
   args: { placement: 'bottom' },
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          Bottom
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        Bottom
+      </Button>
     </Tooltip>
   ),
 };
@@ -163,11 +161,9 @@ export const Left: Story = {
   args: { placement: 'left' },
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          Left
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        Left
+      </Button>
     </Tooltip>
   ),
 };
@@ -176,11 +172,9 @@ export const Right: Story = {
   args: { placement: 'right' },
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          Right
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        Right
+      </Button>
     </Tooltip>
   ),
 };
@@ -189,11 +183,9 @@ export const Disabled: Story = {
   args: { isDisabled: true, defaultOpen: false },
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          Tooltip disabled
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        Tooltip disabled
+      </Button>
     </Tooltip>
   ),
 };
@@ -206,11 +198,9 @@ export const LongContent: Story = {
   },
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          Long tooltip
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        Long tooltip
+      </Button>
     </Tooltip>
   ),
 };
@@ -219,11 +209,9 @@ export const SlowDelay: Story = {
   args: { delay: 1200, defaultOpen: false },
   render: (args) => (
     <Tooltip {...args}>
-      <TooltipTrigger aria-label="More info">
-        <Button color="secondary" size="sm">
-          Hover (1.2s delay)
-        </Button>
-      </TooltipTrigger>
+      <Button color="secondary" size="sm">
+        Hover (1.2s delay)
+      </Button>
     </Tooltip>
   ),
 };

--- a/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,229 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Button } from '../Button';
+import { Tooltip, TooltipTrigger } from './Tooltip';
+
+// Explicit `Meta<typeof Tooltip>` annotation (rather than `satisfies`)
+// keeps the kit's deep RAC generic chains out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+const meta: Meta<typeof Tooltip> = {
+  title: 'Web Primitives/Tooltip',
+  component: Tooltip,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-tooltip',
+    },
+  },
+  args: {
+    title: 'Tooltip text',
+    placement: 'top',
+    arrow: false,
+    delay: 300,
+    closeDelay: 0,
+    isDisabled: false,
+    defaultOpen: true,
+  },
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    placement: {
+      control: 'select',
+      options: [
+        'top',
+        'top start',
+        'top end',
+        'bottom',
+        'bottom start',
+        'bottom end',
+        'left',
+        'left top',
+        'left bottom',
+        'right',
+        'right top',
+        'right bottom',
+      ],
+    },
+    arrow: { control: 'boolean' },
+    delay: { control: { type: 'number', min: 0, max: 2000, step: 100 } },
+    closeDelay: { control: { type: 'number', min: 0, max: 2000, step: 100 } },
+    isDisabled: { control: 'boolean' },
+    isOpen: { control: 'boolean' },
+    defaultOpen: { control: 'boolean' },
+    offset: { control: { type: 'number', min: 0, max: 40, step: 1 } },
+    crossOffset: { control: { type: 'number', min: -40, max: 40, step: 1 } },
+    trigger: { control: 'inline-radio', options: ['focus', undefined] },
+    onOpenChange: { control: false, action: 'open-changed' },
+    children: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: 240,
+          padding: 24,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+// Kit-internal props that aren't useful as Storybook controls but
+// flow through type-checking; covered by the F6 prop-coverage gate.
+export const excludeFromArgs = [
+  'shouldFlip',
+  'arrowBoundaryOffset',
+  'containerPadding',
+  'shouldUpdatePosition',
+  'isEntering',
+  'isExiting',
+  'UNSAFE_className',
+  'UNSAFE_style',
+  'translate',
+  'slot',
+];
+
+export const Default: Story = {
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          Hover me
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: 'Renamed',
+    description: 'The previous name was archived to keep history clean.',
+  },
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          Hover me
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};
+
+export const WithArrow: Story = {
+  args: { arrow: true },
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          With arrow
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};
+
+export const Top: Story = {
+  args: { placement: 'top' },
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          Top
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};
+
+export const Bottom: Story = {
+  args: { placement: 'bottom' },
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          Bottom
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};
+
+export const Left: Story = {
+  args: { placement: 'left' },
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          Left
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};
+
+export const Right: Story = {
+  args: { placement: 'right' },
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          Right
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};
+
+export const Disabled: Story = {
+  args: { isDisabled: true, defaultOpen: false },
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          Tooltip disabled
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};
+
+export const LongContent: Story = {
+  args: {
+    title: 'A long-form tooltip',
+    description:
+      'Tooltips are best for short single-line hints. When the content needs more than two lines, consider a Popover (P13) or move the content into the surrounding UI instead.',
+  },
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          Long tooltip
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};
+
+export const SlowDelay: Story = {
+  args: { delay: 1200, defaultOpen: false },
+  render: (args) => (
+    <Tooltip {...args}>
+      <TooltipTrigger aria-label="More info">
+        <Button color="secondary" size="sm">
+          Hover (1.2s delay)
+        </Button>
+      </TooltipTrigger>
+    </Tooltip>
+  ),
+};

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,15 @@
+// Glaon Tooltip — thin wrap around the Untitled UI kit `Tooltip`
+// source under `packages/ui/src/components/base/tooltip/tooltip.tsx`.
+// Per CLAUDE.md's UUI Source Rule, the structural HTML/CSS,
+// portal-based positioning (offset / crossOffset / placement /
+// flip), and entrance / exit animations come from the kit (built on
+// react-aria-components `<TooltipTrigger>` + `<Tooltip>`); Glaon's
+// contribution is the wrap layer (token override via `theme.css` +
+// `glaon-overrides.css`, prop API consistency, Figma
+// `parameters.design` mapping in the story).
+//
+// `TooltipTrigger` is the icon-only button helper that the kit
+// composes the Tooltip around. We re-export it too so consumers can
+// reach the full kit catalogue from a single `@glaon/ui` import.
+
+export { Tooltip, TooltipTrigger } from '../base/tooltip/tooltip';

--- a/packages/ui/src/components/Tooltip/index.ts
+++ b/packages/ui/src/components/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export { Tooltip, TooltipTrigger } from './Tooltip';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,5 +21,6 @@ export * from './components/Stat';
 export * from './components/Switch';
 export * from './components/Tabs';
 export * from './components/Textarea';
+export * from './components/Tooltip';
 export * from './components/TopBar';
 export * from './theme';


### PR DESCRIPTION
## Summary

Twelfth Phase 1 primitive group (P12) — the smallest portal-based primitive and a proving ground for the overlay ladder (Popover P13, Modal P14, Drawer P15, Toast P16). The kit \`Tooltip\` source has been in the repo since P3 Avatar / P5 Input pulled it as a transitive dep, so this PR is a thin re-export wrap — same shape as Button / Badge / ProgressBar.

The kit's RAC \`<TooltipTrigger>\` + \`<Tooltip>\` foundation handles the full a11y contract: portal placement with \`flip\` + \`offset\` + \`crossOffset\`, focus + hover triggers, escape close, \`aria-describedby\` wiring on the trigger element, and matching entrance / exit animations keyed on placement.

## Surface

- \`Tooltip\` — \`title\` / \`description\` / \`arrow\` / \`delay\` (default 300ms) / \`closeDelay\` / \`placement\` (full 12-position matrix from RAC) / \`offset\` / \`crossOffset\` / \`isDisabled\` / \`isOpen\` / \`defaultOpen\` / \`trigger\` / \`onOpenChange\` plus children.
- \`TooltipTrigger\` — icon-only \`<Button>\` helper.

## Scope (In)

- \`components/Tooltip/{Tooltip.tsx,Tooltip.stories.tsx,index.ts}\` — wrap + 10 stories (Default, WithDescription, WithArrow, Top, Bottom, Left, Right, Disabled, LongContent, SlowDelay).
- \`packages/ui/src/index.ts\` barrel re-exports the new family.
- Kit source already in place at \`base/tooltip/tooltip.tsx\` (with \`@ts-nocheck\` since P3).

## Scope (Out)

- **Popover** — P13.
- **Rich content tooltip** — Phase 2 (or delegate to Popover).
- **RN \`Tooltip.native.tsx\`** — UUI is web-only; deferred to follow-up. The mobile pattern is long-press, not hover, and needs native gesture wiring.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui build\` clean (\`tsc -b\`)
- [x] \`pnpm --filter @glaon/ui test --run\` — 66 passing (was 63; +3 for Tooltip × 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\` severity
- [ ] Storybook spot-check: light + dark; placement matrix renders correctly, escape closes, focus + hover both trigger
- [ ] Chromatic snapshots accepted (intentional new-component diffs — open state captured because \`defaultOpen: true\` in meta)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)