### PR TITLE
feat(ui): Logo primitive + stories

### DIFF
--- a/packages/ui/src/components/Logo/Logo.controls.ts
+++ b/packages/ui/src/components/Logo/Logo.controls.ts
@@ -1,0 +1,63 @@
+// `Logo.controls.ts` — single source of truth for the Logo prop matrix.
+// Story (`Logo.stories.tsx`) imports the spec and spreads it into
+// `meta.args` / `meta.argTypes`; MDX docs (`Logo.mdx`) render it via
+// `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const variantOptions = ['wordmark', 'symbol'] as const;
+const themeOptions = ['light', 'dark'] as const;
+
+export const logoControls = {
+  variant: {
+    type: 'inline-radio',
+    options: variantOptions,
+    default: 'wordmark',
+    description:
+      'Which mark to render. `wordmark` is the full logotype; `symbol` is the standalone glyph for compact contexts (favicons, avatar fallbacks, top-bar collapse states).',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof variantOptions)[number]>,
+  theme: {
+    type: 'inline-radio',
+    options: themeOptions,
+    default: 'light',
+    description:
+      'Contrast variant. `light` renders the brand-500 body for light surfaces; `dark` swaps to base-dirty (off-white) for dark or brand-tinted surfaces. Independent from the app `<ThemeProvider>` — pick the value that contrasts with the immediate background.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof themeOptions)[number]>,
+  background: {
+    type: 'color',
+    default: 'transparent',
+    description:
+      'CSS background applied to the wrapper. Defaults to `transparent`. Use the color picker to preview the mark on a brand surface — confirms contrast for the chosen `theme`.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'text',
+    description:
+      'Width of the rendered mark. Number → `px`; string → forwarded verbatim (`100%`, `4rem`). Height scales via the SVG `viewBox` aspect ratio. Leave empty for the SVG natural size.',
+    category: 'Style',
+  } satisfies ControlSpec<number | string>,
+  label: {
+    type: 'text',
+    default: 'Glaon',
+    description:
+      'Accessible label exposed via `aria-label` when the logo is announced as an image. Ignored when `decorative` is true.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  decorative: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Hide from assistive tech (`aria-hidden="true"`). Use when the logo is purely ornamental — e.g. paired with a visible "Glaon" wordmark elsewhere on the page.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  className: {
+    type: false,
+    description: 'Tailwind / className override hook for the wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const logoExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Logo/Logo.mdx
+++ b/packages/ui/src/components/Logo/Logo.mdx
@@ -1,0 +1,100 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as LogoStories from './Logo.stories';
+
+<Meta of={LogoStories} />
+
+# Logo
+
+Glaon brand identity primitive. Renders the wordmark or the standalone
+symbol, with a contrast variant for light vs. dark surfaces. SVG paths
+are inlined from `packages/assets/glaon{,_dark}.svg` and
+`symbol{,_dark}.svg` so the wrap renders without a Vite SVG plugin or
+asset loader in the consuming app.
+
+## When to use
+
+- **Top bar / header** — full `wordmark` on the marketing site,
+  `symbol` on the in-app top bar when horizontal space is tight.
+- **Auth screens** — `wordmark` centered above the login form.
+- **Splash / boot** — `symbol` for app icon style framing.
+- **Empty states** — `symbol` with `decorative` to anchor an empty
+  panel without screen-reader noise.
+
+## When NOT to use
+
+- **Avatar** — the user's profile picture is owned by [Avatar](?path=/docs/web-primitives-avatar--docs); use that with the symbol as a fallback only when no profile photo exists.
+- **Inline brand mention in body copy** — write "Glaon" as text;
+  inserting an inline SVG breaks line-height and typography rhythm.
+
+## Anatomy
+
+<Canvas of={LogoStories.AllVariants} />
+
+The mark is composed of two visual elements:
+
+- **Body** — the wordmark glyphs / symbol ring. Fill resolves through
+  `currentColor`; the wrapper picks `var(--brand-500)` for the
+  `light` theme and `var(--base-dirty)` for the `dark` theme.
+- **Accent** — the orange dot (`var(--red-500)`). Brand-canonical and
+  theme-invariant — it stays the same on both surfaces.
+
+```tsx
+<Logo variant="wordmark" theme="light" size={240} />
+<Logo variant="symbol" theme="dark" background="var(--brand-700)" size={96} />
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Theme prop vs. app theme
+
+The `theme` prop is **independent** from the app-level
+`<ThemeProvider>`. Source design tokens are single-mode today (Figma
+Variables don't yet expose Theme: Dark — see #140). `theme` here
+expresses contrast intent against the immediate surrounding surface,
+not the global app theme.
+
+When the dark token binding lands, this contract still holds: a
+`theme="dark"` Logo continues to mean "render on dark / brand-tinted
+surface", regardless of which app-level theme is active.
+
+## Accessibility
+
+- Default behaviour: the wrapper renders with `role="img"` and
+  `aria-label="Glaon"`. Override the label only when context demands
+  a longer description (e.g. "Glaon — Home Assistant frontend").
+- Set `decorative` when the logo duplicates information already
+  available to screen readers (a visible "Glaon" headline elsewhere
+  on the page). The wrapper switches to `aria-hidden="true"` and
+  drops the `role`.
+- Contrast: pair `theme="light"` with surfaces lighter than
+  `var(--neutral-200)`; use `theme="dark"` for surfaces darker than
+  `var(--brand-300)`. The Storybook **AllVariants** story is the
+  canonical contrast check.
+
+## Source SVGs
+
+The four canonical SVGs live in [`packages/assets/`](../../../assets/):
+
+- `glaon.svg` — light wordmark
+- `glaon_dark.svg` — dark wordmark
+- `symbol.svg` — light symbol
+- `symbol_dark.svg` — dark symbol
+
+The component inlines paths from the **light** files and switches the
+body fill via `currentColor` to render the dark variant — the only
+visual difference between the light and dark source files is the body
+fill, which our color strategy parameterizes.
+
+## Related components
+
+- [Avatar](?path=/docs/web-primitives-avatar--docs) — for user profile
+  photos; can render a Logo-shaped fallback for unknown users.
+- [TopBar](?path=/docs/web-primitives-topbar--docs) — typical host for
+  the wordmark variant.

--- a/packages/ui/src/components/Logo/Logo.stories.tsx
+++ b/packages/ui/src/components/Logo/Logo.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { Logo } from './Logo';
+import { logoControls, logoExcludeFromArgs } from './Logo.controls';
+
+const { args, argTypes } = defineControls(logoControls);
+
+const meta: Meta<typeof Logo> = {
+  title: 'Web Primitives/Logo',
+  component: Logo,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/JLbLmCMDdhxOisbVYiAo5C/Brand-Guidelines?node-id=web-primitives-logo',
+    },
+  },
+  args,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div style={{ padding: 24 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Logo>;
+
+export const excludeFromArgs = logoExcludeFromArgs;
+
+export const Default: Story = {
+  args: { size: 240 },
+};
+
+export const Symbol: Story = {
+  args: { variant: 'symbol', size: 96 },
+};
+
+export const Dark: Story = {
+  args: { theme: 'dark', size: 240, background: 'var(--brand-700)' },
+};
+
+export const SymbolDark: Story = {
+  args: { variant: 'symbol', theme: 'dark', size: 96, background: 'var(--brand-700)' },
+};
+
+export const Decorative: Story = {
+  args: { variant: 'symbol', size: 96, decorative: true },
+};
+
+// Gallery — all four variants on their natural surfaces. Mirrors the
+// Brand Guideline placement grid so designers can verify pixel parity
+// against the Figma frame.
+export const AllVariants: Story = {
+  args: { size: 220 },
+  render: (storyArgs) => {
+    const swatches: { theme: 'light' | 'dark'; background: string; label: string }[] = [
+      { theme: 'light', background: 'var(--base-white)', label: 'light · base-white' },
+      { theme: 'light', background: 'var(--base-dirty)', label: 'light · base-dirty' },
+      { theme: 'dark', background: 'var(--brand-500)', label: 'dark · brand-500' },
+      { theme: 'dark', background: 'var(--brand-700)', label: 'dark · brand-700' },
+    ];
+    return (
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+        {swatches.flatMap(({ theme, background, label }) =>
+          (['wordmark', 'symbol'] as const).map((variant) => (
+            <div
+              key={`${variant}-${theme}-${background}`}
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 8,
+                padding: 24,
+                borderRadius: 12,
+                background,
+                border: '1px solid var(--neutral-200)',
+              }}
+            >
+              <Logo
+                {...storyArgs}
+                variant={variant}
+                theme={theme}
+                background="transparent"
+                size={variant === 'wordmark' ? 220 : 80}
+              />
+              <span
+                style={{
+                  fontSize: 12,
+                  color: theme === 'dark' ? 'var(--base-dirty)' : 'var(--neutral-700)',
+                }}
+              >
+                {variant} · {label}
+              </span>
+            </div>
+          )),
+        )}
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/components/Logo/Logo.tsx
+++ b/packages/ui/src/components/Logo/Logo.tsx
@@ -1,0 +1,148 @@
+// Glaon Logo — brand identity primitive. Renders the wordmark or the
+// standalone symbol. SVG paths are inlined here (sourced from
+// `packages/assets/glaon{,_dark}.svg` and `symbol{,_dark}.svg`) so the
+// wrap works in any consumer without a Vite SVG plugin or asset
+// loader.
+//
+// Color strategy:
+// - Body fill resolves through `currentColor`. The wrapper sets
+//   `color` to `var(--brand-500)` on the light theme and
+//   `var(--base-dirty)` on the dark theme — both Glaon design tokens
+//   emitted by Style Dictionary into `dist/tokens/web.css`.
+// - Accent fill is the brand-canonical orange (`var(--red-500)`),
+//   theme-invariant — it stays the same on both surfaces.
+//
+// The `theme` prop is intentionally independent from the app-level
+// `<ThemeProvider>`. Source tokens are single-mode today (#140
+// follow-up adds Theme: Dark). `theme` here expresses contrast intent
+// against the immediate surface, not the global app theme.
+
+import type { CSSProperties } from 'react';
+
+export type LogoVariant = 'wordmark' | 'symbol';
+export type LogoTheme = 'light' | 'dark';
+
+export interface LogoProps {
+  /**
+   * Which mark to render. `wordmark` is the full Glaon logotype;
+   * `symbol` is the standalone glyph (favicons, avatar fallbacks,
+   * compact navigation chrome).
+   * @default 'wordmark'
+   */
+  variant?: LogoVariant;
+  /**
+   * Contrast variant. `light` renders the brand-500 body (for light
+   * surfaces); `dark` swaps to the off-white body (for dark or
+   * brand-tinted surfaces). Independent from the app's
+   * `<ThemeProvider>` — pick the value that contrasts with the
+   * immediate background.
+   * @default 'light'
+   */
+  theme?: LogoTheme;
+  /**
+   * Width of the rendered mark. Number is treated as `px`; string is
+   * forwarded verbatim (`100%`, `4rem`, etc.). Height scales via the
+   * SVG `viewBox` aspect ratio.
+   */
+  size?: number | string;
+  /**
+   * CSS background applied to the wrapper. Useful for previewing the
+   * mark on a colored panel (story controls, brand-guideline tiles).
+   * @default 'transparent'
+   */
+  background?: string;
+  /** Tailwind / className override hook for the wrapper. */
+  className?: string;
+  /**
+   * Accessible label. Defaults to `'Glaon'`. Set `''` together with
+   * `decorative` for purely ornamental usage.
+   */
+  label?: string;
+  /**
+   * Hide from assistive tech (sets `aria-hidden`). Use when the logo
+   * is decorative — e.g. paired with a visible "Glaon" wordmark
+   * elsewhere on the page.
+   * @default false
+   */
+  decorative?: boolean;
+}
+
+const bodyFill: Record<LogoTheme, string> = {
+  light: 'var(--brand-500)',
+  dark: 'var(--base-dirty)',
+};
+
+const accentFill = 'var(--red-500)';
+
+function Wordmark() {
+  return (
+    <svg
+      viewBox="0 0 530 239"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <path
+        d="M493.705 71.344C513.756 71.344 530 88.6004 530 111.266V176.428H497.766V116.674C497.766 107.402 491.167 100.448 481.776 100.448C472.385 100.448 464.77 107.402 464.77 116.674V176.428H432.282V73.4044H464.77V86.0248C471.877 77.0103 482.029 71.344 493.705 71.344Z"
+        fill="currentColor"
+      />
+      <path
+        d="M363.039 178.489C329.028 178.489 306.439 155.823 306.439 124.916C306.439 94.0092 329.028 71.344 363.039 71.344C397.05 71.344 419.385 94.0092 419.385 124.916C419.385 155.823 397.05 178.489 363.039 178.489ZM363.039 149.384C376.745 149.127 387.151 138.825 387.151 124.916C387.151 111.008 376.745 100.706 363.039 100.448C349.079 100.706 338.927 111.008 338.927 124.916C338.927 138.825 349.079 149.127 363.039 149.384Z"
+        fill="currentColor"
+      />
+      <path
+        d="M300.276 149.642H304.845V176.428C302.56 177.458 299.515 178.489 296.215 178.489C282.509 178.489 271.341 171.535 264.996 160.975C256.874 171.792 244.945 178.489 230.224 178.489C202.051 178.489 179.969 154.793 179.969 124.916C179.969 95.0394 202.051 71.344 230.224 71.344C241.899 71.344 251.544 75.4649 259.158 82.419V73.4044H291.393V139.597C291.393 148.097 295.961 149.642 300.276 149.642ZM236.569 149.384C249.767 149.384 260.681 138.567 260.681 124.916C260.681 111.266 249.767 100.448 236.569 100.448C223.117 100.448 212.457 111.266 212.457 124.916C212.457 138.567 223.117 149.384 236.569 149.384Z"
+        fill="currentColor"
+      />
+      <path d="M134.766 176.428V0H167.254V176.428H134.766Z" fill="currentColor" />
+      <path
+        d="M114.469 73.4044L114.723 177.458C114.723 215.577 92.6415 238.5 55.5849 238.5C28.9346 238.5 9.89869 226.395 1.52287 205.275L31.2189 193.17C35.0261 203.472 43.9095 209.911 55.5849 209.911C72.0827 209.911 82.489 198.321 82.489 179.261V165.611C74.1132 173.595 62.9455 178.489 50.2549 178.489C22.0817 178.489 0 154.793 0 124.916C0 94.7819 22.0817 71.344 50.2549 71.344C62.6917 71.344 73.6056 75.98 81.9814 83.7068V73.4044H114.469ZM58.3769 149.384C71.8289 149.384 82.7429 138.567 82.7429 124.916C82.7429 111.266 71.8289 100.448 58.3769 100.448C44.9248 100.448 34.2647 111.266 34.2647 124.916C34.2647 138.567 44.9248 149.384 58.3769 149.384Z"
+        fill="currentColor"
+      />
+      <rect x="348" y="39" width="30" height="90" rx="5" style={{ fill: accentFill }} />
+    </svg>
+  );
+}
+
+function Symbol() {
+  return (
+    <svg
+      viewBox="0 0 113 140"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: '100%', height: 'auto', display: 'block' }}
+    >
+      <path
+        d="M56.6002 139.489C22.5893 139.489 0 116.823 0 85.9163C0 55.0092 22.5893 32.344 56.6002 32.344C90.611 32.344 112.947 55.0092 112.947 85.9163C112.947 116.823 90.611 139.489 56.6002 139.489ZM56.6002 110.384C70.306 110.127 80.7123 99.8245 80.7123 85.9163C80.7123 72.0081 70.306 61.7057 56.6002 61.4482C42.6405 61.7057 32.488 72.0081 32.488 85.9163C32.488 99.8245 42.6405 110.127 56.6002 110.384Z"
+        fill="currentColor"
+      />
+      <rect x="41.5612" y="0" width="30" height="90" rx="5" style={{ fill: accentFill }} />
+    </svg>
+  );
+}
+
+export function Logo({
+  variant = 'wordmark',
+  theme = 'light',
+  size,
+  background = 'transparent',
+  className,
+  label = 'Glaon',
+  decorative = false,
+}: LogoProps) {
+  const wrapperStyle: CSSProperties = {
+    display: 'inline-flex',
+    color: bodyFill[theme],
+    background,
+    ...(size !== undefined ? { width: size } : {}),
+  };
+  const a11yProps = decorative
+    ? { 'aria-hidden': true as const }
+    : { role: 'img' as const, 'aria-label': label };
+
+  return (
+    <span className={className} style={wrapperStyle} {...a11yProps}>
+      {variant === 'wordmark' ? <Wordmark /> : <Symbol />}
+    </span>
+  );
+}

--- a/packages/ui/src/components/Logo/index.ts
+++ b/packages/ui/src/components/Logo/index.ts
@@ -1,0 +1,1 @@
+export { Logo, type LogoProps, type LogoTheme, type LogoVariant } from './Logo';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,7 @@ export * from './components/Checkbox';
 export * from './components/Drawer';
 export * from './components/Input';
 export * from './components/List';
+export * from './components/Logo';
 export * from './components/Modal';
 export * from './components/Popover';
 export * from './components/PressableButton';


### PR DESCRIPTION
## Summary

- New `Logo` primitive at [packages/ui/src/components/Logo](packages/ui/src/components/Logo/) — renders the Glaon wordmark or standalone symbol with a contrast variant for light vs. dark surfaces.
- SVG paths inlined from [packages/assets/](packages/assets/) (`glaon{,_dark}.svg` + `symbol{,_dark}.svg`) — no Vite SVG plugin or asset loader needed in consumers.
- Color strategy uses Glaon design tokens emitted by Style Dictionary: body resolves through `currentColor` (`var(--brand-500)` light / `var(--base-dirty)` dark); accent fills with `var(--red-500)`, theme-invariant.
- Ships with `Logo.controls.ts` + `Logo.stories.tsx` (5 named stories + a 4×2 gallery `AllVariants` story showing every variant on its canonical surface) + `Logo.mdx`.

## Scope

### In

- [packages/ui/src/components/Logo/Logo.tsx](packages/ui/src/components/Logo/Logo.tsx) — `variant: 'wordmark' | 'symbol'`, `theme: 'light' | 'dark'`, `size`, `background` (default `transparent`), `label`, `decorative`, `className`.
- [packages/ui/src/components/Logo/Logo.controls.ts](packages/ui/src/components/Logo/Logo.controls.ts) — typed control spec (`defineControls` / `excludeFromArgs`), F6 prop-coverage compatible.
- [packages/ui/src/components/Logo/Logo.stories.tsx](packages/ui/src/components/Logo/Logo.stories.tsx) — `Default`, `Symbol`, `Dark`, `SymbolDark`, `Decorative`, `AllVariants`.
- [packages/ui/src/components/Logo/Logo.mdx](packages/ui/src/components/Logo/Logo.mdx) — anatomy, when/when-not-to-use, variants, props, theme-vs-app-theme rationale, a11y, source-SVG pointers.
- [packages/ui/src/components/Logo/index.ts](packages/ui/src/components/Logo/index.ts) + barrel export from [packages/ui/src/index.ts](packages/ui/src/index.ts).

### Out

- React Native counterpart (separate issue, P9-RN-style follow-up).
- `packages/assets/` workspace package promotion (`@glaon/assets`) — not needed for this PR; component inlines paths.
- Animated splash / boot variant — separate issue.
- Logo's `theme` prop binding to `<ThemeProvider>` — left independent because source tokens are single-mode (#140 follow-up).

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — 87/87 unit assertions green (includes F6 prop-coverage gate)
- [ ] `pnpm --filter @glaon/ui test:stories` — runs in CI (local skipped: Playwright Chromium not installed on dev box)
- [ ] Storybook localhost:6006 — `AllVariants` gallery renders on all 4 swatches; `Default` / `Symbol` / `Dark` / `Decorative` render; Controls panel shows `background` color picker switching the wrapper background; MDX page renders with full anatomy and props
- [ ] Chromatic build green; AllVariants snapshot matches Brand Guideline placement

## A11y notes

- Default: wrapper carries `role="img"` + `aria-label="Glaon"`.
- `decorative` flips to `aria-hidden="true"` and drops the role — for purely ornamental usage.
- `addon-a11y` runs at `error` severity; no exceptions.

## Open follow-ups

- Figma `node-id=web-primitives-logo` mapping needs to be set in the Brand Guideline component description (`storybook-id: logo`) for Chromatic Figma diff (#53). Will coordinate with design after merge.

Closes #283