### PR TITLE
feat(ui): controls + MDX docs for List (F1.5-18)

### DIFF
--- a/packages/ui/src/components/List/List.controls.ts
+++ b/packages/ui/src/components/List/List.controls.ts
@@ -1,0 +1,60 @@
+// `List.controls.ts` — single source of truth for List's variant
+// matrix. Story (`List.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`List.mdx`)
+// reads the same spec via `<Controls />`.
+//
+// Note: ListItem-only props (`leading`, `trailing`, `onClick`,
+// `current`) and ListItemAction-only props belong on the child
+// components, not the root `<List>`. They flow through
+// `react-docgen-typescript` because of the static-property merge,
+// so they appear in `excludeFromArgs`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+export const listControls = {
+  dividers: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Render thin border dividers between items (`divide-y`). Useful for settings panels, transaction logs, or any layout where row boundaries help scanning.',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  bordered: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Wrap the list in a card surface (`bg-primary` + ring + rounded). Use when the list sits on a busy background; combine with `dividers` for the canonical "settings card" look.',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  emptyState: {
+    type: false,
+    description:
+      'Custom node shown when the list has no children. Falls back to a centred "No items to show." caption — override for product-specific empty states ("No devices yet" with a CTA, etc.).',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<List.Item leading={…} trailing={…}>` rows. The kit auto-renders `<ul role="list">` so axe sees the list semantics; an interactive item (`onClick`) gets keyboard / focus / hover styling automatically.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer container.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// `react-docgen-typescript` walks the static-property namespace
+// (`List.Item`, `List.ItemAction`) and surfaces those sub-components'
+// props on the merged root signature. They belong on the children,
+// not the root — the F6 prop-coverage gate accepts them via this
+// allowlist.
+export const listExcludeFromArgs = defineExcludeFromArgs([
+  // ListItem-only props.
+  'leading',
+  'trailing',
+  'onClick',
+  'current',
+] as const);

--- a/packages/ui/src/components/List/List.mdx
+++ b/packages/ui/src/components/List/List.mdx
@@ -1,0 +1,101 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as ListStories from './List.stories';
+
+<Meta of={ListStories} />
+
+# List
+
+Vertical, semantic list primitive for ordered or homogeneous rows.
+Renders as `<ul role="list">` so axe sees the list semantics, with
+optional `bordered` card chrome and `dividers` between rows. Use
+List for repetitive items where the rows share a layout — settings,
+device entries, member lists, recent activity.
+
+## When to use
+
+- Settings panels with parallel rows: "Privacy", "Notifications",
+  "Display & accessibility".
+- Member / contact / team lists with avatar + name + email columns.
+- Device / scene / automation entries with status badges or action
+  buttons.
+- Recent activity feeds where each row carries the same anatomy.
+- Any "stack of homogeneous items where you want a card chrome
+  around the group" surface.
+
+## When NOT to use
+
+- **Tabular / multi-column data** with sortable headers → use [Table](?path=/docs/web-primitives-table--docs); a List is one column with optional leading / trailing affordances.
+- **Per-item rich layouts** (different anatomy per row) → use individual [Card](?path=/docs/web-primitives-card--docs) instances; List rows share a row template.
+- **Application navigation** (devices / scenes / automations as a side panel) → use [SideNav](?path=/docs/web-primitives-sidenav--docs); List rows aren't auto-`<a>`-anchored.
+- **Single-line hint inline** → render a paragraph; List ships chrome you don't need for one row.
+
+## Anatomy
+
+<Canvas of={ListStories.WithActions} />
+
+Each row composes left → centre → right:
+
+- **`leading`** — optional slot for an Avatar, Checkbox, or icon
+  glyph. Renders to the left of the content with `text-fg-quaternary`
+  default colour.
+- **Children** — main content area (any node tree). The kit
+  vertically stacks the children inside a `flex-col` so multi-line
+  text wraps cleanly.
+- **`trailing`** — optional slot for a `<List.ItemAction>` button,
+  status [Badge](?path=/docs/web-primitives-badge--docs), or a chevron glyph. Renders to the right with
+  `gap-2` between multiple trailing nodes.
+
+```tsx
+<List dividers bordered>
+  <List.Item
+    leading={<Avatar size="sm" alt="Olivia" initials="OR" />}
+    trailing={<List.ItemAction onClick={onEdit}>Edit</List.ItemAction>}
+  >
+    <span className="font-semibold text-primary">Olivia Rhye</span>
+    <span className="text-tertiary">olivia@glaon.app</span>
+  </List.Item>
+</List>
+```
+
+`<List.ItemAction>` is a real `<button>` — fires a click when the
+user activates it, separate from any whole-row `onClick` on the
+parent `<List.Item>`.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The kit forwards `role="list"` on the outer `<ul>` and
+  `role="listitem"` on each `<li>`. Tailwind's `list-style: none`
+  reset would normally strip implicit list semantics — explicit
+  roles keep VoiceOver / NVDA / JAWS announcing "list, N items"
+  on entry.
+- An interactive `<List.Item onClick={…}>` gets a focus ring,
+  `cursor-pointer`, hover styling, and (when `current` is set)
+  `aria-current="page"`. The `<li>` itself isn't keyboard-focusable
+  by default — use `<a>` / `<button>` inside the row when
+  destination semantics matter (e.g. nav lists), or wrap the item in
+  a [Modal](?path=/docs/web-primitives-modal--docs) trigger if it opens a dialog.
+- For selectable lists, render a [Checkbox](?path=/docs/web-primitives-checkbox--docs) inside `leading` (with
+  `aria-label` set to the row's primary text). The Checkbox owns
+  selection a11y; the row itself stays a presentational `<li>`.
+- The empty-state fallback renders a non-list `<div>` so axe doesn't
+  flag a "list with zero items" pattern. Custom `emptyState` content
+  follows the same pattern.
+- For long lists (50+ items) virtualisation belongs in the feature
+  layer (TanStack Virtual or similar) — the List primitive deliberately
+  doesn't ship a virtualiser to keep the chrome composable.
+
+## Related components
+
+- [Table](?path=/docs/web-primitives-table--docs) — multi-column tabular data with sortable headers.
+- [Card](?path=/docs/web-primitives-card--docs) — rich per-item layout when rows don't share a template.
+- [SideNav](?path=/docs/web-primitives-sidenav--docs) — application navigation (auto-anchored, with active state).
+- [Avatar](?path=/docs/web-primitives-avatar--docs) / [Badge](?path=/docs/web-primitives-badge--docs) — common leading / trailing slot inhabitants.

--- a/packages/ui/src/components/List/List.stories.tsx
+++ b/packages/ui/src/components/List/List.stories.tsx
@@ -1,40 +1,38 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Avatar } from '../Avatar';
 import { Badge } from '../Badge';
 import { Checkbox } from '../Checkbox';
 import { storybookIcons } from '../../icons/storybook';
 import { List } from './List';
+import { listControls, listExcludeFromArgs } from './List.controls';
 
 const Bell = storybookIcons.bell;
 const Settings = storybookIcons.settings;
 const Star = storybookIcons.star;
 const User = storybookIcons.user;
 
+const { args, argTypes } = defineControls(listControls);
+
 // Explicit `Meta<typeof List>` annotation (rather than `satisfies`)
 // keeps the merged static-property type out of the exported `meta`
 // signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `List.controls.ts`;
+// `tags: ['autodocs']` removed because `List.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof List> = {
   title: 'Web Primitives/List',
   component: List,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-list',
     },
   },
-  args: {
-    dividers: false,
-    bordered: false,
-  },
-  argTypes: {
-    dividers: { control: 'boolean' },
-    bordered: { control: 'boolean' },
-    emptyState: { control: false, table: { disable: true } },
-    children: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 480 }}>
@@ -46,6 +44,8 @@ const meta: Meta<typeof List> = {
 
 export default meta;
 type Story = StoryObj<typeof List>;
+
+export const excludeFromArgs = listExcludeFromArgs;
 
 export const Default: Story = {
   render: (args) => (


### PR DESCRIPTION
## Summary

- Converts P17 (List) primitive to the controls + MDX docs pattern from F1.5-1.
- `List.controls.ts` covers root-level List props (`dividers`, `bordered`, `emptyState`, `children`, `className`); ListItem-only props stay in `excludeFromArgs`.
- New `List.mdx` ships the 6 mandatory sections plus the `List.Item` / `List.ItemAction` composition contract and the empty-state + axe `role="list"` a11y notes.
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

## Scope

**In**

- `packages/ui/src/components/List/List.controls.ts`
- `packages/ui/src/components/List/List.mdx`
- `packages/ui/src/components/List/List.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Other P-group conversions remain on their own issues.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — List MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #292