### PR TITLE
feat(ui): controls + MDX docs for Input/Textarea (F1.5-6)

### DIFF
--- a/packages/ui/src/components/Input/Input.controls.ts
+++ b/packages/ui/src/components/Input/Input.controls.ts
@@ -1,0 +1,206 @@
+// `Input.controls.ts` — single source of truth for Input's variant
+// matrix. Story (`Input.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Input.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+import { storybookIcons } from '../../icons/storybook';
+
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+const typeOptions = ['text', 'email', 'password', 'number', 'tel', 'url'] as const;
+
+export const inputControls = {
+  label: {
+    type: 'text',
+    default: 'Email address',
+    description:
+      'Visible label rendered above the field. Always provide one — labels are the primary affordance for axe `label` and `aria-input-field-name`. For visually hidden labels, prefer `aria-label` instead.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  placeholder: {
+    type: 'text',
+    default: 'olivia@untitledui.com',
+    description:
+      'Hint text shown when the field is empty. Never use placeholder as a substitute for a label — it disappears on focus and fails axe `placeholder-only`.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the field. Doubles as the error message when `isInvalid` is true (the kit re-styles it red and adds `aria-describedby`).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  tooltip: {
+    type: 'text',
+    description:
+      'Inline tooltip trigger appended to the label (info icon). Use for short clarifying copy when `hint` would clutter the layout.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale. `sm` for compact toolbars / table cells, `md` (default) for forms, `lg` for hero sign-up / search affordances.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  type: {
+    type: 'inline-radio',
+    options: typeOptions,
+    default: 'text',
+    description:
+      "Native HTML input type. `password` activates the kit's built-in show/hide toggle; `email` / `tel` / `url` / `number` set the appropriate mobile keyboard.",
+    category: 'Behavior',
+  } satisfies ControlSpec<(typeof typeOptions)[number]>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Block all interaction and dim the field. The native `disabled` attribute is forwarded so axe and assistive tech treat the field as inert.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isReadOnly: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Field is selectable + copyable but the value cannot be edited. Prefer over `isDisabled` when the value should remain accessible to screen readers and copy/paste.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isRequired: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Mark the field as required (renders an indicator next to the label and forwards `aria-required`). Use `hideRequiredIndicator` to drop the visual marker on dense forms while keeping the a11y semantics.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  isInvalid: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Surface validation error styling (red border + ring). Pair with a `hint` to describe the error; the kit wires `aria-invalid` + `aria-describedby` automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  hideRequiredIndicator: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Hide the visual `*` next to the label even when `isRequired` is true. Keep `isRequired` set so the a11y contract still reports the field as required.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  icon: {
+    type: 'select',
+    options: Object.keys(storybookIcons),
+    mapping: storybookIcons,
+    description:
+      'Leading icon glyph rendered inside the field. Use kit `@untitledui/icons` exports; the kit handles sizing + colour. Pair with a meaningful `aria-label` if the icon conveys meaning beyond the label.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  shortcut: {
+    type: 'text',
+    description:
+      'Keyboard-shortcut hint rendered on the trailing edge (e.g. `⌘ K` for search). Decorative — register the actual key handler at the page level.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  value: {
+    type: 'text',
+    description:
+      'Controlled value. Pair with `onChange` to manage state outside the input. Leave undefined for uncontrolled usage with `defaultValue`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  defaultValue: {
+    type: 'text',
+    description:
+      'Initial value for uncontrolled usage. The kit forwards this to the native `<input defaultValue>`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  name: {
+    type: 'text',
+    description:
+      'Form field name forwarded to the native input — required for native form submission.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onChange: {
+    type: false,
+    action: 'changed',
+    description:
+      'Fires on every keystroke with the new string value (RAC TextField onChange contract).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onBlur: {
+    type: false,
+    action: 'blurred',
+    description: 'Fires when focus leaves the field — typical place to run validation.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onFocus: {
+    type: false,
+    action: 'focused',
+    description: 'Fires when focus enters the field.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  inputClassName: {
+    type: false,
+    description: 'Tailwind override hook for the native `<input>` element itself.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  iconClassName: {
+    type: false,
+    description: 'Tailwind override hook for the leading icon slot.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  wrapperClassName: {
+    type: false,
+    description: 'Tailwind override hook for the input + icon wrapper (between label and hint).',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  tooltipClassName: {
+    type: false,
+    description: 'Tailwind override hook for the inline label tooltip trigger.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  ref: {
+    type: false,
+    description: 'Forwarded ref to the kit `<TextField>` wrapper.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  groupRef: {
+    type: false,
+    description: 'Forwarded ref to the input group element (input + leading icon + shortcut).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+// react-aria-components forwards a number of props from RAC TextField
+// (`autoFocus`, `validate`, `validationBehavior`, …) that we don't
+// surface as Storybook controls; the F6 prop-coverage gate accepts
+// them via this allowlist instead.
+export const inputExcludeFromArgs = defineExcludeFromArgs([
+  'autoFocus',
+  'validate',
+  'validationBehavior',
+  'inputMode',
+  'minLength',
+  'maxLength',
+  'pattern',
+  'autoComplete',
+  'enterKeyHint',
+  'spellCheck',
+  'autoCorrect',
+  'autoCapitalize',
+  'form',
+  'translate',
+  'slot',
+  'children',
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'aria-errormessage',
+  'data-rac',
+] as const);

--- a/packages/ui/src/components/Input/Input.mdx
+++ b/packages/ui/src/components/Input/Input.mdx
@@ -1,0 +1,81 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as InputStories from './Input.stories';
+
+<Meta of={InputStories} />
+
+# Input
+
+Single-line text field with built-in label, helper text, validation
+state, optional leading icon, and a kit-provided password show/hide
+toggle. The most common form primitive in the kit — every text-style
+field you can imagine starts here.
+
+## When to use
+
+- Any single-line text capture: email, phone, search, name, URL.
+- Password fields (the kit's `type="password"` ships its own
+  show/hide affordance — no extra wiring needed).
+- Inline filtering / search affordances inside toolbars (use
+  `size="sm"` and a leading `search` icon).
+- As the trigger element of a controlled select / autocomplete (when
+  paired with the upcoming Combobox primitive).
+
+## When NOT to use
+
+- **Multi-line content** → use [Textarea](?path=/docs/web-primitives-textarea--docs).
+- **Single yes/no toggle** → use [Switch](?path=/docs/web-primitives-switch--docs) or [Checkbox](?path=/docs/web-primitives-checkbox--docs).
+- **Free-form rich text** → out of scope for Phase 1; queue a Phase 2 RichText primitive.
+- **Numeric range** → use the upcoming Slider primitive (numeric Input is fine for free-form integers).
+
+## Anatomy
+
+<Canvas of={InputStories.WithHelper} />
+
+Top-to-bottom: optional `label` (with optional inline `tooltip` and
+required indicator), the input group (optional leading `icon`, native
+`<input>`, optional trailing `shortcut` hint), and an optional `hint`
+caption that re-styles to red when `isInvalid` is true.
+
+```tsx
+<Input
+  label="Email address"
+  type="email"
+  icon={MailIcon}
+  placeholder="olivia@untitledui.com"
+  hint="We will only use this address to send you order updates."
+  isRequired
+/>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Always set `label`. Visible labels satisfy axe `label` and pair the
+  field with assistive tech automatically; placeholder-only labels
+  fail.
+- For visually hidden labels (e.g. an icon-only search field) use
+  `aria-label` on the wrapper instead of dropping the `label` prop.
+- `isRequired` forwards `aria-required="true"` even when the visual
+  marker is hidden via `hideRequiredIndicator` — keep the prop set so
+  the a11y contract holds on dense forms.
+- `isInvalid` re-styles the hint to red AND wires
+  `aria-invalid="true"` + `aria-describedby` to the hint node, so
+  screen readers announce the error along with the label.
+- Password fields render a kit-provided show/hide button with
+  `aria-pressed` toggling between "Show password" / "Hide password".
+- The leading `icon` is decorative — pair the field with a meaningful
+  `label` (or `aria-label`) so the icon's intent is conveyed in text.
+
+## Related components
+
+- [Textarea](?path=/docs/web-primitives-textarea--docs) — multi-line counterpart with the same label / hint / validation contract.
+- [Checkbox](?path=/docs/web-primitives-checkbox--docs) / [Radio](?path=/docs/web-primitives-radio--docs) / [Switch](?path=/docs/web-primitives-switch--docs) — boolean form controls when an Input would be overkill.
+- [Select](?path=/docs/web-primitives-select--docs) — when the value comes from a fixed set of options instead of free text.

--- a/packages/ui/src/components/Input/Input.stories.tsx
+++ b/packages/ui/src/components/Input/Input.stories.tsx
@@ -2,8 +2,10 @@ import type { ComponentType, HTMLAttributes } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { storybookIcons } from '../../icons/storybook';
 import { Input } from './Input';
+import { inputControls, inputExcludeFromArgs } from './Input.controls';
 
 // The kit `Input` typed `icon` as `ComponentType<HTMLAttributes<...>>`
 // while our shared picker (`icons/storybook.ts`) is typed loosely as
@@ -12,65 +14,28 @@ import { Input } from './Input';
 type InputIcon = ComponentType<HTMLAttributes<HTMLOrSVGElement>>;
 const icon = (name: keyof typeof storybookIcons): InputIcon => storybookIcons[name] as InputIcon;
 
+const { args, argTypes } = defineControls(inputControls);
+
 // Explicit `Meta<typeof Input>` annotation (rather than `satisfies`)
 // keeps the kit's unexported deep prop shapes (RAC `TextFieldProps`)
 // out of the exported `meta` signature — `tsc --noEmit` runs with
 // `declaration: true` and trips TS4023 / TS2742 when the inferred
 // meta references types that aren't portably named.
+//
+// Phase 1.5: `args` + `argTypes` come from `Input.controls.ts`;
+// `tags: ['autodocs']` removed because `Input.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Input> = {
   title: 'Web Primitives/Input',
   component: Input,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-input',
     },
   },
-  args: {
-    label: 'Email address',
-    placeholder: 'olivia@untitledui.com',
-    size: 'md',
-    isDisabled: false,
-    isReadOnly: false,
-    isRequired: false,
-    type: 'text',
-  },
-  argTypes: {
-    label: { control: 'text' },
-    placeholder: { control: 'text' },
-    hint: { control: 'text' },
-    tooltip: { control: 'text' },
-    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
-    type: {
-      control: 'inline-radio',
-      options: ['text', 'email', 'password', 'number', 'tel', 'url'],
-    },
-    isDisabled: { control: 'boolean' },
-    isReadOnly: { control: 'boolean' },
-    isRequired: { control: 'boolean' },
-    isInvalid: { control: 'boolean' },
-    hideRequiredIndicator: { control: 'boolean' },
-    icon: {
-      control: 'select',
-      options: Object.keys(storybookIcons),
-      mapping: storybookIcons,
-    },
-    shortcut: { control: 'text' },
-    value: { control: 'text' },
-    defaultValue: { control: 'text' },
-    name: { control: 'text' },
-    onChange: { control: false, action: 'changed' },
-    onBlur: { control: false, action: 'blurred' },
-    onFocus: { control: false, action: 'focused' },
-    className: { control: false, table: { disable: true } },
-    inputClassName: { control: false, table: { disable: true } },
-    iconClassName: { control: false, table: { disable: true } },
-    wrapperClassName: { control: false, table: { disable: true } },
-    tooltipClassName: { control: false, table: { disable: true } },
-    ref: { control: false, table: { disable: true } },
-    groupRef: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 360 }}>
@@ -83,37 +48,7 @@ const meta: Meta<typeof Input> = {
 export default meta;
 type Story = StoryObj<typeof Input>;
 
-// react-aria-components forwards a number of props from RAC TextField
-// (`autoFocus`, `validate`, `validationBehavior`, …) that we don't
-// surface as Storybook controls; the F6 prop-coverage gate accepts
-// them via this allowlist instead.
-export const excludeFromArgs = [
-  'autoFocus',
-  'validate',
-  'validationBehavior',
-  'inputMode',
-  'minLength',
-  'maxLength',
-  'pattern',
-  'autoComplete',
-  'enterKeyHint',
-  'spellCheck',
-  'autoCorrect',
-  'autoCapitalize',
-  'form',
-  'isInvalid',
-  'translate',
-  // Forwarded internally to `<TextField>` slot when used inside RAC
-  // composite collections; not user-facing knobs.
-  'slot',
-  'children',
-  'aria-label',
-  'aria-labelledby',
-  'aria-describedby',
-  'aria-details',
-  'aria-errormessage',
-  'data-rac',
-];
+export const excludeFromArgs = inputExcludeFromArgs;
 
 export const Default: Story = {};
 

--- a/packages/ui/src/components/Textarea/Textarea.controls.ts
+++ b/packages/ui/src/components/Textarea/Textarea.controls.ts
@@ -1,0 +1,186 @@
+// `Textarea.controls.ts` — single source of truth for Textarea's
+// variant matrix. Story (`Textarea.stories.tsx`) imports the spec and
+// spreads it into `meta.args` / `meta.argTypes`; MDX docs
+// (`Textarea.mdx`) reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md'] as const;
+
+export const textareaControls = {
+  label: {
+    type: 'text',
+    default: 'Description',
+    description:
+      'Visible label rendered above the field. Always provide one — labels satisfy axe `label` and pair the field with assistive tech automatically. Use `aria-label` only when a visible label would clutter the layout (e.g. inline note widgets).',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  placeholder: {
+    type: 'text',
+    default: 'Tell us a bit about yourself…',
+    description:
+      'Hint text shown when the field is empty. Never use placeholder as a substitute for a label — it disappears on focus and fails axe `placeholder-only`.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the field. Doubles as the error message when `isInvalid` is true (the kit re-styles it red and adds `aria-describedby`).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  tooltip: {
+    type: 'text',
+    description:
+      'Inline tooltip trigger appended to the label (info icon). Use for short clarifying copy when `hint` would crowd the field.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale. `sm` for compact comment composers, `md` (default) for forms and long-form notes.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  rows: {
+    type: 'number',
+    min: 1,
+    max: 20,
+    step: 1,
+    default: 4,
+    description:
+      'Native `<textarea rows>` — sets the initial visible height. Users can still drag the resize handle past this height.',
+    category: 'Style',
+  } satisfies ControlSpec<number>,
+  cols: {
+    type: 'number',
+    min: 10,
+    max: 100,
+    step: 5,
+    description:
+      'Native `<textarea cols>` — sets the initial visible width. Prefer driving width via the parent container; only set `cols` when you need a hard character-grid sizing.',
+    category: 'Style',
+  } satisfies ControlSpec<number>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Block all interaction and dim the field. The native `disabled` attribute is forwarded so axe and assistive tech treat the field as inert.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isReadOnly: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Field is selectable + copyable but the value cannot be edited. Prefer over `isDisabled` when the value should remain accessible to screen readers and copy/paste.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isRequired: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Mark the field as required (renders an indicator next to the label and forwards `aria-required`). Use `hideRequiredIndicator` to drop the visual marker on dense forms while keeping the a11y semantics.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  isInvalid: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Surface validation error styling (red border + ring). Pair with a `hint` to describe the error; the kit wires `aria-invalid` + `aria-describedby` automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  hideRequiredIndicator: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Hide the visual `*` next to the label even when `isRequired` is true. Keep `isRequired` set so the a11y contract still reports the field as required.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  value: {
+    type: 'text',
+    description:
+      'Controlled value. Pair with `onChange` to manage state outside the field. Leave undefined for uncontrolled usage with `defaultValue`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  defaultValue: {
+    type: 'text',
+    description:
+      'Initial value for uncontrolled usage. The kit forwards this to the native `<textarea defaultValue>`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  name: {
+    type: 'text',
+    description:
+      'Form field name forwarded to the native textarea — required for native form submission.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onChange: {
+    type: false,
+    action: 'changed',
+    description:
+      'Fires on every keystroke with the new string value (RAC TextField onChange contract).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onBlur: {
+    type: false,
+    action: 'blurred',
+    description: 'Fires when focus leaves the field — typical place to run validation.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onFocus: {
+    type: false,
+    action: 'focused',
+    description: 'Fires when focus enters the field.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  textAreaClassName: {
+    type: false,
+    description: 'Tailwind override hook for the native `<textarea>` element itself.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  ref: {
+    type: false,
+    description: 'Forwarded ref to the kit `<TextField>` wrapper.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  textAreaRef: {
+    type: false,
+    description: 'Forwarded ref to the underlying `<textarea>` element.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+// react-aria-components forwards a number of props from RAC TextField
+// that we don't surface as Storybook controls; the F6 prop-coverage
+// gate accepts them via this allowlist instead.
+export const textareaExcludeFromArgs = defineExcludeFromArgs([
+  'autoFocus',
+  'validate',
+  'validationBehavior',
+  'inputMode',
+  'minLength',
+  'maxLength',
+  'pattern',
+  'autoComplete',
+  'enterKeyHint',
+  'spellCheck',
+  'autoCorrect',
+  'autoCapitalize',
+  'form',
+  'translate',
+  'slot',
+  'children',
+  'type',
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'aria-errormessage',
+  'data-rac',
+] as const);

--- a/packages/ui/src/components/Textarea/Textarea.mdx
+++ b/packages/ui/src/components/Textarea/Textarea.mdx
@@ -1,0 +1,76 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as TextareaStories from './Textarea.stories';
+
+<Meta of={TextareaStories} />
+
+# Textarea
+
+Multi-line text field with the same label / helper / validation
+contract as Input. Use whenever the user might type more than a single
+line — descriptions, comments, free-form notes.
+
+## When to use
+
+- Long-form descriptions, comments, release notes, profile bios.
+- Markdown / rich text composers that fall back to plain text.
+- Any field where soft-wrap matters (the kit forwards the native
+  `wrap="soft"` behavior automatically).
+
+## When NOT to use
+
+- **Single-line capture** → use [Input](?path=/docs/web-primitives-input--docs); a Textarea on a single-line value wastes vertical space and confuses keyboard users (Enter inserts a newline instead of submitting).
+- **Code / monospaced editing** → out of scope for Phase 1; queue a Phase 2 CodeEditor primitive.
+- **Rich text with formatting toolbars** → out of scope; queue a Phase 2 RichText primitive.
+
+## Anatomy
+
+<Canvas of={TextareaStories.WithHelper} />
+
+Top-to-bottom: optional `label` (with optional inline `tooltip` and
+required indicator), the multi-line `<textarea>` (with the kit's
+resize handle in the bottom-right corner), and an optional `hint`
+caption that re-styles to red when `isInvalid` is true.
+
+```tsx
+<Textarea
+  label="Description"
+  placeholder="Tell us a bit about yourself…"
+  hint="Markdown is supported."
+  rows={4}
+  isRequired
+/>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Always set `label`. Visible labels satisfy axe `label` and pair the
+  field with assistive tech automatically; placeholder-only labels
+  fail.
+- Enter inserts a newline (it does not submit the surrounding form).
+  When the Textarea sits inside a form, surface a separate Submit
+  button — the kit will not interpret Enter as submit.
+- `isRequired` forwards `aria-required="true"` even when the visual
+  marker is hidden via `hideRequiredIndicator` — keep the prop set so
+  the a11y contract holds on dense forms.
+- `isInvalid` re-styles the hint to red AND wires
+  `aria-invalid="true"` + `aria-describedby` to the hint node, so
+  screen readers announce the error along with the label.
+- The resize handle is operable with mouse + touch; keyboard users
+  can rely on `rows` plus content scroll instead. Don't disable
+  resize via CSS without a strong reason — it removes a useful
+  affordance.
+
+## Related components
+
+- [Input](?path=/docs/web-primitives-input--docs) — single-line counterpart with the same label / hint / validation contract and a built-in password toggle.
+- [Select](?path=/docs/web-primitives-select--docs) — when the value comes from a fixed set of options instead of free text.
+- [Checkbox](?path=/docs/web-primitives-checkbox--docs) / [Radio](?path=/docs/web-primitives-radio--docs) / [Switch](?path=/docs/web-primitives-switch--docs) — boolean form controls when a Textarea would be overkill.

--- a/packages/ui/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/ui/src/components/Textarea/Textarea.stories.tsx
@@ -1,54 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Textarea } from './Textarea';
+import { textareaControls, textareaExcludeFromArgs } from './Textarea.controls';
+
+const { args, argTypes } = defineControls(textareaControls);
 
 // Explicit `Meta<typeof Textarea>` annotation (rather than `satisfies`)
 // keeps the kit's unexported deep prop shapes (RAC `TextFieldProps`)
 // out of the exported `meta` signature — `tsc --noEmit` runs with
 // `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Textarea.controls.ts`;
+// `tags: ['autodocs']` removed because `Textarea.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Textarea> = {
   title: 'Web Primitives/Textarea',
   component: Textarea,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-textarea',
     },
   },
-  args: {
-    label: 'Description',
-    placeholder: 'Tell us a bit about yourself…',
-    size: 'md',
-    rows: 4,
-    isDisabled: false,
-    isReadOnly: false,
-    isRequired: false,
-  },
-  argTypes: {
-    label: { control: 'text' },
-    placeholder: { control: 'text' },
-    hint: { control: 'text' },
-    tooltip: { control: 'text' },
-    size: { control: 'inline-radio', options: ['sm', 'md'] },
-    rows: { control: { type: 'number', min: 1, max: 20, step: 1 } },
-    cols: { control: { type: 'number', min: 10, max: 100, step: 5 } },
-    isDisabled: { control: 'boolean' },
-    isReadOnly: { control: 'boolean' },
-    isRequired: { control: 'boolean' },
-    isInvalid: { control: 'boolean' },
-    hideRequiredIndicator: { control: 'boolean' },
-    value: { control: 'text' },
-    defaultValue: { control: 'text' },
-    name: { control: 'text' },
-    onChange: { control: false, action: 'changed' },
-    onBlur: { control: false, action: 'blurred' },
-    onFocus: { control: false, action: 'focused' },
-    className: { control: false, table: { disable: true } },
-    textAreaClassName: { control: false, table: { disable: true } },
-    ref: { control: false, table: { disable: true } },
-    textAreaRef: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 480 }}>
@@ -61,34 +37,7 @@ const meta: Meta<typeof Textarea> = {
 export default meta;
 type Story = StoryObj<typeof Textarea>;
 
-// react-aria-components forwards a number of props from RAC TextField
-// that we don't surface as Storybook controls; the F6 prop-coverage
-// gate accepts them via this allowlist instead.
-export const excludeFromArgs = [
-  'autoFocus',
-  'validate',
-  'validationBehavior',
-  'inputMode',
-  'minLength',
-  'maxLength',
-  'pattern',
-  'autoComplete',
-  'enterKeyHint',
-  'spellCheck',
-  'autoCorrect',
-  'autoCapitalize',
-  'form',
-  'translate',
-  'slot',
-  'children',
-  'type',
-  'aria-label',
-  'aria-labelledby',
-  'aria-describedby',
-  'aria-details',
-  'aria-errormessage',
-  'data-rac',
-];
+export const excludeFromArgs = textareaExcludeFromArgs;
 
 export const Default: Story = {};
 


### PR DESCRIPTION
## Summary

- Converts P5 primitives (Input + Textarea) to the controls + MDX docs pattern established in F1.5-1.
- `Input.controls.ts` covers all 26 props; `Textarea.controls.ts` covers all 22 props with descriptions per row.
- New `Input.mdx` + `Textarea.mdx` ship the 6 mandatory sections (When to use / When NOT / Anatomy / Variants / Props / A11y / Related).
- Stories drop `tags: ['autodocs']`, consume `defineControls`, and re-export `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/Input/Input.controls.ts` — typed `defineControls` spec
- `packages/ui/src/components/Input/Input.mdx` — narrative docs page
- `packages/ui/src/components/Input/Input.stories.tsx` — refactored to helper
- `packages/ui/src/components/Textarea/Textarea.controls.ts`
- `packages/ui/src/components/Textarea/Textarea.mdx`
- `packages/ui/src/components/Textarea/Textarea.stories.tsx`

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Input + Textarea MDX pages render; Stories anchor lists every variant; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green (no unintended snapshot diffs; only expected docs additions)

Closes #266