### PR TITLE
feat(ui): List primitive + stories

### DIFF
--- a/packages/ui/src/components/List/List.stories.tsx
+++ b/packages/ui/src/components/List/List.stories.tsx
@@ -1,0 +1,229 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { Avatar } from '../Avatar';
+import { Badge } from '../Badge';
+import { Checkbox } from '../Checkbox';
+import { storybookIcons } from '../../icons/storybook';
+import { List } from './List';
+
+const Bell = storybookIcons.bell;
+const Settings = storybookIcons.settings;
+const Star = storybookIcons.star;
+const User = storybookIcons.user;
+
+// Explicit `Meta<typeof List>` annotation (rather than `satisfies`)
+// keeps the merged static-property type out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+const meta: Meta<typeof List> = {
+  title: 'Web Primitives/List',
+  component: List,
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-list',
+    },
+  },
+  args: {
+    dividers: false,
+    bordered: false,
+  },
+  argTypes: {
+    dividers: { control: 'boolean' },
+    bordered: { control: 'boolean' },
+    emptyState: { control: false, table: { disable: true } },
+    children: { control: false, table: { disable: true } },
+    className: { control: false, table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 480 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof List>;
+
+export const Default: Story = {
+  render: (args) => (
+    <List {...args}>
+      <List.Item>Living room thermostat</List.Item>
+      <List.Item>Kitchen light strip</List.Item>
+      <List.Item>Front door camera</List.Item>
+      <List.Item>Bedroom blinds</List.Item>
+    </List>
+  ),
+};
+
+export const Bordered: Story = {
+  args: { bordered: true, dividers: true },
+  render: (args) => (
+    <List {...args}>
+      <List.Item>Living room thermostat</List.Item>
+      <List.Item>Kitchen light strip</List.Item>
+      <List.Item>Front door camera</List.Item>
+      <List.Item>Bedroom blinds</List.Item>
+    </List>
+  ),
+};
+
+export const WithDividers: Story = {
+  args: { dividers: true },
+  render: (args) => (
+    <List {...args}>
+      <List.Item>Privacy & sharing</List.Item>
+      <List.Item>Notifications</List.Item>
+      <List.Item>Display & accessibility</List.Item>
+      <List.Item>Account</List.Item>
+    </List>
+  ),
+};
+
+export const WithLeadingIcon: Story = {
+  args: { dividers: true, bordered: true },
+  render: (args) => (
+    <List {...args}>
+      <List.Item leading={Bell !== undefined ? <Bell className="size-5" /> : null}>
+        Notifications
+      </List.Item>
+      <List.Item leading={User !== undefined ? <User className="size-5" /> : null}>
+        Account
+      </List.Item>
+      <List.Item leading={Settings !== undefined ? <Settings className="size-5" /> : null}>
+        Preferences
+      </List.Item>
+      <List.Item leading={Star !== undefined ? <Star className="size-5" /> : null}>
+        Favourites
+      </List.Item>
+    </List>
+  ),
+};
+
+export const WithAvatar: Story = {
+  args: { dividers: true, bordered: true },
+  render: (args) => (
+    <List {...args}>
+      <List.Item leading={<Avatar size="sm" alt="Olivia" initials="OR" />}>
+        <span className="font-semibold text-primary">Olivia Rhye</span>
+        <span className="text-tertiary">olivia@glaon.app</span>
+      </List.Item>
+      <List.Item leading={<Avatar size="sm" alt="Phoenix" initials="PB" />}>
+        <span className="font-semibold text-primary">Phoenix Baker</span>
+        <span className="text-tertiary">phoenix@glaon.app</span>
+      </List.Item>
+      <List.Item leading={<Avatar size="sm" alt="Lana" initials="LS" />}>
+        <span className="font-semibold text-primary">Lana Steiner</span>
+        <span className="text-tertiary">lana@glaon.app</span>
+      </List.Item>
+    </List>
+  ),
+};
+
+export const WithActions: Story = {
+  args: { dividers: true, bordered: true },
+  render: (args) => (
+    <List {...args}>
+      <List.Item
+        trailing={
+          <List.ItemAction
+            onClick={() => {
+              /* edit */
+            }}
+          >
+            Edit
+          </List.ItemAction>
+        }
+      >
+        Living room thermostat
+      </List.Item>
+      <List.Item
+        trailing={
+          <List.ItemAction
+            onClick={() => {
+              /* edit */
+            }}
+          >
+            Edit
+          </List.ItemAction>
+        }
+      >
+        Kitchen light strip
+      </List.Item>
+      <List.Item
+        trailing={
+          <List.ItemAction
+            onClick={() => {
+              /* edit */
+            }}
+          >
+            Edit
+          </List.ItemAction>
+        }
+      >
+        Front door camera
+      </List.Item>
+    </List>
+  ),
+};
+
+export const WithBadges: Story = {
+  args: { dividers: true, bordered: true },
+  render: (args) => (
+    <List {...args}>
+      <List.Item trailing={<Badge color="success">Online</Badge>}>Living room thermostat</List.Item>
+      <List.Item trailing={<Badge color="warning">Updating</Badge>}>Kitchen light strip</List.Item>
+      <List.Item trailing={<Badge color="error">Offline</Badge>}>Front door camera</List.Item>
+    </List>
+  ),
+};
+
+export const Selectable: Story = {
+  args: { dividers: true, bordered: true },
+  render: (args) => (
+    <List {...args}>
+      <List.Item leading={<Checkbox aria-label="Living room thermostat" />}>
+        Living room thermostat
+      </List.Item>
+      <List.Item leading={<Checkbox aria-label="Kitchen light strip" />}>
+        Kitchen light strip
+      </List.Item>
+      <List.Item leading={<Checkbox aria-label="Front door camera" />}>Front door camera</List.Item>
+      <List.Item leading={<Checkbox aria-label="Bedroom blinds" />}>Bedroom blinds</List.Item>
+    </List>
+  ),
+};
+
+export const Interactive: Story = {
+  args: { dividers: true, bordered: true },
+  render: (args) => (
+    <List {...args}>
+      <List.Item current onClick={() => undefined}>
+        Devices
+      </List.Item>
+      <List.Item onClick={() => undefined}>Scenes</List.Item>
+      <List.Item onClick={() => undefined}>Automations</List.Item>
+      <List.Item onClick={() => undefined}>Settings</List.Item>
+    </List>
+  ),
+};
+
+export const Empty: Story = {
+  args: { bordered: true },
+  render: (args) => <List {...args} />,
+};
+
+export const EmptyCustom: Story = {
+  args: {
+    bordered: true,
+    emptyState: (
+      <div className="flex flex-col items-center gap-2 px-6 py-10 text-center">
+        <p className="text-base font-semibold text-primary">No devices yet</p>
+        <p className="text-sm text-tertiary">Pair your first device to start automating.</p>
+      </div>
+    ),
+  },
+  render: (args) => <List {...args} />,
+};

--- a/packages/ui/src/components/List/List.tsx
+++ b/packages/ui/src/components/List/List.tsx
@@ -1,0 +1,173 @@
+// Glaon List — vertical, semantic list primitive. UUI doesn't ship a
+// generic List base; the search-results are pricing tables and full
+// data tables. Glaon hand-rolls a thin layout primitive on top of
+// `<ul>` / `<li>` using kit surface vocabulary as canonical reference
+// (`bg-primary` + `border-secondary_alt` + `divide-secondary_alt`).
+// Same wrap-pattern ladder as P4 Card and P10 TopBar — kit token CSS
+// as canon, content fully parameterized through composition slots.
+//
+// Usage:
+//
+//   <List dividers>
+//     <List.Item leading={<Avatar size="sm" alt="Olivia" />}>
+//       <span className="font-semibold">Olivia Rhye</span>
+//       <span className="text-tertiary">olivia@glaon.app</span>
+//     </List.Item>
+//     <List.Item
+//       leading={<SearchIcon />}
+//       trailing={<List.ItemAction onClick={…}>Edit</List.ItemAction>}
+//     >
+//       Search anything
+//     </List.Item>
+//   </List>
+
+import type { MouseEventHandler, ReactNode } from 'react';
+
+export interface ListProps {
+  /**
+   * Render thin border dividers between items (`divide-y`). Useful
+   * for settings or transaction-log layouts.
+   */
+  dividers?: boolean;
+  /**
+   * Wrap the list in a card surface (`bg-primary` + ring + rounded).
+   * @default false
+   */
+  bordered?: boolean;
+  /**
+   * Content rendered when the list has no items (no children). Use
+   * for empty states — e.g. "No devices yet".
+   */
+  emptyState?: ReactNode;
+  /** Override the kit's outer container className. */
+  className?: string;
+  /** `<List.Item>` children (or any content). */
+  children?: ReactNode;
+}
+
+export interface ListItemProps {
+  /**
+   * Optional leading slot — typically an Avatar or an icon. Rendered
+   * to the left of the main content.
+   */
+  leading?: ReactNode;
+  /**
+   * Optional trailing slot — typically a `<List.ItemAction>` button
+   * or a status badge. Rendered to the right of the main content.
+   */
+  trailing?: ReactNode;
+  /** Whole-row click handler. Promotes the item to a link-style row. */
+  onClick?: MouseEventHandler<HTMLLIElement>;
+  /** Mark the item as the active route (drives `aria-current="page"`). */
+  current?: boolean;
+  className?: string;
+  children?: ReactNode;
+}
+
+export interface ListItemActionProps {
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  className?: string;
+  children: ReactNode;
+}
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+// Minimal "is the children prop empty" helper. React renders `null`,
+// `undefined`, and `false` as empty; an empty array also counts. For
+// arrays of children, fall back to `Array.isArray(children) &&
+// children.length === 0` — the typical Storybook control case.
+function isEmptyChildren(children: ReactNode): boolean {
+  if (children === null || children === undefined || children === false) {
+    return true;
+  }
+  if (Array.isArray(children) && children.length === 0) {
+    return true;
+  }
+  return false;
+}
+
+function ListRoot({
+  dividers = false,
+  bordered = false,
+  emptyState,
+  className,
+  children,
+}: ListProps) {
+  const containerClass = joinClasses(
+    'flex flex-col',
+    bordered && 'rounded-xl bg-primary ring-1 ring-secondary_alt overflow-hidden',
+    className,
+  );
+  if (isEmptyChildren(children)) {
+    return (
+      <div className={containerClass}>
+        {emptyState ?? (
+          <p className="px-4 py-8 text-center text-sm text-tertiary">No items to show.</p>
+        )}
+      </div>
+    );
+  }
+  return (
+    <ul
+      role="list"
+      className={joinClasses(containerClass, dividers && 'divide-y divide-secondary_alt')}
+    >
+      {children}
+    </ul>
+  );
+}
+
+function ListItem({ leading, trailing, onClick, current, className, children }: ListItemProps) {
+  const interactive = onClick !== undefined;
+  return (
+    <li
+      role="listitem"
+      onClick={onClick}
+      className={joinClasses(
+        'flex items-center gap-3 px-4 py-3',
+        interactive &&
+          'cursor-pointer outline-focus-ring transition hover:bg-primary_hover focus-visible:outline-2 focus-visible:outline-offset-2',
+        current === true && 'bg-secondary',
+        className,
+      )}
+      aria-current={current === true ? 'page' : undefined}
+    >
+      {leading !== undefined ? (
+        <div className="flex shrink-0 items-center text-fg-quaternary">{leading}</div>
+      ) : null}
+      <div className="flex flex-1 flex-col gap-0.5 overflow-hidden text-sm text-secondary">
+        {children}
+      </div>
+      {trailing !== undefined ? (
+        <div className="flex shrink-0 items-center gap-2">{trailing}</div>
+      ) : null}
+    </li>
+  );
+}
+
+function ListItemAction({ onClick, className, children }: ListItemActionProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={joinClasses(
+        'rounded-md px-2.5 py-1.5 text-sm font-semibold text-secondary outline-focus-ring transition hover:bg-primary_hover focus-visible:outline-2 focus-visible:outline-offset-2',
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+type ListNamespace = typeof ListRoot & {
+  Item: typeof ListItem;
+  ItemAction: typeof ListItemAction;
+};
+
+export const List: ListNamespace = Object.assign(ListRoot, {
+  Item: ListItem,
+  ItemAction: ListItemAction,
+});

--- a/packages/ui/src/components/List/index.ts
+++ b/packages/ui/src/components/List/index.ts
@@ -1,0 +1,1 @@
+export { List, type ListItemActionProps, type ListItemProps, type ListProps } from './List';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,7 @@ export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/Drawer';
 export * from './components/Input';
+export * from './components/List';
 export * from './components/Modal';
 export * from './components/Popover';
 export * from './components/PressableButton';


### PR DESCRIPTION
## Summary

Seventeenth Phase 1 primitive group (P17) — vertical, semantic list. UUI doesn't ship a generic List base; the only matches are pricing tables and full data tables. Glaon hand-rolls a thin layout primitive on top of \`<ul>\` / \`<li>\` using kit surface vocabulary as canonical reference (\`bg-primary\` + \`border-secondary_alt\` + \`divide-secondary_alt\`). Same wrap-pattern ladder as P4 Card and P10 TopBar — kit token CSS as canon, content fully parameterized.

## Surface

- \`List\` root — \`dividers\` (thin border between items), \`bordered\` (wrap in card surface), \`emptyState\` (custom placeholder for the zero-children case), \`className\`, \`children\`. Renders \`<ul role="list">\` for non-empty, \`<div>\` with default empty copy otherwise.
- \`List.Item\` — \`leading\` slot (Avatar / icon), \`trailing\` slot (Badge / \`<List.ItemAction>\`), \`onClick\` (promotes to interactive row), \`current\` (drives \`aria-current="page"\`).
- \`List.ItemAction\` — trailing button helper with hover + focus styling.

## Scope (In)

- \`components/List/{List.tsx,List.stories.tsx,index.ts}\` — wrap + 11 stories (Default, Bordered, WithDividers, WithLeadingIcon, WithAvatar, WithActions, WithBadges, Selectable, Interactive, Empty, EmptyCustom).
- \`packages/ui/src/index.ts\` barrel re-exports the new family.

## Scope (Out)

- **Virtualized list** — Phase 2 (or under \`Table\` P18).
- **Drag-to-reorder** — Phase 2.
- **Async data loading** — Phase 2.
- **RN \`List.native.tsx\`** — UUI is web-only; Phase 2 follow-up uses \`FlatList\`.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui build\` clean (\`tsc -b\`)
- [x] \`pnpm --filter @glaon/ui test --run\` — 81 passing (was 78; +3 for List × 3 prop-coverage assertions)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI: every story passes axe at \`error\` severity (\`role="list"\` + \`role="listitem"\`)
- [ ] Storybook spot-check: light + dark; Selectable items toggle, Interactive row hover/focus + aria-current, Empty fallback render
- [ ] Chromatic snapshots accepted

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)