### PR TITLE
feat(ui): controls + MDX docs for Tabs (F1.5-9)

### DIFF
--- a/packages/ui/src/components/Tabs/Tabs.controls.ts
+++ b/packages/ui/src/components/Tabs/Tabs.controls.ts
@@ -1,0 +1,99 @@
+// `Tabs.controls.ts` — single source of truth for Tabs's variant
+// matrix. Story (`Tabs.stories.tsx`) imports the spec and spreads it
+// into `meta.args` / `meta.argTypes`; MDX docs (`Tabs.mdx`) reads
+// the same spec via `<Controls />`.
+//
+// Note: the visual variant (`type` — line / underline / button-brand /
+// button-gray) and `size` are TabList-only props, set on
+// `<Tabs.List>` rather than the root `<Tabs>`. They appear in
+// `excludeFromArgs` so the F6 prop-coverage gate stays green without
+// surfacing irrelevant root-level controls.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const orientationOptions = ['horizontal', 'vertical'] as const;
+const keyboardActivationOptions = ['automatic', 'manual'] as const;
+
+export const tabsControls = {
+  defaultSelectedKey: {
+    type: 'text',
+    default: 'overview',
+    description:
+      'Initial selected tab `id` for uncontrolled usage. Leave `selectedKey` undefined when using this so RAC manages selection internally.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  selectedKey: {
+    type: 'text',
+    description:
+      'Controlled selected tab `id`. Pair with `onSelectionChange` to manage state outside the component.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  orientation: {
+    type: 'inline-radio',
+    options: orientationOptions,
+    default: 'horizontal',
+    description:
+      'Layout direction. `horizontal` (default) renders the TabList above the panels; `vertical` renders the list to the side (compose with flex/grid in the parent).',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof orientationOptions)[number]>,
+  keyboardActivation: {
+    type: 'inline-radio',
+    options: keyboardActivationOptions,
+    default: 'manual',
+    description:
+      'Arrow-key behaviour. `manual` (default) moves focus only — Space / Enter activates the focused tab. `automatic` activates on focus, mirroring the WAI-ARIA "automatic" pattern (use sparingly — keyboard users can scrub through panels by accident).',
+    category: 'A11y',
+  } satisfies ControlSpec<(typeof keyboardActivationOptions)[number]>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Disable the entire Tabs group. Individual tabs can be disabled via `<Tabs.Trigger isDisabled>`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  onSelectionChange: {
+    type: false,
+    action: 'selection-changed',
+    description: 'Fires when the selected tab changes (RAC contract — receives the new key).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<Tabs.List>` (containing `<Tabs.Trigger>` rows) and one `<Tabs.Content id="…">` per tab. The static-property namespace mirrors the Radix idiom while the kit re-exports `Tab` / `TabList` / `TabPanel` for direct use.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// `react-docgen-typescript` walks the static-property namespace on
+// `Tabs` (Tabs.List, Tabs.Trigger, Tabs.Content) and surfaces their
+// own props on the root signature too. The TabList-only props
+// (`size`, `type`, `items`, `fullWidth`) belong on `<Tabs.List>` per
+// the Glaon API; expose them via the sub-component story rather than
+// the root meta. The remaining entries are RAC-forwarded props.
+export const tabsExcludeFromArgs = defineExcludeFromArgs([
+  // TabList-only props (set on `<Tabs.List type=… size=… fullWidth>`).
+  'size',
+  'type',
+  'items',
+  'fullWidth',
+  // RAC-forwarded props not useful as Storybook knobs.
+  'autoFocus',
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'translate',
+  'slot',
+  'data-rac',
+  'ref',
+  'id',
+  'style',
+  'dir',
+] as const);

--- a/packages/ui/src/components/Tabs/Tabs.mdx
+++ b/packages/ui/src/components/Tabs/Tabs.mdx
@@ -1,0 +1,92 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as TabsStories from './Tabs.stories';
+
+<Meta of={TabsStories} />
+
+# Tabs
+
+Switch between sibling views that share the same surface. Built on
+react-aria-components — Glaon adds the visual variants (`underline`,
+`button-brand`, `button-gray`, `line`) and exposes a Radix-style
+namespace (`Tabs.List` / `Tabs.Trigger` / `Tabs.Content`) on top of
+the kit's `Tab` / `TabList` / `TabPanel` exports.
+
+## When to use
+
+- Switch between peer views inside a single page or section: profile
+  tabs (Overview / Settings / Billing), settings tab strips, log
+  level filters.
+- Sectioning content where only one view is relevant at a time and
+  navigating between them is fast (sub-second cognitive switch).
+- Date-range pickers (Day / Week / Month / Year) — the
+  `button-gray` variant is the canonical look for these.
+
+## When NOT to use
+
+- **Distinct top-level navigation** → use [SideNav](?path=/docs/web-primitives-sidenav--docs) or [TopBar](?path=/docs/web-primitives-topbar--docs); tabs imply peer views, not site navigation.
+- **More than ~7 options** → the row gets unscannable; use [Select](?path=/docs/web-primitives-select--docs) or refactor the IA.
+- **Wizards / multi-step forms** → use a Stepper pattern (Phase 2); tabs let users skip ahead in any order, which breaks step semantics.
+- **Mutually exclusive form options** → use [Radio](?path=/docs/web-primitives-radio--docs) inside the form; tabs change the visible surface, not the form value.
+
+## Anatomy
+
+<Canvas of={TabsStories.Default} />
+
+Compose with three slots:
+
+- **`Tabs.List`** — owns the visual variant (`type`), size, and
+  `fullWidth` flag. Houses one or more `<Tabs.Trigger>` rows.
+- **`Tabs.Trigger`** — clickable tab head. Accepts `id` (key),
+  `label`, optional `icon`, optional `badge`, optional `isDisabled`.
+- **`Tabs.Content`** — the panel rendered when the matching `id` is
+  selected. One per Trigger.
+
+```tsx
+<Tabs defaultSelectedKey="overview">
+  <Tabs.List type="button-brand">
+    <Tabs.Trigger id="overview" label="Overview" />
+    <Tabs.Trigger id="settings" label="Settings" />
+    <Tabs.Trigger id="billing" label="Billing" />
+  </Tabs.List>
+  <Tabs.Content id="overview">…</Tabs.Content>
+  <Tabs.Content id="settings">…</Tabs.Content>
+  <Tabs.Content id="billing">…</Tabs.Content>
+</Tabs>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The kit forwards `role="tablist"` / `role="tab"` / `role="tabpanel"`
+  and the `aria-controls` / `aria-labelledby` cross-references
+  automatically; do not override the roles.
+- Always set a label for the TabList — either a visible heading
+  above it or `aria-label` / `aria-labelledby` on the `<Tabs.List>`
+  itself. Without it, screen readers announce the group as "tab
+  list" with no context.
+- Default `keyboardActivation: 'manual'` — Arrow keys move focus
+  only; Space / Enter activates the focused tab. This is the WAI-ARIA
+  recommended pattern for screen-reader users (focusing a tab
+  shouldn't load its panel).
+- Use `keyboardActivation: 'automatic'` only when the panels are
+  cheap to switch between and don't carry side-effects — otherwise
+  keyboard users scrub through state unintentionally.
+- For vertical orientation, use Up/Down arrows to navigate (the kit
+  switches the arrow-key contract automatically).
+- `<Tabs.Trigger isDisabled>` keeps the tab focusable but
+  unactivatable — better than removing the trigger (so the IA stays
+  consistent across users).
+
+## Related components
+
+- [SideNav](?path=/docs/web-primitives-sidenav--docs) / [TopBar](?path=/docs/web-primitives-topbar--docs) — site-level navigation, not peer-view switching.
+- [Select](?path=/docs/web-primitives-select--docs) — when there are too many options for a tab strip.
+- [Breadcrumb](?path=/docs/web-primitives-breadcrumb--docs) — hierarchical context (parent/child); Tabs are peer relationships.

--- a/packages/ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.stories.tsx
@@ -2,37 +2,31 @@ import type { ReactNode } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { storybookIcons } from '../../icons/storybook';
 import { Tabs } from './Tabs';
+import { tabsControls, tabsExcludeFromArgs } from './Tabs.controls';
+
+const { args, argTypes } = defineControls(tabsControls);
 
 // Explicit `Meta<typeof Tabs>` annotation (rather than `satisfies`)
 // keeps the kit's deep RAC generic chains out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Tabs.controls.ts`;
+// `tags: ['autodocs']` removed because `Tabs.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Tabs> = {
   title: 'Web Primitives/Tabs',
   component: Tabs,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-tabs',
     },
   },
-  args: {
-    defaultSelectedKey: 'overview',
-    orientation: 'horizontal',
-    keyboardActivation: 'manual',
-  },
-  argTypes: {
-    defaultSelectedKey: { control: 'text' },
-    selectedKey: { control: 'text' },
-    orientation: { control: 'inline-radio', options: ['horizontal', 'vertical'] },
-    keyboardActivation: { control: 'inline-radio', options: ['automatic', 'manual'] },
-    isDisabled: { control: 'boolean' },
-    onSelectionChange: { control: false, action: 'selection-changed' },
-    children: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 640 }}>
@@ -45,32 +39,7 @@ const meta: Meta<typeof Tabs> = {
 export default meta;
 type Story = StoryObj<typeof Tabs>;
 
-// `react-docgen-typescript` walks the static-property namespace on
-// `Tabs` (Tabs.List, Tabs.Trigger, Tabs.Content) and surfaces their
-// own props on the root signature too. The TabList-only props
-// (`size`, `type`, `items`, `fullWidth`) belong on `<Tabs.List>` per
-// the Glaon API; expose them via the sub-component story rather than
-// the root meta.
-export const excludeFromArgs = [
-  // TabList-only props (set on `<Tabs.List type=… size=… fullWidth>`).
-  'size',
-  'type',
-  'items',
-  'fullWidth',
-  // RAC-forwarded props not useful as Storybook knobs.
-  'autoFocus',
-  'aria-label',
-  'aria-labelledby',
-  'aria-describedby',
-  'aria-details',
-  'translate',
-  'slot',
-  'data-rac',
-  'ref',
-  'id',
-  'style',
-  'dir',
-];
+export const excludeFromArgs = tabsExcludeFromArgs;
 
 const samplePanel = (text: string): ReactNode => (
   <div className="p-4 text-sm text-secondary">{text}</div>


### PR DESCRIPTION
## Summary

- Converts P8 (Tabs) primitive to the controls + MDX docs pattern from F1.5-1.
- `Tabs.controls.ts` covers root-level Tabs props with descriptions per row; TabList-only props (`size`, `type`, `items`, `fullWidth`) stay in `excludeFromArgs` so they don't surface as irrelevant root knobs.
- New `Tabs.mdx` ships the 6 mandatory sections plus the `Tabs.List` / `Tabs.Trigger` / `Tabs.Content` composition contract.
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/Tabs/Tabs.controls.ts`
- `packages/ui/src/components/Tabs/Tabs.mdx`
- `packages/ui/src/components/Tabs/Tabs.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Tabs MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #273