### PR TITLE
feat(ui): Drawer primitive + stories

### DIFF
--- a/packages/ui/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,290 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Button } from '../Button';
+import { Input } from '../Input';
+import { Textarea } from '../Textarea';
+import { Drawer } from './Drawer';
+
+// Explicit `Meta<typeof Drawer>` annotation (rather than `satisfies`)
+// keeps the merged static-property type out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+const meta: Meta<typeof Drawer> = {
+  title: 'Web Primitives/Drawer',
+  component: Drawer,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-drawer',
+    },
+  },
+  args: {
+    defaultOpen: false,
+  },
+  argTypes: {
+    isOpen: { control: 'boolean' },
+    defaultOpen: { control: 'boolean' },
+    onOpenChange: { control: false, action: 'open-changed' },
+    children: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: 400,
+          padding: 24,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+const SampleHeader = () => (
+  <>
+    <h2 className="text-lg font-semibold text-primary">Settings</h2>
+    <p className="text-sm text-tertiary">Tweak the defaults for this workspace.</p>
+  </>
+);
+
+const SampleBody = () => (
+  <p className="text-sm text-secondary">
+    Drawer content sits in a slide-in panel. Use it for forms, filters, or any flow where the user
+    needs context from the page behind the panel.
+  </p>
+);
+
+const SampleFooter = () => (
+  <>
+    <Button color="secondary" size="sm">
+      Cancel
+    </Button>
+    <Button color="primary" size="sm">
+      Save
+    </Button>
+  </>
+);
+
+export const Default: Story = {
+  render: (args) => (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button color="secondary" size="sm">
+          Open drawer
+        </Button>
+      </Drawer.Trigger>
+      <Drawer.Content>
+        <Drawer.Header>
+          <SampleHeader />
+        </Drawer.Header>
+        <Drawer.Body>
+          <SampleBody />
+        </Drawer.Body>
+        <Drawer.Footer>
+          <SampleFooter />
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  ),
+};
+
+export const SideRight: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button color="secondary" size="sm">
+          Right
+        </Button>
+      </Drawer.Trigger>
+      <Drawer.Content side="right">
+        <Drawer.Header>
+          <h2 className="text-lg font-semibold text-primary">Right</h2>
+        </Drawer.Header>
+        <Drawer.Body>
+          <SampleBody />
+        </Drawer.Body>
+        <Drawer.Footer>
+          <SampleFooter />
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  ),
+};
+
+export const SideLeft: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button color="secondary" size="sm">
+          Left
+        </Button>
+      </Drawer.Trigger>
+      <Drawer.Content side="left">
+        <Drawer.Header>
+          <h2 className="text-lg font-semibold text-primary">Left</h2>
+        </Drawer.Header>
+        <Drawer.Body>
+          <SampleBody />
+        </Drawer.Body>
+        <Drawer.Footer>
+          <SampleFooter />
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  ),
+};
+
+export const SideTop: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button color="secondary" size="sm">
+          Top
+        </Button>
+      </Drawer.Trigger>
+      <Drawer.Content side="top">
+        <Drawer.Header>
+          <h2 className="text-lg font-semibold text-primary">Top</h2>
+        </Drawer.Header>
+        <Drawer.Body>
+          <SampleBody />
+        </Drawer.Body>
+        <Drawer.Footer>
+          <SampleFooter />
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  ),
+};
+
+export const SideBottom: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button color="secondary" size="sm">
+          Bottom
+        </Button>
+      </Drawer.Trigger>
+      <Drawer.Content side="bottom">
+        <Drawer.Header>
+          <h2 className="text-lg font-semibold text-primary">Bottom</h2>
+        </Drawer.Header>
+        <Drawer.Body>
+          <SampleBody />
+        </Drawer.Body>
+        <Drawer.Footer>
+          <SampleFooter />
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  ),
+};
+
+export const WithForm: Story = {
+  render: (args) => (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button color="primary" size="sm">
+          Pair device
+        </Button>
+      </Drawer.Trigger>
+      <Drawer.Content side="right" size="md">
+        <Drawer.Header>
+          <h2 className="text-lg font-semibold text-primary">Pair device</h2>
+          <p className="text-sm text-tertiary">Enter the serial and an optional label.</p>
+        </Drawer.Header>
+        <Drawer.Body>
+          <div className="flex flex-col gap-4">
+            <Input label="Device name" placeholder="Living room thermostat" size="md" />
+            <Input label="Serial number" placeholder="GLA-XXXX-XXXX" size="md" />
+            <Textarea label="Notes" placeholder="Optional install notes…" size="md" rows={3} />
+          </div>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Button color="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button color="primary" size="sm">
+            Pair
+          </Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  ),
+};
+
+export const Persistent: Story = {
+  // RAC's `isDismissable` and `isKeyboardDismissDisabled` belong on
+  // the overlay (`Drawer.Content`), not the `<DialogTrigger>` root.
+  render: (args) => (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button color="primary" size="sm">
+          Persistent drawer
+        </Button>
+      </Drawer.Trigger>
+      <Drawer.Content side="right" isDismissable={false} isKeyboardDismissDisabled>
+        <Drawer.Header>
+          <h2 className="text-lg font-semibold text-primary">Required confirmation</h2>
+          <p className="text-sm text-tertiary">
+            Click-outside and escape are disabled — choose an option below.
+          </p>
+        </Drawer.Header>
+        <Drawer.Body>
+          <p className="text-sm text-secondary">
+            Use this for irreversible flows where dismissing the drawer shouldn&apos;t accidentally
+            cancel in-progress work.
+          </p>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Button color="secondary" size="sm">
+            Stay
+          </Button>
+          <Button color="primary-destructive" size="sm">
+            Continue
+          </Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  ),
+};
+
+export const SizeFull: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button color="secondary" size="sm">
+          Full
+        </Button>
+      </Drawer.Trigger>
+      <Drawer.Content side="right" size="full">
+        <Drawer.Header>
+          <h2 className="text-lg font-semibold text-primary">Full-screen drawer</h2>
+        </Drawer.Header>
+        <Drawer.Body>
+          <p className="text-sm text-secondary">
+            Useful when the drawer needs the full viewport — e.g. a multi-pane editor or a takeover
+            form.
+          </p>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Button color="primary" size="sm">
+            Done
+          </Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  ),
+};

--- a/packages/ui/src/components/Drawer/Drawer.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,234 @@
+// Glaon Drawer — edge-anchored, focus-trapped overlay (slide-in
+// panel). Same RAC overlay primitives as Modal (P14) — no separate
+// kit source ships for a generic drawer; the only kit "slide-out"
+// templates are PRO application snippets with hard-coded content.
+// Glaon hand-rolls the chrome using kit surface vocabulary
+// (`bg-primary` + `shadow-2xl` + `ring-secondary_alt`) and
+// composes RAC `<DialogTrigger>` + `<ModalOverlay>` + `<Modal>` +
+// `<Dialog>` directly — RAC's animation primitives drive the
+// slide-from-edge motion via Tailwind state hooks.
+//
+// Usage:
+//
+//   <Drawer>
+//     <Drawer.Trigger>
+//       <Button>Open settings</Button>
+//     </Drawer.Trigger>
+//     <Drawer.Content side="right" size="md">
+//       <Drawer.Header>…</Drawer.Header>
+//       <Drawer.Body>…</Drawer.Body>
+//       <Drawer.Footer>…</Drawer.Footer>
+//     </Drawer.Content>
+//   </Drawer>
+//
+// The RAC foundation provides focus-trap + return on close, scroll
+// lock on the backdrop, escape close, click-outside dismiss (when
+// `isDismissable`), `aria-labelledby` / `aria-describedby` wiring
+// on the inner dialog.
+
+import type { ReactNode } from 'react';
+
+import {
+  Dialog as AriaDialog,
+  DialogTrigger as AriaDialogTrigger,
+  type DialogTriggerProps as AriaDialogTriggerProps,
+  Modal as AriaModal,
+  ModalOverlay as AriaModalOverlay,
+  type ModalOverlayProps as AriaModalOverlayProps,
+} from 'react-aria-components';
+
+export type DrawerSide = 'left' | 'right' | 'top' | 'bottom';
+export type DrawerSize = 'sm' | 'md' | 'lg' | 'full';
+
+export interface DrawerProps extends AriaDialogTriggerProps {
+  /** Trigger + content slots. Use `Drawer.Trigger` and `Drawer.Content`. */
+  children: ReactNode;
+}
+
+export interface DrawerTriggerProps {
+  /**
+   * Focusable element that opens the drawer. RAC's `<DialogTrigger>`
+   * auto-wires `aria-expanded` + `aria-controls` against the dialog.
+   */
+  children: ReactNode;
+}
+
+export interface DrawerContentProps extends Omit<AriaModalOverlayProps, 'children'> {
+  /** Edge to anchor the panel to. @default 'right' */
+  side?: DrawerSide;
+  /**
+   * Cross-axis size: width for `left` / `right`, height for
+   * `top` / `bottom`. `full` covers the entire viewport.
+   * @default 'md'
+   */
+  size?: DrawerSize;
+  /** Static panel content. */
+  children: ReactNode;
+}
+
+export interface DrawerHeaderProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export interface DrawerBodyProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export interface DrawerFooterProps {
+  className?: string;
+  children: ReactNode;
+}
+
+// Tailwind class fragments per side. Position pins the panel to the
+// edge; `slide-in-from-*` / `slide-out-to-*` drive entry / exit.
+const sidePosition: Record<DrawerSide, string> = {
+  left: 'inset-y-0 left-0 h-full max-h-screen',
+  right: 'inset-y-0 right-0 h-full max-h-screen',
+  top: 'inset-x-0 top-0 w-full',
+  bottom: 'inset-x-0 bottom-0 w-full',
+};
+
+const sideEnter: Record<DrawerSide, string> = {
+  left: 'slide-in-from-left',
+  right: 'slide-in-from-right',
+  top: 'slide-in-from-top',
+  bottom: 'slide-in-from-bottom',
+};
+
+const sideExit: Record<DrawerSide, string> = {
+  left: 'slide-out-to-left',
+  right: 'slide-out-to-right',
+  top: 'slide-out-to-top',
+  bottom: 'slide-out-to-bottom',
+};
+
+// Per-side size: width for vertical sides, height for horizontal.
+const sideSize: Record<DrawerSide, Record<DrawerSize, string>> = {
+  left: {
+    sm: 'w-72 max-w-[90vw]',
+    md: 'w-96 max-w-[90vw]',
+    lg: 'w-[32rem] max-w-[90vw]',
+    full: 'w-screen',
+  },
+  right: {
+    sm: 'w-72 max-w-[90vw]',
+    md: 'w-96 max-w-[90vw]',
+    lg: 'w-[32rem] max-w-[90vw]',
+    full: 'w-screen',
+  },
+  top: {
+    sm: 'h-48 max-h-[90vh]',
+    md: 'h-72 max-h-[90vh]',
+    lg: 'h-[28rem] max-h-[90vh]',
+    full: 'h-screen',
+  },
+  bottom: {
+    sm: 'h-48 max-h-[90vh]',
+    md: 'h-72 max-h-[90vh]',
+    lg: 'h-[28rem] max-h-[90vh]',
+    full: 'h-screen',
+  },
+};
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+function DrawerRoot({ children, ...rest }: DrawerProps) {
+  return <AriaDialogTrigger {...rest}>{children}</AriaDialogTrigger>;
+}
+
+function DrawerTrigger({ children }: DrawerTriggerProps) {
+  return <>{children}</>;
+}
+
+function DrawerContent({
+  side = 'right',
+  size = 'md',
+  className,
+  children,
+  ...rest
+}: DrawerContentProps) {
+  return (
+    <AriaModalOverlay
+      {...rest}
+      className={(state) =>
+        joinClasses(
+          'fixed inset-0 z-50 bg-overlay/70 backdrop-blur-[6px]',
+          state.isEntering && 'duration-200 ease-out animate-in fade-in',
+          state.isExiting && 'duration-150 ease-in animate-out fade-out',
+        )
+      }
+    >
+      <AriaModal
+        className={(state) =>
+          joinClasses(
+            'fixed bg-primary shadow-2xl ring-1 ring-secondary_alt outline-hidden',
+            sidePosition[side],
+            sideSize[side][size],
+            state.isEntering && `duration-300 ease-out animate-in ${sideEnter[side]}`,
+            state.isExiting && `duration-200 ease-in animate-out ${sideExit[side]}`,
+            typeof className === 'function' ? className(state) : className,
+          )
+        }
+      >
+        <AriaDialog className="flex h-full w-full flex-col outline-hidden">{children}</AriaDialog>
+      </AriaModal>
+    </AriaModalOverlay>
+  );
+}
+
+function DrawerHeader({ className, children }: DrawerHeaderProps) {
+  return (
+    <div
+      className={joinClasses(
+        'flex flex-col gap-1 border-b border-secondary_alt px-6 pt-6 pb-4',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+function DrawerBody({ className, children }: DrawerBodyProps) {
+  // `tabIndex={0}` lets keyboard users focus the scrollable body and
+  // page through with arrow keys — axe `scrollable-region-focusable`
+  // requires this on every element that scrolls. Same fix as Modal.
+  return (
+    <div tabIndex={0} className={joinClasses('flex-1 overflow-y-auto px-6 py-5', className)}>
+      {children}
+    </div>
+  );
+}
+
+function DrawerFooter({ className, children }: DrawerFooterProps) {
+  return (
+    <div
+      className={joinClasses(
+        'flex justify-end gap-3 border-t border-secondary_alt px-6 pt-4 pb-6',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type DrawerNamespace = typeof DrawerRoot & {
+  Trigger: typeof DrawerTrigger;
+  Content: typeof DrawerContent;
+  Header: typeof DrawerHeader;
+  Body: typeof DrawerBody;
+  Footer: typeof DrawerFooter;
+};
+
+export const Drawer: DrawerNamespace = Object.assign(DrawerRoot, {
+  Trigger: DrawerTrigger,
+  Content: DrawerContent,
+  Header: DrawerHeader,
+  Body: DrawerBody,
+  Footer: DrawerFooter,
+});

--- a/packages/ui/src/components/Drawer/index.ts
+++ b/packages/ui/src/components/Drawer/index.ts
@@ -1,0 +1,11 @@
+export {
+  Drawer,
+  type DrawerBodyProps,
+  type DrawerContentProps,
+  type DrawerFooterProps,
+  type DrawerHeaderProps,
+  type DrawerProps,
+  type DrawerSide,
+  type DrawerSize,
+  type DrawerTriggerProps,
+} from './Drawer';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,6 +10,7 @@ export * from './components/Breadcrumb';
 export * from './components/Button';
 export * from './components/Card';
 export * from './components/Checkbox';
+export * from './components/Drawer';
 export * from './components/Input';
 export * from './components/Modal';
 export * from './components/Popover';


### PR DESCRIPTION
## Summary

Fifteenth Phase 1 primitive group (P15) — edge-anchored, focus-trapped slide-in panel. The kit doesn't ship a generic Drawer base; the only "slide-out" templates are PRO application snippets with hard-coded content. Glaon hand-rolls the chrome using kit surface vocabulary (\`bg-primary\` + \`shadow-2xl\` + \`ring-secondary_alt\`) and composes react-aria-components' \`<DialogTrigger>\` + \`<ModalOverlay>\` + \`<Modal>\` + \`<Dialog>\` directly — RAC's animation primitives drive slide-from-edge motion via Tailwind state hooks.

The RAC foundation handles the full a11y contract: focus-trap + return on close, scroll lock on the backdrop, escape close, click-outside dismiss (when \`isDismissable\`), \`aria-labelledby\` wiring on the inner dialog.

## Surface

- \`Drawer\` root — forwards RAC \`<DialogTrigger>\` props (\`isOpen\` / \`defaultOpen\` / \`onOpenChange\`).
- \`Drawer.Trigger\` — passthrough namespace marker; RAC auto-detects the first focusable child.
- \`Drawer.Content\` — wraps overlay + modal + dialog with Glaon chrome plus \`side\` (\`left\` / \`right\` / \`top\` / \`bottom\`) and \`size\` (\`sm\` / \`md\` / \`lg\` / \`full\`) props. Forwards \`isDismissable\` and \`isKeyboardDismissDisabled\`.
- \`Drawer.Header\` / \`Drawer.Body\` / \`Drawer.Footer\` — layout slots matching Modal's chrome conventions; \`Drawer.Body\` carries \`tabIndex={0}\` for axe \`scrollable-region-focusable\` (same fix as Modal P14).

## Scope (In)

- \`components/Drawer/{Drawer.tsx,Drawer.stories.tsx,index.ts}\` — wrap + 8 stories (Default, SideRight, SideLeft, SideTop, SideBottom, WithForm, Persistent, SizeFull).
- \`packages/ui/src/index.ts\` barrel re-exports the new family.
- No new kit files — re-uses RAC primitives and the existing \`base/tooltip/\`, \`base/buttons/\`, \`base/input/\` deps.

## Scope (Out)

- **Modal** — P14.
- **Mobile bottom-sheet** primitive (RN-specific, iOS HIG / Material patterns) — Phase 2.
- **RN \`Drawer.native.tsx\`** — UUI is web-only; deferred to follow-up. Mobile pattern uses \`react-native-reanimated\` for slide-in + pan-gesture dismiss.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui build\` clean (\`tsc -b\`)
- [x] \`pnpm --filter @glaon/ui test --run\` — 75 passing (was 72; +3 for Drawer × 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\` severity (focus-trap, aria-labelledby on Header h2, scrollable-region-focusable on Body)
- [ ] Storybook spot-check: light + dark; side matrix renders, escape closes, focus returns to trigger after close, Persistent doesn't dismiss
- [ ] Chromatic snapshots accepted (open-state baselines for every side + Form + Persistent + Full)

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)