### PR TITLE
feat(ui): controls + MDX docs for Drawer (F1.5-16)

### DIFF
--- a/packages/ui/src/components/Drawer/Drawer.controls.ts
+++ b/packages/ui/src/components/Drawer/Drawer.controls.ts
@@ -1,0 +1,68 @@
+// `Drawer.controls.ts` — single source of truth for Drawer's variant
+// matrix. Story (`Drawer.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Drawer.mdx`)
+// reads the same spec via `<Controls />`.
+//
+// Note: `side`, `size`, `isDismissable`, `isKeyboardDismissDisabled`
+// (and the kit-internal animation slots) live on `<Drawer.Content>`
+// (which extends RAC `ModalOverlayProps`), not on the root
+// `<Drawer>`. They flow through `react-docgen-typescript` because of
+// the static-property merge but stay in `excludeFromArgs`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+export const drawerControls = {
+  isOpen: {
+    type: 'boolean',
+    description:
+      "Controlled open state. Pair with `onOpenChange` to manage state outside the component. Usually unnecessary — RAC's `<DialogTrigger>` handles the click-trigger / Escape / click-outside contract by itself.",
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  defaultOpen: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Initial open state for uncontrolled usage. Set `true` for snapshot stories so Chromatic captures the open panel with its trapped focus state.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  onOpenChange: {
+    type: false,
+    action: 'open-changed',
+    description:
+      'Fires when the open state changes (RAC `<DialogTrigger>` contract — receives the new boolean).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<Drawer.Trigger>` (a focusable child — Button, link, etc.) and `<Drawer.Content side="…" size="…">` containing `<Drawer.Header>` / `<Drawer.Body>` / `<Drawer.Footer>`. The kit\'s `<DialogTrigger>` wires `aria-expanded` / `aria-controls` automatically.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+// `<Drawer.Content>` props (side, size, dismiss flags, animation
+// slots) and the kit's RAC-forwarded slots flow through
+// `react-docgen-typescript` because of the static-property merge but
+// belong on the children. The F6 prop-coverage gate accepts them via
+// this allowlist.
+export const drawerExcludeFromArgs = defineExcludeFromArgs([
+  // DrawerContent-only props (set on `<Drawer.Content side=… size=… isDismissable=…>`).
+  'side',
+  'size',
+  'isDismissable',
+  'isKeyboardDismissDisabled',
+  'shouldCloseOnInteractOutside',
+  'isEntering',
+  'isExiting',
+  'className',
+  'style',
+  // Header / Body / Footer-only.
+  'ref',
+  // RAC-forwarded.
+  'UNSAFE_className',
+  'UNSAFE_style',
+  'translate',
+  'slot',
+  'data-rac',
+] as const);

--- a/packages/ui/src/components/Drawer/Drawer.mdx
+++ b/packages/ui/src/components/Drawer/Drawer.mdx
@@ -1,0 +1,112 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as DrawerStories from './Drawer.stories';
+
+<Meta of={DrawerStories} />
+
+# Drawer
+
+Edge-anchored, focus-trapped overlay panel. Slides in from one of
+four sides (`left` / `right` / `top` / `bottom`) and shares Modal's
+RAC foundation — focus trap, scroll lock, Escape dismiss,
+click-outside dismiss, and `aria-labelledby` / `aria-describedby`
+wiring all come for free. Use Drawer when the user needs side
+context from the page behind the panel; otherwise reach for Modal.
+
+## When to use
+
+- Filter / settings panels anchored to one edge so the user can see
+  the affected list behind: log filters, search facets, layer
+  controls.
+- Multi-step forms (pair device, configure integration) where the
+  back-of-page context still informs the workflow.
+- Detail / inspector views (record details, log line metadata,
+  device specs) anchored to `right` while the table stays visible.
+- Mobile-style sheet UI (use `side="bottom"`) for quick actions on
+  narrower viewports.
+
+## When NOT to use
+
+- **Center-anchored decision dialog** → use [Modal](?path=/docs/web-primitives-modal--docs); a Drawer pulls focus to one side and looks lopsided for confirmations.
+- **Inline tweak / quick edit anchored to a trigger** → use [Popover](?path=/docs/web-primitives-popover--docs); Popovers don't trap focus and feel less heavy.
+- **System-level notification** → use [Toast](?path=/docs/web-primitives-toast--docs).
+- **Full-page route** that warrants its own URL → route to a dedicated screen instead — the Drawer's content shouldn't be shareable in isolation.
+- **Persistent app-shell side nav** → use [SideNav](?path=/docs/web-primitives-sidenav--docs); SideNav is always-on chrome, Drawer is an on-demand overlay.
+
+## Anatomy
+
+<Canvas of={DrawerStories.WithForm} />
+
+Compose with these slots:
+
+- **`Drawer.Trigger`** — focusable child that opens the panel.
+- **`Drawer.Content`** — the panel surface itself. Owns `side`
+  (`left` / `right` (default) / `top` / `bottom`), `size` (`sm` /
+  `md` / `lg` / `full`), and the dismiss flags
+  (`isDismissable`, `isKeyboardDismissDisabled`).
+- **`Drawer.Header`** — title + optional subtitle, with a bottom
+  border.
+- **`Drawer.Body`** — main content area. Scrollable
+  (`overflow-y-auto`) so long forms render an internal scrollbar
+  instead of pushing footer buttons off-screen.
+- **`Drawer.Footer`** — action buttons aligned to the end. Order:
+  dismiss / cancel on the left, primary action on the right.
+
+```tsx
+<Drawer>
+  <Drawer.Trigger>
+    <Button>Open settings</Button>
+  </Drawer.Trigger>
+  <Drawer.Content side="right" size="md">
+    <Drawer.Header>
+      <h2>Settings</h2>
+    </Drawer.Header>
+    <Drawer.Body>…</Drawer.Body>
+    <Drawer.Footer>
+      <Button color="secondary">Cancel</Button>
+      <Button color="primary">Save</Button>
+    </Drawer.Footer>
+  </Drawer.Content>
+</Drawer>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The kit forwards `role="dialog"` + `aria-modal="true"` on the
+  panel surface and wires `aria-expanded` / `aria-controls` between
+  the trigger and the dialog automatically — do not override the
+  roles.
+- Focus traps inside the drawer while open and returns to the
+  trigger on close (RAC `<DialogTrigger>` contract). Tab cycles
+  inside the panel; Shift-Tab cycles in reverse.
+- Escape closes the panel (unless `isKeyboardDismissDisabled` is
+  set on `Drawer.Content`); click-outside dismisses (unless
+  `isDismissable={false}`).
+- `Drawer.Body` is `tabIndex={0}` so keyboard users can scroll
+  long content with arrow keys. Without this, axe
+  `scrollable-region-focusable` fails on every overflowing body.
+- Provide a heading via `Drawer.Header` (e.g. `<h2>`) — the kit
+  wires `aria-labelledby` to whichever element renders the title,
+  so screen readers announce it on open.
+- For `side="bottom"` (mobile sheet) use `size="sm"` or `md` so
+  the user can still see partial page context above; `full` should
+  be reserved for true takeover flows.
+- Avoid nested dialogs (`role="dialog"` inside `role="dialog"`).
+  For confirmation steps inside a drawer flow, use a `Persistent`
+  pattern (disable click-outside + Escape) on the drawer rather
+  than spawning a Modal on top.
+
+## Related components
+
+- [Modal](?path=/docs/web-primitives-modal--docs) — center-anchored dialog; better fit for confirmations / blocking decisions.
+- [Popover](?path=/docs/web-primitives-popover--docs) — inline anchored overlay; no focus trap, no scroll lock.
+- [SideNav](?path=/docs/web-primitives-sidenav--docs) — persistent app-shell side navigation chrome (always-on, not on-demand).
+- [Toast](?path=/docs/web-primitives-toast--docs) — overlay notification with no required interaction.

--- a/packages/ui/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.stories.tsx
@@ -1,32 +1,32 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Button } from '../Button';
 import { Input } from '../Input';
 import { Textarea } from '../Textarea';
 import { Drawer } from './Drawer';
+import { drawerControls, drawerExcludeFromArgs } from './Drawer.controls';
+
+const { args, argTypes } = defineControls(drawerControls);
 
 // Explicit `Meta<typeof Drawer>` annotation (rather than `satisfies`)
 // keeps the merged static-property type out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Drawer.controls.ts`;
+// `tags: ['autodocs']` removed because `Drawer.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Drawer> = {
   title: 'Web Primitives/Drawer',
   component: Drawer,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-drawer',
     },
   },
-  args: {
-    defaultOpen: false,
-  },
-  argTypes: {
-    isOpen: { control: 'boolean' },
-    defaultOpen: { control: 'boolean' },
-    onOpenChange: { control: false, action: 'open-changed' },
-    children: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div
@@ -46,6 +46,8 @@ const meta: Meta<typeof Drawer> = {
 
 export default meta;
 type Story = StoryObj<typeof Drawer>;
+
+export const excludeFromArgs = drawerExcludeFromArgs;
 
 const SampleHeader = () => (
   <>


### PR DESCRIPTION
## Summary

- Converts P15 (Drawer) primitive to the controls + MDX docs pattern from F1.5-1.
- `Drawer.controls.ts` covers root-level open-state props (`isOpen`, `defaultOpen`, `onOpenChange`, `children`); DrawerContent-only props (`side`, `size`, `isDismissable`, `isKeyboardDismissDisabled`, animation slots) stay in `excludeFromArgs`.
- New `Drawer.mdx` ships the 6 mandatory sections plus the `Drawer.Trigger` / `Drawer.Content` / `Drawer.Header` / `Drawer.Body` / `Drawer.Footer` composition contract and the focus-trap a11y notes (`scrollable-region-focusable`, sheet-mode sizing guidance, nested-dialog warning).
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/Drawer/Drawer.controls.ts`
- `packages/ui/src/components/Drawer/Drawer.mdx`
- `packages/ui/src/components/Drawer/Drawer.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Drawer MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #288