### PR TITLE
feat(ui): controls + MDX docs for Modal (F1.5-15)

### DIFF
--- a/packages/ui/src/components/Modal/Modal.controls.ts
+++ b/packages/ui/src/components/Modal/Modal.controls.ts
@@ -1,0 +1,66 @@
+// `Modal.controls.ts` — single source of truth for Modal's variant
+// matrix. Story (`Modal.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Modal.mdx`)
+// reads the same spec via `<Controls />`.
+//
+// Note: `size`, `isDismissable`, `isKeyboardDismissDisabled`, and
+// the kit-internal animation slots live on `<Modal.Content>` (which
+// extends RAC `ModalOverlayProps`), not on the root `<Modal>`. They
+// flow through `react-docgen-typescript` because of the static-
+// property merge but stay in `excludeFromArgs`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+export const modalControls = {
+  isOpen: {
+    type: 'boolean',
+    description:
+      "Controlled open state. Pair with `onOpenChange` to manage state outside the component. Usually unnecessary — RAC's `<DialogTrigger>` handles the click-trigger / Escape / click-outside contract by itself.",
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  defaultOpen: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Initial open state for uncontrolled usage. Set `true` for snapshot stories so Chromatic captures the open dialog with its trapped focus state.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  onOpenChange: {
+    type: false,
+    action: 'open-changed',
+    description:
+      'Fires when the open state changes (RAC `<DialogTrigger>` contract — receives the new boolean).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<Modal.Trigger>` (a focusable child — Button, link, etc.) and `<Modal.Content size="…">` containing `<Modal.Header>` / `<Modal.Body>` / `<Modal.Footer>`. The kit\'s `<DialogTrigger>` wires `aria-expanded` / `aria-controls` automatically.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+// `<Modal.Content>` props (size, dismiss flags, animation slots) and
+// the kit's RAC-forwarded slots flow through `react-docgen-typescript`
+// because of the static-property merge but belong on the children.
+// The F6 prop-coverage gate accepts them via this allowlist.
+export const modalExcludeFromArgs = defineExcludeFromArgs([
+  // ModalContent-only props (set on `<Modal.Content size=… isDismissable=…>`).
+  'size',
+  'isDismissable',
+  'isKeyboardDismissDisabled',
+  'shouldCloseOnInteractOutside',
+  'isEntering',
+  'isExiting',
+  'className',
+  'style',
+  // Header / Body / Footer-only.
+  'ref',
+  // RAC-forwarded.
+  'UNSAFE_className',
+  'UNSAFE_style',
+  'translate',
+  'slot',
+  'data-rac',
+] as const);

--- a/packages/ui/src/components/Modal/Modal.mdx
+++ b/packages/ui/src/components/Modal/Modal.mdx
@@ -1,0 +1,110 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as ModalStories from './Modal.stories';
+
+<Meta of={ModalStories} />
+
+# Modal
+
+Focus-trapped, scroll-locked dialog overlay. Built on the kit's
+`application/modals/modal.tsx` (which wraps react-aria-components'
+`<ModalOverlay>` + `<Modal>` + `<Dialog>` chain) — backdrop
+animation, focus return on close, scroll lock, Escape dismiss, and
+`aria-labelledby` / `aria-describedby` wiring all come from the kit.
+Use Modal when the surrounding UI must be blocked while the user
+makes a decision.
+
+## When to use
+
+- Confirmation dialogs for destructive actions (delete project,
+  revoke API key).
+- Short multi-step flows where the user must complete the dialog
+  before returning to the page (pair device, invite member).
+- Forms that don't need their own page but still warrant focus —
+  rename, share-link, edit-metadata.
+- Required acknowledgements (Terms of Service, post-incident
+  notice) — combine with `Persistent` to disable click-outside +
+  Escape so the user must use a footer button.
+
+## When NOT to use
+
+- **Inline tweak / quick edit anchored to a trigger** → use [Popover](?path=/docs/web-primitives-popover--docs); Popovers don't trap focus, don't lock scroll, and feel less heavy.
+- **Side-anchored panel** (filter sheet, log details, settings) → use [Drawer](?path=/docs/web-primitives-drawer--docs).
+- **System-level notification** (save success, error toast) → use [Toast](?path=/docs/web-primitives-toast--docs).
+- **Single-line hint** → use [Tooltip](?path=/docs/web-primitives-tooltip--docs).
+- **Content-heavy edit experience** that warrants a full page → route to a dedicated screen instead — Modals shouldn't host long-form work.
+
+## Anatomy
+
+<Canvas of={ModalStories.WithForm} />
+
+Compose with these slots:
+
+- **`Modal.Trigger`** — focusable child that opens the dialog.
+- **`Modal.Content`** — the dialog surface itself. Owns `size`
+  (`sm` / `md` / `lg` / `full`) and the dismiss flags
+  (`isDismissable`, `isKeyboardDismissDisabled`).
+- **`Modal.Header`** — title + optional subtitle, with a bottom
+  border.
+- **`Modal.Body`** — main content area. Scrollable
+  (`overflow-y-auto`) so long forms / Terms of Service render an
+  internal scrollbar instead of pushing footer buttons off-screen.
+- **`Modal.Footer`** — action buttons aligned to the end. Order:
+  dismiss / cancel on the left, primary action on the right.
+
+```tsx
+<Modal>
+  <Modal.Trigger>
+    <Button>Open</Button>
+  </Modal.Trigger>
+  <Modal.Content size="md">
+    <Modal.Header>
+      <h2>Confirm</h2>
+    </Modal.Header>
+    <Modal.Body>…content…</Modal.Body>
+    <Modal.Footer>
+      <Button color="secondary">Cancel</Button>
+      <Button color="primary">Save</Button>
+    </Modal.Footer>
+  </Modal.Content>
+</Modal>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The kit forwards `role="dialog"` + `aria-modal="true"` on the
+  surface and wires `aria-expanded` / `aria-controls` between the
+  trigger and the dialog automatically — do not override the roles.
+- Focus traps inside the modal while open and returns to the
+  trigger on close (RAC `<DialogTrigger>` contract). Tab cycles
+  inside the dialog; Shift-Tab cycles in reverse.
+- Escape closes the dialog (unless `isKeyboardDismissDisabled` is
+  set on `Modal.Content`); click-outside dismisses (unless
+  `isDismissable={false}`).
+- The `Modal.Body` is `tabIndex={0}` so keyboard users can scroll
+  long content with arrow keys. Without this, axe
+  `scrollable-region-focusable` fails on every overflowing body.
+- Don't autofocus a destructive button — the initial focus should
+  land on the first focusable element (input, primary CTA), never
+  "Delete".
+- Provide a heading via `Modal.Header` (e.g. `<h2>`) — the kit
+  wires `aria-labelledby` to whichever element renders the title,
+  so screen readers announce it on open.
+- Avoid nested dialogs (`role="dialog"` inside `role="dialog"`).
+  For confirmation steps inside a modal flow, dismiss the parent
+  first or use a `Persistent` confirmation pattern instead.
+
+## Related components
+
+- [Popover](?path=/docs/web-primitives-popover--docs) — inline anchored overlay; no focus trap, no scroll lock.
+- [Drawer](?path=/docs/web-primitives-drawer--docs) — side-anchored panel for filters / settings.
+- [Toast](?path=/docs/web-primitives-toast--docs) — overlay notification with no required interaction.
+- [Tooltip](?path=/docs/web-primitives-tooltip--docs) — short hover/focus-revealed hint.

--- a/packages/ui/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui/src/components/Modal/Modal.stories.tsx
@@ -1,32 +1,32 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Button } from '../Button';
 import { Input } from '../Input';
 import { Textarea } from '../Textarea';
 import { Modal } from './Modal';
+import { modalControls, modalExcludeFromArgs } from './Modal.controls';
+
+const { args, argTypes } = defineControls(modalControls);
 
 // Explicit `Meta<typeof Modal>` annotation (rather than `satisfies`)
 // keeps the merged static-property type out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Modal.controls.ts`;
+// `tags: ['autodocs']` removed because `Modal.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Modal> = {
   title: 'Web Primitives/Modal',
   component: Modal,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-modal',
     },
   },
-  args: {
-    defaultOpen: false,
-  },
-  argTypes: {
-    isOpen: { control: 'boolean' },
-    defaultOpen: { control: 'boolean' },
-    onOpenChange: { control: false, action: 'open-changed' },
-    children: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div
@@ -46,6 +46,8 @@ const meta: Meta<typeof Modal> = {
 
 export default meta;
 type Story = StoryObj<typeof Modal>;
+
+export const excludeFromArgs = modalExcludeFromArgs;
 
 const SampleHeader = () => (
   <>


### PR DESCRIPTION
## Summary

- Converts P14 (Modal) primitive to the controls + MDX docs pattern from F1.5-1.
- `Modal.controls.ts` covers root-level open-state props (`isOpen`, `defaultOpen`, `onOpenChange`, `children`); ModalContent-only props (size, isDismissable, isKeyboardDismissDisabled, animation slots) stay in `excludeFromArgs`.
- New `Modal.mdx` ships the 6 mandatory sections plus the `Modal.Trigger` / `Modal.Content` / `Modal.Header` / `Modal.Body` / `Modal.Footer` composition contract and the focus-trap a11y notes (`scrollable-region-focusable`, autofocus rules, nested-dialog warning).
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/Modal/Modal.controls.ts`
- `packages/ui/src/components/Modal/Modal.mdx`
- `packages/ui/src/components/Modal/Modal.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Modal MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #286