### PR TITLE
feat(ui): controls + MDX docs for Toast (F1.5-17)

### DIFF
--- a/packages/ui/src/components/Toast/Toast.controls.ts
+++ b/packages/ui/src/components/Toast/Toast.controls.ts
@@ -1,0 +1,65 @@
+// `Toast.controls.ts` — single source of truth for Toast's variant
+// matrix. Story (`Toast.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Toast.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const intentOptions = ['info', 'success', 'warning', 'danger'] as const;
+
+export const toastControls = {
+  title: {
+    type: 'text',
+    default: 'Saved successfully',
+    description:
+      'Bold first line of the toast. Keep it short and scannable — toasts are read in motion. Match the verb tense to the outcome ("Saved", "Could not save").',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  description: {
+    type: 'text',
+    default: 'Your changes are live across the workspace.',
+    description:
+      'Optional secondary line under the title. Use sparingly — long descriptions push the action button below the fold and slow down the read.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  intent: {
+    type: 'inline-radio',
+    options: intentOptions,
+    default: 'info',
+    description:
+      'Severity / colour group for the leading icon. `info` (default) for neutral updates, `success` for confirmation, `warning` for soft alerts, `danger` for failures.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof intentOptions)[number]>,
+  duration: {
+    type: 'number',
+    min: 0,
+    max: 30000,
+    step: 500,
+    default: 0,
+    description:
+      'Auto-dismiss delay in ms. `0` (story default) keeps the toast visible until the user dismisses it — handy for screenshot capture. Production callers usually pass `4000`–`6000`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<number>,
+  hideClose: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Hide the dismiss `×` button. Use only when an action button (`action.label`) is the sole dismissal path — never on a persistent toast (`duration: 0`).',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  action: {
+    type: 'object',
+    description:
+      'Optional CTA shape `{ label: string, onPress: () => void }`. Renders a button under the description; the toast auto-dismisses after `onPress` fires.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onDismiss: {
+    type: false,
+    action: 'dismissed',
+    description: 'Fires when the toast is dismissed (auto, via action, or via the close button).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+export const toastExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Toast/Toast.mdx
+++ b/packages/ui/src/components/Toast/Toast.mdx
@@ -1,0 +1,101 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as ToastStories from './Toast.stories';
+
+<Meta of={ToastStories} />
+
+# Toast
+
+Transient feedback overlay. Toasts fly into the top-right corner of
+the viewport, announce themselves to assistive tech, optionally
+auto-dismiss after a few seconds, and don't interrupt the user's
+current task. Pair with `<ToastProvider>` (mounted once at the app
+root) and the `useToast()` hook to enqueue toasts imperatively from
+anywhere in the tree.
+
+## When to use
+
+- Confirmation that a background action succeeded ("Saved",
+  "Settings stored", "Pairing started").
+- Error notifications for failures the user can ignore or retry
+  ("Connection lost — reconnecting in the background").
+- Soft warnings tied to time / state ("Token rotation in 24
+  hours").
+- Update prompts with a single CTA ("New version available
+  — Install").
+
+## When NOT to use
+
+- **Critical decision the user must address right now** → use [Modal](?path=/docs/web-primitives-modal--docs); toasts can be missed.
+- **Persistent system status** → render an inline [Banner](?path=/docs/web-primitives-banner--docs) at the top of the surface.
+- **Inline form-field error** → use the field's `isInvalid` + `hint` (Input / Textarea / Select); toasts are wrong for adjacency-bound feedback.
+- **Single-line hover hint** → use [Tooltip](?path=/docs/web-primitives-tooltip--docs).
+- **Overlay surface that needs the user's full attention** → use [Modal](?path=/docs/web-primitives-modal--docs) or [Drawer](?path=/docs/web-primitives-drawer--docs).
+
+## Anatomy
+
+<Canvas of={ToastStories.WithAction} />
+
+A pill-shaped card (max width ~24rem) with:
+
+- **Leading icon** — driven by `intent` (info / success / warning / danger), `aria-hidden`.
+- **Title** — bold first line; this is what screen readers announce first.
+- **Description** — optional secondary line for context.
+- **Action button** — optional CTA. Auto-dismisses after `onPress`.
+- **Close button** — `aria-label="Dismiss"` `×` glyph; hidden when
+  `hideClose` is set.
+
+```tsx
+const { show } = useToast();
+
+show({
+  intent: 'success',
+  title: 'Saved',
+  description: 'Configuration applied.',
+  duration: 4000,
+});
+```
+
+For one-off snapshot stories you can also render a frozen `<Toast>`
+card directly — the queue is optional, but production callers should
+always go through `useToast().show()` so the queue manages lifecycles
+and the portal mount.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The toast root carries `role="status"` + `aria-live="polite"` +
+  `aria-atomic="true"` so screen readers announce the full title +
+  description as one update on insert.
+- The portal viewport (`<ToastProvider>`'s fixed-position container)
+  also carries `aria-live="polite"` — combined with per-toast
+  `aria-atomic="true"`, screen readers announce only the new toast,
+  not the entire stack.
+- Use `aria-live="polite"` (not `assertive`) so toasts don't
+  interrupt the user mid-sentence. For hard-failure cases that
+  _must_ interrupt, use a [Modal](?path=/docs/web-primitives-modal--docs) instead.
+- Auto-dismiss is fine for confirmations but **never** for errors
+  the user might miss — bump `duration` to `0` (manual dismissal)
+  for `intent="danger"` toasts that announce a critical failure.
+- The leading icon is `aria-hidden` — the meaning is carried by the
+  text. Don't communicate severity through icon-only toasts.
+- Action and close buttons are real `<button>` elements with
+  visible focus rings; they're keyboard-reachable while the toast
+  is mounted (Tab from the trigger that fired the toast).
+- For `hideClose: true` toasts, an action button is the only
+  dismissal path — never combine `hideClose: true` with
+  `duration: 0`, which strands the user.
+
+## Related components
+
+- [Banner](?path=/docs/web-primitives-banner--docs) — persistent system status pinned to the page (not transient overlay).
+- [Alert](?path=/docs/web-primitives-alert--docs) — inline notification adjacent to the affected content.
+- [Modal](?path=/docs/web-primitives-modal--docs) — interrupting dialog for decisions the user must address now.
+- [Tooltip](?path=/docs/web-primitives-tooltip--docs) — short hover/focus-revealed hint anchored to a trigger.

--- a/packages/ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/ui/src/components/Toast/Toast.stories.tsx
@@ -1,41 +1,31 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Button } from '../Button';
 import { Toast, useToast } from './Toast';
+import { toastControls, toastExcludeFromArgs } from './Toast.controls';
+
+const { args, argTypes } = defineControls(toastControls);
 
 // Explicit `Meta<typeof Toast>` annotation (rather than `satisfies`)
 // keeps the unexported helper interfaces (`ToastEntry`,
 // `ToastContextValue`) out of the exported `meta` signature —
 // `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Toast.controls.ts`;
+// `tags: ['autodocs']` removed because `Toast.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Toast> = {
   title: 'Web Primitives/Toast',
   component: Toast,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-toast',
     },
   },
-  args: {
-    title: 'Saved successfully',
-    description: 'Your changes are live across the workspace.',
-    intent: 'info',
-    duration: 0,
-    hideClose: false,
-  },
-  argTypes: {
-    title: { control: 'text' },
-    description: { control: 'text' },
-    intent: {
-      control: 'inline-radio',
-      options: ['info', 'success', 'warning', 'danger'],
-    },
-    duration: { control: { type: 'number', min: 0, max: 30000, step: 500 } },
-    hideClose: { control: 'boolean' },
-    action: { control: 'object' },
-    onDismiss: { control: false, action: 'dismissed' },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ padding: 24 }}>
@@ -47,6 +37,8 @@ const meta: Meta<typeof Toast> = {
 
 export default meta;
 type Story = StoryObj<typeof Toast>;
+
+export const excludeFromArgs = toastExcludeFromArgs;
 
 export const Default: Story = {};
 


### PR DESCRIPTION
## Summary

- Converts P16 (Toast) primitive to the controls + MDX docs pattern from F1.5-1.
- `Toast.controls.ts` covers every public Toast prop (`title`, `description`, `intent`, `duration`, `hideClose`, `action`, `onDismiss`) with descriptions per row.
- New `Toast.mdx` ships the 6 mandatory sections plus the `useToast()` queue pattern, the persistent / hideClose anti-combo warning, and the polite-vs-assertive a11y guidance.
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/Toast/Toast.controls.ts`
- `packages/ui/src/components/Toast/Toast.mdx`
- `packages/ui/src/components/Toast/Toast.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Toast MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #290