### PR TITLE
feat(ui): Popover primitive + stories

### DIFF
--- a/packages/ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/src/components/Popover/Popover.stories.tsx
@@ -1,0 +1,186 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Button } from '../Button';
+import { Input } from '../Input';
+import { Popover } from './Popover';
+
+// Explicit `Meta<typeof Popover>` annotation (rather than `satisfies`)
+// keeps the merged static-property type out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+const meta: Meta<typeof Popover> = {
+  title: 'Web Primitives/Popover',
+  component: Popover,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-popover',
+    },
+  },
+  args: {
+    defaultOpen: false,
+  },
+  argTypes: {
+    isOpen: { control: 'boolean' },
+    defaultOpen: { control: 'boolean' },
+    onOpenChange: { control: false, action: 'open-changed' },
+    children: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: 320,
+          padding: 24,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Popover {...args}>
+      <Popover.Trigger>
+        <Button color="secondary" size="sm">
+          Open popover
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content>
+        <div className="w-64 p-4">
+          <p className="text-sm font-semibold text-primary">Popover title</p>
+          <p className="mt-1 text-sm text-secondary">
+            Popovers are click-triggered overlays for richer content than a tooltip.
+          </p>
+        </div>
+      </Popover.Content>
+    </Popover>
+  ),
+};
+
+export const Top: Story = {
+  render: (args) => (
+    <Popover {...args}>
+      <Popover.Trigger>
+        <Button color="secondary" size="sm">
+          Top
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content placement="top">
+        <div className="w-64 p-4">
+          <p className="text-sm text-secondary">Placed above the trigger.</p>
+        </div>
+      </Popover.Content>
+    </Popover>
+  ),
+};
+
+export const Bottom: Story = {
+  render: (args) => (
+    <Popover {...args}>
+      <Popover.Trigger>
+        <Button color="secondary" size="sm">
+          Bottom
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content placement="bottom">
+        <div className="w-64 p-4">
+          <p className="text-sm text-secondary">Placed below the trigger.</p>
+        </div>
+      </Popover.Content>
+    </Popover>
+  ),
+};
+
+export const Left: Story = {
+  render: (args) => (
+    <Popover {...args}>
+      <Popover.Trigger>
+        <Button color="secondary" size="sm">
+          Left
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content placement="left">
+        <div className="w-64 p-4">
+          <p className="text-sm text-secondary">Placed to the left.</p>
+        </div>
+      </Popover.Content>
+    </Popover>
+  ),
+};
+
+export const Right: Story = {
+  render: (args) => (
+    <Popover {...args}>
+      <Popover.Trigger>
+        <Button color="secondary" size="sm">
+          Right
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content placement="right">
+        <div className="w-64 p-4">
+          <p className="text-sm text-secondary">Placed to the right.</p>
+        </div>
+      </Popover.Content>
+    </Popover>
+  ),
+};
+
+export const WithRichContent: Story = {
+  render: (args) => (
+    <Popover {...args}>
+      <Popover.Trigger>
+        <Button color="secondary" size="sm">
+          Quick edit
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content>
+        <div className="flex w-80 flex-col gap-4 p-5">
+          <div>
+            <p className="text-sm font-semibold text-primary">Rename project</p>
+            <p className="mt-1 text-xs text-tertiary">
+              The new name shows up everywhere this project is referenced.
+            </p>
+          </div>
+          <Input aria-label="Project name" placeholder="New project name" size="sm" />
+          <div className="flex justify-end gap-2">
+            <Button color="secondary" size="sm">
+              Cancel
+            </Button>
+            <Button color="primary" size="sm">
+              Save
+            </Button>
+          </div>
+        </div>
+      </Popover.Content>
+    </Popover>
+  ),
+};
+
+export const DefaultOpen: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Popover {...args}>
+      <Popover.Trigger>
+        <Button color="secondary" size="sm">
+          Default-open
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content>
+        <div className="w-64 p-4">
+          <p className="text-sm text-secondary">
+            Useful for snapshotting the open state in Chromatic.
+          </p>
+        </div>
+      </Popover.Content>
+    </Popover>
+  ),
+};

--- a/packages/ui/src/components/Popover/Popover.tsx
+++ b/packages/ui/src/components/Popover/Popover.tsx
@@ -1,0 +1,112 @@
+// Glaon Popover — click-triggered, rich-content overlay primitive.
+// UUI ships only a Select-specific `<Popover>` wrap (under
+// `base/select/popover.tsx`) that hard-codes a trigger-width sizing
+// and dropdown-style chrome. For the generic, click-to-open
+// composition pattern this issue calls for, we hand-roll on top of
+// react-aria-components' `<DialogTrigger>` + `<Popover>` +
+// `<Dialog>` chain using kit surface vocabulary as canonical
+// reference (`bg-primary` + `rounded-lg` + `shadow-lg` +
+// `ring-secondary_alt`). RAC's portal placement (offset /
+// crossOffset / placement / flip), focus return on close, escape
+// close, and click-outside dismiss come for free.
+//
+// Usage:
+//
+//   <Popover>
+//     <Popover.Trigger>
+//       <Button>Open menu</Button>
+//     </Popover.Trigger>
+//     <Popover.Content placement="bottom start">
+//       <div className="p-4">…rich content…</div>
+//     </Popover.Content>
+//   </Popover>
+
+import type { ReactNode } from 'react';
+
+import {
+  DialogTrigger as AriaDialogTrigger,
+  Dialog as AriaDialog,
+  Popover as AriaPopover,
+  type DialogTriggerProps as AriaDialogTriggerProps,
+  type PopoverProps as AriaPopoverProps,
+} from 'react-aria-components';
+
+export interface PopoverProps extends AriaDialogTriggerProps {
+  /** Trigger + content slots. Use `Popover.Trigger` and `Popover.Content`. */
+  children: ReactNode;
+}
+
+export interface PopoverTriggerProps {
+  /**
+   * The focusable element that opens the popover. RAC's
+   * `<DialogTrigger>` auto-wires the trigger's `aria-expanded` /
+   * `aria-controls` against the popover.
+   */
+  children: ReactNode;
+}
+
+// Narrow `children` to plain `ReactNode` rather than the kit's
+// `ChildrenOrFunction<PopoverRenderProps>` — the inner
+// `<AriaDialog>` only accepts a `DialogRenderProps`-shaped function
+// and the two signatures don't overlap. Glaon callers always pass
+// static content; the popover's render-state hooks are still
+// reachable via `<AriaPopover>` for any consumer that needs them.
+export interface PopoverContentProps extends Omit<AriaPopoverProps, 'children'> {
+  children: ReactNode;
+}
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+function PopoverRoot({ children, ...rest }: PopoverProps) {
+  return <AriaDialogTrigger {...rest}>{children}</AriaDialogTrigger>;
+}
+
+// `Popover.Trigger` is a passthrough — RAC's `<DialogTrigger>`
+// recognises whichever focusable child is rendered first as the
+// trigger, so we just forward children. Wrapping in a
+// `<Fragment>`-like helper keeps the namespace symmetric with
+// `<Popover.Content>` for application teams used to the Radix
+// trigger / content split.
+function PopoverTrigger({ children }: PopoverTriggerProps) {
+  return <>{children}</>;
+}
+
+function PopoverContent({
+  children,
+  className,
+  placement = 'bottom',
+  offset = 8,
+  ...rest
+}: PopoverContentProps) {
+  return (
+    <AriaPopover
+      placement={placement}
+      offset={offset}
+      {...rest}
+      className={(state) =>
+        joinClasses(
+          'z-50 origin-(--trigger-anchor-point) overflow-hidden rounded-lg bg-primary shadow-lg ring-1 ring-secondary_alt outline-hidden will-change-transform',
+          state.isEntering &&
+            'duration-150 ease-out animate-in fade-in placement-top:slide-in-from-bottom-0.5 placement-bottom:slide-in-from-top-0.5 placement-left:slide-in-from-right-0.5 placement-right:slide-in-from-left-0.5',
+          state.isExiting &&
+            'duration-100 ease-in animate-out fade-out placement-top:slide-out-to-bottom-0.5 placement-bottom:slide-out-to-top-0.5 placement-left:slide-out-to-right-0.5 placement-right:slide-out-to-left-0.5',
+          typeof className === 'function' ? className(state) : className,
+        )
+      }
+    >
+      <AriaDialog className="outline-hidden">{children}</AriaDialog>
+    </AriaPopover>
+  );
+}
+
+type PopoverNamespace = typeof PopoverRoot & {
+  Trigger: typeof PopoverTrigger;
+  Content: typeof PopoverContent;
+};
+
+export const Popover: PopoverNamespace = Object.assign(PopoverRoot, {
+  Trigger: PopoverTrigger,
+  Content: PopoverContent,
+});

--- a/packages/ui/src/components/Popover/index.ts
+++ b/packages/ui/src/components/Popover/index.ts
@@ -1,0 +1,6 @@
+export {
+  Popover,
+  type PopoverContentProps,
+  type PopoverProps,
+  type PopoverTriggerProps,
+} from './Popover';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -11,6 +11,7 @@ export * from './components/Button';
 export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/Input';
+export * from './components/Popover';
 export * from './components/PressableButton';
 export * from './components/ProgressBar';
 export * from './components/Radio';


### PR DESCRIPTION
## Summary

Thirteenth Phase 1 primitive group (P13) — click-triggered, rich-content overlay. UUI ships only a Select-specific \`<Popover>\` wrap (\`base/select/popover.tsx\`) that hard-codes trigger-width sizing + dropdown chrome, so Glaon hand-rolls a generic Popover on top of react-aria-components' \`<DialogTrigger>\` + \`<Popover>\` + \`<Dialog>\` chain using kit surface vocabulary as canonical reference (\`bg-primary\` + \`rounded-lg\` + \`shadow-lg\` + \`ring-secondary_alt\`).

The RAC foundation handles the full a11y contract — portal placement with \`flip\` + \`offset\` + \`crossOffset\`, focus return on close, escape close, click-outside dismiss, and \`aria-expanded\` / \`aria-controls\` wiring on the trigger.

## Surface

- \`Popover\` root: forwards RAC \`<DialogTrigger>\` props (\`isOpen\` / \`defaultOpen\` / \`onOpenChange\` / \`trigger\`).
- \`Popover.Trigger\` — passthrough that documents the trigger slot; RAC auto-detects the first focusable child.
- \`Popover.Content\` — wraps RAC \`<Popover>\` + \`<Dialog>\` with Glaon chrome and placement-keyed entrance / exit animations.

## Scope (In)

- \`components/Popover/{Popover.tsx,Popover.stories.tsx,index.ts}\` — wrap + 7 stories (Default, Top, Bottom, Left, Right, WithRichContent, DefaultOpen).
- \`packages/ui/src/index.ts\` barrel re-exports the new family.

## Scope (Out)

- **Toast** — P16; positional but different use case.
- **Dropdown menu** — composes Popover + List in Phase 2.
- **RN \`Popover.native.tsx\`** — UUI is web-only; deferred to follow-up.

## Notable details

- \`Popover.Content.children\` is narrowed to plain \`ReactNode\` rather than the kit's \`ChildrenOrFunction<PopoverRenderProps>\`. The inner \`<AriaDialog>\` only accepts a \`DialogRenderProps\`-shaped function and the two signatures don't overlap. Glaon callers always pass static content; the popover's render-state hooks remain reachable via a direct \`<AriaPopover>\` import for any consumer that needs them.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui build\` clean (\`tsc -b\`)
- [x] \`pnpm --filter @glaon/ui test --run\` — 69 passing (was 66; +3 for Popover × 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\` severity
- [ ] Storybook spot-check: light + dark; placement matrix renders, escape closes, focus returns to trigger after close
- [ ] Chromatic snapshots accepted (DefaultOpen captures the open-state baseline)

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)