### PR TITLE
feat(ui): controls + MDX docs for Popover (F1.5-14)

### DIFF
--- a/packages/ui/src/components/Popover/Popover.controls.ts
+++ b/packages/ui/src/components/Popover/Popover.controls.ts
@@ -1,0 +1,68 @@
+// `Popover.controls.ts` — single source of truth for Popover's
+// variant matrix. Story (`Popover.stories.tsx`) imports the spec and
+// spreads it into `meta.args` / `meta.argTypes`; MDX docs
+// (`Popover.mdx`) reads the same spec via `<Controls />`.
+//
+// Note: `placement` / `offset` / `crossOffset` and the rich-content
+// styling live on `<Popover.Content>` (they extend RAC `PopoverProps`),
+// not on the root `<Popover>`. They appear in `excludeFromArgs`
+// rather than `argTypes` since `react-docgen-typescript` surfaces
+// them via the static-property merge but they belong on the child.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+export const popoverControls = {
+  isOpen: {
+    type: 'boolean',
+    description:
+      "Controlled open state. Pair with `onOpenChange` to manage state outside the component. Use sparingly — RAC's default click-trigger / Escape / click-outside contract is usually right.",
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  defaultOpen: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Initial open state for uncontrolled usage. Set `true` for snapshot stories so Chromatic captures the open canvas.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  onOpenChange: {
+    type: false,
+    action: 'open-changed',
+    description:
+      'Fires when the open state changes (RAC `<DialogTrigger>` contract — receives the new boolean).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<Popover.Trigger>` (a focusable child — Button, link, etc.) and `<Popover.Content placement="…">` (any rich React tree). RAC wires `aria-expanded` / `aria-controls` between trigger and surface automatically.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+// `<Popover.Content>` props (placement / offset / crossOffset / kit-
+// internal animation slots) flow through `react-docgen-typescript`
+// because of the static-property merge but belong on the child
+// component. The F6 prop-coverage gate accepts them via this
+// allowlist.
+export const popoverExcludeFromArgs = defineExcludeFromArgs([
+  // PopoverContent-only props (set on `<Popover.Content placement=… offset=…>`).
+  'placement',
+  'offset',
+  'crossOffset',
+  'shouldFlip',
+  'arrowBoundaryOffset',
+  'containerPadding',
+  'shouldUpdatePosition',
+  'isEntering',
+  'isExiting',
+  'className',
+  'style',
+  'UNSAFE_className',
+  'UNSAFE_style',
+  // RAC-forwarded.
+  'translate',
+  'slot',
+  'data-rac',
+] as const);

--- a/packages/ui/src/components/Popover/Popover.mdx
+++ b/packages/ui/src/components/Popover/Popover.mdx
@@ -1,0 +1,92 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as PopoverStories from './Popover.stories';
+
+<Meta of={PopoverStories} />
+
+# Popover
+
+Click-triggered, rich-content overlay. Built on react-aria-components
+(`<DialogTrigger>` + `<Popover>` + `<Dialog>`) — focus return on
+close, Escape dismiss, click-outside dismiss, and portal positioning
+all come from the kit. Use Popover when a Tooltip is too small and a
+Modal is too disruptive.
+
+## When to use
+
+- Inline editors anchored to a trigger: rename, quick-edit, filter
+  picker, colour swatch.
+- Menus that need richer content than plain text (icons, sub-labels,
+  shortcuts) but don't warrant a full Modal.
+- Helper UIs: keyboard shortcut cheat sheets, mini-forms (project
+  rename, share link), filter expanders.
+- Composite triggers like "Quick add" or "Reactions" where the user
+  picks one of several actions.
+
+## When NOT to use
+
+- **Single-line hint** → use [Tooltip](?path=/docs/web-primitives-tooltip--docs); it activates on hover/focus and is the WAI-ARIA tooltip pattern.
+- **Critical decision / form that should block the surrounding UI** → use [Modal](?path=/docs/web-primitives-modal--docs); Popovers don't block interaction with the page.
+- **Side-anchored panel** → use [Drawer](?path=/docs/web-primitives-drawer--docs).
+- **Toast / system notification** → use [Toast](?path=/docs/web-primitives-toast--docs).
+- **Site-wide menu (account picker, app launcher)** that should persist between routes → render an inline panel; popovers dismiss on click-outside which fights the use case.
+
+## Anatomy
+
+<Canvas of={PopoverStories.WithRichContent} />
+
+Two composition slots:
+
+- **`Popover.Trigger`** — a focusable child (Button, link, anything
+  that takes focus). RAC's `<DialogTrigger>` recognises whichever
+  focusable element is rendered first.
+- **`Popover.Content`** — the popover surface. `placement` /
+  `offset` / `crossOffset` (and the kit's flip / animation slots)
+  live here, not on the root.
+
+```tsx
+<Popover>
+  <Popover.Trigger>
+    <Button>Open menu</Button>
+  </Popover.Trigger>
+  <Popover.Content placement="bottom start">
+    <div className="p-4">…rich content…</div>
+  </Popover.Content>
+</Popover>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The kit forwards `role="dialog"` on the popover surface and
+  `aria-expanded` / `aria-controls` on the trigger automatically —
+  do not override the roles.
+- Focus traps inside the popover while open and returns to the
+  trigger on close (RAC `<DialogTrigger>` contract).
+- Escape closes the popover; click-outside closes the popover;
+  Tab cycles focus inside the surface (no automatic close on Tab —
+  unlike a menu).
+- The trigger is the only path to opening the popover. Keep the
+  trigger element keyboard-operable (a `<Button>`, `<a>`, or
+  `tabIndex={0}` element) — non-focusable triggers leave keyboard
+  users stranded.
+- Avoid placing additional dialogs inside a Popover (`role="dialog"`
+  inside `role="dialog"`). For nested affordances, dismiss the
+  popover first, then open the dialog.
+- Don't autofocus a destructive button inside the popover — the
+  initial focus should land on the first focusable element (input
+  or "primary" CTA), not "Delete".
+
+## Related components
+
+- [Tooltip](?path=/docs/web-primitives-tooltip--docs) — short, hover/focus-revealed hint; can't host buttons / inputs.
+- [Modal](?path=/docs/web-primitives-modal--docs) — full-surface dialog that blocks interaction with the page.
+- [Drawer](?path=/docs/web-primitives-drawer--docs) — side-anchored panel for filters / settings.
+- [Toast](?path=/docs/web-primitives-toast--docs) — overlay notification with no required interaction.

--- a/packages/ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/src/components/Popover/Popover.stories.tsx
@@ -1,31 +1,31 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Button } from '../Button';
 import { Input } from '../Input';
 import { Popover } from './Popover';
+import { popoverControls, popoverExcludeFromArgs } from './Popover.controls';
+
+const { args, argTypes } = defineControls(popoverControls);
 
 // Explicit `Meta<typeof Popover>` annotation (rather than `satisfies`)
 // keeps the merged static-property type out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Popover.controls.ts`;
+// `tags: ['autodocs']` removed because `Popover.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Popover> = {
   title: 'Web Primitives/Popover',
   component: Popover,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-popover',
     },
   },
-  args: {
-    defaultOpen: false,
-  },
-  argTypes: {
-    isOpen: { control: 'boolean' },
-    defaultOpen: { control: 'boolean' },
-    onOpenChange: { control: false, action: 'open-changed' },
-    children: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div
@@ -45,6 +45,8 @@ const meta: Meta<typeof Popover> = {
 
 export default meta;
 type Story = StoryObj<typeof Popover>;
+
+export const excludeFromArgs = popoverExcludeFromArgs;
 
 export const Default: Story = {
   render: (args) => (


### PR DESCRIPTION
## Summary

- Converts P13 (Popover) primitive to the controls + MDX docs pattern from F1.5-1.
- `Popover.controls.ts` covers root-level open-state props (`isOpen`, `defaultOpen`, `onOpenChange`, `children`); PopoverContent-only props (`placement`, `offset`, `crossOffset`) stay in `excludeFromArgs`.
- New `Popover.mdx` ships the 6 mandatory sections plus the `Popover.Trigger` / `Popover.Content` composition contract.
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/Popover/Popover.controls.ts`
- `packages/ui/src/components/Popover/Popover.mdx`
- `packages/ui/src/components/Popover/Popover.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Popover MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #284