### PR TITLE
feat(ui): controls + MDX docs for Breadcrumb (F1.5-10)

### DIFF
--- a/packages/ui/src/components/Breadcrumb/Breadcrumb.controls.ts
+++ b/packages/ui/src/components/Breadcrumb/Breadcrumb.controls.ts
@@ -1,0 +1,76 @@
+// `Breadcrumb.controls.ts` — single source of truth for Breadcrumb's
+// variant matrix. Story (`Breadcrumb.stories.tsx`) imports the spec
+// and spreads it into `meta.args` / `meta.argTypes`; MDX docs
+// (`Breadcrumb.mdx`) reads the same spec via `<Controls />`.
+//
+// Note: BreadcrumbItem-only props (`href`, `icon`, `isEllipsis`,
+// `avatarSrc`, `onClick`) and BreadcrumbAccountItem-only props
+// (`items`, `selectedKey`, `onSelectionChange`) are routed through
+// `excludeFromArgs` rather than `argTypes` — they belong on the
+// child components, not the root `<Breadcrumb>`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const typeOptions = ['text', 'text-line', 'button'] as const;
+const dividerOptions = ['chevron', 'slash'] as const;
+
+export const breadcrumbControls = {
+  type: {
+    type: 'inline-radio',
+    options: typeOptions,
+    default: 'text',
+    description:
+      'Visual treatment for items. `text` (default) is plain text crumbs, `text-line` adds an underline on hover (Apple-style), `button` renders each crumb as a pill / chip.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof typeOptions)[number]>,
+  divider: {
+    type: 'inline-radio',
+    options: dividerOptions,
+    default: 'chevron',
+    description:
+      'Glyph rendered between items. `chevron` (default) follows the kit / web convention; `slash` matches GitHub-style breadcrumbs and dense URLs.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof dividerOptions)[number]>,
+  maxVisibleItems: {
+    type: 'number',
+    min: 2,
+    max: 10,
+    step: 1,
+    default: 4,
+    description:
+      'Cap on items rendered before truncation kicks in. The middle of the path collapses behind a `…` ellipsis once the count exceeds this — first / last / current always remain visible. Tune for narrow surfaces.',
+    category: 'Behavior',
+  } satisfies ControlSpec<number>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<Breadcrumb.Item href="…">…</Breadcrumb.Item>` for each segment. The kit auto-inserts dividers between items and renders the last item as the "current page" (no link styling).',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer `<nav aria-label="Breadcrumbs">` element.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// `react-docgen-typescript` walks the static-property namespace
+// (`Breadcrumb.Item`, `Breadcrumb.AccountItem`) and surfaces those
+// sub-components' props on the merged root signature. Storybook's
+// `ArgTypes<BreadcrumbsProps>` type only allows root props, so we
+// can't add these to `argTypes`; surface them through the F6
+// `excludeFromArgs` allowlist instead — consumers set them on
+// `<Breadcrumb.Item …>`, not the root.
+export const breadcrumbExcludeFromArgs = defineExcludeFromArgs([
+  // BreadcrumbItem-only props.
+  'href',
+  'icon',
+  'isEllipsis',
+  'avatarSrc',
+  'onClick',
+  // BreadcrumbAccountItem-only props.
+  'items',
+  'selectedKey',
+  'onSelectionChange',
+] as const);

--- a/packages/ui/src/components/Breadcrumb/Breadcrumb.mdx
+++ b/packages/ui/src/components/Breadcrumb/Breadcrumb.mdx
@@ -1,0 +1,78 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as BreadcrumbStories from './Breadcrumb.stories';
+
+<Meta of={BreadcrumbStories} />
+
+# Breadcrumb
+
+Hierarchical path navigation. Renders the user's location inside an
+information architecture as a chain of links culminating in the
+current page. Web only — RN counterpart is queued as a follow-up
+issue (Phase 2 mobile primitive work).
+
+## When to use
+
+- Pages two or more levels deep where users need to trace back: file
+  paths, project hierarchies, multi-section settings.
+- Long-form workflows where users want to jump back to an ancestor
+  without using the browser back button.
+- Any page where the title alone doesn't communicate context (e.g.
+  generic names like "Settings" / "Details" / "Edit").
+
+## When NOT to use
+
+- **Top-level pages** (home, dashboard root) — there's nothing to
+  navigate back to.
+- **Peer view switching inside a single page** → use [Tabs](?path=/docs/web-primitives-tabs--docs).
+- **Site-level navigation chrome** → use [TopBar](?path=/docs/web-primitives-topbar--docs) / [SideNav](?path=/docs/web-primitives-sidenav--docs); breadcrumbs sit _inside_ the page content, not in the global chrome.
+- **Two-step wizards / forms** → use a Stepper pattern (Phase 2); breadcrumbs imply random-access navigation.
+
+## Anatomy
+
+<Canvas of={BreadcrumbStories.Default} />
+
+A `<nav aria-label="Breadcrumbs">` landmark wrapping a list of
+`<Breadcrumb.Item>` segments separated by a divider glyph. The last
+item renders as the current page (no `href`, no link styling).
+
+```tsx
+<Breadcrumb type="text" divider="chevron">
+  <Breadcrumb.Item href="/">Home</Breadcrumb.Item>
+  <Breadcrumb.Item href="/projects">Projects</Breadcrumb.Item>
+  <Breadcrumb.Item>Glaon</Breadcrumb.Item>
+</Breadcrumb>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The kit wraps the list in `<nav aria-label="Breadcrumbs">` so the
+  landmark is announced as a navigation region by screen readers.
+- The current page (last item, no `href`) gets `aria-current="page"`
+  automatically — screen readers announce it distinctly from the
+  ancestor links.
+- Truncation collapses middle items behind a `…` ellipsis dropdown;
+  the dropdown is keyboard-operable (Space / Enter to open, arrows
+  to navigate, Escape to close) and announces the hidden items via
+  `aria-haspopup="menu"`.
+- Avoid placing more than **one** `<Breadcrumb>` per page — multiple
+  `<nav aria-label="Breadcrumbs">` landmarks fail axe
+  `landmark-unique`. (For the same reason there's no Variants gallery
+  story — see `Breadcrumb.stories.tsx` for the rationale.)
+- Keep crumb labels short and meaningful. Generic names ("Detail",
+  "Edit") fail in screen-reader rotor lists; favour the entity name
+  ("Glaon", "Issue #184").
+
+## Related components
+
+- [Tabs](?path=/docs/web-primitives-tabs--docs) — peer-view switching, not hierarchical context.
+- [TopBar](?path=/docs/web-primitives-topbar--docs) / [SideNav](?path=/docs/web-primitives-sidenav--docs) — site navigation chrome (sit outside the page content).
+- [Avatar](?path=/docs/web-primitives-avatar--docs) — paired with `Breadcrumb.AccountItem` for project / org switchers in the breadcrumb chain.

--- a/packages/ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/ui/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,37 +1,31 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { storybookIcons } from '../../icons/storybook';
 import { Breadcrumb } from './Breadcrumb';
+import { breadcrumbControls, breadcrumbExcludeFromArgs } from './Breadcrumb.controls';
+
+const { args, argTypes } = defineControls(breadcrumbControls);
 
 // Explicit `Meta<typeof Breadcrumb>` annotation (rather than
 // `satisfies`) keeps the kit's deep RAC generic chains out of the
 // exported `meta` signature — `tsc --noEmit` runs with
 // `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Breadcrumb.controls.ts`;
+// `tags: ['autodocs']` removed because `Breadcrumb.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Breadcrumb> = {
   title: 'Web Primitives/Breadcrumb',
   component: Breadcrumb,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-breadcrumb',
     },
   },
-  args: {
-    type: 'text',
-    divider: 'chevron',
-    maxVisibleItems: 4,
-  },
-  argTypes: {
-    type: {
-      control: 'inline-radio',
-      options: ['text', 'text-line', 'button'],
-    },
-    divider: { control: 'inline-radio', options: ['chevron', 'slash'] },
-    maxVisibleItems: { control: { type: 'number', min: 2, max: 10, step: 1 } },
-    children: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 720 }}>
@@ -44,25 +38,7 @@ const meta: Meta<typeof Breadcrumb> = {
 export default meta;
 type Story = StoryObj<typeof Breadcrumb>;
 
-// `react-docgen-typescript` walks the static-property namespace
-// (`Breadcrumb.Item`, `Breadcrumb.AccountItem`) and surfaces those
-// sub-components' props on the merged root signature. Storybook's
-// `ArgTypes<BreadcrumbsProps>` type only allows root props, so we
-// can't add these to `argTypes`; surface them through the F6
-// `excludeFromArgs` allowlist instead — consumers set them on
-// `<Breadcrumb.Item …>`, not the root.
-export const excludeFromArgs = [
-  // BreadcrumbItem-only props.
-  'href',
-  'icon',
-  'isEllipsis',
-  'avatarSrc',
-  'onClick',
-  // BreadcrumbAccountItem-only props.
-  'items',
-  'selectedKey',
-  'onSelectionChange',
-];
+export const excludeFromArgs = breadcrumbExcludeFromArgs;
 
 export const Default: Story = {
   render: (args) => (


### PR DESCRIPTION
## Summary

- Converts P9 (Breadcrumb) primitive to the controls + MDX docs pattern from F1.5-1.
- `Breadcrumb.controls.ts` covers root-level Breadcrumb props (`type`, `divider`, `maxVisibleItems`); BreadcrumbItem-only and BreadcrumbAccountItem-only props stay in `excludeFromArgs`.
- New `Breadcrumb.mdx` ships the 6 mandatory sections plus the landmark-unique caveat (why there's no Variants gallery story).
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/Breadcrumb/Breadcrumb.controls.ts`
- `packages/ui/src/components/Breadcrumb/Breadcrumb.mdx`
- `packages/ui/src/components/Breadcrumb/Breadcrumb.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- RN Breadcrumb counterpart remains queued as a separate (Phase 2) issue.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Breadcrumb MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #275