### PR TITLE
feat(ui): controls + MDX docs for Table (F1.5-19)

### DIFF
--- a/packages/ui/src/components/Table/Table.controls.ts
+++ b/packages/ui/src/components/Table/Table.controls.ts
@@ -1,0 +1,90 @@
+// `Table.controls.ts` — single source of truth for Table's variant
+// matrix. Story (`Table.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Table.mdx`)
+// reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md'] as const;
+const selectionModeOptions = ['none', 'single', 'multiple'] as const;
+
+export const tableControls = {
+  'aria-label': {
+    type: 'text',
+    default: 'Devices',
+    description:
+      'Accessible name for the entire table — required for axe `aria-required-children` / `region`. Pair with a visible heading above the table when one exists; for a heading-less surface this prop is the only label.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Vertical density. `md` (default) for standard data; `sm` for dense surfaces (admin tables, log readers) where many rows must fit on screen.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  selectionMode: {
+    type: 'inline-radio',
+    options: selectionModeOptions,
+    description:
+      '`none` (default) for read-only data, `single` for radio-style row selection, `multiple` for checkbox column with optional select-all in the header.',
+    category: 'Behavior',
+  } satisfies ControlSpec<(typeof selectionModeOptions)[number]>,
+  onRowAction: {
+    type: false,
+    action: 'row-action',
+    description:
+      'Fires on row activation (click / Enter). RAC routes Space to selection (when `selectionMode` is set) and Enter to row action — keep them distinct so keyboard users can pick *and* open.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onSelectionChange: {
+    type: false,
+    action: 'selection-changed',
+    description:
+      'Fires when the selected row set changes (RAC contract — receives a `Set<Key> | "all">`).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onSortChange: {
+    type: false,
+    action: 'sort-changed',
+    description:
+      'Fires when the sort descriptor changes (RAC contract — receives `{ column, direction }`). Set `<Table.Head allowsSorting>` to opt a column in.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<Table.Header>` containing one `<Table.Head id="…">` per column, then `<Table.Body>` containing one `<Table.Row id="…">` per data row, each housing `<Table.Cell>` children.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer `<table>` wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// RAC-forwarded props that aren't useful as Storybook controls but
+// flow through type-checking; covered by the F6 prop-coverage gate.
+export const tableExcludeFromArgs = defineExcludeFromArgs([
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'translate',
+  'slot',
+  'data-rac',
+  'autoFocus',
+  'selectedKeys',
+  'defaultSelectedKeys',
+  'disabledKeys',
+  'disallowEmptySelection',
+  'selectionBehavior',
+  'sortDescriptor',
+  'defaultSortDescriptor',
+  'dependencies',
+  'dragAndDropHooks',
+  'isDisabled',
+  'escapeKeyBehavior',
+] as const);

--- a/packages/ui/src/components/Table/Table.mdx
+++ b/packages/ui/src/components/Table/Table.mdx
@@ -1,0 +1,116 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as TableStories from './Table.stories';
+
+<Meta of={TableStories} />
+
+# Table
+
+Multi-column tabular data primitive. Built on react-aria-components
+(`<Table>` + `<TableHeader>` + `<Column>` + `<Row>` + `<Cell>` +
+`<TableBody>`) — sortable headers, row selection, sticky headers,
+and full keyboard navigation come from the kit. Use Table when the
+data has fixed columns and the user needs to compare values across
+rows.
+
+## When to use
+
+- Dashboards / admin surfaces showing rows of data with several
+  columns: device inventory, user lists, log tables, transaction
+  records.
+- Sortable data where users need to reorder by column ("Last
+  seen", "Name").
+- Selection workflows: bulk-archive, bulk-delete, bulk-export
+  where the user picks multiple rows.
+- Read-only data summaries inside dashboards (set
+  `selectionMode="none"` and skip `allowsSorting` per column).
+
+## When NOT to use
+
+- **Single-column homogeneous rows** → use [List](?path=/docs/web-primitives-list--docs); a Table for one column is overkill chrome.
+- **Per-row rich layouts** that don't share a column template → use [Card](?path=/docs/web-primitives-card--docs) instances.
+- **Pagination / virtualisation / faceted filtering** → wait for the Phase 2 `DataTable` application primitive; the base Table is deliberately scoped to the basic surface.
+- **Form / settings layout** → use [List](?path=/docs/web-primitives-list--docs) with `<List.Item leading={…} trailing={…}>` rows.
+
+## Anatomy
+
+<Canvas of={TableStories.WithSortableHeader} />
+
+Compose with these slots:
+
+- **`Table.Header`** — sticky `<thead>` row. Houses one
+  `<Table.Head id="…">` per column. Set `allowsSorting` on a head
+  to opt that column into the sort affordance.
+- **`Table.Body`** — `<tbody>` wrapper. Pass `renderEmptyState` to
+  customise the empty fallback; the default empty body still
+  honours the column structure.
+- **`Table.Row`** — one row per data record (`id` doubles as the
+  RAC key for selection / sorting bookkeeping).
+- **`Table.Cell`** — one cell per column. Cells inherit the
+  vertical density from the parent table's `size`.
+
+```tsx
+<Table aria-label="Devices" selectionMode="multiple">
+  <Table.Header>
+    <Table.Head id="name" allowsSorting>
+      Device
+    </Table.Head>
+    <Table.Head id="room">Room</Table.Head>
+    <Table.Head id="status">Status</Table.Head>
+  </Table.Header>
+  <Table.Body>
+    {devices.map((d) => (
+      <Table.Row key={d.id} id={d.id}>
+        <Table.Cell>{d.name}</Table.Cell>
+        <Table.Cell>{d.room}</Table.Cell>
+        <Table.Cell>{statusBadge(d.status)}</Table.Cell>
+      </Table.Row>
+    ))}
+  </Table.Body>
+</Table>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- **Always set `aria-label`** (or `aria-labelledby` referencing a
+  visible heading) on the root `<Table>`. Without a label, axe
+  `aria-required-children` / `region` flags the table as
+  unidentified — screen readers can't announce what the data
+  represents.
+- The kit forwards `role="grid"` semantics on the table,
+  `role="rowheader"` on header cells, and `role="gridcell"` on
+  body cells automatically. RAC also wires `aria-sort` on
+  sortable columns and `aria-selected` on rows when
+  `selectionMode` is set.
+- Keyboard contract (RAC): Arrow keys move focus cell-by-cell;
+  Home / End jump to row start / end; Page Up / Down scroll;
+  Space toggles selection (when `selectionMode` is set); Enter
+  fires `onRowAction` (use it to open a detail view rather than
+  navigating directly).
+- For long tables, the sticky header keeps column context visible
+  while scrolling — don't disable `position: sticky` on the
+  `<thead>`.
+- Selectable tables render a checkbox column automatically.
+  Provide an `aria-label` on each row's primary text via the
+  cell content (e.g. the first cell's text already labels the
+  row); RAC reads the row's first text node into the row's
+  selection-cell aria-name.
+- For row-action affordances (edit / archive / view), use
+  `<TableRowActionsDropdown>` (re-exported from `Table.tsx`) or
+  render an icon button in a trailing cell — never make the row
+  itself navigate, since that conflicts with selection mode.
+
+## Related components
+
+- [List](?path=/docs/web-primitives-list--docs) — single-column homogeneous rows; lighter chrome.
+- [Card](?path=/docs/web-primitives-card--docs) — rich per-item layout when rows can't share a template.
+- [Badge](?path=/docs/web-primitives-badge--docs) — status pill commonly rendered inside a `Status` cell.
+- [Checkbox](?path=/docs/web-primitives-checkbox--docs) — RAC's selection-mode column wraps this primitive automatically.

--- a/packages/ui/src/components/Table/Table.stories.tsx
+++ b/packages/ui/src/components/Table/Table.stories.tsx
@@ -1,39 +1,31 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { Badge } from '../Badge';
 import { Table } from './Table';
+import { tableControls, tableExcludeFromArgs } from './Table.controls';
+
+const { args, argTypes } = defineControls(tableControls);
 
 // Explicit `Meta<typeof Table>` annotation (rather than `satisfies`)
 // keeps the kit's deep RAC generic chains and the merged static-
 // property type out of the exported `meta` signature — `tsc --noEmit`
 // runs with `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `Table.controls.ts`;
+// `tags: ['autodocs']` removed because `Table.mdx` replaces the
+// docs tab.
 const meta: Meta<typeof Table> = {
   title: 'Web Primitives/Table',
   component: Table,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-table',
     },
   },
-  args: {
-    'aria-label': 'Devices',
-    size: 'md',
-  },
-  argTypes: {
-    'aria-label': { control: 'text' },
-    size: { control: 'inline-radio', options: ['sm', 'md'] },
-    selectionMode: {
-      control: 'inline-radio',
-      options: ['none', 'single', 'multiple'],
-    },
-    onRowAction: { control: false, action: 'row-action' },
-    onSelectionChange: { control: false, action: 'selection-changed' },
-    onSortChange: { control: false, action: 'sort-changed' },
-    children: { control: false, table: { disable: true } },
-    className: { control: false, table: { disable: true } },
-  },
+  args,
+  argTypes,
   decorators: [
     (Story) => (
       <div style={{ width: 720 }}>
@@ -46,28 +38,7 @@ const meta: Meta<typeof Table> = {
 export default meta;
 type Story = StoryObj<typeof Table>;
 
-// RAC-forwarded props that aren't useful as Storybook controls but
-// flow through type-checking; covered by the F6 prop-coverage gate.
-export const excludeFromArgs = [
-  'aria-labelledby',
-  'aria-describedby',
-  'aria-details',
-  'translate',
-  'slot',
-  'data-rac',
-  'autoFocus',
-  'selectedKeys',
-  'defaultSelectedKeys',
-  'disabledKeys',
-  'disallowEmptySelection',
-  'selectionBehavior',
-  'sortDescriptor',
-  'defaultSortDescriptor',
-  'dependencies',
-  'dragAndDropHooks',
-  'isDisabled',
-  'escapeKeyBehavior',
-];
+export const excludeFromArgs = tableExcludeFromArgs;
 
 interface DeviceRow {
   id: string;


### PR DESCRIPTION
## Summary

- Converts P18 (Table) primitive to the controls + MDX docs pattern from F1.5-1.
- `Table.controls.ts` covers root-level Table props (`aria-label`, `size`, `selectionMode`, `onRowAction`, `onSelectionChange`, `onSortChange`, `children`, `className`); RAC-internal slots (`selectedKeys`, `defaultSelectedKeys`, `disabledKeys`, `dragAndDropHooks`, etc.) stay in `excludeFromArgs`.
- New `Table.mdx` ships the 6 mandatory sections plus the `Table.Header` / `Table.Body` / `Table.Row` / `Table.Cell` composition contract, the Phase 2 DataTable scope boundary, and the keyboard / a11y contract.
- Story drops `tags: ['autodocs']`, consumes `defineControls`, and re-exports `excludeFromArgs` from the controls module.

**Final P-group conversion in Phase 1.5** — closes the conversion slice (F1.5-2 through F1.5-19) opened by the F1.5-1 helper PR.

## Scope

**In**

- `packages/ui/src/components/Table/Table.controls.ts`
- `packages/ui/src/components/Table/Table.mdx`
- `packages/ui/src/components/Table/Table.stories.tsx` refactor

**Out**

- No changes to component APIs or visual treatment.
- Phase 2 `DataTable` (pagination / virtualisation / multi-column sort / faceted filtering) stays out of scope.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 84/84 prop-coverage assertions green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Table MDX page renders; "Show code" panel open by default; Controls show description per row
- [ ] Chromatic build green

Closes #294