### PR TITLE
feat(ui): controls + MDX docs for Card (F1.5-5)

### DIFF
--- a/packages/ui/src/components/Card/Card.controls.ts
+++ b/packages/ui/src/components/Card/Card.controls.ts
@@ -1,0 +1,47 @@
+// `Card.controls.ts` — single source of truth for Card's variant
+// matrix. Story (`Card.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Card.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const variantOptions = ['default', 'elevated', 'muted'] as const;
+
+export const cardControls = {
+  variant: {
+    type: 'inline-radio',
+    options: variantOptions,
+    default: 'default',
+    description:
+      'Visual style. `default` for standard surfaces, `elevated` for emphasis (heavier shadow), `muted` for nested or secondary content (tinted background).',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof variantOptions)[number]>,
+  interactive: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Promote the card to a clickable surface. Wraps the content in a react-aria-components `<Button>` so keyboard activation, focus ring, and `role="button"` come for free. Pair with `onPress`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  onPress: {
+    type: false,
+    action: 'pressed',
+    description:
+      'Fires when an interactive card is activated (click, Enter, Space). Ignored unless `interactive` is true.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  children: {
+    type: false,
+    description:
+      'Card content. Compose with `Card.Header`, `Card.Body`, and `Card.Footer` slot components for clean section dividers.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer container.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const cardExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Card/Card.mdx
+++ b/packages/ui/src/components/Card/Card.mdx
@@ -1,0 +1,82 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as CardStories from './Card.stories';
+
+<Meta of={CardStories} />
+
+# Card
+
+Container surface that groups related content. Use Card to give a
+section a clear boundary, optional header / footer chrome, and an
+optional clickable affordance for whole-row interactions (device
+tiles, settings entries, navigation cards).
+
+## When to use
+
+- Dashboard tiles: KPI Stats, recent activity, quick actions.
+- Settings groups: a panel of related toggles + helper text.
+- Selectable / tappable items: device entries, scenes, automations
+  (use `interactive` so the entire card is keyboard-activatable).
+- Empty-state placeholders that need a chrome distinct from
+  surrounding content.
+
+## When NOT to use
+
+- **Page-level wrapper** → use the layout / page primitive, not Card.
+- **Inline metadata** → use [Badge](?path=/docs/web-primitives-badge--docs).
+- **Modal / dialog content** → wrap in [Modal](?path=/docs/web-primitives-modal--docs); Modal already provides the surface chrome.
+
+## Anatomy
+
+<Canvas of={CardStories.WithHeaderFooter} />
+
+Three composition slots, each is a thin layout helper:
+
+- **`Card.Header`** — top-of-card region with bottom border. Use for
+  titles, subtitle, supporting metadata.
+- **`Card.Body`** — main content area with default padding.
+- **`Card.Footer`** — bottom region with top border. Use for action
+  buttons or summary content.
+
+```tsx
+<Card variant="default" interactive onPress={handlePress}>
+  <Card.Header>
+    <h3 className="text-lg font-semibold text-primary">Project Glaon</h3>
+    <p className="text-sm text-tertiary">Updated 2 hours ago</p>
+  </Card.Header>
+  <Card.Body>…</Card.Body>
+  <Card.Footer>
+    <Button color="secondary" size="sm">Cancel</Button>
+    <Button color="primary" size="sm">Open</Button>
+  </Card.Footer>
+</Card>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Static cards render as plain `<div>` — purely visual containers,
+  no role overrides.
+- `interactive` cards render the kit's react-aria-components
+  `<Button>` underneath so they're keyboard-activatable (Enter +
+  Space), expose `role="button"`, and inherit the focus-ring styles
+  from the design tokens.
+- Avoid placing additional interactive elements (links, buttons)
+  inside an `interactive` Card — that creates nested-interactive
+  controls which fail axe rules.
+- For hierarchical content, use semantic headings inside
+  `Card.Header` (e.g. `<h2>` / `<h3>`) so screen readers can navigate
+  the card structure.
+
+## Related components
+
+- [Modal](?path=/docs/web-primitives-modal--docs) / [Drawer](?path=/docs/web-primitives-drawer--docs) — overlay surfaces that already include chrome.
+- [List](?path=/docs/web-primitives-list--docs) — Card and List sometimes overlap; pick List for ordered / homogeneous items, Card for richer per-item layouts.
+- [Stat](?path=/docs/web-primitives-stat--docs) — fits naturally inside `Card.Body` for KPI dashboards.

--- a/packages/ui/src/components/Card/Card.stories.tsx
+++ b/packages/ui/src/components/Card/Card.stories.tsx
@@ -1,32 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Button } from '../Button';
 import { Card } from './Card';
+import { cardControls, cardExcludeFromArgs } from './Card.controls';
+
+const { args, argTypes } = defineControls(cardControls);
 
 // Explicit `Meta<typeof Card>` annotation (rather than `satisfies`)
 // keeps storybook csf-internal types out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Card.controls.ts`;
+// `tags: ['autodocs']` removed because `Card.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Card> = {
   title: 'Web Primitives/Card',
   component: Card,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-card',
     },
   },
-  args: {
-    variant: 'default',
-    interactive: false,
-  },
-  argTypes: {
-    variant: { control: 'inline-radio', options: ['default', 'elevated', 'muted'] },
-    interactive: { control: 'boolean' },
-    onPress: { control: false, action: 'pressed' },
-    children: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 480 }}>
@@ -38,6 +36,8 @@ const meta: Meta<typeof Card> = {
 
 export default meta;
 type Story = StoryObj<typeof Card>;
+
+export const excludeFromArgs = cardExcludeFromArgs;
 
 const sampleBody = (
   <Card.Body>


### PR DESCRIPTION
## Summary

P4 conversion. Card has a static-property namespace (\`Card.Header\` / \`Card.Body\` / \`Card.Footer\`) — \`Card.controls.ts\` covers the root component props; the sub-component composition pattern is documented in MDX with a code snippet.

## What lands

- \`Card.controls.ts\` — 5 entries (variant / interactive / onPress / children / className).
- \`Card.mdx\` — When to use / When NOT / Anatomy (with full composition snippet) / Variants / Props / A11y / Related; cross-links Modal / Drawer / List / Stat.
- \`Card.stories.tsx\` — refactored to \`defineControls()\`, \`tags: ['autodocs']\` removed.

## Test plan

- [x] type-check / lint / knip / test --run / build-storybook all clean
- [x] 84/84 unit tests passing (F6 gate green)
- [ ] story-tests CI green
- [ ] Storybook spot-check: Card "Docs" tab shows MDX with anatomy snippet rendered

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)