### PR TITLE
feat(ui): controls + MDX docs for Avatar + Stat (F1.5-4)

### DIFF
--- a/packages/ui/src/components/Avatar/Avatar.controls.ts
+++ b/packages/ui/src/components/Avatar/Avatar.controls.ts
@@ -1,0 +1,123 @@
+// `Avatar.controls.ts` — single source of truth for Avatar's variant
+// matrix. Story (`Avatar.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Avatar.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+import { storybookIcons } from '../../icons/storybook';
+
+const sizeOptions = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const;
+const statusOptions = ['online', 'offline'] as const;
+
+export const avatarControls = {
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale. `xs` for inline lists, `sm` for table rows, `md`–`lg` for cards, `xl`–`2xl` for profile headers.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  src: {
+    type: 'text',
+    description:
+      'Image source URL. When omitted (or load fails) the component falls back to `initials` → `placeholderIcon` → `placeholder` → default user icon.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  alt: {
+    type: 'text',
+    default: 'Olivia Rhye',
+    description:
+      'Accessible name for the avatar image. Always describe who is being represented; meaningless alt text (e.g. "avatar") fails axe `image-alt`.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  initials: {
+    type: 'text',
+    default: 'OR',
+    description:
+      'Initials shown when no image is loaded. Two characters render best; the kit centres them inside the rounded surface.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  rounded: {
+    type: 'boolean',
+    default: true,
+    description:
+      'Render as a circle (`true`, default). Set to `false` for a rounded-square avatar (e.g. company logos).',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  border: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Add an outer ring around the avatar — useful when avatars overlap or sit on busy backgrounds.',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  contrastBorder: {
+    type: 'boolean',
+    default: false,
+    description: 'Add a thin inner contrast border around the image.',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  verified: {
+    type: 'boolean',
+    default: false,
+    description: 'Show the verified-tick badge in the bottom-right corner.',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  focusable: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Render a focus ring when the parent group is focused (e.g. inside a `<Link>` or `<Button>`). The Avatar itself is non-interactive.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  status: {
+    type: 'inline-radio',
+    options: statusOptions,
+    description:
+      'Status indicator pill in the bottom-right corner — `online` (green) or `offline` (grey). Mutually exclusive with `verified` and `count`.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof statusOptions)[number]>,
+  count: {
+    type: 'number',
+    min: 0,
+    max: 99,
+    step: 1,
+    description:
+      'Numeric badge in the bottom-right corner (e.g. unread count). Mutually exclusive with `status` and `verified`.',
+    category: 'Content',
+  } satisfies ControlSpec<number>,
+  placeholderIcon: {
+    type: 'select',
+    options: Object.keys(storybookIcons),
+    mapping: storybookIcons,
+    description:
+      'Icon shown when there is no `src` and no `initials`. Defaults to the kit `User01` glyph.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  placeholder: {
+    type: false,
+    description:
+      'Fully custom React node rendered when there is no `src` / `initials` / `placeholderIcon`. Last-resort fallback slot.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  badge: {
+    type: false,
+    description:
+      'Custom corner badge slot (overrides `status` / `verified` / `count`). Use for company logos or other rich indicators.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer container.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  contentClassName: {
+    type: false,
+    description: 'Tailwind override hook for the inner image / initials wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const avatarExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Avatar/Avatar.mdx
+++ b/packages/ui/src/components/Avatar/Avatar.mdx
@@ -1,0 +1,64 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as AvatarStories from './Avatar.stories';
+
+<Meta of={AvatarStories} />
+
+# Avatar
+
+Profile placeholder for a person, account, or entity. Falls back from
+image → initials → icon → custom slot so the cell never collapses
+empty. Lighter than a Card (P4) and more identity-specific than a
+Badge (P1).
+
+## When to use
+
+- List rows, table cells, comment threads — anywhere a name needs
+  visual identification.
+- Profile headers (size `xl` / `2xl`) with verified ticks or status
+  indicators.
+- TopBar / SideNav user-section corner.
+- AvatarGroup compositions (Phase 2) — base unit.
+
+## When NOT to use
+
+- **Decorative imagery only** → use a plain `<img>` with the
+  appropriate `alt`.
+- **Logo + wordmark blocks** → use a dedicated brand component, not
+  an Avatar.
+
+## Anatomy
+
+<Canvas of={AvatarStories.Default} />
+
+Layout: rounded surface with image fill, fallback content (initials
+/ icon / placeholder) when no image, optional outer border, optional
+corner badge (status indicator / verified tick / count / custom slot).
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Pass a meaningful `alt` — describe **who** the avatar represents,
+  not what it is. ("Olivia Rhye" not "Avatar").
+- Initials are wrapped in `<span>` with text colour that meets WCAG
+  AA contrast (kit was patched in P3 to use `text-secondary` instead
+  of `text-quaternary` — see `base/avatar/avatar.tsx` GLAON PATCH).
+- Status indicators (`status`) are decorative; the meaningful state
+  ("Online", "Offline") should also appear in surrounding text or
+  `aria-label`.
+- The `focusable` prop lets the avatar inherit a focus ring when
+  wrapped inside an interactive element (link, button) — the Avatar
+  itself stays non-interactive.
+
+## Related components
+
+- [Badge](?path=/docs/web-primitives-badge--docs) — `Avatar.count` prop reuses Badge styling.
+- [Stat](?path=/docs/web-primitives-stat--docs) — KPI cards (often paired with Avatar in user / actor contexts).
+- [List](?path=/docs/web-primitives-list--docs) — Avatar fits naturally in `List.Item.leading` slot.

--- a/packages/ui/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/ui/src/components/Avatar/Avatar.stories.tsx
@@ -1,65 +1,37 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
-import { storybookIcons } from '../../icons/storybook';
+import { defineControls } from '../_internal/controls';
 import { Avatar } from './Avatar';
+import { avatarControls, avatarExcludeFromArgs } from './Avatar.controls';
+
+const { args, argTypes } = defineControls(avatarControls);
 
 // Explicit `Meta<typeof Avatar>` annotation (rather than `satisfies`)
 // keeps the kit's unexported `AvatarProps` shape out of the exported
 // `meta` signature — `tsc --noEmit` runs with `declaration: true` and
 // trips TS4023 / TS2742 when the inferred meta references types that
 // aren't portably named.
+//
+// Phase 1.5: `args` + `argTypes` come from `Avatar.controls.ts`;
+// `tags: ['autodocs']` removed because `Avatar.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Avatar> = {
   title: 'Web Primitives/Avatar',
   component: Avatar,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-avatar',
     },
   },
-  args: {
-    size: 'md',
-    alt: 'Olivia Rhye',
-    initials: 'OR',
-    rounded: true,
-    border: false,
-    contrastBorder: false,
-    verified: false,
-    focusable: false,
-  },
-  argTypes: {
-    size: {
-      control: 'inline-radio',
-      options: ['xs', 'sm', 'md', 'lg', 'xl', '2xl'],
-    },
-    src: { control: 'text' },
-    alt: { control: 'text' },
-    initials: { control: 'text' },
-    rounded: { control: 'boolean' },
-    border: { control: 'boolean' },
-    contrastBorder: { control: 'boolean' },
-    verified: { control: 'boolean' },
-    focusable: { control: 'boolean' },
-    status: {
-      control: 'inline-radio',
-      options: ['online', 'offline', undefined],
-    },
-    count: { control: { type: 'number', min: 0, max: 99, step: 1 } },
-    placeholderIcon: {
-      control: 'select',
-      options: Object.keys(storybookIcons),
-      mapping: storybookIcons,
-    },
-    placeholder: { control: false, table: { disable: true } },
-    badge: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-    contentClassName: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
 };
 
 export default meta;
 type Story = StoryObj<typeof Avatar>;
+
+export const excludeFromArgs = avatarExcludeFromArgs;
 
 export const Default: Story = {};
 

--- a/packages/ui/src/components/Stat/Stat.controls.ts
+++ b/packages/ui/src/components/Stat/Stat.controls.ts
@@ -1,0 +1,53 @@
+// `Stat.controls.ts` — single source of truth for Stat's variant
+// matrix. Story (`Stat.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Stat.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+
+export const statControls = {
+  label: {
+    type: 'text',
+    default: 'Total revenue',
+    description:
+      'Caption rendered under the value (e.g. "Total revenue", "Active users", "Conversion rate"). Pairs visually with the metric value above it.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  value: {
+    type: 'text',
+    default: '$32,400',
+    description:
+      'Headline metric — the dominant character of the card. Typically a number or currency string; ReactNode is accepted for richer formatting.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale. `sm` for tight dashboards, `md` for default cards, `lg` for hero KPIs.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  delta: {
+    type: 'object',
+    description:
+      'Optional change indicator: `{ value: "+12.5%", direction: "up" | "down" | "neutral" }`. Renders an arrow + colored text next to the value.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  prefix: {
+    type: false,
+    description:
+      'Leading slot rendered before the value — typically a currency icon, unit, or trend mini-chart. Accepts any ReactNode.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer container.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const statExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Stat/Stat.mdx
+++ b/packages/ui/src/components/Stat/Stat.mdx
@@ -1,0 +1,57 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as StatStories from './Stat.stories';
+
+<Meta of={StatStories} />
+
+# Stat
+
+Single-metric KPI card. Shows one bold value with a caption underneath
+and an optional change indicator. Designed for dashboard hero rows
+and inline KPI strips.
+
+## When to use
+
+- Dashboard hero row: 3–4 Stat cards comparing today's vs. yesterday's
+  numbers (revenue, sign-ups, errors).
+- Inline metric inside a Card body — value + label + delta.
+- Profile / project headers: "12 projects", "98% uptime", etc.
+
+## When NOT to use
+
+- **Numeric badge inside a list item** → use [Badge](?path=/docs/web-primitives-badge--docs) (`12 unread`).
+- **Determinate progress** → use [ProgressBar](?path=/docs/web-primitives-progressbar--docs).
+- **Sparkline / multi-point trend** → wait for the Phase 2 chart
+  primitive; embed the chart inside `prefix`.
+
+## Anatomy
+
+<Canvas of={StatStories.Default} />
+
+Layout: optional `prefix` slot (currency icon, unit), bold value,
+optional inline delta indicator (arrow + percentage + colour),
+caption (`label`) below.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The Stat root renders `<dl>` with `<dd>` (value) above `<dt>`
+  (label) using `flex-col-reverse` — visually the value is on top
+  but the document order satisfies axe `definition-list`.
+- Delta colour tokens (`text-success-700` / `text-error-700` /
+  `text-secondary`) pass WCAG AA contrast at small text sizes.
+- The arrow icon inside the delta is `aria-hidden` — the text
+  (e.g. "+12.5%") carries the meaningful change.
+
+## Related components
+
+- [Badge](?path=/docs/web-primitives-badge--docs) — inline status / count.
+- [Card](?path=/docs/web-primitives-card--docs) — Stat fits naturally inside `Card.Body`.
+- [ProgressBar](?path=/docs/web-primitives-progressbar--docs) — when the metric represents progress, not a snapshot.

--- a/packages/ui/src/components/Stat/Stat.stories.tsx
+++ b/packages/ui/src/components/Stat/Stat.stories.tsx
@@ -2,38 +2,36 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 import { CurrencyDollar } from '@untitledui/icons';
 
+import { defineControls } from '../_internal/controls';
 import { Stat } from './Stat';
+import { statControls, statExcludeFromArgs } from './Stat.controls';
+
+const { args, argTypes } = defineControls(statControls);
 
 // Explicit `Meta<typeof Stat>` annotation (rather than `satisfies`)
 // keeps storybook csf-internal types out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Stat.controls.ts`;
+// `tags: ['autodocs']` removed because `Stat.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Stat> = {
   title: 'Web Primitives/Stat',
   component: Stat,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-stat',
     },
   },
-  args: {
-    label: 'Total revenue',
-    value: '$32,400',
-    size: 'md',
-  },
-  argTypes: {
-    label: { control: 'text' },
-    value: { control: 'text' },
-    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
-    delta: { control: 'object' },
-    prefix: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
 };
 
 export default meta;
 type Story = StoryObj<typeof Stat>;
+
+export const excludeFromArgs = statExcludeFromArgs;
 
 export const Default: Story = {};
 


### PR DESCRIPTION
## Summary

P3 conversion in the Phase 1.5 ladder. Each component gets a typed \`<Component>.controls.ts\` spec and a \`<Component>.mdx\` narrative docs page; story refactored to use \`defineControls()\` helper, \`tags: ['autodocs']\` removed.

## Avatar

- \`Avatar.controls.ts\` — 15 entries covering the kit's full prop surface (sizes, status, count, verified, fallback chain).
- \`Avatar.mdx\` — When to use / When NOT / Anatomy / Variants / Props / A11y / Related; cross-links to Badge, Stat, List.
- A11y notes flag the kit's text-quaternary→text-secondary contrast patch (P3 GLAON PATCH).

## Stat

- \`Stat.controls.ts\` — 6 entries (label / value / size / delta / prefix / className).
- \`Stat.mdx\` — full 6 sections; cross-links Badge / Card / ProgressBar.
- A11y notes flag the \`<dl>\` / \`<dd>\` / \`<dt>\` flex-col-reverse trick that satisfies axe \`definition-list\`.

## Test plan

- [x] type-check / lint / knip / test --run / build / build-storybook all clean
- [x] 84/84 unit tests passing (F6 gate green)
- [ ] story-tests CI green
- [ ] Storybook spot-check: Avatar / Stat Docs tabs show MDX, "Show code" panel open

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)