### PR TITLE
feat(ui): restore F1.5-1 foundation + add P1 docs (F1.5-1+2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,10 @@ Secure custom frontend for Home Assistant. Web + wall tablet + mobile from a sin
 
 - Every new UI component (web or mobile) ships in the same PR with at least one Storybook story. No story, no merge.
 - Stories live next to the component as `<Component>.stories.tsx` using CSF 3.0.
+- Each component also ships with `<Component>.controls.ts` (typed control spec — single source of truth for variants + descriptions, consumed by both stories and MDX docs) and `<Component>.mdx` (narrative docs page replacing autodocs). Use the `defineControls` helper from `packages/ui/src/components/_internal/controls.ts`; the helper output stays compatible with the F6 prop-coverage gate.
 - Minimum per component: default state + at least one edge case (disabled / loading / error / empty, whichever applies).
 - Accessibility: `@storybook/addon-a11y` is enabled with `a11y.test: 'error'`. Don't silently disable; document any intentional exception inline.
-- Prop or variant additions to an existing component must update the corresponding stories in the same PR.
+- Prop or variant additions to an existing component must update the corresponding stories, controls spec, and MDX docs in the same PR.
 - Details and conventions: [docs/storybook.md](docs/storybook.md).
 
 ## E2E Smoke Rule (MANDATORY)

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -315,3 +315,29 @@ export const DarkOnly: Story = {
 - **`storybook` komutu "Cannot find module"** → `pnpm install` çalıştırdın mı? Paketler `packages/ui`'nin devDeps'inde; workspace kurulumu zorunlu.
 - **Story'de tip hatası** → `satisfies Meta<typeof Component>` kalıbını kullan; props inference'ı doğru çalışır.
 - **a11y uyarıları takılıyor** → kasıtlı istisna varsa story'de `parameters.a11y.test = 'off'` kullan ve yorum yaz; default'u sessizce gevşetme.
+
+## Phase 1.5 — Controls spec + MDX docs (MANDATORY)
+
+Yeni component eklerken her zaman üç dosya çıkar — Storybook stories file'ı tek başına yeterli değildir.
+
+### Üç dosya kontratı
+
+1. **`<Component>.controls.ts`** — typed control spec, story + MDX'in tek kaynağı.
+2. **`<Component>.stories.tsx`** — `defineControls(spec)` ile meta'yı kurar; `tags: ['autodocs']` **kullanılmaz** (MDX devraldı).
+3. **`<Component>.mdx`** — narrative docs sayfası: When to use / When NOT / Anatomy / Variants / Props / A11y / Related.
+
+### `defineControls` helper
+
+`packages/ui/src/components/_internal/controls.ts` her prop için tek bir `ControlSpec` kabul eder. `description` alanı zorunlu — Storybook controls panelinde **ve** MDX `<Controls />` block'unda aynı string render olur.
+
+### MDX kurulum notu
+
+`@storybook/addon-docs` `packages/ui/devDependencies`'de zorunlu. `.storybook/main.ts` `addons` listesinde de yer alır. MDX import'ları her zaman `@storybook/addon-docs/blocks` yolundan yapılır (Storybook 10'da `@storybook/blocks` doğrudan resolve edilmez).
+
+### Source code panel default açık
+
+`.storybook/preview.ts` `parameters.docs.source.state: 'open'` set ediyor. Her story canvas'ında JSX snippet "Show code" butonu basılmadan görünür.
+
+### F6 prop-coverage gate uyumu
+
+`defineControls` çıktısı doğrudan F6 gate'in beklediği shape'i üretir (`args` ∪ `argTypes` ∪ `excludeFromArgs` her prop'u kapsar). Test (`packages/ui/src/__tests__/prop-coverage.test.ts`) değişmeden çalışır.

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -12,6 +12,10 @@ export default defineMain({
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-designs',
+    // `addon-docs` enables MDX file processing — Storybook 10 ships
+    // autodocs in core but `*.mdx` parsing needs this addon
+    // explicitly so Phase 1.5's per-component docs pages compile.
+    '@storybook/addon-docs',
     '@storybook/addon-themes',
     '@storybook/addon-vitest',
     'storybook-dark-mode',

--- a/packages/ui/.storybook/preview.ts
+++ b/packages/ui/.storybook/preview.ts
@@ -20,6 +20,16 @@ const preview: Preview = {
     a11y: {
       test: 'error',
     },
+    docs: {
+      // Surface the JSX snippet panel under every story canvas by
+      // default — Storybook 10 already renders it on demand via the
+      // "Show code" button, but Phase 1.5 wants the source visible
+      // without the extra click so consumers learn the API by
+      // reading the live snippet next to the rendered output.
+      source: {
+        state: 'open',
+      },
+    },
   },
   decorators: [
     withThemeByDataAttribute({

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,7 @@
     "@glaon/config": "workspace:*",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-designs": "^11.1.3",
+    "@storybook/addon-docs": "^10.3.5",
     "@storybook/addon-mcp": "^0.6.0",
     "@storybook/addon-themes": "^10.3.5",
     "@storybook/addon-vitest": "^10.3.5",

--- a/packages/ui/src/components/Badge/Badge.controls.ts
+++ b/packages/ui/src/components/Badge/Badge.controls.ts
@@ -1,0 +1,64 @@
+// `Badge.controls.ts` — single source of truth for Badge's variant
+// matrix. Story (`Badge.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Badge.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const typeOptions = ['pill-color', 'color', 'modern'] as const;
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+const colorOptions = [
+  'gray',
+  'brand',
+  'error',
+  'warning',
+  'success',
+  'slate',
+  'sky',
+  'blue',
+  'indigo',
+  'purple',
+  'pink',
+  'orange',
+] as const;
+
+export const badgeControls = {
+  children: {
+    type: 'text',
+    default: 'Label',
+    description:
+      'Bold inline text shown inside the badge. Keep to 1–2 words; for multi-line use Alert (P2).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  type: {
+    type: 'inline-radio',
+    options: typeOptions,
+    default: 'pill-color',
+    description:
+      'Shape variant. `pill-color` is fully rounded; `color` is square-ish; `modern` strips the colour fill for a minimal chip.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof typeOptions)[number]>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description: 'Visual scale; `sm` for dense lists, `lg` for headline counts.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  color: {
+    type: 'select',
+    options: colorOptions,
+    default: 'gray',
+    description:
+      'Semantic palette. Use `success` / `warning` / `error` for status meanings; `brand` for promoted highlights; `gray` for neutral metadata.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof colorOptions)[number]>,
+  className: {
+    type: false,
+    description:
+      "Tailwind override hook. Stories don't expose this — consumers can pass extra utility classes when needed.",
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const badgeExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Badge/Badge.mdx
+++ b/packages/ui/src/components/Badge/Badge.mdx
@@ -1,0 +1,65 @@
+{/_ Glaon Badge — narrative docs page. Storybook auto-discovers
+`_.mdx`from the`stories`glob in`.storybook/main.ts` and
+    surfaces this page under the same sidebar entry as the Badge
+    stories (`Web Primitives/Badge`→ "Docs" tab). The content
+    references the same`badgeControls` spec that drives the story
+canvas, so the docs panel and the controls panel never drift. \*/}
+
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as BadgeStories from './Badge.stories';
+
+<Meta of={BadgeStories} />
+
+# Badge
+
+Inline label for status, category, or count. Visually paired with a
+number, icon, or short text. Lighter than an Alert (P2) and lower-stakes
+than a Toast (P16) — Badge is non-interactive metadata.
+
+## When to use
+
+- Show device status next to a name: **Online** / **Offline** / **Updating**.
+- Indicate counts inside list items (12 unread, 3 errors).
+- Tag entities by category (Active / Archived / Draft).
+- Highlight new or beta features (a `brand`-coloured `New` chip).
+
+## When NOT to use
+
+- **Multi-line messages** → use [Alert](?path=/docs/web-primitives-alert--docs) for inline status.
+- **Standalone notifications** → use [Toast](?path=/docs/web-primitives-toast--docs) for transient feedback.
+- **Calls to action** → Badges are non-interactive. Use [Button](?path=/docs/web-primitives-button--docs).
+
+## Anatomy
+
+<Canvas of={BadgeStories.Default} />
+
+A Badge is a single-line, fully-styled `<span>`. It does not accept
+icons through props in this primitive — for icon + text combinations
+use the kit's `BadgeWithIcon` (also re-exported from `@glaon/ui`).
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Renders inline as a `<span>`; no role override is needed for purely
+  decorative use.
+- For status meaning, **never rely on colour alone** — the text content
+  must convey the same information (axe `aria-allowed-attr` and design
+  system contrast tokens both enforce this).
+- When wrapping a meaningful label, pair Badge with surrounding text:
+  `<span>Status: <Badge color="success">Online</Badge></span>` so screen
+  readers announce the relationship.
+
+## Related components
+
+- [Alert](?path=/docs/web-primitives-alert--docs) — inline message with title + body.
+- [Toast](?path=/docs/web-primitives-toast--docs) — transient overlay notification.
+- [Avatar](?path=/docs/web-primitives-avatar--docs) — `Avatar.count` prop renders Badge styling.
+- [Stat](?path=/docs/web-primitives-stat--docs) — KPI card with optional delta indicator.

--- a/packages/ui/src/components/Badge/Badge.mdx
+++ b/packages/ui/src/components/Badge/Badge.mdx
@@ -1,10 +1,3 @@
-{/_ Glaon Badge — narrative docs page. Storybook auto-discovers
-`_.mdx`from the`stories`glob in`.storybook/main.ts` and
-    surfaces this page under the same sidebar entry as the Badge
-    stories (`Web Primitives/Badge`→ "Docs" tab). The content
-    references the same`badgeControls` spec that drives the story
-canvas, so the docs panel and the controls panel never drift. \*/}
-
 import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
 
 import * as BadgeStories from './Badge.stories';

--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -1,53 +1,37 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Badge } from './Badge';
+import { badgeControls, badgeExcludeFromArgs } from './Badge.controls';
+
+const { args, argTypes } = defineControls(badgeControls);
 
 // Explicit `Meta<typeof Badge>` annotation (rather than `satisfies`) keeps
 // the kit's unexported `BadgeProps` interface out of the exported type
 // signature — `tsc --noEmit` runs with `declaration: true` and TS4023
 // fires when an exported `meta` resolves to a non-exported nominal type.
+//
+// Phase 1.5: `args` + `argTypes` come from `Badge.controls.ts` so the
+// story file stays declarative; the MDX docs page (`Badge.mdx`) reads
+// from the same spec. `tags: ['autodocs']` removed — the MDX page
+// replaces autodocs as the per-component documentation entry point.
 const meta: Meta<typeof Badge> = {
   title: 'Web Primitives/Badge',
   component: Badge,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-badge',
     },
   },
-  args: {
-    children: 'Label',
-    type: 'pill-color',
-    size: 'md',
-    color: 'gray',
-  },
-  argTypes: {
-    type: { control: 'inline-radio', options: ['pill-color', 'color', 'modern'] },
-    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
-    color: {
-      control: 'select',
-      options: [
-        'gray',
-        'brand',
-        'error',
-        'warning',
-        'success',
-        'slate',
-        'sky',
-        'blue',
-        'indigo',
-        'purple',
-        'pink',
-        'orange',
-      ],
-    },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
 };
 
 export default meta;
 type Story = StoryObj<typeof Badge>;
+
+export const excludeFromArgs = badgeExcludeFromArgs;
 
 export const Default: Story = {};
 

--- a/packages/ui/src/components/ProgressBar/ProgressBar.controls.ts
+++ b/packages/ui/src/components/ProgressBar/ProgressBar.controls.ts
@@ -1,0 +1,79 @@
+// `ProgressBar.controls.ts` — single source of truth for ProgressBar's
+// variant matrix. Story (`ProgressBar.stories.tsx`) imports the spec
+// and spreads it into `meta.args` / `meta.argTypes`; MDX docs
+// (`ProgressBar.mdx`) reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const labelPositionOptions = ['right', 'bottom', 'top-floating', 'bottom-floating'] as const;
+
+export const progressBarControls = {
+  value: {
+    type: 'number',
+    min: 0,
+    max: 100,
+    step: 1,
+    default: 60,
+    description:
+      'Current progress value. Coerced into a 0–100 percent against `min` / `max` for the bar fill and the formatted label.',
+    category: 'Content',
+  } satisfies ControlSpec<number>,
+  min: {
+    type: 'number',
+    min: 0,
+    max: 100,
+    step: 1,
+    default: 0,
+    description: 'Lower bound of the value range. Default 0.',
+    category: 'Content',
+  } satisfies ControlSpec<number>,
+  max: {
+    type: 'number',
+    min: 0,
+    max: 1000,
+    step: 10,
+    default: 100,
+    description: 'Upper bound of the value range. Default 100.',
+    category: 'Content',
+  } satisfies ControlSpec<number>,
+  labelPosition: {
+    type: 'inline-radio',
+    options: labelPositionOptions,
+    default: 'right',
+    description:
+      'Where the formatted percentage label renders relative to the bar. `right` / `bottom` pin the text statically; `top-floating` / `bottom-floating` track the fill horizontally with a tooltip-style chip.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof labelPositionOptions)[number]>,
+  valueFormatter: {
+    type: false,
+    action: 'format',
+    description:
+      'Optional `(value, percentage) => ReactNode` formatter. Receives both the raw value and the calculated percentage so consumers can render units (`32 / 100 MB`, `3 of 5 steps`).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer track element.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  progressClassName: {
+    type: false,
+    description: 'Tailwind override hook for the inner fill element.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  'aria-label': {
+    type: 'text',
+    default: 'Progress',
+    description:
+      'Accessible name for the progressbar. Required by axe `aria-progressbar-name` whenever no `aria-labelledby` points at a labelling element.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  'aria-labelledby': {
+    type: 'text',
+    description: 'ID(s) of element(s) that label the progressbar. Alternative to `aria-label`.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const progressBarExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/ProgressBar/ProgressBar.mdx
+++ b/packages/ui/src/components/ProgressBar/ProgressBar.mdx
@@ -1,0 +1,60 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as ProgressBarStories from './ProgressBar.stories';
+
+<Meta of={ProgressBarStories} />
+
+# ProgressBar
+
+Determinate progress indicator. Shows the user how far along a task
+is when the percentage is known. For unknown duration prefer
+**Spinner**; for transient feedback prefer **Toast**.
+
+## When to use
+
+- File upload / download progress.
+- Multi-step wizard or onboarding flow.
+- Storage / quota meters (32 of 100 GB used).
+- Any task where the user cares about how much is left.
+
+## When NOT to use
+
+- **Indeterminate work** (fetch, save, reconnect) → use [Spinner](?path=/docs/web-primitives-spinner--docs).
+- **Empty / loading state** for a list → the host component's empty
+  slot is more appropriate.
+- **Status announcement** ("uploaded successfully") → use [Toast](?path=/docs/web-primitives-toast--docs).
+
+## Anatomy
+
+<Canvas of={ProgressBarStories.Default} />
+
+The bar exposes a track + fill DIV pair. The fill width is computed
+from `((value − min) / (max − min)) × 100%`. Optional label rendered
+inside, beside, or above (depends on `labelPosition`).
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Renders as `<div role="progressbar">` with `aria-valuenow` /
+  `aria-valuemin` / `aria-valuemax` wired automatically.
+- **`aria-label` is required** — axe `aria-progressbar-name` fires
+  on every progressbar element without an accessible name. Always
+  pass `aria-label` (or `aria-labelledby` if a sibling element
+  already names the bar).
+- The kit was patched to forward `aria-label` and `aria-labelledby`
+  through `ProgressBarBase` (kit shipped without this support; see
+  `base/progress-indicators/progress-indicators.tsx` GLAON PATCH).
+- The fill animation is CSS `transform: translateX()` — respects
+  `prefers-reduced-motion` automatically (no JS-driven motion).
+
+## Related components
+
+- [Spinner](?path=/docs/web-primitives-spinner--docs) — indeterminate progress.
+- [Stat](?path=/docs/web-primitives-stat--docs) — KPI card with optional delta indicator.

--- a/packages/ui/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/ui/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,46 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { ProgressBar } from './ProgressBar';
+import { progressBarControls, progressBarExcludeFromArgs } from './ProgressBar.controls';
+
+const { args, argTypes } = defineControls(progressBarControls);
 
 // Explicit `Meta<typeof ProgressBar>` annotation (rather than `satisfies`)
 // keeps storybook's csf-internal types out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true` and trips
 // TS2742 on inferred references to `storybook/internal/csf`.
+//
+// Phase 1.5: `args` + `argTypes` come from `ProgressBar.controls.ts`;
+// `tags: ['autodocs']` removed because `ProgressBar.mdx` replaces
+// the docs tab.
 const meta: Meta<typeof ProgressBar> = {
   title: 'Web Primitives/ProgressBar',
   component: ProgressBar,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-progressbar',
     },
   },
-  args: {
-    value: 60,
-    min: 0,
-    max: 100,
-    labelPosition: 'right',
-    // Default accessible name. axe `aria-progressbar-name` requires every
-    // `role="progressbar"` element to expose a name; the kit doesn't
-    // imply one from sibling label text. Stories override per-context
-    // when a more specific label fits.
-    'aria-label': 'Progress',
-  },
-  argTypes: {
-    value: { control: { type: 'number', min: 0, max: 100, step: 1 } },
-    min: { control: { type: 'number', min: 0, max: 100, step: 1 } },
-    max: { control: { type: 'number', min: 0, max: 1000, step: 10 } },
-    labelPosition: {
-      control: 'inline-radio',
-      options: ['right', 'bottom', 'top-floating', 'bottom-floating'],
-    },
-    valueFormatter: { control: false, action: 'format' },
-    className: { control: false, table: { disable: true } },
-    progressClassName: { control: false, table: { disable: true } },
-    'aria-label': { control: 'text' },
-    'aria-labelledby': { control: 'text' },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 320, padding: 24 }}>
@@ -52,6 +36,8 @@ const meta: Meta<typeof ProgressBar> = {
 
 export default meta;
 type Story = StoryObj<typeof ProgressBar>;
+
+export const excludeFromArgs = progressBarExcludeFromArgs;
 
 export const Default: Story = {};
 

--- a/packages/ui/src/components/Spinner/Spinner.controls.ts
+++ b/packages/ui/src/components/Spinner/Spinner.controls.ts
@@ -1,0 +1,38 @@
+// `Spinner.controls.ts` — single source of truth for Spinner's variant
+// matrix. Story (`Spinner.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Spinner.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const typeOptions = ['line-simple', 'line-spinner', 'dot-circle'] as const;
+const sizeOptions = ['sm', 'md', 'lg', 'xl'] as const;
+
+export const spinnerControls = {
+  type: {
+    type: 'inline-radio',
+    options: typeOptions,
+    default: 'line-simple',
+    description:
+      'Visual style. `line-simple` is a thin partial circle (default for inline indicators); `line-spinner` is a filled brand arc (used inside Buttons via `isLoading`); `dot-circle` is a gradient-stroke dotted ring (richer empty-state pattern).',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof typeOptions)[number]>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'sm',
+    description:
+      'Visual scale. `sm` for inline buttons / inputs; `md` / `lg` for section-level loading; `xl` for full-page suspense fallbacks.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  label: {
+    type: 'text',
+    default: '',
+    description:
+      'Optional caption rendered below the spinner. When present provides an accessible name for the busy region; when empty the parent must label the loading state via `aria-label`.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const spinnerExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Spinner/Spinner.mdx
+++ b/packages/ui/src/components/Spinner/Spinner.mdx
@@ -1,0 +1,53 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as SpinnerStories from './Spinner.stories';
+
+<Meta of={SpinnerStories} />
+
+# Spinner
+
+Indeterminate loading indicator. Communicates that work is in progress
+when the duration is unknown — for known progress prefer **ProgressBar**.
+
+## When to use
+
+- Inline inside a Button (`isLoading` prop already wires this).
+- Inside a list cell while a row is fetching its own data.
+- As a section-level placeholder while a panel waits for its first
+  payload (combined with a `label` for screen readers).
+- Full-page Suspense fallback during route transitions.
+
+## When NOT to use
+
+- **Determinate progress** (file upload, multi-step task) → use [ProgressBar](?path=/docs/web-primitives-progressbar--docs).
+- **Long-running background work** with no UI to block → use a [Toast](?path=/docs/web-primitives-toast--docs) instead so the user can keep working.
+- **Empty states** (no data exists yet) → use the empty-state slot of the host component, not a spinner.
+
+## Anatomy
+
+<Canvas of={SpinnerStories.Default} />
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Wraps the SVG in a `<div role="status">` flex container — screen
+  readers announce changes to its child text.
+- The SVG itself is `aria-hidden`; the visible label is the accessible
+  name. Always pass `label` for non-decorative uses, or wrap the
+  spinner in an element that provides an accessible name (e.g. a
+  Button with text content).
+- Animation respects `prefers-reduced-motion`: the kit's
+  `animate-spin` Tailwind utility falls back to a static state when
+  the user opts out.
+
+## Related components
+
+- [ProgressBar](?path=/docs/web-primitives-progressbar--docs) — determinate progress with known percentage.
+- [Button](?path=/docs/web-primitives-button--docs) — `isLoading` prop renders Spinner inline automatically.

--- a/packages/ui/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/ui/src/components/Spinner/Spinner.stories.tsx
@@ -1,39 +1,37 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Spinner } from './Spinner';
+import { spinnerControls, spinnerExcludeFromArgs } from './Spinner.controls';
+
+const { args, argTypes } = defineControls(spinnerControls);
 
 // Explicit `Meta<typeof Spinner>` annotation (rather than `satisfies`)
 // keeps the kit's unexported `LoadingIndicatorProps` interface out of
 // the exported `meta` signature — `tsc --noEmit` runs with
 // `declaration: true` and TS4023 fires when an exported `meta` resolves
 // to a non-exported nominal type.
+//
+// Phase 1.5: `args` + `argTypes` come from `Spinner.controls.ts`;
+// `tags: ['autodocs']` removed because `Spinner.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Spinner> = {
   title: 'Web Primitives/Spinner',
   component: Spinner,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-spinner',
     },
   },
-  args: {
-    type: 'line-simple',
-    size: 'sm',
-    label: '',
-  },
-  argTypes: {
-    type: {
-      control: 'inline-radio',
-      options: ['line-simple', 'line-spinner', 'dot-circle'],
-    },
-    size: { control: 'inline-radio', options: ['sm', 'md', 'lg', 'xl'] },
-    label: { control: 'text' },
-  },
+  args,
+  argTypes,
 };
 
 export default meta;
 type Story = StoryObj<typeof Spinner>;
+
+export const excludeFromArgs = spinnerExcludeFromArgs;
 
 export const Default: Story = {};
 

--- a/packages/ui/src/components/_internal/controls.ts
+++ b/packages/ui/src/components/_internal/controls.ts
@@ -1,0 +1,159 @@
+// `defineControls` — typed config → Storybook `meta.args` + `meta.argTypes`.
+//
+// Phase 1.5 introduces a `<Component>.controls.ts` file next to every
+// `<Component>.stories.tsx`. The controls file declares each public prop
+// once: its Storybook control type, options, default value, and a
+// human-readable description. The story imports the spec, calls
+// `defineControls()`, and spreads the result into the story meta. Same
+// spec can be referenced from `<Component>.mdx` so the docs panel
+// matches the controls panel verbatim.
+//
+// The helper output shape is intentionally aligned with the F6
+// prop-coverage gate (`packages/ui/src/__tests__/prop-coverage.test.ts`)
+// — `args` keys + `argTypes` keys + the optional named-export
+// `excludeFromArgs` array still satisfy the "every prop covered" rule
+// without changes to the test.
+
+import type { Args, ArgTypes } from '@storybook/react-native-web-vite';
+
+/**
+ * Storybook control category — drives the grouping in the controls
+ * panel. Keep the set small and stable so docs stay scannable.
+ */
+export type ControlCategory = 'Content' | 'Style' | 'Behavior' | 'A11y';
+
+/**
+ * One control spec for a single prop. The `type` mirrors Storybook's
+ * `argTypes[key].control.type` plus the literal `false` to disable the
+ * row entirely (e.g. for kit-internal slot props).
+ */
+export interface ControlSpec<TValue> {
+  /** Storybook control flavour. `false` hides the control row. */
+  type: 'text' | 'boolean' | 'inline-radio' | 'select' | 'number' | 'object' | 'color' | false;
+  /** Enum / select options. Required when `type` is `inline-radio` or `select`. */
+  options?: readonly TValue[];
+  /** Default value rendered in `meta.args`. */
+  default?: TValue;
+  /** Number control min (only when `type === 'number'`). */
+  min?: number;
+  /** Number control max (only when `type === 'number'`). */
+  max?: number;
+  /** Number control step (only when `type === 'number'`). */
+  step?: number;
+  /**
+   * Human-readable description of what this prop does. Surfaces in
+   * the Storybook controls panel and (when MDX docs reference the
+   * same spec) in the docs page.
+   */
+  description: string;
+  /** Optional grouping in the controls panel. */
+  category?: ControlCategory;
+  /**
+   * Mapping table for icon-style picker — `{ none: undefined, plus: PlusIcon }`.
+   * Storybook renders the keys as the picker labels and forwards the
+   * mapped values as the actual prop value.
+   */
+  mapping?: Record<string, unknown>;
+  /**
+   * Storybook action name for callback props (`{ action: 'pressed' }`
+   * fires actions panel events on activation).
+   */
+  action?: string;
+}
+
+/** Map of prop name → control spec. */
+type ComponentControls = Record<string, ControlSpec<unknown>>;
+
+/**
+ * Compile a controls spec into Storybook's `meta.args` + `meta.argTypes`.
+ *
+ * - `args` carries every spec entry that has a `default` (so the story
+ *   renders with realistic initial state).
+ * - `argTypes` carries every spec entry's full `control` config plus
+ *   `description` and `table.category`, so the controls panel and
+ *   autodocs render the right widget and copy.
+ *
+ * The keys returned in both objects mirror the spec keys exactly, so
+ * the F6 prop-coverage gate's union check (`args ∪ argTypes ∪
+ * excludeFromArgs`) stays satisfied without any test changes.
+ */
+export function defineControls(spec: ComponentControls): {
+  args: Args;
+  argTypes: Partial<ArgTypes>;
+} {
+  const args: Args = {};
+  const argTypes: Record<string, unknown> = {};
+
+  for (const [key, entry] of Object.entries(spec)) {
+    if (entry.default !== undefined) {
+      args[key] = entry.default;
+    }
+    argTypes[key] = toArgType(entry);
+  }
+
+  return { args, argTypes: argTypes as Partial<ArgTypes> };
+}
+
+function toArgType(entry: ControlSpec<unknown>): unknown {
+  const table: { category?: string; disable?: boolean } = {};
+  if (entry.category !== undefined) {
+    table.category = entry.category;
+  }
+  if (entry.type === false) {
+    table.disable = true;
+    const result: Record<string, unknown> = {
+      control: false,
+      description: entry.description,
+      table,
+    };
+    if (entry.action !== undefined) {
+      result.action = entry.action;
+    }
+    return result;
+  }
+
+  let control: unknown;
+  if (entry.type === 'number') {
+    const numberControl: { type: 'number'; min?: number; max?: number; step?: number } = {
+      type: 'number',
+    };
+    if (entry.min !== undefined) numberControl.min = entry.min;
+    if (entry.max !== undefined) numberControl.max = entry.max;
+    if (entry.step !== undefined) numberControl.step = entry.step;
+    control = numberControl;
+  } else if (entry.type === 'inline-radio' || entry.type === 'select') {
+    control = entry.type;
+  } else {
+    control = entry.type;
+  }
+
+  const result: Record<string, unknown> = {
+    control,
+    description: entry.description,
+    table,
+  };
+  if (entry.options !== undefined) {
+    result.options = entry.options;
+  }
+  if (entry.mapping !== undefined) {
+    result.mapping = entry.mapping;
+  }
+  if (entry.action !== undefined) {
+    result.action = entry.action;
+  }
+  return result;
+}
+
+/**
+ * Marker helper for the F6 prop-coverage gate. Pass any prop names that
+ * the gate's `react-docgen-typescript` introspection extracts but that
+ * the controls spec deliberately omits (RAC-internal `slot`,
+ * `aria-*`-forwarded props, kit-internal class names, etc.).
+ *
+ * Returns the input array unchanged — the helper exists so each
+ * controls file imports it explicitly and the named-export contract
+ * with the gate is documented.
+ */
+export function excludeFromArgs(props: readonly string[]): readonly string[] {
+  return props;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,7 +229,10 @@ importers:
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@storybook/addon-designs':
         specifier: ^11.1.3
-        version: 11.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 11.1.3(@storybook/addon-docs@10.3.5(@types/react@19.2.14)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      '@storybook/addon-docs':
+        specifier: ^10.3.5
+        version: 10.3.5(@types/react@19.2.14)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@storybook/addon-mcp':
         specifier: ^0.6.0
         version: 0.6.0(@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5)(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.7.3)
@@ -1414,6 +1417,12 @@ packages:
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
 
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -2255,6 +2264,11 @@ packages:
       react-dom:
         optional: true
 
+  '@storybook/addon-docs@10.3.5':
+    resolution: {integrity: sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA==}
+    peerDependencies:
+      storybook: ^10.3.5
+
   '@storybook/addon-mcp@0.6.0':
     resolution: {integrity: sha512-E79m2S7ik9wiF1AnI49fwbLQkrD03PicIZpCdeFhbbB19MF4tKFKyaQtbT3f6eaAP4EP2+COLDVLCQ7B3rGF4w==}
     peerDependencies:
@@ -2580,6 +2594,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
@@ -8107,6 +8124,12 @@ snapshots:
     dependencies:
       '@braidai/lang': 1.1.2
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.14
+      react: 19.2.5
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
@@ -8840,15 +8863,33 @@ snapshots:
       axe-core: 4.11.3
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/addon-designs@11.1.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+  '@storybook/addon-designs@11.1.3(@storybook/addon-docs@10.3.5(@types/react@19.2.14)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
     dependencies:
       '@figspec/react': 2.0.1(@types/react@19.2.14)(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
+      '@storybook/addon-docs': 10.3.5(@types/react@19.2.14)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     transitivePeerDependencies:
       - '@types/react'
+
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@storybook/csf-plugin': 10.3.5(rollup@4.60.2)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+      '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
 
   '@storybook/addon-mcp@0.6.0(@storybook/addon-vitest@10.3.5(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5)(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5))(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@5.7.3)':
     dependencies:
@@ -9180,6 +9221,8 @@ snapshots:
       '@types/istanbul-lib-report': 3.0.3
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdx@2.0.13': {}
 
   '@types/node@22.19.17':
     dependencies:


### PR DESCRIPTION
## Recovery context

PR #253 (F1.5-1) merged with an **empty squash** — during a force-push to amend the commit subject under 72 chars, branch confusion left the remote tree pointed at a renovate commit, so the squash merge captured no file changes. The development tip claims F1.5-1 landed but \`packages/ui/src/components/_internal/controls.ts\` + Badge files + Storybook config + docs updates never materialized on \`development\`.

This PR **re-applies F1.5-1 in full** and adds **F1.5-2 (Spinner + ProgressBar)** on top so the foundation lands together with the first conversion slice.

## What lands

### F1.5-1 (re-apply)

- \`_internal/controls.ts\` — \`defineControls()\` + \`excludeFromArgs()\` helpers. Typed \`ControlSpec\` entries (type / options / default / description / category / mapping) compile into Storybook \`meta.args\` + \`meta.argTypes\`. Description surfaces in both the controls panel and MDX \`<Controls />\`.
- \`.storybook/preview.ts\` — \`parameters.docs.source.state: 'open'\` defaults JSX snippet panel under every canvas.
- \`.storybook/main.ts\` — \`@storybook/addon-docs\` in addons list.
- \`packages/ui/package.json\` — \`@storybook/addon-docs\` devDep.
- \`Badge.controls.ts\` (5 entries) + \`Badge.mdx\` (full sections) + \`Badge.stories.tsx\` refactor (helper-driven, no \`tags: ['autodocs']\`).
- \`CLAUDE.md\` Storybook Rule extended with controls + MDX requirement.
- \`docs/storybook.md\` Phase 1.5 section: three-file contract, helper API, MDX import path note (\`@storybook/addon-docs/blocks\`), F6 gate compatibility, source panel default.

### F1.5-2 (P1 conversion — Spinner + ProgressBar)

- \`Spinner.controls.ts\` (3 entries: type / size / label) + \`Spinner.mdx\` (When to use / When NOT / Anatomy / Variants / Props / A11y / Related) + \`Spinner.stories.tsx\` refactor.
- \`ProgressBar.controls.ts\` (9 entries, incl. \`aria-label\` / \`aria-labelledby\` for axe \`aria-progressbar-name\` compliance) + \`ProgressBar.mdx\` + \`ProgressBar.stories.tsx\` refactor.

Badge was already converted in F1.5-1, so this PR completes the full P1 conversion.

## Why combined

PR #253's empty merge means \`development\` is missing the foundation files. F1.5-2 depends on \`_internal/controls.ts\`, so it can't be split into a separate PR until the foundation is restored. Combining the two slices is the simplest recovery path; the next 16 conversions (F1.5-3 … F1.5-19) can each be separate PRs as originally planned.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui build\` clean (\`tsc -b\`)
- [x] \`pnpm --filter @glaon/ui test --run\` — 84/84 passing (F6 prop-coverage gate green)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI green
- [ ] Storybook spot-check: Badge / Spinner / ProgressBar "Docs" tabs show MDX (not autodocs); "Show code" panel open by default; controls panel rows have descriptions
- [ ] Chromatic UI Tests baseline accept

Closes #252
Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)