### PR TITLE
feat(ui): controls + MDX docs for Select (F1.5-8)

### DIFF
--- a/packages/ui/src/components/Select/Select.controls.ts
+++ b/packages/ui/src/components/Select/Select.controls.ts
@@ -1,0 +1,174 @@
+// `Select.controls.ts` — single source of truth for Select's variant
+// matrix. Story (`Select.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Select.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+
+export const selectControls = {
+  label: {
+    type: 'text',
+    default: 'Country',
+    description:
+      'Visible label rendered above the trigger. Always provide one — labels satisfy axe `label` and pair the Select with assistive tech automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the trigger. Doubles as the error message when `isInvalid` is true (the kit re-styles it red and adds `aria-describedby`).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  placeholder: {
+    type: 'text',
+    default: 'Select a country',
+    description:
+      'Hint text shown when no option is selected. Never use placeholder as a substitute for a label — use the `label` prop instead.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  tooltip: {
+    type: 'text',
+    description:
+      'Inline tooltip trigger appended to the label (info icon). Use for short clarifying copy when `hint` would crowd the field.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale. `sm` for compact toolbars / table cells, `md` (default) for forms, `lg` for hero affordances.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Block all interaction and dim the trigger. The kit forwards `aria-disabled` so axe and assistive tech treat the Select as inert.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isInvalid: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Surface validation error styling (red border + ring on the trigger). Pair with a `hint` to describe the error; the kit wires `aria-invalid` + `aria-describedby` automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  isRequired: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Mark the field as required (renders an indicator next to the label and forwards `aria-required`). Use `hideRequiredIndicator` to drop the visual marker on dense forms while keeping the a11y semantics.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  hideRequiredIndicator: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Hide the visual `*` next to the label even when `isRequired` is true. Keep `isRequired` set so the a11y contract still reports the field as required.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  selectedKey: {
+    type: 'text',
+    description:
+      'Controlled selection — the `id` of the currently selected `SelectItem`. Pair with `onSelectionChange` to manage state outside.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  defaultSelectedKey: {
+    type: 'text',
+    description:
+      'Initial selection for uncontrolled usage — the `id` of the option to start selected. Leave `selectedKey` undefined when using this so RAC manages state internally.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  name: {
+    type: 'text',
+    description:
+      'Form field name forwarded to the hidden native input — required for native form submission.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onSelectionChange: {
+    type: false,
+    action: 'selection-changed',
+    description: 'Fires when the selected option changes (RAC contract — receives the new key).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onOpenChange: {
+    type: false,
+    action: 'open-changed',
+    description:
+      'Fires when the popover opens or closes (RAC contract — receives the new boolean).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onBlur: {
+    type: false,
+    action: 'blurred',
+    description: 'Fires when focus leaves the trigger.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onFocus: {
+    type: false,
+    action: 'focused',
+    description: 'Fires when focus enters the trigger.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  items: {
+    type: false,
+    description:
+      'Array of option objects (`{ id, label, … }`) rendered into the popover ListBox. Pair with `children` (a render function) for typed dynamic collections.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  children: {
+    type: false,
+    description:
+      'Render function `(item) => <SelectItem id={item.id} label={item.label} />` — the kit drives RAC `<ListBox>` collection via this signature.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  icon: {
+    type: false,
+    description: 'Optional leading icon rendered inside the trigger button.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  popoverClassName: {
+    type: false,
+    description: 'Tailwind override hook for the popover surface that wraps the option list.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  ref: {
+    type: false,
+    description: 'Forwarded ref to the kit `<Select>` wrapper element.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+// RAC-forwarded props that aren't useful as Storybook knobs but flow
+// through type-checking; covered by the F6 prop-coverage gate.
+export const selectExcludeFromArgs = defineExcludeFromArgs([
+  'autoFocus',
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'aria-errormessage',
+  'excludeFromTabOrder',
+  'form',
+  'translate',
+  'slot',
+  'data-rac',
+  'menuTrigger',
+  'shouldFlip',
+  'disabledKeys',
+  'validate',
+  'validationBehavior',
+  'isOpen',
+  'defaultOpen',
+  'autoComplete',
+  'key',
+] as const);

--- a/packages/ui/src/components/Select/Select.mdx
+++ b/packages/ui/src/components/Select/Select.mdx
@@ -1,0 +1,79 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as SelectStories from './Select.stories';
+
+<Meta of={SelectStories} />
+
+# Select
+
+Single-value picker that opens a popover ListBox of options. Built on
+react-aria-components — keyboard navigation (arrow / typeahead /
+Escape), focus trapping, and screen-reader announcements come from
+the kit. Sibling primitives (`ComboBox`, `MultiSelect`,
+`NativeSelect`) are re-exported for the search / multi-value /
+native-form variants.
+
+## When to use
+
+- Pick one value from a known set of 6+ options where comparing all
+  options at once isn't useful.
+- Form fields with a long but bounded list (countries, currencies,
+  timezones).
+- Inline filter triggers in toolbars (use `size="sm"`).
+
+## When NOT to use
+
+- **2–5 mutually exclusive options** → use [Radio](?path=/docs/web-primitives-radio--docs); seeing all options at a glance helps comparison.
+- **Independent boolean** → use [Checkbox](?path=/docs/web-primitives-checkbox--docs) or [Switch](?path=/docs/web-primitives-switch--docs).
+- **Free-form value not in a known set** → use [Input](?path=/docs/web-primitives-input--docs).
+- **Search-as-you-type** → use the `WithSearch` story / sibling `ComboBox` primitive instead of plain Select.
+- **Native picker (e.g. iOS-style mobile dropdown)** → use the `Native` story / sibling `NativeSelect` primitive.
+
+## Anatomy
+
+<Canvas of={SelectStories.Default} />
+
+A trigger button (label + selected value or placeholder + chevron),
+which opens a popover containing the option ListBox. Items render
+via the `children` render function consuming the `items` collection.
+
+```tsx
+<Select label="Country" items={COUNTRIES}>
+  {(item) => <SelectItem id={item.id} label={item.label} />}
+</Select>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Always set `label`. Visible labels satisfy axe `label` and pair the
+  Select with assistive tech automatically. For visually hidden
+  labels (rare) use `aria-label` instead.
+- Keyboard contract (RAC): Space / Enter / Arrow Down opens the
+  popover; Arrow keys move focus through items; typeahead jumps to
+  matching options; Escape closes without selecting; Enter selects
+  the focused option.
+- The popover is focus-trapped — Tab cycles within the ListBox until
+  the popover closes (Escape or selection).
+- `isInvalid` re-styles the hint to red AND wires
+  `aria-invalid="true"` + `aria-describedby` to the hint node, so
+  screen readers announce the error along with the label.
+- `isRequired` forwards `aria-required="true"` even when the visual
+  marker is hidden via `hideRequiredIndicator` — keep the prop set so
+  the a11y contract holds on dense forms.
+- For 50+ options, prefer `ComboBox` (search) — long ListBoxes are
+  hard to navigate with screen readers regardless of focus
+  management.
+
+## Related components
+
+- [Radio](?path=/docs/web-primitives-radio--docs) — single choice from a small set (2–5) where seeing all options helps.
+- [Checkbox](?path=/docs/web-primitives-checkbox--docs) — independent boolean (multi-select).
+- [Input](?path=/docs/web-primitives-input--docs) — free-form text capture when the value isn't from a fixed set.

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import {
   ComboBox,
   MultiSelect,
@@ -8,51 +9,29 @@ import {
   SelectItem,
   type SelectItemType,
 } from './Select';
+import { selectControls, selectExcludeFromArgs } from './Select.controls';
+
+const { args, argTypes } = defineControls(selectControls);
 
 // Explicit `Meta<typeof Select>` annotation (rather than `satisfies`)
 // keeps the kit's deep RAC generic chains (`AriaSelectProps<SelectItemType>`
 // etc.) out of the exported `meta` signature — `tsc --noEmit` runs with
 // `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Select.controls.ts`;
+// `tags: ['autodocs']` removed because `Select.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Select> = {
   title: 'Web Primitives/Select',
   component: Select,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-select',
     },
   },
-  args: {
-    label: 'Country',
-    placeholder: 'Select a country',
-    size: 'md',
-    isDisabled: false,
-  },
-  argTypes: {
-    label: { control: 'text' },
-    hint: { control: 'text' },
-    placeholder: { control: 'text' },
-    tooltip: { control: 'text' },
-    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
-    isDisabled: { control: 'boolean' },
-    isInvalid: { control: 'boolean' },
-    isRequired: { control: 'boolean' },
-    hideRequiredIndicator: { control: 'boolean' },
-    selectedKey: { control: 'text' },
-    defaultSelectedKey: { control: 'text' },
-    name: { control: 'text' },
-    onSelectionChange: { control: false, action: 'selection-changed' },
-    onOpenChange: { control: false, action: 'open-changed' },
-    onBlur: { control: false, action: 'blurred' },
-    onFocus: { control: false, action: 'focused' },
-    items: { control: false, table: { disable: true } },
-    children: { control: false, table: { disable: true } },
-    icon: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-    popoverClassName: { control: false, table: { disable: true } },
-    ref: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 360 }}>
@@ -65,33 +44,7 @@ const meta: Meta<typeof Select> = {
 export default meta;
 type Story = StoryObj<typeof Select>;
 
-// RAC-forwarded props that aren't useful as Storybook knobs but flow
-// through type-checking; covered by the F6 prop-coverage gate.
-export const excludeFromArgs = [
-  'autoFocus',
-  'aria-label',
-  'aria-labelledby',
-  'aria-describedby',
-  'aria-details',
-  'aria-errormessage',
-  'excludeFromTabOrder',
-  'form',
-  'translate',
-  'slot',
-  'data-rac',
-  'menuTrigger',
-  'shouldFlip',
-  'disabledKeys',
-  'validate',
-  'validationBehavior',
-  'isOpen',
-  'defaultOpen',
-  'autoComplete',
-  // Kit popover surface — not knobs.
-  'key',
-  'children',
-  'items',
-];
+export const excludeFromArgs = selectExcludeFromArgs;
 
 const COUNTRIES: SelectItemType[] = [
   { id: 'tr', label: 'Türkiye' },


### PR DESCRIPTION
## Summary

- Converts P7 (Select) primitive to the controls + MDX docs pattern from F1.5-1.
- `Select.controls.ts` covers every public prop with descriptions per row.
- New `Select.mdx` ships the 6 mandatory sections, including notes on sibling primitives (`ComboBox`, `MultiSelect`, `NativeSelect`).
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/Select/Select.controls.ts`
- `packages/ui/src/components/Select/Select.mdx`
- `packages/ui/src/components/Select/Select.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Select MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #271