### PR TITLE
feat(ui): badge parametric wrap + badgegroup primitive

### DIFF
--- a/packages/ui/src/components/Badge/Badge.controls.ts
+++ b/packages/ui/src/components/Badge/Badge.controls.ts
@@ -2,9 +2,15 @@
 // matrix. Story (`Badge.stories.tsx`) imports the spec and spreads
 // it into `meta.args` / `meta.argTypes`; MDX docs (`Badge.mdx`)
 // reads the same spec via `<Controls />`.
+//
+// Phase 2 expansion (#299): Glaon `<Badge>` is now a parametric wrap
+// over the kit's 7 sibling primitives. The new `icon` discriminator
+// + slot props (`iconComponent`, `imgSrc`, `flag`, `onClose`) match
+// Figma's `Icon` axis 1:1.
 
 import type { ControlSpec } from '../_internal/controls';
 import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+import { storybookIcons } from '../../icons/storybook';
 
 const typeOptions = ['pill-color', 'color', 'modern'] as const;
 const sizeOptions = ['sm', 'md', 'lg'] as const;
@@ -22,13 +28,23 @@ const colorOptions = [
   'pink',
   'orange',
 ] as const;
+const iconKindOptions = [
+  'none',
+  'dot',
+  'leading',
+  'trailing',
+  'only',
+  'avatar',
+  'flag',
+  'close',
+] as const;
 
 export const badgeControls = {
   children: {
     type: 'text',
     default: 'Label',
     description:
-      'Bold inline text shown inside the badge. Keep to 1–2 words; for multi-line use Alert (P2).',
+      'Bold inline text shown inside the badge. Keep to 1–2 words; for multi-line use Alert (P2). Optional when `icon === "only"`.',
     category: 'Content',
   } satisfies ControlSpec<string>,
   type: {
@@ -54,6 +70,47 @@ export const badgeControls = {
       'Semantic palette. Use `success` / `warning` / `error` for status meanings; `brand` for promoted highlights; `gray` for neutral metadata. Note: `type="modern"` always renders the neutral grey treatment regardless of the selected colour (the kit ships only one modern variant; see #258).',
     category: 'Style',
   } satisfies ControlSpec<(typeof colorOptions)[number]>,
+  icon: {
+    type: 'select',
+    options: iconKindOptions,
+    default: 'none',
+    description:
+      "Slot discriminator (matches Figma's Icon axis). `none` (default) renders the bare kit `Badge`; `dot` adds a status dot; `leading` / `trailing` add an icon on the matching side; `only` renders an icon-only chip; `avatar` embeds an image; `flag` embeds a country flag; `close` adds an X dismissal button. Pair with the matching slot prop (`iconComponent` / `imgSrc` / `flag` / `onClose`).",
+    category: 'Content',
+  } satisfies ControlSpec<(typeof iconKindOptions)[number]>,
+  iconComponent: {
+    type: 'select',
+    options: Object.keys(storybookIcons),
+    mapping: storybookIcons,
+    description:
+      'Icon glyph used when `icon` is `leading`, `trailing`, or `only`. Pulled from the curated storybook picker so every kit `@untitledui/icons` glyph is reachable.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  imgSrc: {
+    type: 'text',
+    description:
+      'Image URL for `icon === "avatar"`. Renders inline as a 16px circular image — pair with a meaningful `children` label so screen readers can announce the entity.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  flag: {
+    type: 'text',
+    description:
+      'ISO-3166-1 alpha-2 country code (e.g. `TR`, `US`, `GB`) for `icon === "flag"`. The kit ships flags for every country code in `FlagTypes`.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  onClose: {
+    type: false,
+    action: 'close-clicked',
+    description:
+      'Click handler for the X button when `icon === "close"`. Fires on click + keyboard activation (Space / Enter).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  closeLabel: {
+    type: 'text',
+    description:
+      'Accessible label for the X close button when `icon === "close"`. Forwarded as `aria-label` so screen readers announce the action (e.g. "Remove filter").',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
   className: {
     type: false,
     description:

--- a/packages/ui/src/components/Badge/Badge.mdx
+++ b/packages/ui/src/components/Badge/Badge.mdx
@@ -7,8 +7,14 @@ import * as BadgeStories from './Badge.stories';
 # Badge
 
 Inline label for status, category, or count. Visually paired with a
-number, icon, or short text. Lighter than an Alert (P2) and lower-stakes
-than a Toast (P16) — Badge is non-interactive metadata.
+number, icon, or short text. Lighter than an Alert (P2) and
+lower-stakes than a Toast (P16) — Badge is non-interactive metadata
+(except when `icon === 'close'`, which surfaces a single dismissal
+affordance).
+
+The Glaon `<Badge>` is a parametric wrap over the kit's 7 sibling
+primitives. The `icon` discriminator picks the right shape, mirroring
+the Figma `web-primitives-badge` `Icon` axis 1:1.
 
 ## When to use
 
@@ -16,20 +22,49 @@ than a Toast (P16) — Badge is non-interactive metadata.
 - Indicate counts inside list items (12 unread, 3 errors).
 - Tag entities by category (Active / Archived / Draft).
 - Highlight new or beta features (a `brand`-coloured `New` chip).
+- Filter chips with a dismissal affordance (`icon="close"`).
+- Profile / member tiles with embedded avatars (`icon="avatar"`).
 
 ## When NOT to use
 
 - **Multi-line messages** → use [Alert](?path=/docs/web-primitives-alert--docs) for inline status.
 - **Standalone notifications** → use [Toast](?path=/docs/web-primitives-toast--docs) for transient feedback.
-- **Calls to action** → Badges are non-interactive. Use [Button](?path=/docs/web-primitives-button--docs).
+- **Promotional text + CTA pair** → use [BadgeGroup](?path=/docs/web-primitives-badgegroup--docs) (text label + chevron action).
+- **Primary calls to action** → use [Button](?path=/docs/web-primitives-button--docs); Badge dismissal close button is for the badge itself, not page-level actions.
 
 ## Anatomy
 
-<Canvas of={BadgeStories.Default} />
+<Canvas of={BadgeStories.Icons} />
 
-A Badge is a single-line, fully-styled `<span>`. It does not accept
-icons through props in this primitive — for icon + text combinations
-use the kit's `BadgeWithIcon` (also re-exported from `@glaon/ui`).
+A Badge is a single-line, fully-styled `<span>` (or `<button>` slot
+when `icon === 'close'`). The `icon` discriminator dispatches to the
+right kit primitive:
+
+| `icon` value     | Kit primitive     | Slot prop                 |
+| ---------------- | ----------------- | ------------------------- |
+| `none` (default) | `Badge`           | —                         |
+| `dot`            | `BadgeWithDot`    | (kit-rendered dot)        |
+| `leading`        | `BadgeWithIcon`   | `iconComponent`           |
+| `trailing`       | `BadgeWithIcon`   | `iconComponent`           |
+| `only`           | `BadgeIcon`       | `iconComponent`           |
+| `avatar`         | `BadgeWithImage`  | `imgSrc`                  |
+| `flag`           | `BadgeWithFlag`   | `flag` (ISO-3166 alpha-2) |
+| `close`          | `BadgeWithButton` | `onClose` + `closeLabel`  |
+
+```tsx
+<Badge icon="dot" color="success">Online</Badge>
+<Badge icon="leading" iconComponent={Star01} color="brand">Pro</Badge>
+<Badge icon="avatar" imgSrc="…" color="gray">Olivia Rhye</Badge>
+<Badge icon="flag" flag="TR" color="gray">Türkiye</Badge>
+<Badge icon="close" onClose={dismiss} closeLabel="Remove filter">
+  Active filter
+</Badge>
+```
+
+For consumers that prefer narrower types (e.g. tree-shaking the
+dispatcher), `BadgeBase` and `BadgeWithDot` / `BadgeWithIcon` /
+`BadgeIcon` / `BadgeWithImage` / `BadgeWithFlag` / `BadgeWithButton`
+are still re-exported by name from `@glaon/ui`.
 
 ## Variants
 
@@ -49,9 +84,17 @@ use the kit's `BadgeWithIcon` (also re-exported from `@glaon/ui`).
 - When wrapping a meaningful label, pair Badge with surrounding text:
   `<span>Status: <Badge color="success">Online</Badge></span>` so screen
   readers announce the relationship.
+- `icon="close"` renders a real `<button>` element; always provide a
+  meaningful `closeLabel` (e.g. `"Remove filter"`) so screen readers
+  announce the action — without it, axe `button-name` flags the
+  unlabelled button.
+- `icon="only"` (icon-only chip) renders no visible text, so the
+  surrounding context must convey what the chip represents (pair
+  with a text label nearby or wrap in a tooltip).
 
 ## Related components
 
+- [BadgeGroup](?path=/docs/web-primitives-badgegroup--docs) — promo / "What's new" chip with an inline Badge + label + CTA pair.
 - [Alert](?path=/docs/web-primitives-alert--docs) — inline message with title + body.
 - [Toast](?path=/docs/web-primitives-toast--docs) — transient overlay notification.
 - [Avatar](?path=/docs/web-primitives-avatar--docs) — `Avatar.count` prop renders Badge styling.

--- a/packages/ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/ui/src/components/Badge/Badge.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 import { defineControls } from '../_internal/controls';
-import { Badge } from './Badge';
+import { storybookIcons } from '../../icons/storybook';
+import { Badge, type BadgeIconKind } from './Badge';
 import { badgeControls, badgeExcludeFromArgs } from './Badge.controls';
 
 const { args, argTypes } = defineControls(badgeControls);
@@ -15,6 +16,11 @@ const { args, argTypes } = defineControls(badgeControls);
 // story file stays declarative; the MDX docs page (`Badge.mdx`) reads
 // from the same spec. `tags: ['autodocs']` removed — the MDX page
 // replaces autodocs as the per-component documentation entry point.
+//
+// #299: Glaon `<Badge>` is now a parametric wrap dispatching to the
+// kit's 7 sibling primitives via the `icon` discriminator. Default
+// remains backwards-compatible — `icon` defaults to `'none'`, so
+// existing canvases are byte-equal.
 const meta: Meta<typeof Badge> = {
   title: 'Web Primitives/Badge',
   component: Badge,
@@ -107,6 +113,53 @@ export const Types: Story = {
       {(['pill-color', 'color', 'modern'] as const).map((type) => (
         <Badge key={type} {...args} type={type}>
           {type}
+        </Badge>
+      ))}
+    </div>
+  ),
+};
+
+// `Icons` matrix surfaces every value of the `icon` discriminator
+// in one canvas, so callers can see how the parametric wrap dispatches
+// to each kit primitive. Per-icon slot props (`iconComponent`,
+// `imgSrc`, `flag`, `onClose`) are baked in here for the demo —
+// controls that drive *those* slots stay live for the Default story
+// where the user explores them interactively.
+const StarIcon = storybookIcons.star;
+
+const ICON_KINDS: { icon: BadgeIconKind; label: string }[] = [
+  { icon: 'none', label: 'Label' },
+  { icon: 'dot', label: 'Dot' },
+  { icon: 'leading', label: 'Leading' },
+  { icon: 'trailing', label: 'Trailing' },
+  { icon: 'only', label: '' },
+  { icon: 'avatar', label: 'Olivia' },
+  { icon: 'flag', label: 'Türkiye' },
+  { icon: 'close', label: 'Filter' },
+];
+
+export const Icons: Story = {
+  parameters: { controls: { exclude: ['icon', 'iconComponent', 'imgSrc', 'flag', 'onClose'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+      {ICON_KINDS.map(({ icon, label }) => (
+        <Badge
+          key={icon}
+          {...args}
+          icon={icon}
+          iconComponent={
+            icon === 'leading' || icon === 'trailing' || icon === 'only' ? StarIcon : undefined
+          }
+          imgSrc={
+            icon === 'avatar'
+              ? 'https://www.untitledui.com/images/avatars/olivia-rhye?fm=webp&q=80'
+              : undefined
+          }
+          flag={icon === 'flag' ? 'TR' : undefined}
+          onClose={icon === 'close' ? () => undefined : undefined}
+          closeLabel={icon === 'close' ? 'Remove filter' : undefined}
+        >
+          {label}
         </Badge>
       ))}
     </div>

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -1,22 +1,200 @@
-// Glaon Badge — thin wrap around the Untitled UI kit `Badge` source under
-// `packages/ui/src/components/base/badges/badges.tsx`. Per CLAUDE.md's UUI
-// Source Rule, the structural HTML/CSS + variant matrix come from the
-// kit; Glaon's contribution is the wrap layer (token override via
-// `theme.css` + `glaon-overrides.css`, prop API consistency).
+// Glaon Badge — parametric wrap around the Untitled UI kit Badge family
+// under `packages/ui/src/components/base/badges/badges.tsx`.
 //
-// We re-export the kit primitive verbatim so its full prop surface
-// (`type`, `size`, `color`, `children`) is exposed to consumers as
-// `Badge` from `@glaon/ui`. The kit additionally exposes
-// `BadgeWithDot`, `BadgeWithIcon`, `BadgeWithFlag`, `BadgeWithImage`,
-// `BadgeWithButton`, and `BadgeIcon`; surface them too so consumers can
-// reach the full kit catalogue.
+// Per CLAUDE.md's UUI Source Rule, the structural HTML/CSS + variant
+// matrix come from the kit; Glaon's contribution is the wrap layer
+// (token override via `theme.css` + `glaon-overrides.css`, prop API
+// consistency).
+//
+// The kit ships 7 sibling primitives — `Badge`, `BadgeWithDot`,
+// `BadgeWithIcon`, `BadgeIcon`, `BadgeWithImage`, `BadgeWithFlag`,
+// `BadgeWithButton` — each sharing the same `type` / `size` / `color`
+// contract, differing only in the leading/trailing slot content.
+// Figma's Design System models this as a single `<Badge>` component
+// with an `Icon` axis (False / Dot / Avatar / Country / Icon leading /
+// Icon trailing / Only / X close).
+//
+// To match Figma's mental model, the Glaon `<Badge>` wrap is
+// parametric: callers pass an `icon` discriminator and the wrap
+// dispatches internally to the right kit primitive. The 7 kit
+// primitives are still re-exported by name so consumers can reach
+// them directly when they prefer the narrower types (or want
+// tree-shaking to drop the dispatcher).
+//
+// Usage:
+//
+//   <Badge>Default label</Badge>                     // icon='none'
+//   <Badge icon="dot" color="success">Online</Badge>
+//   <Badge icon="leading" iconComponent={Star}>Pro</Badge>
+//   <Badge icon="trailing" iconComponent={ArrowRight}>Continue</Badge>
+//   <Badge icon="only" iconComponent={Star} />
+//   <Badge icon="avatar" imgSrc="…">Olivia</Badge>
+//   <Badge icon="flag" flag="TR">Türkiye</Badge>
+//   <Badge icon="close" onClose={dismiss}>Filter</Badge>
 
-export {
-  Badge,
-  BadgeIcon,
-  BadgeWithButton,
-  BadgeWithDot,
-  BadgeWithFlag,
-  BadgeWithIcon,
-  BadgeWithImage,
+import type { MouseEventHandler, ReactNode } from 'react';
+
+import {
+  Badge as KitBadge,
+  BadgeIcon as KitBadgeIcon,
+  BadgeWithButton as KitBadgeWithButton,
+  BadgeWithDot as KitBadgeWithDot,
+  BadgeWithFlag as KitBadgeWithFlag,
+  BadgeWithIcon as KitBadgeWithIcon,
+  BadgeWithImage as KitBadgeWithImage,
 } from '../base/badges/badges';
+import type { BadgeColors, FlagTypes, IconComponentType, Sizes } from '../base/badges/badge-types';
+
+// Kit-direct exports for consumers that want the narrower per-primitive
+// types (e.g. `BadgeWithDot` enforces a `BadgeWithDot`-shaped contract
+// at compile time). The parametric `Badge` below stays the canonical
+// import for the common case.
+export {
+  KitBadge as BadgeBase,
+  KitBadgeIcon as BadgeIcon,
+  KitBadgeWithButton as BadgeWithButton,
+  KitBadgeWithDot as BadgeWithDot,
+  KitBadgeWithFlag as BadgeWithFlag,
+  KitBadgeWithIcon as BadgeWithIcon,
+  KitBadgeWithImage as BadgeWithImage,
+};
+
+export type BadgeType = 'pill-color' | 'color' | 'modern';
+export type BadgeSize = Sizes;
+export type BadgeColor = BadgeColors;
+export type BadgeFlag = FlagTypes;
+
+/**
+ * Discriminator for the leading / trailing slot. Maps 1:1 to Figma's
+ * `Icon` axis (`web-primitives-badge`) and to the kit's 7 primitives.
+ */
+export type BadgeIconKind =
+  | 'none'
+  | 'dot'
+  | 'leading'
+  | 'trailing'
+  | 'only'
+  | 'avatar'
+  | 'flag'
+  | 'close';
+
+// All slot props admit `undefined` so callers can pass conditionally-
+// resolved values (e.g. `imgSrc={icon === 'avatar' ? src : undefined}`)
+// from a parameterised render. Without `| undefined` here,
+// `exactOptionalPropertyTypes` refuses such call sites.
+export interface BadgeProps {
+  /** Shape variant. */
+  type?: BadgeType | undefined;
+  /** Visual scale. */
+  size?: BadgeSize | undefined;
+  /** Semantic palette. */
+  color?: BadgeColor | undefined;
+  /** Inline label text. Optional when `icon === 'only'`. */
+  children?: ReactNode;
+  /** Tailwind override hook for the outer span. */
+  className?: string | undefined;
+  /**
+   * Slot discriminator. Drives which kit primitive is rendered:
+   * `none` → `Badge`, `dot` → `BadgeWithDot`, `leading` / `trailing`
+   * → `BadgeWithIcon`, `only` → `BadgeIcon`, `avatar` →
+   * `BadgeWithImage`, `flag` → `BadgeWithFlag`, `close` →
+   * `BadgeWithButton`.
+   * @default 'none'
+   */
+  icon?: BadgeIconKind | undefined;
+  /** Icon glyph for `icon === 'leading' | 'trailing' | 'only'`. */
+  iconComponent?: IconComponentType | undefined;
+  /** Image source for `icon === 'avatar'`. */
+  imgSrc?: string | undefined;
+  /** Country code (ISO-2) for `icon === 'flag'`. */
+  flag?: BadgeFlag | undefined;
+  /** Click handler for `icon === 'close'` (X button). */
+  onClose?: MouseEventHandler<HTMLButtonElement> | undefined;
+  /** Accessible label for the X close button (`icon === 'close'`). */
+  closeLabel?: string | undefined;
+}
+
+/**
+ * Glaon Badge — single parametric primitive that dispatches to the
+ * right kit sibling based on the `icon` discriminator. Matches the
+ * Figma `web-primitives-badge` `Icon` axis 1:1.
+ */
+export function Badge({
+  icon = 'none',
+  iconComponent,
+  imgSrc,
+  flag,
+  onClose,
+  closeLabel,
+  type = 'pill-color',
+  size = 'md',
+  color = 'gray',
+  className,
+  children,
+}: BadgeProps) {
+  // Build the shared props object piecewise so undefined values don't
+  // leak through under `exactOptionalPropertyTypes` — the kit's
+  // primitives type `className?: string` strictly (no `| undefined`).
+  const baseProps: { type: BadgeType; size: BadgeSize; color: BadgeColor; className?: string } = {
+    type,
+    size,
+    color,
+  };
+  if (className !== undefined) baseProps.className = className;
+
+  if (icon === 'dot') {
+    return <KitBadgeWithDot {...baseProps}>{children}</KitBadgeWithDot>;
+  }
+
+  if (icon === 'leading' && iconComponent !== undefined) {
+    return (
+      <KitBadgeWithIcon {...baseProps} iconLeading={iconComponent}>
+        {children}
+      </KitBadgeWithIcon>
+    );
+  }
+
+  if (icon === 'trailing' && iconComponent !== undefined) {
+    return (
+      <KitBadgeWithIcon {...baseProps} iconTrailing={iconComponent}>
+        {children}
+      </KitBadgeWithIcon>
+    );
+  }
+
+  if (icon === 'only' && iconComponent !== undefined) {
+    return <KitBadgeIcon {...baseProps} icon={iconComponent} />;
+  }
+
+  if (icon === 'avatar' && imgSrc !== undefined) {
+    return (
+      <KitBadgeWithImage {...baseProps} imgSrc={imgSrc}>
+        {children}
+      </KitBadgeWithImage>
+    );
+  }
+
+  if (icon === 'flag' && flag !== undefined) {
+    return (
+      <KitBadgeWithFlag {...baseProps} flag={flag}>
+        {children}
+      </KitBadgeWithFlag>
+    );
+  }
+
+  if (icon === 'close') {
+    const buttonProps: {
+      onButtonClick?: MouseEventHandler<HTMLButtonElement>;
+      buttonLabel?: string;
+    } = {};
+    if (onClose !== undefined) buttonProps.onButtonClick = onClose;
+    if (closeLabel !== undefined) buttonProps.buttonLabel = closeLabel;
+    return (
+      <KitBadgeWithButton {...baseProps} {...buttonProps}>
+        {children}
+      </KitBadgeWithButton>
+    );
+  }
+
+  return <KitBadge {...baseProps}>{children}</KitBadge>;
+}

--- a/packages/ui/src/components/Badge/index.ts
+++ b/packages/ui/src/components/Badge/index.ts
@@ -1,9 +1,18 @@
 export {
   Badge,
+  BadgeBase,
   BadgeIcon,
   BadgeWithButton,
   BadgeWithDot,
   BadgeWithFlag,
   BadgeWithIcon,
   BadgeWithImage,
+} from './Badge';
+export type {
+  BadgeColor,
+  BadgeFlag,
+  BadgeIconKind,
+  BadgeProps,
+  BadgeSize,
+  BadgeType,
 } from './Badge';

--- a/packages/ui/src/components/BadgeGroup/BadgeGroup.controls.ts
+++ b/packages/ui/src/components/BadgeGroup/BadgeGroup.controls.ts
@@ -1,0 +1,93 @@
+// `BadgeGroup.controls.ts` — single source of truth for BadgeGroup's
+// variant matrix. Story (`BadgeGroup.stories.tsx`) imports the spec
+// and spreads it into `meta.args` / `meta.argTypes`; MDX docs
+// (`BadgeGroup.mdx`) reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+import { storybookIcons } from '../../icons/storybook';
+
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+const placementOptions = ['leading', 'trailing'] as const;
+const colorOptions = [
+  'gray',
+  'brand',
+  'error',
+  'warning',
+  'success',
+  'slate',
+  'sky',
+  'blue',
+  'indigo',
+  'purple',
+  'pink',
+  'orange',
+] as const;
+
+export const badgeGroupControls = {
+  children: {
+    type: 'text',
+    default: 'Read post',
+    description:
+      'Main inline text label. Keep it short — the pill must fit on one line on common viewports.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  addon: {
+    type: false,
+    description:
+      'Inner Badge node, typically `<Badge size="sm">What\'s new</Badge>`. Any ReactNode works (custom counter chip, status pill, tag, …).',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  addonPlacement: {
+    type: 'inline-radio',
+    options: placementOptions,
+    default: 'leading',
+    description:
+      "Where the addon sits relative to the label. Mirrors Figma's `Badge` axis (`Leading` / `Trailing`).",
+    category: 'Style',
+  } satisfies ControlSpec<(typeof placementOptions)[number]>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale. `sm` for dense headers; `md` (default) for hero strips; `lg` for marketing CTAs.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  color: {
+    type: 'select',
+    options: colorOptions,
+    default: 'gray',
+    description:
+      'Surface palette for the outer pill. Mirrors Badge color tokens — pick `brand` for promo announcements, `success` for celebratory release notes, `gray` (default) for neutral updates.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof colorOptions)[number]>,
+  trailingIcon: {
+    type: 'select',
+    options: Object.keys(storybookIcons),
+    mapping: storybookIcons,
+    description:
+      'Trailing icon (commonly a chevron-right indicator). Decorative — `aria-hidden` is forwarded so the label carries the meaning.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  onPress: {
+    type: false,
+    action: 'pressed',
+    description:
+      'Click handler. Setting it (without `href`) renders the group as a `<button>` so the whole pill becomes keyboard-activatable.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  href: {
+    type: 'text',
+    description:
+      'Link destination. Setting it renders the group as an `<a>`. Mutually exclusive with `onPress` — prefer `href` when the destination is shareable.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer pill.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const badgeGroupExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/BadgeGroup/BadgeGroup.mdx
+++ b/packages/ui/src/components/BadgeGroup/BadgeGroup.mdx
@@ -1,0 +1,93 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as BadgeGroupStories from './BadgeGroup.stories';
+
+<Meta of={BadgeGroupStories} />
+
+# BadgeGroup
+
+Pill-shaped composite chip with a small inline Badge + main text +
+optional trailing chevron. Use for "What's new" / release announcements,
+promotional CTAs, or any pattern where a Badge introduces a label.
+
+The Glaon BadgeGroup is hand-rolled — Untitled UI's kit ships only
+hard-coded marketing-page header templates, no generic primitive. The
+wrap uses kit surface vocabulary as canonical reference (`bg-secondary`
+pill, ring, `<Badge>` slot) and parameterises the content fully.
+
+## When to use
+
+- Announcement chips: "What's new — Read post →" at the top of a
+  marketing or dashboard page.
+- Release / changelog highlights: "v1.4 — See changes →".
+- Promotional CTAs anchored to a Badge label: "New — Try the beta →".
+- Compact status + label pairs where a standalone [Badge](?path=/docs/web-primitives-badge--docs) feels too small.
+
+## When NOT to use
+
+- **Inline status next to a name** → use [Badge](?path=/docs/web-primitives-badge--docs); BadgeGroup adds outer chrome that's wasted on simple chips.
+- **Page-level alert** → use [Alert](?path=/docs/web-primitives-alert--docs); BadgeGroup is for compact inline announcements, not multi-line messages.
+- **Top-bar navigation** → use [TopBar](?path=/docs/web-primitives-topbar--docs).
+- **CTA-heavy hero section** → use [Button](?path=/docs/web-primitives-button--docs); a primary CTA shouldn't hide inside a pill.
+
+## Anatomy
+
+<Canvas of={BadgeGroupStories.Default} />
+
+Three composition slots arranged left-to-right (or reversed when
+`addonPlacement="trailing"`):
+
+- **`addon`** — inner Badge node, typically `<Badge size="sm">What's new</Badge>`.
+- **Children** — main text label (one line).
+- **`trailingIcon`** — optional decorative glyph (commonly a chevron).
+
+```tsx
+<BadgeGroup
+  color="brand"
+  size="md"
+  addon={<Badge color="brand">What's new</Badge>}
+  trailingIcon={ChevronRight}
+  onPress={() => navigate('/blog/release')}
+>
+  Read post
+</BadgeGroup>
+```
+
+The whole pill activates as a single `<button>` when `onPress` is
+set, or as an `<a>` when `href` is set. Without either, BadgeGroup
+renders a presentational `<span>` (use this for purely visual
+announcements that don't need a click target).
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The pill uses `role="button"` (when `onPress`) or `role="link"`
+  (when `href`) automatically via the underlying element — no role
+  override needed.
+- For interactive groups, the inner Badge and trailing icon are
+  decorative; the children's text is the accessible name. Avoid
+  cluttering it with status words ("New: Read post about the new release") —
+  shorter is better for screen-reader rotor lists.
+- The `trailingIcon` is `aria-hidden` — pair the chevron with a verb
+  in the children (`Read post →`, not `→` alone) so the label reads
+  as a sentence.
+- For purely presentational groups (no `onPress` / no `href`), the
+  `<span>` wrapper is non-focusable — that's intentional, since
+  there's no action to fire.
+- Don't nest a BadgeGroup inside another interactive container
+  (Card, ListItem with `onClick`, …) — that creates nested-interactive
+  controls which fail axe.
+
+## Related components
+
+- [Badge](?path=/docs/web-primitives-badge--docs) — the inner addon slot is typically a Badge instance.
+- [Alert](?path=/docs/web-primitives-alert--docs) — multi-line inline status / announcement.
+- [Toast](?path=/docs/web-primitives-toast--docs) — transient overlay notification.
+- [Button](?path=/docs/web-primitives-button--docs) — when the primary action stands alone (no Badge label).

--- a/packages/ui/src/components/BadgeGroup/BadgeGroup.stories.tsx
+++ b/packages/ui/src/components/BadgeGroup/BadgeGroup.stories.tsx
@@ -1,0 +1,176 @@
+import type { FC } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { Badge } from '../Badge';
+import { storybookIcons } from '../../icons/storybook';
+import { BadgeGroup } from './BadgeGroup';
+import { badgeGroupControls, badgeGroupExcludeFromArgs } from './BadgeGroup.controls';
+
+// `storybookIcons.<key>` is typed as `IconComponent | undefined` (so
+// the `none` option resolves to `undefined`); `BadgeGroup.trailingIcon`
+// requires non-undefined under `exactOptionalPropertyTypes`. Cast
+// once via this helper for the canonical-icon stories.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+const icon = (key: keyof typeof storybookIcons): FC<any> =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+  storybookIcons[key] as FC<any>;
+const chevronRight = icon('chevronRight');
+
+const { args, argTypes } = defineControls(badgeGroupControls);
+
+// Explicit `Meta<typeof BadgeGroup>` annotation (rather than
+// `satisfies`) keeps the unexported `BadgeGroupProps` interface out
+// of the exported `meta` signature — `tsc --noEmit` runs with
+// `declaration: true` and TS4023 fires when an exported `meta`
+// resolves to a non-exported nominal type.
+//
+// The Default story bakes a sensible `<Badge>` instance into the
+// `addon` slot so the canvas renders meaningfully. Storybook
+// controls don't expose `addon` directly (it's `type: false` in the
+// controls spec) since picking a ReactNode through a knob doesn't
+// match how callers actually use the component.
+const meta: Meta<typeof BadgeGroup> = {
+  title: 'Web Primitives/BadgeGroup',
+  component: BadgeGroup,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-badge-group',
+    },
+  },
+  args: {
+    ...args,
+    addon: <Badge size="sm">What&rsquo;s new</Badge>,
+  },
+  argTypes,
+};
+
+export default meta;
+type Story = StoryObj<typeof BadgeGroup>;
+
+export const excludeFromArgs = badgeGroupExcludeFromArgs;
+
+export const Default: Story = {};
+
+export const Brand: Story = {
+  args: {
+    color: 'brand',
+    addon: (
+      <Badge color="brand" size="sm">
+        New
+      </Badge>
+    ),
+  },
+};
+
+export const WithTrailingChevron: Story = {
+  args: {
+    color: 'brand',
+    addon: (
+      <Badge color="brand" size="sm">
+        v1.4
+      </Badge>
+    ),
+    trailingIcon: chevronRight,
+    children: 'See release notes',
+  },
+};
+
+export const TrailingPlacement: Story = {
+  args: {
+    color: 'success',
+    addonPlacement: 'trailing',
+    addon: (
+      <Badge color="success" size="sm">
+        Live
+      </Badge>
+    ),
+    children: 'API status',
+  },
+};
+
+export const AsLink: Story = {
+  args: {
+    color: 'brand',
+    addon: (
+      <Badge color="brand" size="sm">
+        What&rsquo;s new
+      </Badge>
+    ),
+    trailingIcon: chevronRight,
+    href: '#',
+    children: 'Read post',
+  },
+};
+
+export const Pressable: Story = {
+  args: {
+    color: 'brand',
+    addon: (
+      <Badge color="brand" size="sm">
+        Beta
+      </Badge>
+    ),
+    trailingIcon: chevronRight,
+    onPress: () => undefined,
+    children: 'Try the new editor',
+  },
+};
+
+export const Sizes: Story = {
+  parameters: { controls: { exclude: ['size'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, alignItems: 'flex-start' }}>
+      {(['sm', 'md', 'lg'] as const).map((size) => (
+        <BadgeGroup key={size} {...args} size={size} />
+      ))}
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  parameters: { controls: { exclude: ['color'] } },
+  render: (args) => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(3, max-content)',
+        gap: 12,
+        alignItems: 'center',
+      }}
+    >
+      {(
+        [
+          'gray',
+          'brand',
+          'error',
+          'warning',
+          'success',
+          'slate',
+          'sky',
+          'blue',
+          'indigo',
+          'purple',
+          'pink',
+          'orange',
+        ] as const
+      ).map((color) => (
+        <BadgeGroup
+          key={color}
+          {...args}
+          color={color}
+          addon={
+            <Badge color={color} size="sm">
+              {color}
+            </Badge>
+          }
+        >
+          Read more
+        </BadgeGroup>
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/BadgeGroup/BadgeGroup.tsx
+++ b/packages/ui/src/components/BadgeGroup/BadgeGroup.tsx
@@ -1,0 +1,152 @@
+// Glaon BadgeGroup — text + Badge composite. UUI's kit doesn't ship a
+// generic BadgeGroup primitive; the closest references in the source
+// are marketing-page header templates that hard-code their own
+// "What's new + Read post" announcement chips. Per the UUI Source
+// Rule's "no kit source" exception, Glaon hand-rolls a parameterised
+// wrap using kit surface vocabulary as canonical reference (`bg-secondary`
+// pill, inline `<Badge>` slot, optional trailing chevron icon).
+//
+// The Figma `web-primitives-badge-group` component (under
+// [Badges page](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=12-539))
+// has these axes:
+//   - Badge: `Leading` | `Trailing` (where the inner Badge sits)
+//   - Size: `sm` | `md` | `lg`
+//   - Color: matches Badge palette (12 colors)
+//
+// Usage:
+//
+//   <BadgeGroup
+//     color="brand"
+//     size="md"
+//     addon={<Badge>What's new</Badge>}
+//     trailingIcon={ChevronRight}
+//     onPress={() => navigate('/blog/release')}
+//   >
+//     Read post
+//   </BadgeGroup>
+//
+// The whole group activates as a single `<button>` when `onPress`
+// is set, or an `<a>` when `href` is set; otherwise it renders as a
+// presentational `<span>`.
+
+import type { FC, MouseEventHandler, ReactNode } from 'react';
+
+import type { BadgeColor, BadgeSize } from '../Badge';
+
+// `@untitledui/icons` declares per-file icon types; type the slot
+// loosely to match `storybookIcons` and the kit's own `IconComponent`.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+type IconComponent = FC<any>;
+
+export type BadgeGroupAddonPlacement = 'leading' | 'trailing';
+
+export interface BadgeGroupProps {
+  /** Inner Badge node — typically `<Badge>What's new</Badge>` but any node works. */
+  addon: ReactNode;
+  /**
+   * Position of the addon relative to the main label. Mirrors Figma's
+   * `Badge` axis (`Leading` / `Trailing`). @default 'leading'
+   */
+  addonPlacement?: BadgeGroupAddonPlacement;
+  /** Visual scale. @default 'md' */
+  size?: BadgeSize;
+  /** Surface palette for the outer pill. @default 'gray' */
+  color?: BadgeColor;
+  /** Optional trailing icon (commonly a chevron). */
+  trailingIcon?: IconComponent;
+  /**
+   * Click handler. Renders the group as a `<button>` so the whole
+   * pill is keyboard-activatable.
+   */
+  onPress?: MouseEventHandler<HTMLButtonElement>;
+  /**
+   * Link destination. Renders the group as an `<a>` so the whole
+   * pill is keyboard-activatable. Mutually exclusive with `onPress`.
+   */
+  href?: string;
+  /** Tailwind override hook. */
+  className?: string;
+  /** Main inline text label. */
+  children: ReactNode;
+}
+
+const sizeStyles: Record<BadgeSize, string> = {
+  sm: 'gap-1.5 py-0.5 pl-0.5 pr-2 text-xs font-medium',
+  md: 'gap-2 py-1 pl-1 pr-2.5 text-sm font-medium',
+  lg: 'gap-2.5 py-1.5 pl-1.5 pr-3 text-sm font-medium',
+};
+
+const surfaceColors: Record<BadgeColor, string> = {
+  gray: 'bg-secondary text-secondary ring-secondary_alt',
+  brand: 'bg-utility-brand-50 text-utility-brand-700 ring-utility-brand-200',
+  error: 'bg-utility-error-50 text-utility-error-700 ring-utility-error-200',
+  warning: 'bg-utility-warning-50 text-utility-warning-700 ring-utility-warning-200',
+  success: 'bg-utility-success-50 text-utility-success-700 ring-utility-success-200',
+  slate: 'bg-utility-gray-blue-50 text-utility-gray-blue-700 ring-utility-gray-blue-200',
+  sky: 'bg-utility-blue-light-50 text-utility-blue-light-700 ring-utility-blue-light-200',
+  blue: 'bg-utility-blue-50 text-utility-blue-700 ring-utility-blue-200',
+  indigo: 'bg-utility-indigo-50 text-utility-indigo-700 ring-utility-indigo-200',
+  purple: 'bg-utility-purple-50 text-utility-purple-700 ring-utility-purple-200',
+  pink: 'bg-utility-pink-50 text-utility-pink-700 ring-utility-pink-200',
+  orange: 'bg-utility-orange-50 text-utility-orange-700 ring-utility-orange-200',
+};
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+/**
+ * Glaon BadgeGroup — text + Badge composite anchored in a pill
+ * surface. Use for "What's new", release announcements, or any
+ * promo / CTA pair where a Badge introduces a label.
+ */
+export function BadgeGroup({
+  addon,
+  addonPlacement = 'leading',
+  size = 'md',
+  color = 'gray',
+  trailingIcon: TrailingIcon,
+  onPress,
+  href,
+  className,
+  children,
+}: BadgeGroupProps) {
+  const containerClass = joinClasses(
+    'inline-flex w-max items-center whitespace-nowrap rounded-full ring-1 ring-inset',
+    sizeStyles[size],
+    surfaceColors[color],
+    (onPress !== undefined || href !== undefined) &&
+      'cursor-pointer outline-focus-ring transition hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2',
+    className,
+  );
+
+  const inner = (
+    <>
+      {addonPlacement === 'leading' ? addon : null}
+      <span>{children}</span>
+      {addonPlacement === 'trailing' ? addon : null}
+      {TrailingIcon !== undefined ? (
+        <TrailingIcon className="size-4 text-current" aria-hidden="true" />
+      ) : null}
+    </>
+  );
+
+  if (href !== undefined) {
+    return (
+      <a href={href} className={containerClass}>
+        {inner}
+      </a>
+    );
+  }
+
+  if (onPress !== undefined) {
+    return (
+      <button type="button" onClick={onPress} className={containerClass}>
+        {inner}
+      </button>
+    );
+  }
+
+  return <span className={containerClass}>{inner}</span>;
+}

--- a/packages/ui/src/components/BadgeGroup/index.ts
+++ b/packages/ui/src/components/BadgeGroup/index.ts
@@ -1,0 +1,2 @@
+export { BadgeGroup } from './BadgeGroup';
+export type { BadgeGroupAddonPlacement, BadgeGroupProps } from './BadgeGroup';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,7 @@
 export * from './components/Alert';
 export * from './components/Avatar';
 export * from './components/Badge';
+export * from './components/BadgeGroup';
 export * from './components/Banner';
 export * from './components/Breadcrumb';
 export * from './components/Button';


### PR DESCRIPTION
## Summary

- Glaon `<Badge>` artık parametric — 7 kit kardeş primitive'ine (Badge, BadgeWithDot, BadgeWithIcon, BadgeIcon, BadgeWithImage, BadgeWithFlag, BadgeWithButton) tek bir `icon` discriminator'ı (`'none' | 'dot' | 'leading' | 'trailing' | 'only' | 'avatar' | 'flag' | 'close'`) üzerinden dispatch eder. Slot prop'lar (`iconComponent`, `imgSrc`, `flag`, `onClose`, `closeLabel`) Figma `web-primitives-badge` `Icon` axis'iyle bire bir eşleşir.
- Mevcut Default / PillColor / Color / Modern / Sizes / Colors / Types story'leri değişmedi (`icon` default `'none'` → kit `Badge`'i render eder, byte-equal). Yeni `Icons` matrix story discriminator'ın 8 değerini yan yana gösteriyor.
- 7 kit primitive yine ayrı isimle re-export ediliyor (kit-direct kullanım için).
- **`BadgeGroup`** yeni hand-rolled primitive — kit'te source yok, "What's new — Read post →" promo/announcement chip pattern'i. `<Badge>` slot + label + opsiyonel trailing chevron compose eder; `onPress` (button), `href` (anchor) veya presentational (span) modlarında render eder.

## Scope

**In**

- `packages/ui/src/components/Badge/Badge.tsx` — re-export'tan parametric component'a refactor
- `packages/ui/src/components/Badge/Badge.controls.ts` — `icon` + slot prop'lar eklendi
- `packages/ui/src/components/Badge/Badge.stories.tsx` — `Icons` matrix story eklendi
- `packages/ui/src/components/Badge/Badge.mdx` — Anatomy + Related güncellendi
- `packages/ui/src/components/Badge/index.ts` — yeni type export'ları
- `packages/ui/src/components/BadgeGroup/{BadgeGroup.tsx,controls.ts,mdx,stories.tsx,index.ts}` — yeni primitive
- `packages/ui/src/index.ts` — barrel re-export

**Out**

- Figma `Type=Square / Rounded` axis (kit'te tam karşılık yok; ayrı bir UUI patch issue'u açılır gerekirse).
- Figma `State=Hover` axis (CSS pseudo-class'la idare edilir).

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\`
- [x] \`pnpm --filter @glaon/ui lint\`
- [x] \`pnpm knip\`
- [x] \`pnpm --filter @glaon/ui exec vitest run\` — 90/90 prop-coverage assertion yeşil (BadgeGroup yeni primitive +2)
- [x] \`pnpm --filter @glaon/ui build-storybook\`
- [ ] Storybook localhost:6006 — Badge sayfasında \`icon\` dropdown 8 varyantı seçilebilir; Icons matrix story tüm varyantları yan yana gösterir; BadgeGroup yeni component sayfası açılır
- [ ] Chromatic build yeşil (yeni Icons + BadgeGroup baseline'a eklenir; mevcut Badge story canvas'ları byte-equal kalmalı)

Closes #299