### PR TITLE
fix(renovate): align rangeStrategy with syncpack caret policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices", ":semanticCommits"],
   "baseBranchPatterns": ["development"],
+  "rangeStrategy": "replace",
   "timezone": "Europe/Istanbul",
   "schedule": ["before 9am on monday"],
   "prConcurrentLimit": 5,
@@ -36,29 +37,15 @@
       "dependencyDashboardApproval": true
     },
     {
-      "matchPackageNames": [
-        "storybook",
-        "@storybook/**",
-        "storybook-dark-mode"
-      ],
+      "matchPackageNames": ["storybook", "@storybook/**", "storybook-dark-mode"],
       "groupName": "storybook"
     },
     {
-      "matchPackageNames": [
-        "react",
-        "react-dom",
-        "@types/react",
-        "@types/react-dom"
-      ],
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
       "groupName": "react 19"
     },
     {
-      "matchPackageNames": [
-        "react-native",
-        "react-native-web",
-        "expo",
-        "expo-**"
-      ],
+      "matchPackageNames": ["react-native", "react-native-web", "expo", "expo-**"],
       "groupName": "react native + expo"
     },
     {
@@ -85,12 +72,7 @@
       "groupName": "chromatic"
     },
     {
-      "matchPackageNames": [
-        "@commitlint/**",
-        "commitlint",
-        "husky",
-        "lint-staged"
-      ],
+      "matchPackageNames": ["@commitlint/**", "commitlint", "husky", "lint-staged"],
       "groupName": "commit hooks"
     },
     {


### PR DESCRIPTION
## Summary

- Override `config:best-practices`'s `:pinDevDependencies` behavior with `rangeStrategy: "replace"` so Renovate version bumps preserve the existing caret prefix instead of pinning to exact versions.
- This unblocks all Renovate "pin dependencies" PRs that currently fail the `syncpack:lint` check by design (#195, #196, #198, #199).
- Drive-by: prettier-normalize `renovate.json` formatting (single-line arrays where they fit on one line). No semantic change beyond the new option.

## Why

`.syncpackrc.json` enforces `"range": "^"` for non-workspace, non-Expo deps and CI runs `syncpack lint` on every PR. The inherited `:pinDevDependencies` preset writes exact pins, which is the exact opposite. Every Renovate pin-style PR hits the policy wall on the `Cross-workspace dep consistency (syncpack)` step.

`replace` updates the version while keeping the caller's range prefix — caret stays caret, tilde stays tilde. This is the strategy that aligns with the repo's syncpack policy.

## Scope

In:
- `renovate.json`: add top-level `"rangeStrategy": "replace"`
- `renovate.json`: prettier reformat (cosmetic)

Out:
- No `.syncpackrc.json` edits — caret policy stays
- No version bumps — that's what the rebased Renovate PRs will deliver after this lands
- `config:best-practices` stays in `extends` — only the range pinning is overridden

## Test plan

- [ ] CI green on this PR (the only meaningful gate is config validity + prettier; no version churn here)
- [ ] After merge, trigger Renovate rebase on #195/#196/#198/#199 via the dashboard "Click on this checkbox to rebase all open PRs at once"
- [ ] Confirm rebased PRs preserve caret prefixes and pass `syncpack:lint`

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)