### PR TITLE
fix(ui): Badge type='modern' crash on non-gray colors

### DIFF
--- a/packages/ui/src/components/Badge/Badge.controls.ts
+++ b/packages/ui/src/components/Badge/Badge.controls.ts
@@ -51,7 +51,7 @@ export const badgeControls = {
     options: colorOptions,
     default: 'gray',
     description:
-      'Semantic palette. Use `success` / `warning` / `error` for status meanings; `brand` for promoted highlights; `gray` for neutral metadata.',
+      'Semantic palette. Use `success` / `warning` / `error` for status meanings; `brand` for promoted highlights; `gray` for neutral metadata. Note: `type="modern"` always renders the neutral grey treatment regardless of the selected colour (the kit ships only one modern variant; see #258).',
     category: 'Style',
   } satisfies ControlSpec<(typeof colorOptions)[number]>,
   className: {

--- a/packages/ui/src/components/base/badges/badges.tsx
+++ b/packages/ui/src/components/base/badges/badges.tsx
@@ -4,6 +4,16 @@
 // suppress type-check here so `untitledui upgrade` stays a clean replace
 // operation. Re-apply this comment after every kit upgrade until UUI
 // tightens their own types.
+//
+// GLAON PATCH (re-apply on upgrade): the upstream `withPillTypes`
+// `badgeModern` entry only ships a `gray` style. When consumers select
+// `type='modern'` with any other `color` (`brand`, `success`, …) the
+// render path crashes on `colors.styles[color].root` because the lookup
+// is `undefined`. We pre-fill all 12 colors on the modern style with
+// the same gray treatment — modern is intentionally a minimal chip
+// that doesn't carry colour semantics, so falling back to gray
+// preserves the kit's visual intent. Drop this patch once upstream
+// changes the schema. See #258.
 "use client";
 
 import type { MouseEventHandler, ReactNode } from "react";
@@ -92,13 +102,20 @@ const withPillTypes = {
     },
     [badgeTypes.badgeModern]: {
         common: "size-max flex items-center whitespace-nowrap rounded-md ring-1 ring-inset shadow-xs",
-        styles: {
-            gray: {
-                root: "bg-primary text-secondary ring-primary",
-                addon: "text-neutral-500",
-                addonButton: "hover:bg-utility-neutral-100 text-utility-neutral-400 hover:text-utility-neutral-500",
-            },
-        },
+        // GLAON PATCH: replicate the gray treatment across all 12
+        // colors so `type='modern'` doesn't crash when paired with a
+        // non-gray color. Modern intentionally renders neutrally
+        // regardless of the selected color.
+        styles: Object.fromEntries(
+            (Object.keys(filledColors) as BadgeColors[]).map((key) => [
+                key,
+                {
+                    root: "bg-primary text-secondary ring-primary",
+                    addon: "text-neutral-500",
+                    addonButton: "hover:bg-utility-neutral-100 text-utility-neutral-400 hover:text-utility-neutral-500",
+                },
+            ]),
+        ) as Record<BadgeColors, { root: string; addon: string; addonButton: string }>,
     },
 };
 


### PR DESCRIPTION
## Summary

Reported in #258 — the kit \`withPillTypes.badgeModern.styles\` only ships the \`gray\` entry. When the Storybook controls panel switches \`color\` to \`brand\` (or any other non-gray) while \`type='modern'\` is selected, the render path crashes:

\`\`\`
undefined is not an object (evaluating 'colors.styles[color].root')
  at Badge (packages/ui/src/components/base/badges/badges.tsx:131:71)
\`\`\`

## Fix

Modern is intentionally a neutral chip — the kit doesn't ship a coloured modern variant. **Pre-fill all 12 colors** on the modern \`styles\` map with the same gray treatment so the lookup always resolves and the component renders the kit's intended neutral appearance regardless of the selected color.

Same approach as previous kit patches (Avatar contrast fix, ProgressBar aria-label forwarding) — documented inline as a \`GLAON PATCH\` in the kit file's \`@ts-nocheck\` header so it gets re-applied after every \`untitledui upgrade\` until upstream changes the schema.

Also extends \`Badge.controls.ts\` \`color.description\` to flag the "modern always renders grey" caveat — appears in both the Storybook controls panel and the MDX docs.

## Files changed

- \`packages/ui/src/components/base/badges/badges.tsx\` — kit patch (header note + \`Object.fromEntries\` pre-fill).
- \`packages/ui/src/components/Badge/Badge.controls.ts\` — \`color\` description extended.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui build\` clean
- [x] \`pnpm --filter @glaon/ui test --run\` — 84/84 passing (F6 gate green)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI green
- [ ] Storybook spot-check: \`Web Primitives/Badge\` → switch \`type\` to \`modern\`, then cycle \`color\` through all 12 options — no crash, all render with the neutral grey treatment

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)