### PR TITLE
feat(ui): controls + MDX docs for SideNav (F1.5-12)

### DIFF
--- a/packages/ui/src/components/SideNav/SideNav.controls.ts
+++ b/packages/ui/src/components/SideNav/SideNav.controls.ts
@@ -1,0 +1,50 @@
+// `SideNav.controls.ts` — single source of truth for SideNav's
+// variant matrix. Story (`SideNav.stories.tsx`) imports the spec and
+// spreads it into `meta.args` / `meta.argTypes`; MDX docs
+// (`SideNav.mdx`) reads the same spec via `<Controls />`.
+//
+// Note: SideNavGroup-only (`label`) and SideNavItem-only props
+// (`label`, `href`, `icon`, `badge`, `current`, `onClick`) belong on
+// the child components, not the root `<SideNav>`. They flow through
+// `react-docgen-typescript` because of the static-property merge,
+// so they appear in `excludeFromArgs`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+export const sideNavControls = {
+  collapsed: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Reduce the width to icon-only (`w-16`). Useful as a drawer-style collapse on narrow viewports or in dense tablet layouts. Manage the toggle state in the parent — the SideNav itself is purely visual.',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<SideNav.Brand>` (top), one or more `<SideNav.Group label="…">` blocks (middle, each containing `<SideNav.Item>` rows), and `<SideNav.Footer>` (bottom — anchored via `mt-auto`).',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer `<aside>` container.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// `react-docgen-typescript` walks the static-property namespace
+// (Brand / Group / Item / Footer) and surfaces those sub-components'
+// props on the merged root signature. They belong on the children,
+// not the root — the F6 prop-coverage gate accepts them via this
+// allowlist instead.
+export const sideNavExcludeFromArgs = defineExcludeFromArgs([
+  // SideNavGroup-only props.
+  'label',
+  // SideNavItem-only props.
+  'href',
+  'icon',
+  'badge',
+  'current',
+  'onClick',
+] as const);

