### PR TITLE
feat(ui): Modal primitive + stories

### DIFF
--- a/packages/ui/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui/src/components/Modal/Modal.stories.tsx
@@ -1,0 +1,324 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Button } from '../Button';
+import { Input } from '../Input';
+import { Textarea } from '../Textarea';
+import { Modal } from './Modal';
+
+// Explicit `Meta<typeof Modal>` annotation (rather than `satisfies`)
+// keeps the merged static-property type out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+const meta: Meta<typeof Modal> = {
+  title: 'Web Primitives/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-modal',
+    },
+  },
+  args: {
+    defaultOpen: false,
+  },
+  argTypes: {
+    isOpen: { control: 'boolean' },
+    defaultOpen: { control: 'boolean' },
+    onOpenChange: { control: false, action: 'open-changed' },
+    children: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: 320,
+          padding: 24,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+const SampleHeader = () => (
+  <>
+    <h2 className="text-lg font-semibold text-primary">Confirm action</h2>
+    <p className="text-sm text-tertiary">This will permanently apply the change.</p>
+  </>
+);
+
+export const Default: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Open modal
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.Header>
+          <SampleHeader />
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">
+            Modals are focus-trapped overlays for blocking decisions or short multi-step flows.
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button color="primary" size="sm">
+            Confirm
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const SizeSm: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Small
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <h2 className="text-lg font-semibold text-primary">Small modal</h2>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">Best for short confirmations.</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="primary" size="sm">
+            OK
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const SizeMd: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Medium
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="md">
+        <Modal.Header>
+          <h2 className="text-lg font-semibold text-primary">Medium modal</h2>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">Default size for most flows.</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="primary" size="sm">
+            OK
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const SizeLg: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Large
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="lg">
+        <Modal.Header>
+          <h2 className="text-lg font-semibold text-primary">Large modal</h2>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">Roomier layout for forms or rich content.</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="primary" size="sm">
+            OK
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const SizeFull: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Full
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="full">
+        <Modal.Header>
+          <h2 className="text-lg font-semibold text-primary">Full-bleed modal</h2>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">
+            Stretches up to viewport bounds (with margin) — useful for multi-pane editors.
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="primary" size="sm">
+            OK
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const WithForm: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="primary" size="sm">
+          New device
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.Header>
+          <h2 className="text-lg font-semibold text-primary">New device</h2>
+          <p className="text-sm text-tertiary">Pair a device by entering its serial number.</p>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="flex flex-col gap-4">
+            <Input label="Device name" placeholder="Living room thermostat" size="md" />
+            <Input label="Serial number" placeholder="GLA-XXXX-XXXX" size="md" />
+            <Textarea label="Notes" placeholder="Optional install notes…" size="md" rows={3} />
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button color="primary" size="sm">
+            Pair device
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const Scrollable: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Long content
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="md">
+        <Modal.Header>
+          <h2 className="text-lg font-semibold text-primary">Terms of service</h2>
+        </Modal.Header>
+        <Modal.Body className="max-h-[60vh]">
+          {Array.from({ length: 20 }, (_, i) => (
+            <p key={i} className="mb-3 text-sm text-secondary">
+              Section {(i + 1).toString()} — long-form content stretches the modal so the body
+              scrolls while the header and footer stay pinned. The kit ModalOverlay already locks
+              page scroll; the inner Modal.Body adds an internal scrollbar via the max-h constraint.
+            </p>
+          ))}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="secondary" size="sm">
+            Decline
+          </Button>
+          <Button color="primary" size="sm">
+            Accept
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const Persistent: Story = {
+  // RAC's `isDismissable` and `isKeyboardDismissDisabled` live on the
+  // `<ModalOverlay>` (i.e. `Modal.Content`), not the `<DialogTrigger>`
+  // root. Setting both to non-default values blocks click-outside and
+  // escape close — the user must use a footer button to dismiss.
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="primary" size="sm">
+          Persistent modal
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content isDismissable={false} isKeyboardDismissDisabled>
+        <Modal.Header>
+          <h2 className="text-lg font-semibold text-primary">Required confirmation</h2>
+          <p className="text-sm text-tertiary">
+            Click-outside and escape are disabled — choose an option below.
+          </p>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">
+            Use this for irreversible actions where dismissing the dialog shouldn&apos;t
+            accidentally cancel the in-progress flow.
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="secondary" size="sm">
+            Stay
+          </Button>
+          <Button color="primary-destructive" size="sm">
+            Continue anyway
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const Confirmation: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="primary-destructive" size="sm">
+          Delete project
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <h2 className="text-lg font-semibold text-primary">Delete project?</h2>
+          <p className="text-sm text-tertiary">This action cannot be undone.</p>
+        </Modal.Header>
+        <Modal.Footer>
+          <Button color="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button color="primary-destructive" size="sm">
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -1,0 +1,167 @@
+// Glaon Modal — focus-trapped, scroll-locked, backdrop overlay. The
+// kit ships `application/modals/modal.tsx` as a thin re-styling of
+// react-aria-components' `<ModalOverlay>` + `<Modal>` + `<Dialog>` +
+// `<DialogTrigger>` chain (backdrop + zoom-in animations + responsive
+// sizing). Glaon composes those kit primitives into a Trigger /
+// Content / Header / Body / Footer slot pattern so consumers can
+// drop a complete modal in inline:
+//
+//   <Modal>
+//     <Modal.Trigger>
+//       <Button>Open</Button>
+//     </Modal.Trigger>
+//     <Modal.Content size="md">
+//       <Modal.Header>
+//         <h2>Confirm</h2>
+//       </Modal.Header>
+//       <Modal.Body>…content…</Modal.Body>
+//       <Modal.Footer>
+//         <Button color="secondary">Cancel</Button>
+//         <Button color="primary">Save</Button>
+//       </Modal.Footer>
+//     </Modal.Content>
+//   </Modal>
+//
+// The RAC foundation handles the full a11y contract: focus-trap +
+// return on close, scroll lock on the backdrop, escape close,
+// click-outside dismiss (when `isDismissable`), `aria-labelledby` /
+// `aria-describedby` wiring on the dialog.
+
+import type { ReactNode } from 'react';
+
+import {
+  type DialogTriggerProps as AriaDialogTriggerProps,
+  type ModalOverlayProps as AriaModalOverlayProps,
+} from 'react-aria-components';
+
+import {
+  Dialog as KitDialog,
+  DialogTrigger as KitDialogTrigger,
+  Modal as KitModal,
+  ModalOverlay as KitModalOverlay,
+} from '../application/modals/modal';
+
+export type ModalSize = 'sm' | 'md' | 'lg' | 'full';
+
+export interface ModalProps extends AriaDialogTriggerProps {
+  /** Trigger + content slots. Use `Modal.Trigger` and `Modal.Content`. */
+  children: ReactNode;
+}
+
+export interface ModalTriggerProps {
+  /**
+   * Focusable element that opens the modal. RAC's `<DialogTrigger>`
+   * auto-wires `aria-expanded` + `aria-controls` against the dialog.
+   */
+  children: ReactNode;
+}
+
+export interface ModalContentProps extends Omit<AriaModalOverlayProps, 'children'> {
+  /** Width preset; mirrors common dialog scales. @default 'md' */
+  size?: ModalSize;
+  /** Static body content. */
+  children: ReactNode;
+}
+
+export interface ModalHeaderProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export interface ModalBodyProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export interface ModalFooterProps {
+  className?: string;
+  children: ReactNode;
+}
+
+const sizeStyles: Record<ModalSize, string> = {
+  sm: 'sm:max-w-sm',
+  md: 'sm:max-w-md',
+  lg: 'sm:max-w-2xl',
+  full: 'sm:max-w-[min(100vw-4rem,80rem)]',
+};
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+function ModalRoot({ children, ...rest }: ModalProps) {
+  return <KitDialogTrigger {...rest}>{children}</KitDialogTrigger>;
+}
+
+function ModalTrigger({ children }: ModalTriggerProps) {
+  return <>{children}</>;
+}
+
+function ModalContent({ size = 'md', className, children, ...rest }: ModalContentProps) {
+  return (
+    <KitModalOverlay {...rest}>
+      <KitModal
+        className={(state) =>
+          joinClasses(
+            sizeStyles[size],
+            'rounded-xl bg-primary shadow-2xl ring-1 ring-secondary_alt',
+            // Reuse the kit's animations on the inner Modal node.
+            state.isEntering && 'duration-300 ease-out animate-in zoom-in-95',
+            state.isExiting && 'duration-200 ease-in animate-out zoom-out-95',
+            typeof className === 'function' ? className(state) : className,
+          )
+        }
+      >
+        <KitDialog className="flex w-full flex-col p-0 outline-hidden">{children}</KitDialog>
+      </KitModal>
+    </KitModalOverlay>
+  );
+}
+
+function ModalHeader({ className, children }: ModalHeaderProps) {
+  return (
+    <div
+      className={joinClasses(
+        'flex flex-col gap-1 border-b border-secondary_alt px-6 pt-6 pb-4',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ModalBody({ className, children }: ModalBodyProps) {
+  return (
+    <div className={joinClasses('flex-1 overflow-y-auto px-6 py-5', className)}>{children}</div>
+  );
+}
+
+function ModalFooter({ className, children }: ModalFooterProps) {
+  return (
+    <div
+      className={joinClasses(
+        'flex justify-end gap-3 border-t border-secondary_alt px-6 pt-4 pb-6',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type ModalNamespace = typeof ModalRoot & {
+  Trigger: typeof ModalTrigger;
+  Content: typeof ModalContent;
+  Header: typeof ModalHeader;
+  Body: typeof ModalBody;
+  Footer: typeof ModalFooter;
+};
+
+export const Modal: ModalNamespace = Object.assign(ModalRoot, {
+  Trigger: ModalTrigger,
+  Content: ModalContent,
+  Header: ModalHeader,
+  Body: ModalBody,
+  Footer: ModalFooter,
+});

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -132,8 +132,15 @@ function ModalHeader({ className, children }: ModalHeaderProps) {
 }
 
 function ModalBody({ className, children }: ModalBodyProps) {
+  // `tabIndex={0}` lets keyboard users focus the scrollable body and
+  // page through with arrow keys — axe `scrollable-region-focusable`
+  // requires this on every element that scrolls (the Body always
+  // declares `overflow-y-auto`, so it qualifies even when content
+  // fits within the height).
   return (
-    <div className={joinClasses('flex-1 overflow-y-auto px-6 py-5', className)}>{children}</div>
+    <div tabIndex={0} className={joinClasses('flex-1 overflow-y-auto px-6 py-5', className)}>
+      {children}
+    </div>
   );
 }
 

--- a/packages/ui/src/components/Modal/index.ts
+++ b/packages/ui/src/components/Modal/index.ts
@@ -1,0 +1,10 @@
+export {
+  Modal,
+  type ModalBodyProps,
+  type ModalContentProps,
+  type ModalFooterProps,
+  type ModalHeaderProps,
+  type ModalProps,
+  type ModalSize,
+  type ModalTriggerProps,
+} from './Modal';

--- a/packages/ui/src/components/application/modals/modal.tsx
+++ b/packages/ui/src/components/application/modals/modal.tsx
@@ -1,0 +1,45 @@
+// @ts-nocheck
+// UUI kit source — pulled via `npx untitledui add input-field-modal`.
+// Suppress type-check so `untitledui upgrade` stays a clean replace
+// operation. Re-apply after every kit upgrade until UUI tightens types.
+"use client";
+
+import type { DialogProps as AriaDialogProps, ModalOverlayProps as AriaModalOverlayProps } from "react-aria-components";
+import { Dialog as AriaDialog, DialogTrigger as AriaDialogTrigger, Modal as AriaModal, ModalOverlay as AriaModalOverlay } from "react-aria-components";
+import { cx } from "@/utils/cx";
+
+export const DialogTrigger = AriaDialogTrigger;
+
+export const ModalOverlay = (props: AriaModalOverlayProps) => {
+    return (
+        <AriaModalOverlay
+            {...props}
+            className={(state) =>
+                cx(
+                    "fixed inset-0 z-50 flex min-h-dvh w-full items-end justify-center overflow-y-auto bg-overlay/70 px-4 pt-4 pb-[clamp(16px,8vh,64px)] outline-hidden backdrop-blur-[6px] sm:items-center sm:justify-center sm:p-8",
+                    state.isEntering && "duration-300 ease-out animate-in fade-in",
+                    state.isExiting && "duration-200 ease-in animate-out fade-out",
+                    typeof props.className === "function" ? props.className(state) : props.className,
+                )
+            }
+        />
+    );
+};
+
+export const Modal = (props: AriaModalOverlayProps) => (
+    <AriaModal
+        {...props}
+        className={(state) =>
+            cx(
+                "max-h-full w-full align-middle outline-hidden max-sm:overflow-y-auto max-sm:rounded-xl",
+                state.isEntering && "duration-300 ease-out animate-in zoom-in-95",
+                state.isExiting && "duration-200 ease-in animate-out zoom-out-95",
+                typeof props.className === "function" ? props.className(state) : props.className,
+            )
+        }
+    />
+);
+
+export const Dialog = (props: AriaDialogProps) => (
+    <AriaDialog {...props} className={cx("flex w-full items-center justify-center outline-hidden", props.className)} />
+);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -11,6 +11,7 @@ export * from './components/Button';
 export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/Input';
+export * from './components/Modal';
 export * from './components/Popover';
 export * from './components/PressableButton';
 export * from './components/ProgressBar';


### PR DESCRIPTION
## Summary

Fourteenth Phase 1 primitive group (P14) — focus-trapped, scroll-locked, backdrop overlay. The kit ships \`application/modals/modal.tsx\` as a thin re-styling of react-aria-components' \`<ModalOverlay>\` + \`<Modal>\` + \`<Dialog>\` + \`<DialogTrigger>\` chain (backdrop with blur, zoom-in animations, responsive sizing). Glaon composes those kit primitives into a Trigger / Content / Header / Body / Footer slot pattern so a complete modal drops in inline.

The RAC foundation handles the full a11y contract: focus-trap + return on close, scroll lock on the backdrop, escape close, click-outside dismiss (when \`isDismissable\`), \`aria-labelledby\` / \`aria-describedby\` wiring on the dialog.

## Surface

- \`Modal\` root — forwards RAC \`<DialogTrigger>\` props (\`isOpen\` / \`defaultOpen\` / \`onOpenChange\`).
- \`Modal.Trigger\` — passthrough namespace marker; RAC auto-detects the first focusable child.
- \`Modal.Content\` — wraps RAC \`<ModalOverlay>\` + \`<Modal>\` + \`<Dialog>\` with Glaon chrome (\`rounded-xl\` + \`shadow-2xl\` + \`ring-secondary_alt\`) and size presets (\`sm\` / \`md\` / \`lg\` / \`full\`). Forwards \`isDismissable\` and \`isKeyboardDismissDisabled\` to the overlay.
- \`Modal.Header\` / \`Modal.Body\` / \`Modal.Footer\` — layout slots with borders between regions; Body scrolls internally when content exceeds height.

## Scope (In)

- \`components/Modal/{Modal.tsx,Modal.stories.tsx,index.ts}\` — wrap + 9 stories (Default, SizeSm, SizeMd, SizeLg, SizeFull, WithForm, Scrollable, Persistent, Confirmation).
- Kit source placed under \`application/modals/modal.tsx\` (with \`@ts-nocheck\`).
- \`packages/ui/src/index.ts\` barrel re-exports the new family.

## Scope (Out)

- **Drawer** — P15.
- **Confirmation dialog application primitive** (Phase 2).
- **Multi-step modal flows** (Phase 2).
- **RN \`Modal.native.tsx\`** — UUI is web-only; RN gets native presentation via \`react-native-reanimated\` in a follow-up issue.

## Notable details

- Sizing: \`sm: max-w-sm\`, \`md: max-w-md\`, \`lg: max-w-2xl\`, \`full: max-w-[min(100vw-4rem,80rem)]\`. The kit's \`<ModalOverlay>\` already handles mobile breakpoint behaviour (full-bleed below \`sm\`).
- \`isDismissable\` and \`isKeyboardDismissDisabled\` belong on \`<ModalOverlay>\` (i.e. \`Modal.Content\`), not the \`<DialogTrigger>\` root — documented inline in the Persistent story so the next contributor doesn't trip over it.
- Long-form text in the Scrollable story avoids JSX-confusing \`<Tag>\` literals (TS parser treats them as JSX) — uses plain prose instead.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui build\` clean (\`tsc -b\`)
- [x] \`pnpm --filter @glaon/ui test --run\` — 72 passing (was 69; +3 for Modal × 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\` severity (focus-trap, aria-labelledby on Header h2)
- [ ] Storybook spot-check: light + dark; size matrix renders, scroll lock works, focus returns to trigger after close, Persistent doesn't dismiss on outside click
- [ ] Chromatic snapshots accepted (open-state baseline for every size + Scrollable + Confirmation)

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)