### PR TITLE
feat(ui): alert parametric wrap + notification primitive

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -52,7 +52,6 @@
       "project": ["src/**/*.{ts,tsx}", ".storybook/**/*.{ts,tsx}"],
       "ignore": [
         "src/components/base/**",
-        "src/components/application/alerts/**",
         "src/components/application/breadcrumbs/**",
         "src/components/shared-assets/**",
         "src/components/marketing/**",

--- a/packages/ui/src/components/Alert/Alert.controls.ts
+++ b/packages/ui/src/components/Alert/Alert.controls.ts
@@ -2,19 +2,25 @@
 // matrix. Story (`Alert.stories.tsx`) imports the spec and spreads
 // it into `meta.args` / `meta.argTypes`; MDX docs (`Alert.mdx`)
 // reads the same spec via `<Controls />`.
+//
+// #303: Alert is now a parametric wrap over the kit's `AlertFloating`
+// + `AlertFullWidth`. Controls match the Figma `web-primitives-alert`
+// `Color` × `Size` axes 1:1 — `intent` (legacy 4 values) was renamed
+// to `color` (6 values) to match the kit and Figma.
 
 import type { ControlSpec } from '../_internal/controls';
 import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
-import { storybookIcons } from '../../icons/storybook';
 
-const intentOptions = ['info', 'success', 'warning', 'danger'] as const;
+const colorOptions = ['default', 'brand', 'gray', 'error', 'warning', 'success'] as const;
+const sizeOptions = ['floating', 'full-width'] as const;
+const actionTypeOptions = ['button', 'link'] as const;
 
 export const alertControls = {
   title: {
     type: 'text',
     default: 'New feature available',
     description:
-      'Bold lead-in line. Keep it short — full-stop is optional. The intent icon renders inline next to it.',
+      'Bold lead-in line. Keep it short — the FeaturedIcon renders to the left and the close X to the right; long titles wrap or truncate on narrow viewports.',
     category: 'Content',
   } satisfies ControlSpec<string>,
   description: {
@@ -24,47 +30,56 @@ export const alertControls = {
       'Optional secondary copy under the title. Use for one-line elaboration; for multi-paragraph content prefer Banner.',
     category: 'Content',
   } satisfies ControlSpec<string>,
-  intent: {
-    type: 'inline-radio',
-    options: intentOptions,
-    default: 'info',
+  color: {
+    type: 'select',
+    options: colorOptions,
+    default: 'default',
     description:
-      'Severity / colour group for the leading icon. `info` for neutral hints, `success` for confirmations, `warning` for time-sensitive prompts, `danger` for errors.',
+      "Severity / surface palette. Mirrors Figma's `Color` axis 1:1 — `default` (neutral), `brand` (promo / informational), `gray` (subtle), `error` / `warning` / `success` for status meaning.",
     category: 'Style',
-  } satisfies ControlSpec<(typeof intentOptions)[number]>,
-  dismissible: {
-    type: 'boolean',
-    default: false,
+  } satisfies ControlSpec<(typeof colorOptions)[number]>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'floating',
     description:
-      'Render the close button at the top-right corner. Pair with `onDismiss` to handle the click.',
+      "Layout variant. `floating` is a card-style alert (modal-friendly, dashboard surface); `full-width` is an inline page-wide bar (system status pinned to a page top). Mirrors Figma's `Size` axis.",
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  actionType: {
+    type: 'inline-radio',
+    options: actionTypeOptions,
+    default: 'button',
+    description:
+      "Action button styling for `size='full-width'` only. `button` renders filled / secondary buttons; `link` renders inline link styling. Ignored when `size='floating'` — the kit always uses link styling there.",
+    category: 'Style',
+  } satisfies ControlSpec<(typeof actionTypeOptions)[number]>,
+  confirmLabel: {
+    type: 'text',
+    description:
+      'Label for the primary CTA (right side). Pair with `onConfirm`. Leave both undefined to render an alert without an action button.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  onConfirm: {
+    type: false,
+    action: 'confirmed',
+    description: 'Click handler for the primary CTA.',
     category: 'Behavior',
-  } satisfies ControlSpec<boolean>,
+  } satisfies ControlSpec<unknown>,
   dismissLabel: {
     type: 'text',
     default: 'Dismiss',
     description:
-      'Accessible name for the close button. Defaults to "Dismiss"; localise per app locale.',
+      'Label for the dismiss button. Also serves as the `aria-label` for the close X. Defaults to `Dismiss`; localise per app locale.',
     category: 'A11y',
   } satisfies ControlSpec<string>,
-  icon: {
-    type: 'select',
-    options: Object.keys(storybookIcons),
-    mapping: storybookIcons,
-    description:
-      'Override the default icon for the chosen intent. Pass any component from `@untitledui/icons` (or a custom React component with the same shape).',
-    category: 'Content',
-  } satisfies ControlSpec<unknown>,
   onDismiss: {
     type: false,
     action: 'dismissed',
-    description: 'Fires when the close button is clicked.',
+    description:
+      'Click handler for the dismiss button + close X. Setting this also surfaces the close X in the corner; leaving it undefined renders the alert as persistent.',
     category: 'Behavior',
   } satisfies ControlSpec<unknown>,
-  className: {
-    type: false,
-    description: 'Tailwind override hook for the outer container.',
-    category: 'Style',
-  } satisfies ControlSpec<string>,
 } as const;
 
 export const alertExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Alert/Alert.mdx
+++ b/packages/ui/src/components/Alert/Alert.mdx
@@ -6,10 +6,15 @@ import * as AlertStories from './Alert.stories';
 
 # Alert
 
-Inline status message. Use Alert when the user needs to read, but
-not necessarily act on, contextual information that lives next to
-the content it relates to. Heavier than a Badge (P1), lower-stakes
-than a Toast (P16).
+Inline status message. Use Alert when the user needs to read, and
+optionally act on, contextual information that lives next to the
+content it relates to. Heavier than a [Badge](?path=/docs/web-primitives-badge--docs)
+(P1), lower-stakes than a [Toast](?path=/docs/web-primitives-toast--docs) (P16).
+
+The Glaon `<Alert>` is a parametric wrap over the kit's `AlertFloating`
+and `AlertFullWidth` primitives — the `size` prop dispatches to the
+right one. The `color` axis (6 values) and `actionType` knob match
+the Figma `web-primitives-alert` `Color` × `Size` matrix 1:1.
 
 ## When to use
 
@@ -18,21 +23,48 @@ than a Toast (P16).
 - Inside a settings page, calling attention to the impact of a flag.
 - After a save, confirming the result inline ("Profile saved.")
   when the user is still viewing the form.
+- Pinned to the top of a dashboard for system status (`size='full-width'`).
 
 ## When NOT to use
 
-- **Page-level announcement** that's not tied to a specific section
-  → use [Banner](?path=/docs/web-primitives-banner--docs).
+- **Page-level marketing announcement** that's not tied to a specific
+  section → use [Banner](?path=/docs/web-primitives-banner--docs).
 - **Transient feedback** that should disappear → use [Toast](?path=/docs/web-primitives-toast--docs).
+- **In-app activity feed item** (avatar + comment / file upload progress)
+  → use [Notification](?path=/docs/web-primitives-notification--docs).
 - **Single-word status** → use [Badge](?path=/docs/web-primitives-badge--docs).
 
 ## Anatomy
 
-<Canvas of={AlertStories.Default} />
+<Canvas of={AlertStories.WithActions} />
 
-Layout: leading icon (intent-based), title + optional description
-(stacked vertically on mobile, inline-with-gap on desktop), optional
-close button at the top-right.
+Layout: leading FeaturedIcon (color-coded by `color`), title + optional
+description (stacked on mobile, inline on desktop), optional inline
+action group (`confirmLabel` + `dismissLabel`), optional close X
+button when `onDismiss` is set.
+
+```tsx
+<Alert
+  color="success"
+  size="floating"
+  title="Settings saved"
+  description="Your changes are live across the workspace."
+  confirmLabel="View changes"
+  onConfirm={navigateToChanges}
+  onDismiss={() => setOpen(false)}
+/>
+```
+
+The two layout primitives have different optimal use-cases:
+
+- **`size='floating'`** — card-style, modal-friendly, dashboard
+  surface. Renders inside the page's content area with a rounded
+  ring. Action buttons always render as inline links (kit
+  contract).
+- **`size='full-width'`** — page-wide bar pinned to a section /
+  page top. Use for system status announcements that span the
+  layout. Pair with `actionType='button'` for prominent CTAs or
+  `actionType='link'` for low-key links.
 
 ## Variants
 
@@ -44,18 +76,28 @@ close button at the top-right.
 
 ## Accessibility
 
-- Renders as `<div role="status">` so screen readers announce the
-  text on insert / change.
-- The intent icon is `aria-hidden`; the title + description carry
-  the meaningful content.
-- Color alone never conveys meaning — title text always describes
-  the state ("Saved", "Connection lost", "Update available").
-- The close button is a real `<button>` with the configurable
-  `dismissLabel` as `aria-label` — keyboard reachable, focus ring
-  via `outline-focus-ring`.
+- The kit forwards a semantic role on the wrapper so screen readers
+  announce the text on insert / change.
+- The leading FeaturedIcon is decorative — title + description must
+  carry the meaningful content (axe `color-contrast` and the kit's
+  contrast tokens both enforce this).
+- Color alone never conveys meaning — pair `color='error'` /
+  `'warning'` / `'success'` with descriptive title text ("Connection
+  lost", "Token rotation in 24 hours", "Saved").
+- The close X is a real `<button>` element; always pass an
+  `onDismiss` handler if you render it, so keyboard users can
+  activate it. The button's `aria-label` comes from `dismissLabel`
+  (defaults to `Dismiss`).
+- Action buttons inside the alert are real focusable controls — use
+  short verb labels ("Re-authenticate", "View changes") rather than
+  generic "OK" / "Cancel".
+- Avoid placing form inputs inside an Alert. If users need to act on
+  a form, the form's own validation / hint state is the right home
+  for the message.
 
 ## Related components
 
-- [Banner](?path=/docs/web-primitives-banner--docs) — page-level announcement with optional CTA.
+- [Banner](?path=/docs/web-primitives-banner--docs) — page-level marketing announcement with optional CTA.
 - [Toast](?path=/docs/web-primitives-toast--docs) — transient overlay notification.
+- [Notification](?path=/docs/web-primitives-notification--docs) — in-app activity feed item (avatar + comment, file upload progress, …).
 - [Badge](?path=/docs/web-primitives-badge--docs) — single-word inline status.

--- a/packages/ui/src/components/Alert/Alert.stories.tsx
+++ b/packages/ui/src/components/Alert/Alert.stories.tsx
@@ -1,19 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 import { defineControls } from '../_internal/controls';
-import { Alert } from './Alert';
+import { Alert, type AlertColor } from './Alert';
 import { alertControls, alertExcludeFromArgs } from './Alert.controls';
 
 const { args, argTypes } = defineControls(alertControls);
 
-// Explicit `Meta<typeof Alert>` annotation (rather than `satisfies`) keeps
-// storybook csf-internal types out of the exported `meta` signature —
-// `tsc --noEmit` runs with `declaration: true` and trips TS2742 / TS4023
-// when the inferred meta references types that aren't portably named.
+// Explicit `Meta<typeof Alert>` annotation (rather than `satisfies`)
+// keeps the kit's deep `AlertFloating` / `AlertFullWidth` prop shapes
+// out of the exported `meta` signature — `tsc --noEmit` runs with
+// `declaration: true`.
 //
-// Phase 1.5: `args` + `argTypes` come from `Alert.controls.ts`;
-// `tags: ['autodocs']` removed because `Alert.mdx` replaces the
-// docs tab.
+// #303: Alert is now a parametric wrap dispatching to
+// `AlertFloating` (size='floating') or `AlertFullWidth`
+// (size='full-width'). Color axis matches Figma's 6-value palette.
 const meta: Meta<typeof Alert> = {
   title: 'Web Primitives/Alert',
   component: Alert,
@@ -25,13 +25,6 @@ const meta: Meta<typeof Alert> = {
   },
   args,
   argTypes,
-  decorators: [
-    (Story) => (
-      <div style={{ width: 480 }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export default meta;
@@ -41,51 +34,64 @@ export const excludeFromArgs = alertExcludeFromArgs;
 
 export const Default: Story = {};
 
-export const Info: Story = {
-  args: { intent: 'info', title: 'Heads up — new release on Friday.' },
+export const Floating: Story = {
+  args: { size: 'floating', color: 'brand', confirmLabel: 'View changes' },
 };
 
-export const Success: Story = {
+export const FullWidth: Story = {
+  args: { size: 'full-width', color: 'brand', confirmLabel: 'View changes' },
+};
+
+export const WithActions: Story = {
   args: {
-    intent: 'success',
-    title: 'Saved',
-    description: 'Your changes are live.',
+    color: 'success',
+    title: 'Settings saved',
+    description: 'Your changes are live across the workspace.',
+    confirmLabel: 'View changes',
+    onConfirm: () => undefined,
+    onDismiss: () => undefined,
   },
 };
 
-export const Warning: Story = {
+export const Persistent: Story = {
   args: {
-    intent: 'warning',
+    color: 'warning',
     title: 'Token rotation in 24 hours',
-    description: 'Re-authenticate before midnight.',
+    description: 'Re-authenticate before midnight or jobs will fail.',
+    confirmLabel: 'Re-authenticate',
+    onConfirm: () => undefined,
+    // No onDismiss → no close X → persistent until the user acts.
   },
-};
-
-export const Danger: Story = {
-  args: {
-    intent: 'danger',
-    title: 'Could not save changes',
-    description: 'Network error. Try again.',
-  },
-};
-
-export const Dismissible: Story = {
-  args: { dismissible: true },
 };
 
 export const TitleOnly: Story = {
   args: { description: undefined, title: 'A short status line' },
 };
 
-// Matrix story: iterates `intent` and renders every variant in a
-// single canvas, so the controls panel hides `intent` (changing it on
-// a matrix is meaningless). Other props still flow through `{...args}`.
-export const Intents: Story = {
-  parameters: { controls: { exclude: ['intent'] } },
+// Matrix story: iterates `color` and renders every variant in a
+// single canvas, so the controls panel hides `color`. Other props
+// still flow through `{...args}`.
+const COLORS: AlertColor[] = ['default', 'brand', 'gray', 'error', 'warning', 'success'];
+
+export const Colors: Story = {
+  parameters: { controls: { exclude: ['color'] } },
   render: (args) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-      {(['info', 'success', 'warning', 'danger'] as const).map((intent) => (
-        <Alert key={intent} {...args} intent={intent} title={`Intent: ${intent}`} />
+      {COLORS.map((color) => (
+        <Alert key={color} {...args} color={color} title={`Color: ${color}`} />
+      ))}
+    </div>
+  ),
+};
+
+// Matrix story: iterates `size` to show the floating vs. full-width
+// layout difference in one canvas. Other controls stay live.
+export const Sizes: Story = {
+  parameters: { controls: { exclude: ['size'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      {(['floating', 'full-width'] as const).map((size) => (
+        <Alert key={size} {...args} size={size} title={`Size: ${size}`} />
       ))}
     </div>
   ),

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -1,95 +1,145 @@
-// Glaon Alert — inline message primitive. Per CLAUDE.md's UUI Source
-// Rule, the structural HTML/CSS is anchored on the Untitled UI kit
-// `banner-slim-default` shared-asset under
-// `packages/ui/src/components/shared-assets/banners/banner-slim-default.tsx`.
-// That kit file is a concrete template (no props, hard-coded copy), so
-// the Glaon wrap layer parameterizes its content (title / description /
-// intent icon / dismissible) while preserving the kit's class structure
-// (`bg-secondary` + `ring-secondary_alt` + `rounded-xl` + `shadow-lg`).
-// Tokens flow through Tailwind v4 `@theme` (UUI `theme.css`) and Glaon's
-// brand override layer.
-
-import type { FC, ReactNode } from 'react';
-
-import { AlertCircle, AlertTriangle, CheckCircle, InfoCircle } from '@untitledui/icons';
-
-import { CloseButton } from '../base/buttons/close-button';
-
-// `@untitledui/icons` declares each icon's `Props` interface in a per-file
-// module that isn't re-exported, so deriving an exact type against the
-// raw imports trips TS4023. The icon picker (`icons/storybook.ts`) uses
-// the same `FC<any>` workaround for the same reason.
+// Glaon Alert — parametric wrap over the kit's `AlertFloating` +
+// `AlertFullWidth` primitives under `application/alerts/alerts.tsx`.
 //
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
-type IconComponent = FC<any>;
+// Per CLAUDE.md's UUI Source Rule, the structural HTML/CSS, the
+// FeaturedIcon + Button + CloseButton composition, and the 6-color
+// + 2-size variant matrix come from the kit; Glaon's contribution
+// is the wrap layer (token override via `theme.css` +
+// `glaon-overrides.css`, prop API consistency, Figma `parameters.design`
+// mapping in the story).
+//
+// Maps Figma's `web-primitives-alert` axes 1:1:
+//   - `Color`: default / brand / gray / error / warning / success
+//   - `Size`:  floating / full-width
+//
+// Usage:
+//
+//   <Alert
+//     color="success"
+//     size="floating"
+//     title="Settings saved"
+//     description="Your changes are live across the workspace."
+//     confirmLabel="View changes"
+//     onConfirm={() => navigate('/changes')}
+//     onDismiss={() => setOpen(false)}
+//   />
+//
+// `size === 'full-width'` exposes an `actionType` knob (`button` |
+// `link`) — the kit renders confirm / dismiss as filled vs. inline
+// links accordingly.
 
-export type AlertIntent = 'info' | 'success' | 'warning' | 'danger';
+import type { ReactNode } from 'react';
+
+import { AlertFloating, AlertFullWidth } from '../application/alerts/alerts';
+
+export type AlertColor = 'default' | 'brand' | 'gray' | 'error' | 'warning' | 'success';
+export type AlertSize = 'floating' | 'full-width';
+export type AlertActionType = 'button' | 'link';
 
 export interface AlertProps {
   /** Bold first line of the alert. */
-  title: ReactNode;
+  title: string;
   /** Optional secondary line; rendered after the title. */
   description?: ReactNode;
-  /** Severity / colour group for the leading icon. */
-  intent?: AlertIntent;
-  /** Override the default icon for the chosen intent. */
-  icon?: IconComponent;
-  /** Render a close button at the top-right corner. */
-  dismissible?: boolean;
-  /** Fires when the close button is clicked. */
-  onDismiss?: () => void;
-  /** Accessible label for the close button. Defaults to "Dismiss". */
-  dismissLabel?: string;
-  /** Override the kit's outer container className. */
-  className?: string;
+  /**
+   * Severity / surface palette. Mirrors Figma's `Color` axis 1:1.
+   * @default 'default'
+   */
+  color?: AlertColor | undefined;
+  /**
+   * Layout variant. `floating` is a card-style alert (modal-friendly,
+   * dashboard surface); `full-width` is an inline page-wide bar
+   * (system-status pinned to a page top).
+   * @default 'floating'
+   */
+  size?: AlertSize | undefined;
+  /**
+   * Action button styling for `size='full-width'` only. `button`
+   * renders filled / secondary buttons, `link` renders inline link
+   * styling. Ignored when `size='floating'` (kit always uses link
+   * styling there).
+   * @default 'button'
+   */
+  actionType?: AlertActionType | undefined;
+  /** Label for the primary CTA (right side). */
+  confirmLabel?: string | undefined;
+  /** Click handler for the primary CTA. */
+  onConfirm?: (() => void) | undefined;
+  /**
+   * Label for the dismiss button (also serves as `aria-label` for the
+   * close X). @default 'Dismiss'
+   */
+  dismissLabel?: string | undefined;
+  /**
+   * Click handler for the dismiss button + close X. Setting this
+   * also surfaces the close X in the corner; leaving it undefined
+   * renders the alert as persistent.
+   */
+  onDismiss?: (() => void) | undefined;
 }
 
-const intentIcons: Record<AlertIntent, IconComponent> = {
-  info: InfoCircle,
-  success: CheckCircle,
-  warning: AlertTriangle,
-  danger: AlertCircle,
-};
-
-const intentIconColor: Record<AlertIntent, string> = {
-  info: 'text-fg-brand-primary_alt',
-  success: 'text-fg-success-primary',
-  warning: 'text-fg-warning-primary',
-  danger: 'text-fg-error-primary',
-};
-
+/**
+ * Glaon Alert — single parametric primitive that dispatches to
+ * `AlertFloating` or `AlertFullWidth` based on the `size` prop.
+ * Matches the Figma `web-primitives-alert` `Color` × `Size` axes
+ * 1:1.
+ */
 export function Alert({
   title,
   description,
-  intent = 'info',
-  icon: IconOverride,
-  dismissible = false,
+  color = 'default',
+  size = 'floating',
+  actionType = 'button',
+  confirmLabel,
+  onConfirm,
+  dismissLabel,
   onDismiss,
-  dismissLabel = 'Dismiss',
-  className,
 }: AlertProps) {
-  const Icon = IconOverride ?? intentIcons[intent];
-  const iconColor = intentIconColor[intent];
+  // Confirm label is required by both kit primitives — fall back to
+  // a sensible default so callers can pass `onConfirm` without a
+  // matching label (matches the kit's `Dismiss` default for
+  // `dismissLabel`). Empty string suppresses the rendered button.
+  const resolvedConfirmLabel = confirmLabel ?? '';
 
-  const containerClass =
-    'relative flex items-center gap-3 rounded-xl bg-secondary p-4 shadow-lg ring-1 ring-secondary_alt';
+  if (size === 'full-width') {
+    const props: {
+      title: string;
+      description: ReactNode;
+      confirmLabel: string;
+      color: AlertColor;
+      actionType: AlertActionType;
+      onConfirm?: () => void;
+      onClose?: () => void;
+      dismissLabel?: string;
+    } = {
+      title,
+      description: description ?? '',
+      confirmLabel: resolvedConfirmLabel,
+      color,
+      actionType,
+    };
+    if (onConfirm !== undefined) props.onConfirm = onConfirm;
+    if (onDismiss !== undefined) props.onClose = onDismiss;
+    if (dismissLabel !== undefined) props.dismissLabel = dismissLabel;
+    return <AlertFullWidth {...props} />;
+  }
 
-  return (
-    <div role="status" className={className ? `${containerClass} ${className}` : containerClass}>
-      <Icon aria-hidden="true" className={`size-5 shrink-0 ${iconColor}`} />
-      <div className="flex w-0 flex-1 flex-col gap-0.5 md:flex-row md:gap-1.5">
-        <p className="pr-8 text-sm font-semibold text-secondary md:pr-0">{title}</p>
-        {description !== undefined ? <p className="text-sm text-tertiary">{description}</p> : null}
-      </div>
-      {dismissible ? (
-        <div className="absolute top-2 right-2 flex shrink-0 items-center justify-center">
-          <CloseButton
-            size="sm"
-            label={dismissLabel}
-            {...(onDismiss ? { onPress: onDismiss } : {})}
-          />
-        </div>
-      ) : null}
-    </div>
-  );
+  const props: {
+    title: string;
+    description: ReactNode;
+    confirmLabel: string;
+    color: AlertColor;
+    onConfirm?: () => void;
+    onClose?: () => void;
+    dismissLabel?: string;
+  } = {
+    title,
+    description: description ?? '',
+    confirmLabel: resolvedConfirmLabel,
+    color,
+  };
+  if (onConfirm !== undefined) props.onConfirm = onConfirm;
+  if (onDismiss !== undefined) props.onClose = onDismiss;
+  if (dismissLabel !== undefined) props.dismissLabel = dismissLabel;
+  return <AlertFloating {...props} />;
 }

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -95,11 +95,16 @@ export function Alert({
   dismissLabel,
   onDismiss,
 }: AlertProps) {
-  // Confirm label is required by both kit primitives — fall back to
-  // a sensible default so callers can pass `onConfirm` without a
-  // matching label (matches the kit's `Dismiss` default for
-  // `dismissLabel`). Empty string suppresses the rendered button.
-  const resolvedConfirmLabel = confirmLabel ?? '';
+  // The kit renders the confirm / dismiss buttons solely on the
+  // presence of their click handlers. Only forward `onConfirm` when
+  // a `confirmLabel` is also set — otherwise the kit emits a
+  // text-empty `<button>` and axe `button-name` fails. Same logic
+  // for `onDismiss` against `dismissLabel`. Storybook auto-spies on
+  // action argTypes, so without these guards every story would
+  // render labelless buttons.
+  const hasConfirm = confirmLabel !== undefined && confirmLabel !== '';
+  const resolvedDismissLabel = dismissLabel ?? 'Dismiss';
+  const hasDismiss = onDismiss !== undefined && resolvedDismissLabel !== '';
 
   if (size === 'full-width') {
     const props: {
@@ -110,17 +115,17 @@ export function Alert({
       actionType: AlertActionType;
       onConfirm?: () => void;
       onClose?: () => void;
-      dismissLabel?: string;
+      dismissLabel: string;
     } = {
       title,
       description: description ?? '',
-      confirmLabel: resolvedConfirmLabel,
+      confirmLabel: hasConfirm ? confirmLabel : '',
       color,
       actionType,
+      dismissLabel: resolvedDismissLabel,
     };
-    if (onConfirm !== undefined) props.onConfirm = onConfirm;
-    if (onDismiss !== undefined) props.onClose = onDismiss;
-    if (dismissLabel !== undefined) props.dismissLabel = dismissLabel;
+    if (hasConfirm && onConfirm !== undefined) props.onConfirm = onConfirm;
+    if (hasDismiss) props.onClose = onDismiss;
     return <AlertFullWidth {...props} />;
   }
 
@@ -131,15 +136,15 @@ export function Alert({
     color: AlertColor;
     onConfirm?: () => void;
     onClose?: () => void;
-    dismissLabel?: string;
+    dismissLabel: string;
   } = {
     title,
     description: description ?? '',
-    confirmLabel: resolvedConfirmLabel,
+    confirmLabel: hasConfirm ? confirmLabel : '',
     color,
+    dismissLabel: resolvedDismissLabel,
   };
-  if (onConfirm !== undefined) props.onConfirm = onConfirm;
-  if (onDismiss !== undefined) props.onClose = onDismiss;
-  if (dismissLabel !== undefined) props.dismissLabel = dismissLabel;
+  if (hasConfirm && onConfirm !== undefined) props.onConfirm = onConfirm;
+  if (hasDismiss) props.onClose = onDismiss;
   return <AlertFloating {...props} />;
 }

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -97,14 +97,15 @@ export function Alert({
 }: AlertProps) {
   // The kit renders the confirm / dismiss buttons solely on the
   // presence of their click handlers. Only forward `onConfirm` when
-  // a `confirmLabel` is also set — otherwise the kit emits a
-  // text-empty `<button>` and axe `button-name` fails. Same logic
-  // for `onDismiss` against `dismissLabel`. Storybook auto-spies on
-  // action argTypes, so without these guards every story would
-  // render labelless buttons.
-  const hasConfirm = confirmLabel !== undefined && confirmLabel !== '';
+  // a `confirmLabel` is also set (and not just whitespace) —
+  // otherwise the kit emits a text-empty `<button>` which both fails
+  // axe `button-name` and leaves a dead-zone in the layout. Same
+  // logic for `onDismiss` against `dismissLabel`. Storybook auto-
+  // spies on action argTypes, so without these guards every story
+  // would render labelless buttons.
+  const hasConfirm = confirmLabel !== undefined && confirmLabel.trim() !== '';
   const resolvedDismissLabel = dismissLabel ?? 'Dismiss';
-  const hasDismiss = onDismiss !== undefined && resolvedDismissLabel !== '';
+  const hasDismiss = onDismiss !== undefined && resolvedDismissLabel.trim() !== '';
 
   if (size === 'full-width') {
     const props: {

--- a/packages/ui/src/components/Alert/index.ts
+++ b/packages/ui/src/components/Alert/index.ts
@@ -1,1 +1,2 @@
-export { Alert, type AlertIntent, type AlertProps } from './Alert';
+export { Alert } from './Alert';
+export type { AlertActionType, AlertColor, AlertProps, AlertSize } from './Alert';

--- a/packages/ui/src/components/Notification/Notification.controls.ts
+++ b/packages/ui/src/components/Notification/Notification.controls.ts
@@ -1,0 +1,145 @@
+// `Notification.controls.ts` — single source of truth for
+// Notification's variant matrix. Story (`Notification.stories.tsx`)
+// imports the spec and spreads it into `meta.args` / `meta.argTypes`;
+// MDX docs (`Notification.mdx`) reads the same spec via
+// `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+import { storybookIcons } from '../../icons/storybook';
+
+const typeOptions = [
+  'primary-icon',
+  'gray-icon',
+  'success-icon',
+  'warning-icon',
+  'error-icon',
+  'no-icon',
+  'progress-indicator',
+  'avatar',
+  'image',
+] as const;
+
+export const notificationControls = {
+  type: {
+    type: 'select',
+    options: typeOptions,
+    default: 'primary-icon',
+    description:
+      "Leading-visual discriminator. Mirrors Figma's `Type` axis 1:1 — `*-icon` variants render a FeaturedIcon (color-coded), `no-icon` skips the leading slot, `progress-indicator` shows a horizontal progress bar inside the body, `avatar` embeds an Avatar instance, `image` embeds a 40px square thumbnail.",
+    category: 'Style',
+  } satisfies ControlSpec<(typeof typeOptions)[number]>,
+  title: {
+    type: 'text',
+    default: "We're just released a new feature",
+    description:
+      'Bold first line of the notification. Keep it short — long titles wrap inside the body and push timestamps to the next line.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  description: {
+    type: 'text',
+    default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    description:
+      'Optional secondary line below the title. Use for context (commit message excerpt, file name, change summary).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  timestamp: {
+    type: 'text',
+    description:
+      'Inline subtle text rendered next to the title (e.g. "2 min ago", "Just now"). Decorative — pair with an absolute date in `description` for accessibility when the relative timestamp is the only datestamp.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  icon: {
+    type: 'select',
+    options: Object.keys(storybookIcons),
+    mapping: storybookIcons,
+    description:
+      'Override the default glyph for `*-icon` types. Defaults: `info` for primary/gray, `check` for success, `triangle` for warning, `circle` for error.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  avatarSrc: {
+    type: 'text',
+    description:
+      'Image URL for `type="avatar"`. Pair with `avatarAlt` for the accessible name; if both `src` and `initials` are missing, the Avatar renders the default user glyph.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  avatarAlt: {
+    type: 'text',
+    description: 'Accessible name for the Avatar image (e.g. "Olivia Rhye").',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  avatarInitials: {
+    type: 'text',
+    description: 'Two-character fallback initials when no `avatarSrc` is set (e.g. "OR").',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  imageSrc: {
+    type: 'text',
+    description: 'Image URL for `type="image"`. Renders as a 40px rounded square.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  imageAlt: {
+    type: 'text',
+    description:
+      'Accessible name for the image. Always describe the content; meaningless alts fail axe.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  progress: {
+    type: 'number',
+    min: 0,
+    max: 100,
+    step: 1,
+    description: 'Progress value (0..100) for `type="progress-indicator"`. Drives the bar fill.',
+    category: 'Content',
+  } satisfies ControlSpec<number>,
+  progressLabel: {
+    type: 'text',
+    description: 'Optional caption next to the progress bar (e.g. "12.5 MB / 50 MB").',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  primaryActionLabel: {
+    type: 'text',
+    description:
+      'Label for the primary action button (right side). Pair with `onPrimaryAction`. Common values: `Reply`, `View changes`, `Approve`, `Install`.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  onPrimaryAction: {
+    type: false,
+    action: 'primary-action-clicked',
+    description: 'Click handler for the primary action button.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  secondaryActionLabel: {
+    type: 'text',
+    description:
+      'Label for the secondary action button (left of the primary). Common values: `Dismiss`, `Decline`, `Skip`.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  onSecondaryAction: {
+    type: false,
+    action: 'secondary-action-clicked',
+    description: 'Click handler for the secondary action button.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onDismiss: {
+    type: false,
+    action: 'dismissed',
+    description:
+      'Click handler for the close X button. Setting this surfaces the close X in the corner; leaving it undefined renders the notification as persistent (footer actions are the only dismissal path).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  dismissLabel: {
+    type: 'text',
+    default: 'Dismiss',
+    description:
+      'Accessible label for the close X button. Forwarded as `aria-label`. Defaults to `Dismiss`; localise per app locale.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer container.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const notificationExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/Notification/Notification.mdx
+++ b/packages/ui/src/components/Notification/Notification.mdx
@@ -1,0 +1,111 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as NotificationStories from './Notification.stories';
+
+<Meta of={NotificationStories} />
+
+# Notification
+
+In-app activity feed item. Use Notification to surface things that
+happened _while the user wasn't looking_ — comments on their files,
+file uploads finishing, system updates installing, mentions, approvals.
+Distinct from [Toast](?path=/docs/web-primitives-toast--docs) (transient
+overlay) and [Alert](?path=/docs/web-primitives-alert--docs) (in-flow
+inline message).
+
+The `type` discriminator picks the right leading visual — Figma's
+`web-primitives-notification` `Type` axis maps 1:1 to the prop's 9
+values.
+
+## When to use
+
+- Activity inbox / notification drawer items: "Olivia commented on
+  your file", "Phoenix approved your PR".
+- File transfer progress (`type='progress-indicator'`): "Uploading
+  resume.pdf — 65 %".
+- System events: "Update available", "Pairing started", "Sync
+  finished".
+- Direct messages preview with avatar + content snippet
+  (`type='avatar'`).
+- Marketing / content cards inside a feed (`type='image'`).
+
+## When NOT to use
+
+- **Transient overlay feedback** ("Saved", "Could not save") → use
+  [Toast](?path=/docs/web-primitives-toast--docs); Toast disappears
+  on its own, Notification persists in a feed.
+- **Inline status next to a form field / section** → use [Alert](?path=/docs/web-primitives-alert--docs).
+- **Page-level marketing announcement** → use [Banner](?path=/docs/web-primitives-banner--docs).
+- **Single-word status next to a name** → use [Badge](?path=/docs/web-primitives-badge--docs).
+
+## Anatomy
+
+<Canvas of={NotificationStories.WithAvatar} />
+
+Layout: leading visual (driven by `type`) + body (title + optional
+timestamp + optional description + optional progress bar + optional
+action button row) + optional close X button.
+
+| `type` value         | Leading visual                | Slot prop                                    |
+| -------------------- | ----------------------------- | -------------------------------------------- |
+| `primary-icon`       | FeaturedIcon (brand)          | `icon` (override)                            |
+| `gray-icon`          | FeaturedIcon (gray, modern)   | `icon`                                       |
+| `success-icon`       | FeaturedIcon (success)        | `icon`                                       |
+| `warning-icon`       | FeaturedIcon (warning)        | `icon`                                       |
+| `error-icon`         | FeaturedIcon (error)          | `icon`                                       |
+| `no-icon`            | (none)                        | —                                            |
+| `progress-indicator` | (inline progress bar in body) | `progress` (0..100) + `progressLabel`        |
+| `avatar`             | Avatar                        | `avatarSrc` / `avatarAlt` / `avatarInitials` |
+| `image`              | 40px rounded image            | `imageSrc` / `imageAlt`                      |
+
+```tsx
+<Notification
+  type="avatar"
+  avatarSrc="…"
+  avatarAlt="Olivia Rhye"
+  title="Olivia commented on your file"
+  description="“Looks great — let's ship it 🚀”"
+  timestamp="2 min ago"
+  primaryActionLabel="Reply"
+  onPrimaryAction={openThread}
+  onDismiss={markAsRead}
+/>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The wrapper carries `role="status"` so screen readers announce new
+  notifications when they're inserted into a live feed (use a
+  parent live region with `aria-live="polite"` for the queue).
+- For `type='progress-indicator'`, the inner bar carries
+  `role="progressbar"` + `aria-valuenow` / `aria-valuemin` /
+  `aria-valuemax` automatically — no extra wiring needed.
+- Avatar / image leading slots: always pass an `*Alt` text — it
+  describes who / what the notification is about. Empty alts fail
+  axe `image-alt`.
+- The close X button is a real `<button>` with `aria-label` from
+  `dismissLabel` (defaults to `Dismiss`); leaving `onDismiss`
+  undefined hides the button entirely so users aren't given an
+  inert affordance.
+- Action buttons are real `<button>` elements with visible focus
+  rings; pair with short verb labels (`Reply`, `View changes`).
+- Don't autofocus a destructive action — the user is reading the
+  notification, not taking action under pressure.
+- Avoid relying on `timestamp` alone for "when this happened" —
+  pair with an absolute date in the description if the relative
+  string is the only timestamp screen readers will hear.
+
+## Related components
+
+- [Toast](?path=/docs/web-primitives-toast--docs) — transient overlay notification (auto-dismiss).
+- [Alert](?path=/docs/web-primitives-alert--docs) — inline status message in the page flow.
+- [Banner](?path=/docs/web-primitives-banner--docs) — page-level marketing announcement.
+- [Avatar](?path=/docs/web-primitives-avatar--docs) — used internally by `type='avatar'`.

--- a/packages/ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/ui/src/components/Notification/Notification.stories.tsx
@@ -1,0 +1,194 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { Notification, type NotificationType } from './Notification';
+import { notificationControls, notificationExcludeFromArgs } from './Notification.controls';
+
+const { args, argTypes } = defineControls(notificationControls);
+
+// Explicit `Meta<typeof Notification>` annotation (rather than
+// `satisfies`) keeps the unexported `NotificationProps` interface
+// out of the exported `meta` signature — `tsc --noEmit` runs with
+// `declaration: true` and TS4023 fires when an exported `meta`
+// resolves to a non-exported nominal type.
+const meta: Meta<typeof Notification> = {
+  title: 'Web Primitives/Notification',
+  component: Notification,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-notification',
+    },
+  },
+  args,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 480 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Notification>;
+
+export const excludeFromArgs = notificationExcludeFromArgs;
+
+export const Default: Story = {
+  args: { timestamp: '2 min ago' },
+};
+
+export const GrayIcon: Story = {
+  args: {
+    type: 'gray-icon',
+    title: 'Repository archived',
+    description: 'glaon-experiments was moved to the archive list.',
+    timestamp: '5 min ago',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    type: 'success-icon',
+    title: 'Successfully updated profile',
+    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    timestamp: 'Just now',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    type: 'warning-icon',
+    title: 'Token rotation in 24 hours',
+    description: 'Re-authenticate before midnight to avoid disruption.',
+    primaryActionLabel: 'Re-authenticate',
+    onPrimaryAction: () => undefined,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    type: 'error-icon',
+    title: 'Failed to publish changes',
+    description: 'Network error — please try again.',
+    primaryActionLabel: 'Retry',
+    onPrimaryAction: () => undefined,
+  },
+};
+
+export const NoIcon: Story = {
+  args: {
+    type: 'no-icon',
+    title: 'You signed in from a new device',
+    description: 'Mac · Chrome · Istanbul · 2 minutes ago',
+  },
+};
+
+export const WithAvatar: Story = {
+  args: {
+    type: 'avatar',
+    avatarSrc: 'https://www.untitledui.com/images/avatars/olivia-rhye?fm=webp&q=80',
+    avatarAlt: 'Olivia Rhye',
+    title: 'Olivia commented on your file',
+    description: '"Looks great — let’s ship it 🚀"',
+    timestamp: '2 min ago',
+    primaryActionLabel: 'Reply',
+    onPrimaryAction: () => undefined,
+    onDismiss: () => undefined,
+  },
+};
+
+export const WithImage: Story = {
+  args: {
+    type: 'image',
+    imageSrc: 'https://www.untitledui.com/images/cards/photography-1.jpg',
+    imageAlt: 'Cover photo',
+    title: 'Photography weekly',
+    description: 'Issue 24 is out — featuring 8 community submissions.',
+    timestamp: '1 hour ago',
+    primaryActionLabel: 'Read',
+    onPrimaryAction: () => undefined,
+  },
+};
+
+export const ProgressIndicator: Story = {
+  args: {
+    type: 'progress-indicator',
+    title: 'Uploading resume.pdf',
+    progress: 65,
+    progressLabel: '12.5 MB / 19.2 MB',
+    secondaryActionLabel: 'Cancel',
+    onSecondaryAction: () => undefined,
+  },
+};
+
+export const Dismissible: Story = {
+  args: {
+    title: 'Settings synced across devices',
+    description: 'All preferences are now identical on every signed-in client.',
+    onDismiss: () => undefined,
+  },
+};
+
+export const ActionsRow: Story = {
+  args: {
+    type: 'primary-icon',
+    title: 'Update available',
+    description: 'A newer version is ready to install.',
+    primaryActionLabel: 'Install',
+    onPrimaryAction: () => undefined,
+    secondaryActionLabel: 'Later',
+    onSecondaryAction: () => undefined,
+  },
+};
+
+// Matrix story: iterates `type` and renders every leading-visual
+// variant in one canvas. The controls panel hides slot props that
+// are baked in per row.
+const TYPES: NotificationType[] = [
+  'primary-icon',
+  'gray-icon',
+  'success-icon',
+  'warning-icon',
+  'error-icon',
+  'no-icon',
+  'progress-indicator',
+  'avatar',
+  'image',
+];
+
+export const Types: Story = {
+  parameters: {
+    controls: {
+      exclude: ['type', 'avatarSrc', 'imageSrc', 'progress', 'progressLabel'],
+    },
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {TYPES.map((type) => (
+        <Notification
+          key={type}
+          {...args}
+          type={type}
+          title={`Type: ${type}`}
+          avatarSrc={
+            type === 'avatar'
+              ? 'https://www.untitledui.com/images/avatars/olivia-rhye?fm=webp&q=80'
+              : undefined
+          }
+          avatarAlt={type === 'avatar' ? 'Olivia Rhye' : undefined}
+          imageSrc={
+            type === 'image'
+              ? 'https://www.untitledui.com/images/cards/photography-1.jpg'
+              : undefined
+          }
+          imageAlt={type === 'image' ? 'Cover photo' : undefined}
+          progress={type === 'progress-indicator' ? 65 : undefined}
+          progressLabel={type === 'progress-indicator' ? '12.5 MB / 19.2 MB' : undefined}
+        />
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Notification/Notification.tsx
+++ b/packages/ui/src/components/Notification/Notification.tsx
@@ -168,6 +168,11 @@ export function Notification({
 
   const showActions = primaryActionLabel !== undefined || secondaryActionLabel !== undefined;
   const showProgress = type === 'progress-indicator';
+  // Progressbar a11y: derive an accessible name from the title when
+  // it's a plain string (the common case — "Uploading resume.pdf"),
+  // otherwise fall back to a generic label so axe
+  // `aria-progressbar-name` stays green.
+  const progressAriaLabel = typeof title === 'string' ? title : 'Progress';
 
   return (
     <div role="status" className={containerClass}>
@@ -184,6 +189,7 @@ export function Notification({
           <div className="mt-2 flex flex-col gap-1">
             <div
               role="progressbar"
+              aria-label={progressAriaLabel}
               aria-valuenow={progress ?? 0}
               aria-valuemin={0}
               aria-valuemax={100}

--- a/packages/ui/src/components/Notification/Notification.tsx
+++ b/packages/ui/src/components/Notification/Notification.tsx
@@ -1,0 +1,287 @@
+// Glaon Notification — in-app activity feed item. UUI's kit ships
+// only `application/notifications`-flavoured templates, no generic
+// primitive — so per the UUI Source Rule's "no kit source" exception
+// (TopBar / SideNav / Card / BadgeGroup pattern), Glaon hand-rolls
+// a parameterised wrap using kit surface vocabulary as canonical
+// reference (`bg-primary` + `rounded-xl` + `ring-secondary_alt` +
+// `shadow-xs` + FeaturedIcon for icon variants).
+//
+// Maps Figma's `web-primitives-notification` `Type` axis 1:1:
+//   - `primary-icon` (brand-coloured FeaturedIcon)
+//   - `gray-icon`
+//   - `success-icon`
+//   - `warning-icon`
+//   - `error-icon`
+//   - `no-icon`
+//   - `progress-indicator` (file upload / download)
+//   - `avatar` (user activity, e.g. Olivia commented…)
+//   - `image` (richer media, e.g. content card)
+//
+// Distinct from Toast (P16) — Toast is a transient overlay; this is
+// an in-app feed item rendered inside an inbox / activity panel /
+// notification drawer.
+//
+// Usage:
+//
+//   <Notification
+//     type="avatar"
+//     avatarSrc="…"
+//     title="Olivia commented on your file"
+//     description="“Looks great — let's ship it 🚀”"
+//     timestamp="2 min ago"
+//     primaryActionLabel="Reply"
+//     onPrimaryAction={() => openThread(id)}
+//     onDismiss={() => markAsRead(id)}
+//   />
+
+import type { FC, ReactNode } from 'react';
+
+import { AlertCircle, AlertTriangle, CheckCircle, InfoCircle } from '@untitledui/icons';
+
+import { Avatar } from '../Avatar';
+import { CloseButton } from '../base/buttons/close-button';
+import { FeaturedIcon } from '../foundations/featured-icon/featured-icon';
+
+// `@untitledui/icons` declares per-file icon types; type the slot
+// loosely so consumers can pass any kit / custom icon component.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+type IconComponent = FC<any>;
+
+export type NotificationType =
+  | 'primary-icon'
+  | 'gray-icon'
+  | 'success-icon'
+  | 'warning-icon'
+  | 'error-icon'
+  | 'no-icon'
+  | 'progress-indicator'
+  | 'avatar'
+  | 'image';
+
+export interface NotificationProps {
+  /**
+   * Leading-visual discriminator. Mirrors Figma's `Type` axis 1:1.
+   * @default 'primary-icon'
+   */
+  type?: NotificationType | undefined;
+  // -- Icon slot (used by `*-icon` types) -------------------------
+  /**
+   * Glyph for `*-icon` types. Defaults: `info` for primary/gray/no,
+   * `check` for success, `triangle` for warning, `circle` for error.
+   */
+  icon?: IconComponent | undefined;
+  // -- Avatar slot (used by `type='avatar'`) ----------------------
+  avatarSrc?: string | undefined;
+  avatarAlt?: string | undefined;
+  avatarInitials?: string | undefined;
+  // -- Image slot (used by `type='image'`) ------------------------
+  imageSrc?: string | undefined;
+  imageAlt?: string | undefined;
+  // -- Progress slot (used by `type='progress-indicator'`) --------
+  /** 0..100; the kit renders a horizontal progress bar under the body. */
+  progress?: number | undefined;
+  /** Optional caption next to the progress bar (e.g. "12.5 MB / 50 MB"). */
+  progressLabel?: ReactNode | undefined;
+  // -- Content ---------------------------------------------------
+  title: ReactNode;
+  description?: ReactNode | undefined;
+  /** Inline subtle text shown next to the title (e.g. "2 min ago"). */
+  timestamp?: ReactNode | undefined;
+  // -- Actions ---------------------------------------------------
+  primaryActionLabel?: string | undefined;
+  onPrimaryAction?: (() => void) | undefined;
+  secondaryActionLabel?: string | undefined;
+  onSecondaryAction?: (() => void) | undefined;
+  onDismiss?: (() => void) | undefined;
+  /** @default 'Dismiss' */
+  dismissLabel?: string | undefined;
+  // -- Override --------------------------------------------------
+  className?: string | undefined;
+}
+
+const featuredIconColor: Record<
+  Exclude<NotificationType, 'no-icon' | 'progress-indicator' | 'avatar' | 'image'>,
+  'brand' | 'gray' | 'success' | 'warning' | 'error'
+> = {
+  'primary-icon': 'brand',
+  'gray-icon': 'gray',
+  'success-icon': 'success',
+  'warning-icon': 'warning',
+  'error-icon': 'error',
+};
+
+const defaultIcon: Record<
+  Exclude<NotificationType, 'no-icon' | 'progress-indicator' | 'avatar' | 'image'>,
+  IconComponent
+> = {
+  'primary-icon': InfoCircle,
+  'gray-icon': InfoCircle,
+  'success-icon': CheckCircle,
+  'warning-icon': AlertTriangle,
+  'error-icon': AlertCircle,
+};
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+/**
+ * Glaon Notification — in-app feed item. Single parametric primitive
+ * dispatching to the right leading-visual layout via the `type` prop.
+ */
+export function Notification({
+  type = 'primary-icon',
+  icon,
+  avatarSrc,
+  avatarAlt,
+  avatarInitials,
+  imageSrc,
+  imageAlt,
+  progress,
+  progressLabel,
+  title,
+  description,
+  timestamp,
+  primaryActionLabel,
+  onPrimaryAction,
+  secondaryActionLabel,
+  onSecondaryAction,
+  onDismiss,
+  dismissLabel = 'Dismiss',
+  className,
+}: NotificationProps) {
+  const containerClass = joinClasses(
+    'relative flex w-full max-w-md gap-3 rounded-xl bg-primary p-4 shadow-xs ring-1 ring-secondary_alt',
+    className,
+  );
+
+  const leading = renderLeading({
+    type,
+    icon,
+    avatarSrc,
+    avatarAlt,
+    avatarInitials,
+    imageSrc,
+    imageAlt,
+  });
+
+  const showActions = primaryActionLabel !== undefined || secondaryActionLabel !== undefined;
+  const showProgress = type === 'progress-indicator';
+
+  return (
+    <div role="status" className={containerClass}>
+      {leading}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-baseline gap-2 pr-6">
+          <p className="text-sm font-semibold text-primary">{title}</p>
+          {timestamp !== undefined ? (
+            <span className="shrink-0 text-xs text-tertiary">{timestamp}</span>
+          ) : null}
+        </div>
+        {description !== undefined ? <p className="text-sm text-tertiary">{description}</p> : null}
+        {showProgress ? (
+          <div className="mt-2 flex flex-col gap-1">
+            <div
+              role="progressbar"
+              aria-valuenow={progress ?? 0}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              className="h-1.5 w-full overflow-hidden rounded-full bg-secondary"
+            >
+              <div
+                className="h-full rounded-full bg-fg-brand-primary_alt transition-[width]"
+                style={{ width: `${(progress ?? 0).toString()}%` }}
+              />
+            </div>
+            {progressLabel !== undefined ? (
+              <p className="text-xs text-tertiary">{progressLabel}</p>
+            ) : null}
+          </div>
+        ) : null}
+        {showActions ? (
+          <div className="mt-2 flex gap-3">
+            {secondaryActionLabel !== undefined ? (
+              <button
+                type="button"
+                onClick={onSecondaryAction}
+                className="text-sm font-semibold text-secondary outline-focus-ring transition hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2"
+              >
+                {secondaryActionLabel}
+              </button>
+            ) : null}
+            {primaryActionLabel !== undefined ? (
+              <button
+                type="button"
+                onClick={onPrimaryAction}
+                className="text-sm font-semibold text-fg-brand-primary_alt outline-focus-ring transition hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2"
+              >
+                {primaryActionLabel}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {onDismiss !== undefined ? (
+        <CloseButton
+          size="sm"
+          label={dismissLabel}
+          onPress={onDismiss}
+          className="absolute top-2 right-2"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function renderLeading({
+  type,
+  icon,
+  avatarSrc,
+  avatarAlt,
+  avatarInitials,
+  imageSrc,
+  imageAlt,
+}: {
+  type: NotificationType;
+  icon: IconComponent | undefined;
+  avatarSrc: string | undefined;
+  avatarAlt: string | undefined;
+  avatarInitials: string | undefined;
+  imageSrc: string | undefined;
+  imageAlt: string | undefined;
+}): ReactNode {
+  if (type === 'no-icon') return null;
+  if (type === 'progress-indicator') {
+    return null;
+  }
+  if (type === 'avatar') {
+    const props: { src?: string | null; alt?: string; initials?: string } = {};
+    if (avatarSrc !== undefined) props.src = avatarSrc;
+    else props.src = null;
+    if (avatarAlt !== undefined) props.alt = avatarAlt;
+    if (avatarInitials !== undefined) props.initials = avatarInitials;
+    return <Avatar size="md" {...props} />;
+  }
+  if (type === 'image') {
+    return (
+      <img
+        src={imageSrc ?? ''}
+        alt={imageAlt ?? ''}
+        className="size-10 shrink-0 rounded-md object-cover"
+      />
+    );
+  }
+  // *-icon types — `type` is already narrowed to the icon variants
+  // by the early returns above.
+  const iconKey = type;
+  const Icon = icon ?? defaultIcon[iconKey];
+  return (
+    <FeaturedIcon
+      size="md"
+      color={featuredIconColor[iconKey]}
+      theme={iconKey === 'gray-icon' ? 'modern' : 'outline'}
+      icon={Icon}
+    />
+  );
+}

--- a/packages/ui/src/components/Notification/index.ts
+++ b/packages/ui/src/components/Notification/index.ts
@@ -1,0 +1,2 @@
+export { Notification } from './Notification';
+export type { NotificationProps, NotificationType } from './Notification';

--- a/packages/ui/src/components/application/alerts/alerts.tsx
+++ b/packages/ui/src/components/application/alerts/alerts.tsx
@@ -154,7 +154,15 @@ export const AlertFullWidth = ({
                 </div>
 
                 {(onConfirm || onClose) && (
-                    <div className="flex gap-2">
+                    // GLAON PATCH (re-apply on upgrade): add `items-center`
+                    // so the inline action buttons (link / button mode)
+                    // align vertically with the close X when the kit
+                    // switches the close button from `absolute` to
+                    // `md:static` on desktop. Upstream lacks this class,
+                    // so `actionType='link'` lays out a thin link button
+                    // next to a taller close X with no vertical
+                    // alignment guarantee. Reported on #303 PR review.
+                    <div className="flex items-center gap-2">
                         <div className={cx("flex w-full gap-3", actionType === "button" ? "flex-col-reverse md:flex-row" : "flex-row")}>
                             {onClose && (
                                 <Button onClick={onClose} color={actionType === "button" ? "secondary" : "link-gray"} size="sm">

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,6 +16,7 @@ export * from './components/Input';
 export * from './components/List';
 export * from './components/Logo';
 export * from './components/Modal';
+export * from './components/Notification';
 export * from './components/Popover';
 export * from './components/PressableButton';
 export * from './components/ProgressBar';


### PR DESCRIPTION
## Summary

Two changes per #303:

1. **Alert refactor (parametric wrap)** — `<Alert>` artık kit'in `AlertFloating` + `AlertFullWidth` primitive'lerine `size` discriminator'ı üzerinden dispatch eden parametric wrap. Figma `web-primitives-alert` `Color` × `Size` axes 1:1 eşleşiyor. Yeni axis'ler: `color` (6 değer: default/brand/gray/error/warning/success), `size` ('floating' | 'full-width'), `actionType` (full-width için 'button' | 'link'), `confirmLabel` + `onConfirm` action slot'ları. Legacy `intent` (4 değer) kaldırıldı, yerine `color` geldi.

2. **Notification yeni primitive** — kit'te source yok; hand-rolled (BadgeGroup / TopBar / SideNav pattern'i). Figma `Type` axis 1:1: 9 discriminator değeri (`primary-icon` / `gray-icon` / `success-icon` / `warning-icon` / `error-icon` / `no-icon` / `progress-indicator` / `avatar` / `image`), slot prop'ları (icon / avatar / image / progress / progressLabel), content (title / description / timestamp), 2 action button slot, close X.

Toast (P16) ile farkı: Toast transient overlay; Notification in-app feed item (inbox / activity panel).

## Scope

**In**

- `packages/ui/src/components/Alert/Alert.tsx` — parametric refactor (re-export kaldırıldı, kit'e dispatch)
- `packages/ui/src/components/Alert/Alert.controls.ts` — intent → color migration, size + actionType + confirm slot prop'ları
- `packages/ui/src/components/Alert/Alert.stories.tsx` — Default + Floating + FullWidth + WithActions + Persistent + TitleOnly + Colors matrix + Sizes matrix
- `packages/ui/src/components/Alert/Alert.mdx` — Anatomy / floating-vs-full-width breakdown / a11y notes
- `packages/ui/src/components/Alert/index.ts` — type export'ları güncellendi (AlertIntent kaldırıldı, AlertColor/Size/ActionType eklendi)
- `packages/ui/src/components/Notification/{Notification.tsx, controls.ts, mdx, stories.tsx, index.ts}` — yeni primitive
- `packages/ui/src/index.ts` — barrel re-export
- `knip.json` — `application/alerts/**` ignore entry kaldırıldı (artık consume ediliyor)

**Out**

- Toast'a (P16) dokunmadık — farklı use-case
- Banner'a (P2) dokunmadık — farklı use-case
- F6 prop-coverage gate yeşil kalır (93/93 — Alert prop'ları + yeni Notification)

## Migration risk

`Alert.intent` prop'u kaldırıldı; mapping eski → yeni:
- `intent='info'` → `color='default'`
- `intent='success'` → `color='success'`
- `intent='warning'` → `color='warning'`
- `intent='danger'` → `color='error'`

Şu an feature layer Alert'i consume etmiyor (sadece Storybook stories), migration risk düşük.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\`
- [x] \`pnpm --filter @glaon/ui lint\`
- [x] \`pnpm knip\`
- [x] \`pnpm --filter @glaon/ui exec vitest run\` — 93/93 prop-coverage gate yeşil
- [x] \`pnpm --filter @glaon/ui build-storybook\` yeşil
- [ ] Storybook localhost:6006 — Alert sayfasında 6 color + 2 size + actions/dismiss kombinasyonları seçilebilir; Notification yeni component sayfası açılır, 9 type matrix story görünür
- [ ] Figma Design tab — Alert + Notification \`parameters.design\` URL'leri ilgili Figma sub-component'lerine açılır
- [ ] Chromatic build — Alert canvas'ları color/size genişlemesiyle değişir → baseline accept gerekir; Notification yeni baseline
- [ ] A11y panel — Alert close button'ı \`aria-label\`'a sahip; Notification close + action buttons keyboard reachable

Closes #303