--- a/packages/ui/src/components/SideNav/SideNav.mdx
+++ b/packages/ui/src/components/SideNav/SideNav.mdx
@@ -1,0 +1,95 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as SideNavStories from './SideNav.stories';
+
+<Meta of={SideNavStories} />
+
+# SideNav
+
+Application-shell side navigation. Renders the secondary global
+navigation chrome along the left edge: brand on top, grouped nav
+items in the middle, footer items (settings, user card) anchored to
+the bottom.
+
+## When to use
+
+- Secondary global navigation in app-shell layouts (commonly paired
+  with [TopBar](?path=/docs/web-primitives-topbar--docs)). The
+  canonical pattern is "brand + horizontal TopBar across the top,
+  SideNav along the left, page content fills the rest."
+- Long, grouped IA: workspace-level groups separated by eyebrow
+  labels (Workspace / Activity / Account).
+- Dashboards with 5+ top-level destinations where horizontal
+  navigation would feel cramped.
+
+## When NOT to use
+
+- **Hierarchical context inside a single page** → use [Breadcrumb](?path=/docs/web-primitives-breadcrumb--docs); SideNav belongs in the global chrome, not in page content.
+- **Peer-view switching inside a page** → use [Tabs](?path=/docs/web-primitives-tabs--docs).
+- **Mobile / wall-tablet bottom nav** → out of scope for Phase 1; a mobile-shell BottomBar primitive is queued for Phase 2.
+- **Site-wide top nav alone** → use [TopBar](?path=/docs/web-primitives-topbar--docs); SideNav is the _secondary_ axis, not a replacement.
+
+## Anatomy
+
+<Canvas of={SideNavStories.WithGroups} />
+
+Four composition slots, top-to-bottom:
+
+- **`SideNav.Brand`** — logo / wordmark anchor. Hidden in
+  `collapsed` mode unless you provide a 1-character glyph (e.g.
+  "G").
+- **`SideNav.Group`** — optional `label` (uppercase eyebrow,
+  hidden in `collapsed` mode), wraps `<SideNav.Item>` rows in a
+  `<ul>` for `listitem` semantics.
+- **`SideNav.Item`** — `label`, optional `href`, `icon`, `badge`
+  (number / string / ReactNode), and `current` flag (drives
+  `aria-current="page"`).
+- **`SideNav.Footer`** — anchored to the bottom (`mt-auto`). Use
+  for Settings / Profile / a user card.
+
+```tsx
+<SideNav>
+  <SideNav.Brand>
+    <Logo />
+  </SideNav.Brand>
+  <SideNav.Group label="Workspace">
+    <SideNav.Item href="/devices" icon={Cpu01} current label="Devices" />
+    <SideNav.Item href="/scenes" icon={Sun} label="Scenes" />
+  </SideNav.Group>
+  <SideNav.Footer>
+    <SideNav.Item href="/settings" icon={Settings01} label="Settings" />
+  </SideNav.Footer>
+</SideNav>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The root renders `<aside>` containing `<nav aria-label="Sidebar">`
+  so the navigation region is announced distinctly from the TopBar's
+  `aria-label="Primary"` nav.
+- `SideNav.Item` with `current` forwards `aria-current="page"` —
+  screen readers announce the active route distinctly from peers.
+- `SideNav.Group` wraps items in `<ul>` for `listitem` semantics.
+  Items inside `SideNav.Footer` (no list wrapper) render as `<div>`
+  rows so axe doesn't flag a bare `<li>` outside a list.
+- In `collapsed` mode the visible label is hidden but the link
+  retains an `sr-only` accessible name — axe `link-name` stays
+  green and screen readers still announce each destination.
+- Keep one SideNav per page (multiple `aside` landmarks confuse
+  screen-reader rotor lists; the first is announced as
+  `complementary` by default).
+
+## Related components
+
+- [TopBar](?path=/docs/web-primitives-topbar--docs) — primary horizontal navigation chrome; commonly paired with SideNav in app shells.
+- [Breadcrumb](?path=/docs/web-primitives-breadcrumb--docs) — page-level hierarchy (sits inside the page content).
+- [Avatar](?path=/docs/web-primitives-avatar--docs) — fits naturally inside `SideNav.Footer` for a user card.
+- [Badge](?path=/docs/web-primitives-badge--docs) — `SideNav.Item.badge` accepts a Badge node directly when you need richer styling than the auto-rendered count chip.

--- a/packages/ui/src/components/SideNav/SideNav.stories.tsx
+++ b/packages/ui/src/components/SideNav/SideNav.stories.tsx
@@ -2,9 +2,11 @@ import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 import type { FC } from 'react';
 
+import { defineControls } from '../_internal/controls';
 import { Avatar } from '../Avatar';
 import { storybookIcons } from '../../icons/storybook';
 import { SideNav } from './SideNav';
+import { sideNavControls, sideNavExcludeFromArgs } from './SideNav.controls';
 
 // Pull a few icons from the curated picker so stories share the
 // same icon-typing workaround as Button / Alert / TopBar etc. The
@@ -24,27 +26,26 @@ const settings = icon('settings');
 const star = icon('star');
 const user = icon('user');
 
+const { args, argTypes } = defineControls(sideNavControls);
+
 // Explicit `Meta<typeof SideNav>` annotation (rather than `satisfies`)
 // keeps the merged static-property shape out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `SideNav.controls.ts`;
+// `tags: ['autodocs']` removed because `SideNav.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof SideNav> = {
   title: 'Web Primitives/SideNav',
   component: SideNav,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-sidenav',
     },
   },
-  args: {
-    collapsed: false,
-  },
-  argTypes: {
-    collapsed: { control: 'boolean' },
-    children: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ display: 'flex', height: 560 }}>
@@ -56,6 +57,8 @@ const meta: Meta<typeof SideNav> = {
 
 export default meta;
 type Story = StoryObj<typeof SideNav>;
+
+export const excludeFromArgs = sideNavExcludeFromArgs;
 
 const SampleBrand = () => <span className="text-base font-semibold text-primary">Glaon</span>;
 


### PR DESCRIPTION
## Summary

- Converts P11 (SideNav) primitive to the controls + MDX docs pattern from F1.5-1.
- `SideNav.controls.ts` covers root-level props (`collapsed`, `children`, `className`); SideNavGroup-only / SideNavItem-only props stay in `excludeFromArgs`.
- New `SideNav.mdx` ships the 6 mandatory sections plus the four-slot composition contract (`Brand` / `Group` / `Item` / `Footer`) and the collapsed-mode a11y note.
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/SideNav/SideNav.controls.ts`
- `packages/ui/src/components/SideNav/SideNav.mdx`
- `packages/ui/src/components/SideNav/SideNav.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — SideNav MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #279