### PR TITLE
feat(ui): controls + MDX docs for Alert + Banner (F1.5-3)

### DIFF
--- a/packages/ui/src/components/Alert/Alert.controls.ts
+++ b/packages/ui/src/components/Alert/Alert.controls.ts
@@ -1,0 +1,70 @@
+// `Alert.controls.ts` — single source of truth for Alert's variant
+// matrix. Story (`Alert.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Alert.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+import { storybookIcons } from '../../icons/storybook';
+
+const intentOptions = ['info', 'success', 'warning', 'danger'] as const;
+
+export const alertControls = {
+  title: {
+    type: 'text',
+    default: 'New feature available',
+    description:
+      'Bold lead-in line. Keep it short — full-stop is optional. The intent icon renders inline next to it.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  description: {
+    type: 'text',
+    default: 'Check out the new dashboard.',
+    description:
+      'Optional secondary copy under the title. Use for one-line elaboration; for multi-paragraph content prefer Banner.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  intent: {
+    type: 'inline-radio',
+    options: intentOptions,
+    default: 'info',
+    description:
+      'Severity / colour group for the leading icon. `info` for neutral hints, `success` for confirmations, `warning` for time-sensitive prompts, `danger` for errors.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof intentOptions)[number]>,
+  dismissible: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Render the close button at the top-right corner. Pair with `onDismiss` to handle the click.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  dismissLabel: {
+    type: 'text',
+    default: 'Dismiss',
+    description:
+      'Accessible name for the close button. Defaults to "Dismiss"; localise per app locale.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  icon: {
+    type: 'select',
+    options: Object.keys(storybookIcons),
+    mapping: storybookIcons,
+    description:
+      'Override the default icon for the chosen intent. Pass any component from `@untitledui/icons` (or a custom React component with the same shape).',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  onDismiss: {
+    type: false,
+    action: 'dismissed',
+    description: 'Fires when the close button is clicked.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer container.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const alertExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Alert/Alert.mdx
+++ b/packages/ui/src/components/Alert/Alert.mdx
@@ -1,0 +1,61 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as AlertStories from './Alert.stories';
+
+<Meta of={AlertStories} />
+
+# Alert
+
+Inline status message. Use Alert when the user needs to read, but
+not necessarily act on, contextual information that lives next to
+the content it relates to. Heavier than a Badge (P1), lower-stakes
+than a Toast (P16).
+
+## When to use
+
+- Above a form section, explaining a constraint ("Email + password
+  is required to sign in").
+- Inside a settings page, calling attention to the impact of a flag.
+- After a save, confirming the result inline ("Profile saved.")
+  when the user is still viewing the form.
+
+## When NOT to use
+
+- **Page-level announcement** that's not tied to a specific section
+  → use [Banner](?path=/docs/web-primitives-banner--docs).
+- **Transient feedback** that should disappear → use [Toast](?path=/docs/web-primitives-toast--docs).
+- **Single-word status** → use [Badge](?path=/docs/web-primitives-badge--docs).
+
+## Anatomy
+
+<Canvas of={AlertStories.Default} />
+
+Layout: leading icon (intent-based), title + optional description
+(stacked vertically on mobile, inline-with-gap on desktop), optional
+close button at the top-right.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Renders as `<div role="status">` so screen readers announce the
+  text on insert / change.
+- The intent icon is `aria-hidden`; the title + description carry
+  the meaningful content.
+- Color alone never conveys meaning — title text always describes
+  the state ("Saved", "Connection lost", "Update available").
+- The close button is a real `<button>` with the configurable
+  `dismissLabel` as `aria-label` — keyboard reachable, focus ring
+  via `outline-focus-ring`.
+
+## Related components
+
+- [Banner](?path=/docs/web-primitives-banner--docs) — page-level announcement with optional CTA.
+- [Toast](?path=/docs/web-primitives-toast--docs) — transient overlay notification.
+- [Badge](?path=/docs/web-primitives-badge--docs) — single-word inline status.

--- a/packages/ui/src/components/Alert/Alert.stories.tsx
+++ b/packages/ui/src/components/Alert/Alert.stories.tsx
@@ -1,46 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
-import { storybookIcons } from '../../icons/storybook';
+import { defineControls } from '../_internal/controls';
 import { Alert } from './Alert';
+import { alertControls, alertExcludeFromArgs } from './Alert.controls';
+
+const { args, argTypes } = defineControls(alertControls);
 
 // Explicit `Meta<typeof Alert>` annotation (rather than `satisfies`) keeps
 // storybook csf-internal types out of the exported `meta` signature —
 // `tsc --noEmit` runs with `declaration: true` and trips TS2742 / TS4023
 // when the inferred meta references types that aren't portably named.
+//
+// Phase 1.5: `args` + `argTypes` come from `Alert.controls.ts`;
+// `tags: ['autodocs']` removed because `Alert.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Alert> = {
   title: 'Web Primitives/Alert',
   component: Alert,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-alert',
     },
   },
-  args: {
-    title: 'New feature available',
-    description: 'Check out the new dashboard.',
-    intent: 'info',
-    dismissible: false,
-    dismissLabel: 'Dismiss',
-  },
-  argTypes: {
-    title: { control: 'text' },
-    description: { control: 'text' },
-    intent: {
-      control: 'inline-radio',
-      options: ['info', 'success', 'warning', 'danger'],
-    },
-    dismissible: { control: 'boolean' },
-    dismissLabel: { control: 'text' },
-    icon: {
-      control: 'select',
-      options: Object.keys(storybookIcons),
-      mapping: storybookIcons,
-    },
-    onDismiss: { control: false, action: 'dismissed' },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 480 }}>
@@ -52,6 +36,8 @@ const meta: Meta<typeof Alert> = {
 
 export default meta;
 type Story = StoryObj<typeof Alert>;
+
+export const excludeFromArgs = alertExcludeFromArgs;
 
 export const Default: Story = {};
 

--- a/packages/ui/src/components/Banner/Banner.controls.ts
+++ b/packages/ui/src/components/Banner/Banner.controls.ts
@@ -1,0 +1,76 @@
+// `Banner.controls.ts` — single source of truth for Banner's variant
+// matrix. Story (`Banner.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Banner.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+import { storybookIcons } from '../../icons/storybook';
+
+const intentOptions = ['info', 'success', 'warning', 'danger'] as const;
+
+export const bannerControls = {
+  title: {
+    type: 'text',
+    default: 'We use cookies',
+    description:
+      'Bold lead-in line of the announcement. Keep it concise; the description carries the supporting copy.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  description: {
+    type: 'text',
+    default: 'See our cookie policy for details.',
+    description:
+      'Optional secondary line. For multi-paragraph content prefer a Modal or a dedicated page.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  intent: {
+    type: 'inline-radio',
+    options: intentOptions,
+    default: 'info',
+    description:
+      'Severity / colour group for the leading icon. `info` for general announcements (default), `warning` for time-sensitive issues, `success` for global confirmations, `danger` for outage / failure banners.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof intentOptions)[number]>,
+  dismissible: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Render the close button at the top-right corner. Pair with `onDismiss` to persist the dismissed state across sessions.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  dismissLabel: {
+    type: 'text',
+    default: 'Dismiss',
+    description:
+      'Accessible name for the close button. Defaults to "Dismiss"; localise per app locale.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  icon: {
+    type: 'select',
+    options: Object.keys(storybookIcons),
+    mapping: storybookIcons,
+    description:
+      'Override the default icon for the chosen intent. Pass any component from `@untitledui/icons` (or a custom React component with the same shape).',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  actions: {
+    type: false,
+    description:
+      'Action slot — typically one or two `<Button>` elements rendered to the right of the message. Renders below the text on mobile, beside it on desktop.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  onDismiss: {
+    type: false,
+    action: 'dismissed',
+    description: 'Fires when the close button is clicked.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer container.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const bannerExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Banner/Banner.mdx
+++ b/packages/ui/src/components/Banner/Banner.mdx
@@ -1,0 +1,62 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as BannerStories from './Banner.stories';
+
+<Meta of={BannerStories} />
+
+# Banner
+
+Page-level announcement. Use Banner when an event affects the entire
+session or app — cookie consent, planned maintenance, version update,
+global outage notice. Wider visual footprint than Alert; carries an
+optional CTA action.
+
+## When to use
+
+- Top of the page: cookie consent prompt with Accept / Decline buttons.
+- App-wide announcement: "Maintenance in 2 hours" warning across all
+  routes.
+- Update prompt: "New version available" with a single Reload action.
+- Outage notice: "Connection to Home Assistant lost — reconnecting…"
+
+## When NOT to use
+
+- **Section-level inline status** → use [Alert](?path=/docs/web-primitives-alert--docs).
+- **Transient confirmation** → use [Toast](?path=/docs/web-primitives-toast--docs).
+- **Single-word status** → use [Badge](?path=/docs/web-primitives-badge--docs).
+
+## Anatomy
+
+<Canvas of={BannerStories.Default} />
+
+Layout: leading icon (intent-based), title + optional description
+(inline on desktop), optional action slot (1–2 Buttons), optional
+close button at the top-right.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Renders as `<div role="status">` so screen readers announce the
+  banner on insert / change.
+- The intent icon is `aria-hidden`; title + description carry the
+  meaningful content.
+- Action buttons are real `<Button>` instances — keyboard reachable,
+  focus rings inherited from the Button primitive.
+- The close button (when `dismissible`) carries `dismissLabel` as
+  `aria-label`.
+- Persist the dismissed state in `localStorage` or a per-user setting
+  so reopened banners don't re-display indefinitely (orchestration
+  lives in the consumer, not in the primitive).
+
+## Related components
+
+- [Alert](?path=/docs/web-primitives-alert--docs) — section-level inline status.
+- [Toast](?path=/docs/web-primitives-toast--docs) — transient overlay notification.
+- [Modal](?path=/docs/web-primitives-modal--docs) — blocking confirmation that requires user action.

--- a/packages/ui/src/components/Banner/Banner.stories.tsx
+++ b/packages/ui/src/components/Banner/Banner.stories.tsx
@@ -1,49 +1,32 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Button } from '../Button';
-import { storybookIcons } from '../../icons/storybook';
 import { Banner } from './Banner';
+import { bannerControls, bannerExcludeFromArgs } from './Banner.controls';
+
+const { args, argTypes } = defineControls(bannerControls);
 
 // Explicit `Meta<typeof Banner>` annotation (rather than `satisfies`)
 // keeps storybook csf-internal types out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true` and trips
 // TS2742 / TS4023 when the inferred meta references types that aren't
 // portably named.
+//
+// Phase 1.5: `args` + `argTypes` come from `Banner.controls.ts`;
+// `tags: ['autodocs']` removed because `Banner.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Banner> = {
   title: 'Web Primitives/Banner',
   component: Banner,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-banner',
     },
   },
-  args: {
-    title: 'We use cookies',
-    description: 'See our cookie policy for details.',
-    intent: 'info',
-    dismissible: false,
-    dismissLabel: 'Dismiss',
-  },
-  argTypes: {
-    title: { control: 'text' },
-    description: { control: 'text' },
-    intent: {
-      control: 'inline-radio',
-      options: ['info', 'success', 'warning', 'danger'],
-    },
-    dismissible: { control: 'boolean' },
-    dismissLabel: { control: 'text' },
-    icon: {
-      control: 'select',
-      options: Object.keys(storybookIcons),
-      mapping: storybookIcons,
-    },
-    actions: { control: false, table: { disable: true } },
-    onDismiss: { control: false, action: 'dismissed' },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 720 }}>
@@ -55,6 +38,8 @@ const meta: Meta<typeof Banner> = {
 
 export default meta;
 type Story = StoryObj<typeof Banner>;
+
+export const excludeFromArgs = bannerExcludeFromArgs;
 
 export const Default: Story = {};
 


### PR DESCRIPTION
## Summary

P2 conversion in the Phase 1.5 ladder. Each component gets a typed \`<Component>.controls.ts\` spec and a \`<Component>.mdx\` narrative docs page; the story is refactored to use \`defineControls()\` and \`tags: ['autodocs']\` is removed (MDX takes over the docs tab).

## What lands

### Alert

- \`Alert.controls.ts\` — 8 entries: \`title\`, \`description\`, \`intent\` (info / success / warning / danger), \`dismissible\`, \`dismissLabel\`, \`icon\` (storybookIcons mapping), \`onDismiss\` (action), \`className\` (hidden).
- \`Alert.mdx\` — When to use / When NOT / Anatomy / Variants / Props / A11y / Related sections; cross-links to Banner / Toast / Badge.
- \`Alert.stories.tsx\` — refactored to \`defineControls()\`; \`tags: ['autodocs']\` removed.

### Banner

- \`Banner.controls.ts\` — 9 entries (adds \`actions\` slot for CTA buttons).
- \`Banner.mdx\` — full 6 sections; cross-links to Alert / Toast / Modal.
- \`Banner.stories.tsx\` — refactored to helper.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` clean
- [x] \`pnpm --filter @glaon/ui lint\` clean
- [x] \`pnpm knip\` clean
- [x] \`pnpm --filter @glaon/ui test --run\` — 84/84 passing (F6 gate green)
- [x] \`pnpm --filter @glaon/ui build-storybook\` clean
- [ ] story-tests CI green
- [ ] Storybook spot-check: Alert / Banner Docs tab shows MDX (not autodocs); "Show code" panel open; controls panel descriptions render

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)