### PR TITLE
feat(ui): controls + MDX docs for TopBar (F1.5-11)

### DIFF
--- a/packages/ui/src/components/TopBar/TopBar.controls.ts
+++ b/packages/ui/src/components/TopBar/TopBar.controls.ts
@@ -1,0 +1,30 @@
+// `TopBar.controls.ts` — single source of truth for TopBar's variant
+// matrix. Story (`TopBar.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`TopBar.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+export const topBarControls = {
+  compact: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Reduce the bar height (`h-12` instead of `h-16`). Use for dense dashboards or wall-tablet layouts where vertical real estate is at a premium.',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<TopBar.Brand>` (left), `<TopBar.Nav>` (centre — collapses below `md`), and `<TopBar.Actions>` (right). The flex layout assigns slots regardless of declaration order.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer `<header>` container.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const topBarExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/TopBar/TopBar.mdx
+++ b/packages/ui/src/components/TopBar/TopBar.mdx
@@ -1,0 +1,89 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as TopBarStories from './TopBar.stories';
+
+<Meta of={TopBarStories} />
+
+# TopBar
+
+Application-shell header. Renders the global navigation chrome at
+the top of every authenticated page: brand on the left, primary nav
+in the centre, user actions on the right.
+
+## When to use
+
+- Top-level navigation chrome on every authenticated page (web app
+  shell, wall-tablet shell).
+- Marketing / public-site headers when you want the same flex
+  layout but different content.
+- Any surface that needs a brand + nav + actions row across the
+  full width of the page.
+
+## When NOT to use
+
+- **Hierarchical context inside a single page** → use [Breadcrumb](?path=/docs/web-primitives-breadcrumb--docs); TopBar belongs in the global chrome, not in page content.
+- **Peer-view switching inside a page** → use [Tabs](?path=/docs/web-primitives-tabs--docs).
+- **Side navigation** → use [SideNav](?path=/docs/web-primitives-sidenav--docs); TopBar and SideNav often coexist in app shells.
+- **Mobile bottom-nav** → out of scope for Phase 1; a mobile-shell BottomBar primitive is queued for Phase 2.
+
+## Anatomy
+
+<Canvas of={TopBarStories.Default} />
+
+Three composition slots, arranged left → centre → right by the
+flex layout regardless of declaration order:
+
+- **`TopBar.Brand`** — logo / wordmark anchor on the left.
+- **`TopBar.Nav`** — `<nav aria-label="Primary">` row of nav links;
+  collapses below `md` breakpoint (provide a hamburger / drawer in
+  `TopBar.Actions` for mobile).
+- **`TopBar.Actions`** — search input, notifications, avatar / user
+  menu, sign-in button.
+
+```tsx
+<TopBar>
+  <TopBar.Brand>
+    <Logo />
+  </TopBar.Brand>
+  <TopBar.Nav>
+    <a href="/devices">Devices</a>
+    <a href="/scenes">Scenes</a>
+  </TopBar.Nav>
+  <TopBar.Actions>
+    <SearchInput />
+    <Avatar />
+  </TopBar.Actions>
+</TopBar>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The root renders `<header>` so it surfaces as a `banner` landmark
+  to screen readers — keep one TopBar per page (multiple `banner`
+  landmarks fail axe `landmark-unique`).
+- `<TopBar.Nav>` renders `<nav aria-label="Primary">` so the
+  navigation region is announced distinctly from any
+  `<Breadcrumb>` (`aria-label="Breadcrumbs"`) further down the page.
+- The `Nav` slot collapses below `md` — provide a mobile menu
+  trigger in `TopBar.Actions` so navigation stays reachable on
+  small screens.
+- Buttons inside `TopBar.Actions` that show only an icon (e.g.
+  notifications bell) MUST set `aria-label` — otherwise the button
+  has no accessible name.
+- Avoid placing additional `<header>` elements inside the TopBar; a
+  single `banner` landmark is the contract.
+
+## Related components
+
+- [SideNav](?path=/docs/web-primitives-sidenav--docs) — secondary global navigation; commonly paired with TopBar in app shells.
+- [Breadcrumb](?path=/docs/web-primitives-breadcrumb--docs) — page-level hierarchy (sits inside the page content, not in TopBar).
+- [Avatar](?path=/docs/web-primitives-avatar--docs) — fits naturally inside `TopBar.Actions` for the user menu trigger.
+- [Input](?path=/docs/web-primitives-input--docs) — search affordance inside `TopBar.Actions`; pair with a leading `search` icon.

--- a/packages/ui/src/components/TopBar/TopBar.stories.tsx
+++ b/packages/ui/src/components/TopBar/TopBar.stories.tsx
@@ -2,11 +2,13 @@ import type { ComponentType, HTMLAttributes } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Avatar } from '../Avatar';
 import { Button } from '../Button';
 import { Input } from '../Input';
 import { storybookIcons } from '../../icons/storybook';
 import { TopBar } from './TopBar';
+import { topBarControls, topBarExcludeFromArgs } from './TopBar.controls';
 
 // Same workaround as in `Input.stories.tsx` — the kit's `Input.icon`
 // is typed `ComponentType<HTMLAttributes<...>>` while our shared
@@ -16,27 +18,26 @@ type InputIcon = ComponentType<HTMLAttributes<HTMLOrSVGElement>>;
 const inputIcon = (name: keyof typeof storybookIcons): InputIcon =>
   storybookIcons[name] as InputIcon;
 
+const { args, argTypes } = defineControls(topBarControls);
+
 // Explicit `Meta<typeof TopBar>` annotation (rather than `satisfies`)
 // keeps the merged static-property type out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `TopBar.controls.ts`;
+// `tags: ['autodocs']` removed because `TopBar.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof TopBar> = {
   title: 'Web Primitives/TopBar',
   component: TopBar,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-topbar',
     },
   },
-  args: {
-    compact: false,
-  },
-  argTypes: {
-    compact: { control: 'boolean' },
-    children: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 1024 }}>
@@ -48,6 +49,8 @@ const meta: Meta<typeof TopBar> = {
 
 export default meta;
 type Story = StoryObj<typeof TopBar>;
+
+export const excludeFromArgs = topBarExcludeFromArgs;
 
 const SampleBrand = () => <span className="text-base font-semibold text-primary">Glaon</span>;
 


### PR DESCRIPTION
## Summary

- Converts P10 (TopBar) primitive to the controls + MDX docs pattern from F1.5-1.
- `TopBar.controls.ts` covers root-level props (`compact`, `children`, `className`).
- New `TopBar.mdx` ships the 6 mandatory sections plus the `TopBar.Brand` / `TopBar.Nav` / `TopBar.Actions` composition contract, including the mobile collapse caveat for the Nav slot.
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/TopBar/TopBar.controls.ts`
- `packages/ui/src/components/TopBar/TopBar.mdx`
- `packages/ui/src/components/TopBar/TopBar.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — TopBar MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #277