### PR TITLE
feat(ui): controls + MDX docs for Checkbox/Radio/Switch (F1.5-7)

### DIFF
--- a/packages/ui/src/components/Checkbox/Checkbox.controls.ts
+++ b/packages/ui/src/components/Checkbox/Checkbox.controls.ts
@@ -1,0 +1,145 @@
+// `Checkbox.controls.ts` — single source of truth for Checkbox's
+// variant matrix. Story (`Checkbox.stories.tsx`) imports the spec and
+// spreads it into `meta.args` / `meta.argTypes`; MDX docs
+// (`Checkbox.mdx`) reads the same spec via `<Controls />`.
+//
+// Note on selection-state args: RAC `<Checkbox>` switches into
+// controlled mode the moment `isSelected` / `isIndeterminate` /
+// `isReadOnly` / `isRequired` is present (even when `false`). To keep
+// the controls panel surfacing those props as boolean knobs without
+// freezing the runtime checkbox, the entries omit `default` — they
+// appear in `argTypes` but stay out of `args`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md'] as const;
+
+export const checkboxControls = {
+  label: {
+    type: 'text',
+    default: 'I agree to the terms',
+    description:
+      'Visible label rendered to the right of the checkbox. Always provide one — labels satisfy axe `label` and pair the control with assistive tech automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the label. Doubles as the error message when `isInvalid` is true (the kit re-styles it red and adds `aria-describedby`).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'sm',
+    description:
+      'Visual scale. `sm` (default) for forms and dense lists, `md` for hero / focal-point checkboxes (consent flows, settings groups).',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Block all interaction and dim the control. The native `disabled` attribute is forwarded so axe and assistive tech treat the checkbox as inert.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isSelected: {
+    type: 'boolean',
+    description:
+      'Controlled selection state. Setting this prop puts the checkbox in controlled mode — pair with `onChange` to manage state outside.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isIndeterminate: {
+    type: 'boolean',
+    description:
+      'Render the mixed-state glyph (a horizontal bar instead of a check). Use for "select all" headers when some but not all children are checked.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isReadOnly: {
+    type: 'boolean',
+    description:
+      'Field is focusable but not toggleable. Prefer over `isDisabled` when the value should remain accessible to screen readers and copy/paste.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isRequired: {
+    type: 'boolean',
+    description:
+      'Mark the checkbox as required for form submission. Forwards `aria-required="true"` to the underlying input.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  isInvalid: {
+    type: 'boolean',
+    description:
+      'Surface validation error styling (red border + ring). Pair with a `hint` to describe the error; the kit wires `aria-invalid` + `aria-describedby` automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  defaultSelected: {
+    type: 'boolean',
+    description:
+      'Initial selection for uncontrolled usage. Leave `isSelected` undefined when using this so RAC manages state internally.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  name: {
+    type: 'text',
+    description:
+      'Form field name forwarded to the native input — required for native form submission.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  value: {
+    type: 'text',
+    description:
+      'Form field value forwarded when the checkbox is selected (default: `"on"`). Distinct from `isSelected` — this is the submitted payload.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onChange: {
+    type: false,
+    action: 'changed',
+    description:
+      'Fires when the selection state changes (RAC `onChange` contract — receives the new boolean).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onBlur: {
+    type: false,
+    action: 'blurred',
+    description: 'Fires when focus leaves the checkbox.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onFocus: {
+    type: false,
+    action: 'focused',
+    description: 'Fires when focus enters the checkbox.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  ref: {
+    type: false,
+    description: 'Forwarded ref to the kit `<Checkbox>` wrapper element.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+// RAC-forwarded props that aren't useful as Storybook knobs but flow
+// through type-checking; covered by the F6 prop-coverage gate.
+export const checkboxExcludeFromArgs = defineExcludeFromArgs([
+  'autoFocus',
+  'children',
+  'inputRef',
+  'validate',
+  'validationBehavior',
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'aria-errormessage',
+  'aria-controls',
+  'excludeFromTabOrder',
+  'form',
+  'translate',
+  'slot',
+  'data-rac',
+] as const);

--- a/packages/ui/src/components/Checkbox/Checkbox.mdx
+++ b/packages/ui/src/components/Checkbox/Checkbox.mdx
@@ -1,0 +1,66 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as CheckboxStories from './Checkbox.stories';
+
+<Meta of={CheckboxStories} />
+
+# Checkbox
+
+Boolean form control with optional indeterminate state. Built on
+react-aria-components — keyboard and screen-reader behaviour is the
+kit's, Glaon owns the visual treatment.
+
+## When to use
+
+- Independent boolean choice: "Subscribe to newsletter", "Remember me",
+  consent toggles.
+- Multi-select inside a list: each row is independently checkable
+  (use `Indeterminate` on the header for a "select all" row).
+- Settings panels with parallel feature flags (each flag is its own
+  Checkbox).
+
+## When NOT to use
+
+- **Mutually exclusive choice from 2-5 options** → use [Radio](?path=/docs/web-primitives-radio--docs).
+- **On/off setting that takes effect immediately** → use [Switch](?path=/docs/web-primitives-switch--docs); checkboxes traditionally need a Save / Apply step.
+- **More than 5 options** → use [Select](?path=/docs/web-primitives-select--docs) with `multiple` (Phase 2).
+
+## Anatomy
+
+<Canvas of={CheckboxStories.Default} />
+
+A square box (`sm` or `md`) with a check / dash glyph, paired with
+the `label` text and an optional `hint` caption beneath the label.
+
+```tsx
+<Checkbox label="I agree to the terms" isRequired />
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Always set `label`. Visible labels satisfy axe `label` and pair the
+  checkbox with assistive tech automatically. For visually hidden
+  labels (rare) use `aria-label` instead of dropping the prop.
+- Space toggles the checkbox; Enter never toggles it (the kit follows
+  RAC's keyboard contract — Enter is reserved for form submission).
+- `isInvalid` re-styles the hint to red AND wires `aria-invalid="true"`
+  + `aria-describedby` to the hint node, so screen readers announce
+  the error along with the label.
+- `isIndeterminate` forwards `aria-checked="mixed"` (not `"true"`/
+  `"false"`) — assistive tech announces the mixed state correctly.
+- Avoid relying on colour alone to communicate state — the check
+  glyph and the label together carry the meaning.
+
+## Related components
+
+- [Radio](?path=/docs/web-primitives-radio--docs) — mutually exclusive choice within a small set.
+- [Switch](?path=/docs/web-primitives-switch--docs) — boolean that takes effect immediately (no Save step).
+- [Input](?path=/docs/web-primitives-input--docs) — pair with Checkbox for consent flows ("I agree" + "Email address").

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,78 +1,36 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Checkbox } from './Checkbox';
+import { checkboxControls, checkboxExcludeFromArgs } from './Checkbox.controls';
+
+const { args, argTypes } = defineControls(checkboxControls);
 
 // Explicit `Meta<typeof Checkbox>` annotation (rather than `satisfies`)
 // keeps the kit's unexported `CheckboxProps` interface out of the
 // exported `meta` signature — `tsc --noEmit` runs with
 // `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Checkbox.controls.ts`;
+// `tags: ['autodocs']` removed because `Checkbox.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Checkbox> = {
   title: 'Web Primitives/Checkbox',
   component: Checkbox,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-checkbox',
     },
   },
-  // RAC `<Checkbox>` switches into controlled mode the moment any of
-  // `isSelected` / `isIndeterminate` / `isReadOnly` / `isRequired` is
-  // present in the props (even when `false`). With Storybook's args
-  // panel passing those defaults but no matching `onChange` handler
-  // updating external state, the user can't toggle the checkbox at all.
-  // Keep these props in `argTypes` (so the controls panel still
-  // surfaces them as boolean knobs), but leave them out of `args` so
-  // RAC manages selection state internally.
-  args: {
-    label: 'I agree to the terms',
-    size: 'sm',
-    isDisabled: false,
-  },
-  argTypes: {
-    label: { control: 'text' },
-    hint: { control: 'text' },
-    size: { control: 'inline-radio', options: ['sm', 'md'] },
-    isDisabled: { control: 'boolean' },
-    isSelected: { control: 'boolean' },
-    isIndeterminate: { control: 'boolean' },
-    isReadOnly: { control: 'boolean' },
-    isRequired: { control: 'boolean' },
-    isInvalid: { control: 'boolean' },
-    defaultSelected: { control: 'boolean' },
-    name: { control: 'text' },
-    value: { control: 'text' },
-    onChange: { control: false, action: 'changed' },
-    onBlur: { control: false, action: 'blurred' },
-    onFocus: { control: false, action: 'focused' },
-    className: { control: false, table: { disable: true } },
-    ref: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
 };
 
 export default meta;
 type Story = StoryObj<typeof Checkbox>;
 
-// RAC-forwarded props that aren't useful as Storybook knobs but flow
-// through type-checking; covered by the F6 prop-coverage gate.
-export const excludeFromArgs = [
-  'autoFocus',
-  'children',
-  'inputRef',
-  'validate',
-  'validationBehavior',
-  'aria-label',
-  'aria-labelledby',
-  'aria-describedby',
-  'aria-details',
-  'aria-errormessage',
-  'aria-controls',
-  'excludeFromTabOrder',
-  'form',
-  'translate',
-  'slot',
-  'data-rac',
-];
+export const excludeFromArgs = checkboxExcludeFromArgs;
 
 export const Default: Story = {};
 

--- a/packages/ui/src/components/Radio/Radio.controls.ts
+++ b/packages/ui/src/components/Radio/Radio.controls.ts
@@ -1,0 +1,107 @@
+// `Radio.controls.ts` — single source of truth for Radio's variant
+// matrix. Story (`Radio.stories.tsx`) imports the spec and spreads it
+// into `meta.args` / `meta.argTypes`; MDX docs (`Radio.mdx`) reads
+// the same spec via `<Controls />`.
+//
+// `Radio` always renders inside a `<RadioGroup>`. The group owns
+// `size`, `defaultValue` / `value`, `onChange`, and validation state;
+// individual `Radio` instances own `label`, `value`, `hint`, and
+// `isDisabled`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md'] as const;
+
+export const radioControls = {
+  label: {
+    type: 'text',
+    default: 'Email notifications',
+    description:
+      'Visible label rendered to the right of the radio dot. Always provide one — labels satisfy axe `label` and pair the control with assistive tech automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the label. Use to clarify what the option means (e.g. "A weekly digest." next to "Email").',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  value: {
+    type: 'text',
+    default: 'email',
+    description:
+      'Form value forwarded to the parent `<RadioGroup>` when this option is selected. Distinct from the visible `label`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'sm',
+    description:
+      'Visual scale. Mirrors the parent `<RadioGroup>` size; setting it on a single `Radio` overrides the group default.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Block interaction on this option only. The parent group remains operable; users can still pick a different option.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  onBlur: {
+    type: false,
+    action: 'blurred',
+    description: 'Fires when focus leaves this Radio.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onFocus: {
+    type: false,
+    action: 'focused',
+    description: 'Fires when focus enters this Radio.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onFocusChange: {
+    type: false,
+    action: 'focus-changed',
+    description:
+      'Fires whenever the focused state of this Radio toggles (RAC contract — receives the new boolean).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onHoverChange: {
+    type: false,
+    action: 'hover-changed',
+    description: 'Fires whenever the hovered state of this Radio toggles (RAC contract).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  ref: {
+    type: false,
+    description: 'Forwarded ref to the kit `<Radio>` wrapper element.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  inputRef: {
+    type: false,
+    description: 'Forwarded ref to the underlying native `<input type="radio">` element.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+// RAC-forwarded props that aren't useful as Storybook knobs; covered
+// by the F6 prop-coverage gate.
+export const radioExcludeFromArgs = defineExcludeFromArgs([
+  'autoFocus',
+  'children',
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'excludeFromTabOrder',
+  'translate',
+  'slot',
+  'data-rac',
+] as const);

--- a/packages/ui/src/components/Radio/Radio.mdx
+++ b/packages/ui/src/components/Radio/Radio.mdx
@@ -1,0 +1,72 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as RadioStories from './Radio.stories';
+
+<Meta of={RadioStories} />
+
+# Radio
+
+Single-choice selection from a small, mutually exclusive set of
+options. Always renders inside a `<RadioGroup>` — the group manages
+`value` / `defaultValue`, `onChange`, and keyboard navigation between
+options (arrow keys cycle, Tab jumps in/out of the group).
+
+## When to use
+
+- 2–5 mutually exclusive options where seeing all options at once
+  helps comparison: notification channel, theme, currency.
+- Settings panels with grouped boolean-style choices that can't both
+  be true.
+
+## When NOT to use
+
+- **Independent boolean** → use [Checkbox](?path=/docs/web-primitives-checkbox--docs).
+- **On/off setting that takes effect immediately** → use [Switch](?path=/docs/web-primitives-switch--docs).
+- **More than ~5 options** → use [Select](?path=/docs/web-primitives-select--docs); a long radio list overwhelms.
+- **Toggling between two views with equal visual weight** → use [Tabs](?path=/docs/web-primitives-tabs--docs).
+
+## Anatomy
+
+<Canvas of={RadioStories.InGroup} />
+
+A circular dot (`sm` or `md`) paired with a `label` and an optional
+`hint` caption. Multiple Radios live inside a single `<RadioGroup>`
+that owns the controlled / uncontrolled value contract.
+
+```tsx
+<RadioGroup defaultValue="email" aria-label="Notification channel">
+  <Radio value="email" label="Email" hint="A weekly digest." />
+  <Radio value="sms" label="SMS" hint="Immediate alerts." />
+  <Radio value="push" label="Push" hint="App-only notifications." />
+</RadioGroup>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Always provide a group label — either a visible `<Label>` element
+  inside the `<RadioGroup>` or an `aria-label` / `aria-labelledby` on
+  the group itself. Without it, screen readers can't announce what
+  the group represents.
+- Each `Radio` MUST have its own `label` (or `aria-label`). The kit
+  forwards `aria-checked` and `role="radio"` automatically.
+- Arrow keys cycle the focused option; Space selects the focused
+  option; Tab moves between groups (RAC's roving-tabindex contract).
+- `isDisabled` on an individual Radio renders that option as
+  unselectable but keeps the group operable for the rest of the
+  options.
+- Avoid relying on colour alone — the dot glyph and the label
+  together carry the meaning.
+
+## Related components
+
+- [Checkbox](?path=/docs/web-primitives-checkbox--docs) — independent boolean (multi-select).
+- [Switch](?path=/docs/web-primitives-switch--docs) — single boolean that takes effect immediately.
+- [Select](?path=/docs/web-primitives-select--docs) — single choice from a large set of options.

--- a/packages/ui/src/components/Radio/Radio.stories.tsx
+++ b/packages/ui/src/components/Radio/Radio.stories.tsx
@@ -1,41 +1,30 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Radio, RadioGroup } from './Radio';
+import { radioControls, radioExcludeFromArgs } from './Radio.controls';
+
+const { args, argTypes } = defineControls(radioControls);
 
 // Explicit `Meta<typeof Radio>` annotation (rather than `satisfies`)
 // keeps the kit's unexported `RadioButtonProps` interface out of the
 // exported `meta` signature — `tsc --noEmit` runs with
 // `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Radio.controls.ts`;
+// `tags: ['autodocs']` removed because `Radio.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Radio> = {
   title: 'Web Primitives/Radio',
   component: Radio,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-radio',
     },
   },
-  args: {
-    label: 'Email notifications',
-    value: 'email',
-    size: 'sm',
-    isDisabled: false,
-  },
-  argTypes: {
-    label: { control: 'text' },
-    hint: { control: 'text' },
-    value: { control: 'text' },
-    size: { control: 'inline-radio', options: ['sm', 'md'] },
-    isDisabled: { control: 'boolean' },
-    onBlur: { control: false, action: 'blurred' },
-    onFocus: { control: false, action: 'focused' },
-    onFocusChange: { control: false, action: 'focus-changed' },
-    onHoverChange: { control: false, action: 'hover-changed' },
-    className: { control: false, table: { disable: true } },
-    ref: { control: false, table: { disable: true } },
-    inputRef: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <RadioGroup defaultValue="email" aria-label="Notification channel">
@@ -48,19 +37,7 @@ const meta: Meta<typeof Radio> = {
 export default meta;
 type Story = StoryObj<typeof Radio>;
 
-// RAC-forwarded props not useful as Storybook knobs.
-export const excludeFromArgs = [
-  'autoFocus',
-  'children',
-  'aria-label',
-  'aria-labelledby',
-  'aria-describedby',
-  'aria-details',
-  'excludeFromTabOrder',
-  'translate',
-  'slot',
-  'data-rac',
-];
+export const excludeFromArgs = radioExcludeFromArgs;
 
 export const Default: Story = {};
 

--- a/packages/ui/src/components/Switch/Switch.controls.ts
+++ b/packages/ui/src/components/Switch/Switch.controls.ts
@@ -1,0 +1,125 @@
+// `Switch.controls.ts` — single source of truth for Switch's variant
+// matrix. Story (`Switch.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Switch.mdx`)
+// reads the same spec via `<Controls />`.
+//
+// Note on `isSelected`: RAC `<Switch>` switches into controlled mode
+// the moment `isSelected` is present in props (even when `false`).
+// To keep the controls panel surfacing the prop without freezing the
+// runtime switch, the entry omits `default` — it appears in
+// `argTypes` but stays out of `args`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md'] as const;
+
+export const switchControls = {
+  label: {
+    type: 'text',
+    default: 'Enable notifications',
+    description:
+      'Visible label rendered next to the toggle. Always provide one — labels satisfy axe `label` and pair the control with assistive tech automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the label. Use to clarify what the toggle does or note any side-effects ("Takes effect immediately.").',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'sm',
+    description:
+      'Visual scale. `sm` (default) for dense settings panels, `md` for hero / focal-point toggles in card layouts.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  slim: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Render the slim track variant — narrower height, smaller knob. Use when toggles must blend into typography-dense rows (table cells, list items).',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Block all interaction and dim the control. The native `disabled` attribute is forwarded so axe and assistive tech treat the switch as inert.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isSelected: {
+    type: 'boolean',
+    description:
+      'Controlled selection state. Setting this prop puts the switch in controlled mode — pair with `onChange` to manage state outside.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isReadOnly: {
+    type: 'boolean',
+    description:
+      'Switch is focusable but not toggleable. Prefer over `isDisabled` when the value should remain accessible to screen readers.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  defaultSelected: {
+    type: 'boolean',
+    description:
+      'Initial selection for uncontrolled usage. Leave `isSelected` undefined when using this so RAC manages state internally.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  name: {
+    type: 'text',
+    description:
+      'Form field name forwarded to the native input — required for native form submission.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  value: {
+    type: 'text',
+    description:
+      'Form field value forwarded when the switch is on (default: `"on"`). Distinct from `isSelected` — this is the submitted payload.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onChange: {
+    type: false,
+    action: 'changed',
+    description:
+      'Fires when the switch toggles (RAC `onChange` contract — receives the new boolean).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onBlur: {
+    type: false,
+    action: 'blurred',
+    description: 'Fires when focus leaves the switch.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onFocus: {
+    type: false,
+    action: 'focused',
+    description: 'Fires when focus enters the switch.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// RAC-forwarded props that aren't useful as Storybook knobs; covered
+// by the F6 prop-coverage gate.
+export const switchExcludeFromArgs = defineExcludeFromArgs([
+  'autoFocus',
+  'children',
+  'inputRef',
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'aria-controls',
+  'excludeFromTabOrder',
+  'form',
+  'translate',
+  'slot',
+  'data-rac',
+] as const);

--- a/packages/ui/src/components/Switch/Switch.mdx
+++ b/packages/ui/src/components/Switch/Switch.mdx
@@ -1,0 +1,67 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as SwitchStories from './Switch.stories';
+
+<Meta of={SwitchStories} />
+
+# Switch
+
+Boolean toggle that takes effect immediately. Use Switch for settings
+where flipping the control changes the world right away — no Save
+step. Built on react-aria-components.
+
+## When to use
+
+- Settings that take effect on toggle: notifications on/off,
+  airplane mode, dark mode preference.
+- Quick-action toggles inside lists / cards: enable a device,
+  activate a scene.
+- Feature flags exposed in admin panels (with audit trails).
+
+## When NOT to use
+
+- **Boolean inside a form that has a Submit / Save step** → use [Checkbox](?path=/docs/web-primitives-checkbox--docs); the established pattern for "I agree" / "Subscribe to newsletter" is a checkbox, not a switch.
+- **Mutually exclusive choice from a small set** → use [Radio](?path=/docs/web-primitives-radio--docs).
+- **Setting that requires confirmation** → wrap a toggle in a [Modal](?path=/docs/web-primitives-modal--docs); a bare Switch implies "fires immediately" and surprises the user.
+
+## Anatomy
+
+<Canvas of={SwitchStories.On} />
+
+A horizontal track with a sliding knob (`sm` or `md`, optionally
+`slim` for tighter rows), paired with a `label` to the side and an
+optional `hint` caption beneath.
+
+```tsx
+<Switch label="Enable notifications" defaultSelected />
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Always set `label`. Visible labels satisfy axe `label` and pair the
+  control with assistive tech automatically. For visually hidden
+  labels (rare) use `aria-label` instead.
+- Space toggles the switch; Enter never toggles it (the kit follows
+  RAC's keyboard contract — Enter is reserved for form submission).
+- The kit forwards `role="switch"` + `aria-checked` automatically; do
+  not override the role.
+- Avoid relying on track / knob colour alone to communicate state —
+  pair with the label and (when state is non-obvious) a `hint` like
+  "On" / "Off" inline.
+- Confirm destructive actions with a [Modal](?path=/docs/web-primitives-modal--docs). A Switch
+  implies "fires immediately" — if a flip needs a "are you sure?"
+  step, the toggle is not the right primitive.
+
+## Related components
+
+- [Checkbox](?path=/docs/web-primitives-checkbox--docs) — boolean inside a form with a Save step.
+- [Radio](?path=/docs/web-primitives-radio--docs) — single choice from a small set of options.
+- [Modal](?path=/docs/web-primitives-modal--docs) — wrap a Switch in a confirmation dialog when the toggle has destructive consequences.

--- a/packages/ui/src/components/Switch/Switch.stories.tsx
+++ b/packages/ui/src/components/Switch/Switch.stories.tsx
@@ -1,71 +1,36 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Switch } from './Switch';
+import { switchControls, switchExcludeFromArgs } from './Switch.controls';
+
+const { args, argTypes } = defineControls(switchControls);
 
 // Explicit `Meta<typeof Switch>` annotation (rather than `satisfies`)
 // keeps the kit's unexported `ToggleProps` interface out of the
 // exported `meta` signature — `tsc --noEmit` runs with
 // `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Switch.controls.ts`;
+// `tags: ['autodocs']` removed because `Switch.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Switch> = {
   title: 'Web Primitives/Switch',
   component: Switch,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-switch',
     },
   },
-  // RAC `<Switch>` switches into controlled mode the moment `isSelected`
-  // is present in the props (even when `false`). With Storybook's args
-  // panel passing that default but no matching `onChange` handler, the
-  // user can't toggle the switch at all. Keep `isSelected` in
-  // `argTypes` (so the controls panel still surfaces it as a boolean
-  // knob), but leave it out of `args` so RAC manages selection state
-  // internally.
-  args: {
-    label: 'Enable notifications',
-    size: 'sm',
-    slim: false,
-    isDisabled: false,
-  },
-  argTypes: {
-    label: { control: 'text' },
-    hint: { control: 'text' },
-    size: { control: 'inline-radio', options: ['sm', 'md'] },
-    slim: { control: 'boolean' },
-    isDisabled: { control: 'boolean' },
-    isSelected: { control: 'boolean' },
-    isReadOnly: { control: 'boolean' },
-    defaultSelected: { control: 'boolean' },
-    name: { control: 'text' },
-    value: { control: 'text' },
-    onChange: { control: false, action: 'changed' },
-    onBlur: { control: false, action: 'blurred' },
-    onFocus: { control: false, action: 'focused' },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
 };
 
 export default meta;
 type Story = StoryObj<typeof Switch>;
 
-// RAC-forwarded props not useful as Storybook knobs.
-export const excludeFromArgs = [
-  'autoFocus',
-  'children',
-  'inputRef',
-  'aria-label',
-  'aria-labelledby',
-  'aria-describedby',
-  'aria-details',
-  'aria-controls',
-  'excludeFromTabOrder',
-  'form',
-  'translate',
-  'slot',
-  'data-rac',
-];
+export const excludeFromArgs = switchExcludeFromArgs;
 
 export const Default: Story = {};
 


### PR DESCRIPTION
## Summary

- Converts P6 form-control primitives (Checkbox + Radio + Switch) to the controls + MDX docs pattern from F1.5-1.
- Each component ships a typed `defineControls` spec (`Checkbox.controls.ts` / `Radio.controls.ts` / `Switch.controls.ts`) covering every public prop with descriptions per row.
- New MDX pages (`Checkbox.mdx` / `Radio.mdx` / `Switch.mdx`) ship the 6 mandatory sections (When to use / When NOT / Anatomy / Variants / Props / A11y / Related).
- Stories drop `tags: ['autodocs']`, consume `defineControls`, and re-export `excludeFromArgs` from the controls modules.

## Scope

**In**

- `packages/ui/src/components/Checkbox/Checkbox.controls.ts`, `Checkbox.mdx`, `Checkbox.stories.tsx` refactor
- `packages/ui/src/components/Radio/Radio.controls.ts`, `Radio.mdx`, `Radio.stories.tsx` refactor
- `packages/ui/src/components/Switch/Switch.controls.ts`, `Switch.mdx`, `Switch.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues (F1.5-8 ⇒ Select, etc.).

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Checkbox/Radio/Switch MDX pages render; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green (no unintended snapshot diffs)

Closes #269