### PR TITLE
feat(ui): banner parametric refactor (type + theme)

### DIFF
--- a/packages/ui/src/components/Banner/Banner.controls.ts
+++ b/packages/ui/src/components/Banner/Banner.controls.ts
@@ -2,70 +2,131 @@
 // matrix. Story (`Banner.stories.tsx`) imports the spec and spreads
 // it into `meta.args` / `meta.argTypes`; MDX docs (`Banner.mdx`)
 // reads the same spec via `<Controls />`.
+//
+// #305: Banner is now a parametric primitive matching Figma's
+// `web-primitives-banner` `Type` × `Theme` axes 1:1.
 
 import type { ControlSpec } from '../_internal/controls';
 import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
 import { storybookIcons } from '../../icons/storybook';
 
-const intentOptions = ['info', 'success', 'warning', 'danger'] as const;
+const typeOptions = ['text-field', 'single-action', 'dual-action', 'slim'] as const;
+const themeOptions = ['default', 'brand'] as const;
+const inputTypeOptions = ['email', 'text', 'url', 'tel'] as const;
 
 export const bannerControls = {
+  type: {
+    type: 'inline-radio',
+    options: typeOptions,
+    default: 'single-action',
+    description:
+      "Layout discriminator. Mirrors Figma's `Type` axis 1:1 — `text-field` adds an inline email input + submit button; `single-action` exposes one CTA; `dual-action` exposes two CTAs (e.g. cookie banner Decline / Allow); `slim` is a 48px-tall center-aligned strip with title + inline link only.",
+    category: 'Style',
+  } satisfies ControlSpec<(typeof typeOptions)[number]>,
+  theme: {
+    type: 'inline-radio',
+    options: themeOptions,
+    default: 'default',
+    description:
+      "Surface palette. `default` (light tray with ring) for in-flow content; `brand` (dark navy fill) for promotional / hero banners that need to pop. Mirrors Figma's `Theme` axis.",
+    category: 'Style',
+  } satisfies ControlSpec<(typeof themeOptions)[number]>,
   title: {
     type: 'text',
-    default: 'We use cookies',
-    description:
-      'Bold lead-in line of the announcement. Keep it concise; the description carries the supporting copy.',
+    default: 'Stay up to date with the latest news and updates',
+    description: 'Bold first line. Always set. Long titles truncate on desktop and wrap on mobile.',
     category: 'Content',
   } satisfies ControlSpec<string>,
   description: {
     type: 'text',
-    default: 'See our cookie policy for details.',
+    default: 'Be the first to hear about new components, updates, and design resources.',
     description:
-      'Optional secondary line. For multi-paragraph content prefer a Modal or a dedicated page.',
+      "Optional secondary copy. Pass a `ReactNode` to embed inline links (e.g. `Read our <a>Cookie Policy</a>`). Ignored for `type='slim'` — slim renders title + inline link inside `title`.",
     category: 'Content',
-  } satisfies ControlSpec<string>,
-  intent: {
-    type: 'inline-radio',
-    options: intentOptions,
-    default: 'info',
-    description:
-      'Severity / colour group for the leading icon. `info` for general announcements (default), `warning` for time-sensitive issues, `success` for global confirmations, `danger` for outage / failure banners.',
-    category: 'Style',
-  } satisfies ControlSpec<(typeof intentOptions)[number]>,
-  dismissible: {
-    type: 'boolean',
-    default: false,
-    description:
-      'Render the close button at the top-right corner. Pair with `onDismiss` to persist the dismissed state across sessions.',
-    category: 'Behavior',
-  } satisfies ControlSpec<boolean>,
-  dismissLabel: {
-    type: 'text',
-    default: 'Dismiss',
-    description:
-      'Accessible name for the close button. Defaults to "Dismiss"; localise per app locale.',
-    category: 'A11y',
   } satisfies ControlSpec<string>,
   icon: {
     type: 'select',
     options: Object.keys(storybookIcons),
     mapping: storybookIcons,
     description:
-      'Override the default icon for the chosen intent. Pass any component from `@untitledui/icons` (or a custom React component with the same shape).',
+      "Override the leading icon. Defaults to the kit `CheckVerified02` glyph. Ignored for `type='slim'` — slim has no icon.",
     category: 'Content',
   } satisfies ControlSpec<unknown>,
-  actions: {
-    type: false,
+  primaryActionLabel: {
+    type: 'text',
     description:
-      'Action slot — typically one or two `<Button>` elements rendered to the right of the message. Renders below the text on mobile, beside it on desktop.',
+      'Label for the primary CTA (right side). Common values: `Subscribe`, `Read update`, `Allow`. Pair with `onPrimaryAction`. Empty / whitespace strings auto-hide the button.',
     category: 'Content',
+  } satisfies ControlSpec<string>,
+  onPrimaryAction: {
+    type: false,
+    action: 'primary-action-clicked',
+    description: 'Click handler for the primary CTA.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  secondaryActionLabel: {
+    type: 'text',
+    description:
+      "Label for the secondary CTA (left of the primary). Only renders when `type='dual-action'`. Common values: `Decline`, `Skip`.",
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  onSecondaryAction: {
+    type: false,
+    action: 'secondary-action-clicked',
+    description: 'Click handler for the secondary CTA.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  inputPlaceholder: {
+    type: 'text',
+    default: 'Enter your email',
+    description: "Placeholder for the input. Only used when `type='text-field'`.",
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  inputType: {
+    type: 'inline-radio',
+    options: inputTypeOptions,
+    default: 'email',
+    description:
+      'Native input type — drives the mobile keyboard hint. `email` (default) for newsletter signup, `text` for free-form, `url` / `tel` for specialised flows.',
+    category: 'Behavior',
+  } satisfies ControlSpec<(typeof inputTypeOptions)[number]>,
+  inputAriaLabel: {
+    type: 'text',
+    default: 'Email',
+    description:
+      'Accessible label for the input (forwarded as `aria-label`). Required when no visible label exists in the surrounding UI.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  inputValue: {
+    type: 'text',
+    description: 'Controlled input value. Pair with `onInputChange` to manage state outside.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  defaultInputValue: {
+    type: 'text',
+    description: 'Initial input value for uncontrolled usage.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onInputChange: {
+    type: false,
+    action: 'input-changed',
+    description: 'Fires on every keystroke with the new string value.',
+    category: 'Behavior',
   } satisfies ControlSpec<unknown>,
   onDismiss: {
     type: false,
     action: 'dismissed',
-    description: 'Fires when the close button is clicked.',
+    description:
+      'Click handler for the close X. Setting this surfaces the close button; leaving it undefined renders the banner as persistent.',
     category: 'Behavior',
   } satisfies ControlSpec<unknown>,
+  dismissLabel: {
+    type: 'text',
+    default: 'Dismiss',
+    description:
+      'Accessible label for the close X (forwarded as `aria-label`). Defaults to `Dismiss`; localise per app locale.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
   className: {
     type: false,
     description: 'Tailwind override hook for the outer container.',

--- a/packages/ui/src/components/Banner/Banner.mdx
+++ b/packages/ui/src/components/Banner/Banner.mdx
@@ -6,32 +6,81 @@ import * as BannerStories from './Banner.stories';
 
 # Banner
 
-Page-level announcement. Use Banner when an event affects the entire
-session or app — cookie consent, planned maintenance, version update,
-global outage notice. Wider visual footprint than Alert; carries an
-optional CTA action.
+Page-level announcement strip. Use Banner when an event affects the
+entire session or page — cookie consent, newsletter signup, planned
+maintenance, version update, global outage notice. Wider visual
+footprint than [Alert](?path=/docs/web-primitives-alert--docs)
+(which is in-flow / section-level), and unlike
+[Toast](?path=/docs/web-primitives-toast--docs) it persists until
+the user dismisses it or the underlying state changes.
+
+The Glaon `<Banner>` is a parametric primitive. The `type`
+discriminator picks the right layout — Figma's
+`web-primitives-banner` `Type` axis maps 1:1 to the prop's 4 values
+(`text-field` / `single-action` / `dual-action` / `slim`). The
+`theme` axis (`default` / `brand`) swaps the surface palette.
 
 ## When to use
 
-- Top of the page: cookie consent prompt with Accept / Decline buttons.
-- App-wide announcement: "Maintenance in 2 hours" warning across all
-  routes.
-- Update prompt: "New version available" with a single Reload action.
-- Outage notice: "Connection to Home Assistant lost — reconnecting…"
+- Cookie consent prompt at the top of the page (`type='dual-action'`,
+  Decline / Allow).
+- Newsletter signup at the bottom of marketing pages
+  (`type='text-field'` with email input + Subscribe button).
+- Update / changelog announcement (`type='single-action'`, "Read
+  update").
+- App-wide system notice (`type='slim'` with a single inline link —
+  "We've just launched a new feature! Check out the new dashboard.").
 
 ## When NOT to use
 
-- **Section-level inline status** → use [Alert](?path=/docs/web-primitives-alert--docs).
-- **Transient confirmation** → use [Toast](?path=/docs/web-primitives-toast--docs).
+- **Section-level inline status** (form-field error, save
+  confirmation in-place) → use [Alert](?path=/docs/web-primitives-alert--docs).
+- **Transient confirmation** ("Saved", "Could not save") → use
+  [Toast](?path=/docs/web-primitives-toast--docs).
+- **In-app activity feed item** (avatar + comment, file upload
+  progress) → use [Notification](?path=/docs/web-primitives-notification--docs).
 - **Single-word status** → use [Badge](?path=/docs/web-primitives-badge--docs).
+- **Blocking confirmation** that requires user action before
+  proceeding → use [Modal](?path=/docs/web-primitives-modal--docs).
 
 ## Anatomy
 
-<Canvas of={BannerStories.Default} />
+<Canvas of={BannerStories.DualAction} />
 
-Layout: leading icon (intent-based), title + optional description
-(inline on desktop), optional action slot (1–2 Buttons), optional
-close button at the top-right.
+Layout per `type`:
+
+| Type            | Anatomy                                                                                |
+| --------------- | -------------------------------------------------------------------------------------- |
+| `text-field`    | leading icon + title + description + email input + submit button + close X             |
+| `single-action` | leading icon + title + description + 1 button + close X                                |
+| `dual-action`   | leading icon + title + inline-link description + 2 buttons (Decline / Allow) + close X |
+| `slim`          | center-aligned title + inline link + close X (no icon, compact)                        |
+
+```tsx
+<Banner
+  type="dual-action"
+  theme="default"
+  title="We use third-party cookies in order to personalise your experience"
+  description={
+    <>
+      Read our <a href="/cookies">Cookie Policy</a>.
+    </>
+  }
+  primaryActionLabel="Allow"
+  onPrimaryAction={acceptCookies}
+  secondaryActionLabel="Decline"
+  onSecondaryAction={declineCookies}
+  onDismiss={hideBanner}
+/>
+```
+
+The `theme` axis is independent of `type`:
+
+- **`default`** — light surface (`bg-secondary`) with a thin
+  outline ring. Blends with dashboards / content surfaces.
+- **`brand`** — dark navy fill (`bg-utility-brand-700`) with white
+  text. Use for promotional / hero strips that should pop above
+  the page chrome.
 
 ## Variants
 
@@ -43,20 +92,30 @@ close button at the top-right.
 
 ## Accessibility
 
-- Renders as `<div role="status">` so screen readers announce the
+- The wrapper carries `role="status"` so screen readers announce the
   banner on insert / change.
-- The intent icon is `aria-hidden`; title + description carry the
-  meaningful content.
-- Action buttons are real `<Button>` instances — keyboard reachable,
-  focus rings inherited from the Button primitive.
-- The close button (when `dismissible`) carries `dismissLabel` as
-  `aria-label`.
-- Persist the dismissed state in `localStorage` or a per-user setting
-  so reopened banners don't re-display indefinitely (orchestration
-  lives in the consumer, not in the primitive).
+- The leading icon is decorative (`aria-hidden`); the title and
+  description carry the meaningful content.
+- Action buttons + close X are real `<button>` elements with visible
+  focus rings; close X carries `dismissLabel` as `aria-label`
+  (defaults to `Dismiss`).
+- For `type='text-field'`, the email input has `aria-label` set via
+  `inputAriaLabel` (defaults to `Email`); always provide a
+  meaningful value when the surrounding UI doesn't already label
+  the input.
+- Empty / whitespace `primaryActionLabel` / `secondaryActionLabel`
+  values auto-hide the corresponding button so axe `button-name`
+  never trips on text-empty controls.
+- Persist the dismissed state in `localStorage` or a per-user
+  setting so reopened banners don't re-display indefinitely
+  (orchestration lives in the consumer, not in the primitive).
+- Render at most one Banner per page surface — multiple `role="status"`
+  regions stacked together compete for the screen reader's
+  attention queue.
 
 ## Related components
 
 - [Alert](?path=/docs/web-primitives-alert--docs) — section-level inline status.
 - [Toast](?path=/docs/web-primitives-toast--docs) — transient overlay notification.
+- [Notification](?path=/docs/web-primitives-notification--docs) — in-app activity feed item.
 - [Modal](?path=/docs/web-primitives-modal--docs) — blocking confirmation that requires user action.

--- a/packages/ui/src/components/Banner/Banner.stories.tsx
+++ b/packages/ui/src/components/Banner/Banner.stories.tsx
@@ -1,21 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 import { defineControls } from '../_internal/controls';
-import { Button } from '../Button';
-import { Banner } from './Banner';
+import { Banner, type BannerTheme, type BannerType } from './Banner';
 import { bannerControls, bannerExcludeFromArgs } from './Banner.controls';
 
 const { args, argTypes } = defineControls(bannerControls);
 
 // Explicit `Meta<typeof Banner>` annotation (rather than `satisfies`)
-// keeps storybook csf-internal types out of the exported `meta`
-// signature — `tsc --noEmit` runs with `declaration: true` and trips
-// TS2742 / TS4023 when the inferred meta references types that aren't
-// portably named.
+// keeps the unexported `BannerProps` interface out of the exported
+// `meta` signature — `tsc --noEmit` runs with `declaration: true`
+// and TS4023 fires when an exported `meta` resolves to a non-exported
+// nominal type.
 //
-// Phase 1.5: `args` + `argTypes` come from `Banner.controls.ts`;
-// `tags: ['autodocs']` removed because `Banner.mdx` replaces the
-// docs tab.
+// #305: Banner is now a parametric primitive matching Figma's
+// `web-primitives-banner` `Type` × `Theme` axes.
 const meta: Meta<typeof Banner> = {
   title: 'Web Primitives/Banner',
   component: Banner,
@@ -27,13 +25,6 @@ const meta: Meta<typeof Banner> = {
   },
   args,
   argTypes,
-  decorators: [
-    (Story) => (
-      <div style={{ width: 720 }}>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export default meta;
@@ -41,88 +32,222 @@ type Story = StoryObj<typeof Banner>;
 
 export const excludeFromArgs = bannerExcludeFromArgs;
 
-export const Default: Story = {};
-
-export const Info: Story = {
+export const Default: Story = {
   args: {
-    intent: 'info',
-    title: 'New feature live',
-    description: 'Try it from the dashboard.',
+    type: 'single-action',
+    title: "We've just announced our Series A!",
+    description: 'Read about it from our CEO.',
+    primaryActionLabel: 'Read update',
+    onPrimaryAction: () => undefined,
+    onDismiss: () => undefined,
   },
 };
 
-export const Success: Story = {
+export const TextField: Story = {
   args: {
-    intent: 'success',
-    title: 'Backup complete',
-    description: 'All data restored.',
+    type: 'text-field',
+    title: 'Stay up to date with the latest news and updates',
+    description: 'Be the first to hear about new components, updates, and design resources.',
+    inputPlaceholder: 'Enter your email',
+    primaryActionLabel: 'Subscribe',
+    onPrimaryAction: () => undefined,
+    onDismiss: () => undefined,
   },
 };
 
-export const Warning: Story = {
+export const SingleAction: Story = {
   args: {
-    intent: 'warning',
-    title: 'Maintenance window tonight',
-    description: '02:00 – 04:00 UTC.',
+    type: 'single-action',
+    title: "We've just announced our Series A!",
+    description: 'Read about it from our CEO.',
+    primaryActionLabel: 'Read update',
+    onPrimaryAction: () => undefined,
+    onDismiss: () => undefined,
   },
 };
 
-export const Danger: Story = {
+export const DualAction: Story = {
   args: {
-    intent: 'danger',
-    title: 'Connection lost',
-    description: 'Reconnecting…',
-  },
-};
-
-export const Dismissible: Story = {
-  args: { dismissible: true },
-};
-
-export const WithActions: Story = {
-  args: {
-    title: 'We use third-party cookies',
-    description: 'Read our cookie policy.',
-    actions: (
+    type: 'dual-action',
+    title: 'We use third-party cookies in order to personalise your experience',
+    description: (
       <>
-        <Button color="secondary" size="sm">
-          Decline
-        </Button>
-        <Button color="primary" size="sm">
-          Allow
-        </Button>
+        Read our{' '}
+        <a
+          href="#"
+          className="rounded-xs underline decoration-utility-neutral-300 underline-offset-3 outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          Cookie Policy
+        </a>
+        .
       </>
     ),
+    primaryActionLabel: 'Allow',
+    onPrimaryAction: () => undefined,
+    secondaryActionLabel: 'Decline',
+    onSecondaryAction: () => undefined,
+    onDismiss: () => undefined,
   },
 };
 
-export const WithActionsDismissible: Story = {
+export const Slim: Story = {
   args: {
+    type: 'slim',
+    title: "We've just launched a new feature!",
+    description: (
+      <>
+        Check out the{' '}
+        <a
+          href="#"
+          className="rounded-xs underline decoration-utility-neutral-300 underline-offset-3 outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          new dashboard
+        </a>
+        .
+      </>
+    ),
+    onDismiss: () => undefined,
+  },
+};
+
+export const Brand: Story = {
+  args: {
+    theme: 'brand',
+    type: 'single-action',
+    title: "We've just announced our Series A!",
+    description: 'Read about it from our CEO.',
+    primaryActionLabel: 'Read update',
+    onPrimaryAction: () => undefined,
+    onDismiss: () => undefined,
+  },
+};
+
+export const Persistent: Story = {
+  args: {
+    type: 'single-action',
     title: 'Update available',
-    description: 'A new version is ready to install.',
-    dismissible: true,
-    actions: (
+    description: 'A newer version is ready to install.',
+    primaryActionLabel: 'Install',
+    onPrimaryAction: () => undefined,
+    // No onDismiss → no close X → user must use the action button.
+  },
+};
+
+// Matrix story: iterates `type` and renders every layout variant in
+// one canvas. Other props still flow through `{...args}`.
+const TYPES: BannerType[] = ['text-field', 'single-action', 'dual-action', 'slim'];
+
+const SAMPLE: Record<BannerType, { title: string; description?: React.ReactNode }> = {
+  'text-field': {
+    title: 'Stay up to date with the latest news and updates',
+    description: 'Be the first to hear about new components, updates, and design resources.',
+  },
+  'single-action': {
+    title: "We've just announced our Series A!",
+    description: 'Read about it from our CEO.',
+  },
+  'dual-action': {
+    title: 'We use third-party cookies in order to personalise your experience',
+    description: (
       <>
-        <Button color="secondary" size="sm">
-          Later
-        </Button>
-        <Button color="primary" size="sm">
-          Update
-        </Button>
+        Read our{' '}
+        <a
+          href="#"
+          className="rounded-xs underline decoration-utility-neutral-300 underline-offset-3 outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          Cookie Policy
+        </a>
+        .
+      </>
+    ),
+  },
+  slim: {
+    title: "We've just launched a new feature!",
+    description: (
+      <>
+        Check out the{' '}
+        <a
+          href="#"
+          className="rounded-xs underline decoration-utility-neutral-300 underline-offset-3 outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+        >
+          new dashboard
+        </a>
+        .
       </>
     ),
   },
 };
 
-// Matrix story: iterates `intent` and renders every variant in a
-// single canvas, so the controls panel hides `intent`. Other props
-// still flow through `{...args}`.
-export const Intents: Story = {
-  parameters: { controls: { exclude: ['intent'] } },
+const TYPE_PRIMARY: Record<BannerType, string> = {
+  'text-field': 'Subscribe',
+  'single-action': 'Read update',
+  'dual-action': 'Allow',
+  slim: '',
+};
+
+const TYPE_SECONDARY: Record<BannerType, string> = {
+  'text-field': '',
+  'single-action': '',
+  'dual-action': 'Decline',
+  slim: '',
+};
+
+export const Types: Story = {
+  parameters: {
+    controls: {
+      exclude: [
+        'type',
+        'title',
+        'description',
+        'primaryActionLabel',
+        'secondaryActionLabel',
+        'inputPlaceholder',
+      ],
+    },
+  },
   render: (args) => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-      {(['info', 'success', 'warning', 'danger'] as const).map((intent) => (
-        <Banner key={intent} {...args} intent={intent} title={`Intent: ${intent}`} />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {TYPES.map((type) => {
+        const sample = SAMPLE[type];
+        return (
+          <Banner
+            key={type}
+            {...args}
+            type={type}
+            title={sample.title}
+            description={sample.description}
+            primaryActionLabel={TYPE_PRIMARY[type] || undefined}
+            onPrimaryAction={TYPE_PRIMARY[type] ? () => undefined : undefined}
+            secondaryActionLabel={TYPE_SECONDARY[type] || undefined}
+            onSecondaryAction={TYPE_SECONDARY[type] ? () => undefined : undefined}
+          />
+        );
+      })}
+    </div>
+  ),
+};
+
+// Matrix story: iterates `theme` (default + brand) using a
+// `single-action` layout so the colour difference is immediately
+// readable.
+const THEMES: BannerTheme[] = ['default', 'brand'];
+
+export const Themes: Story = {
+  parameters: { controls: { exclude: ['theme'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {THEMES.map((theme) => (
+        <Banner
+          key={theme}
+          {...args}
+          theme={theme}
+          type="single-action"
+          title={`Theme: ${theme}`}
+          description="Read about it from our CEO."
+          primaryActionLabel="Read update"
+          onPrimaryAction={() => undefined}
+          onDismiss={() => undefined}
+        />
       ))}
     </div>
   ),

--- a/packages/ui/src/components/Banner/Banner.tsx
+++ b/packages/ui/src/components/Banner/Banner.tsx
@@ -1,111 +1,368 @@
-// Glaon Banner — page-level announcement primitive. Per CLAUDE.md's UUI
-// Source Rule, the structural HTML/CSS is anchored on the Untitled UI
-// kit `banner-dual-action-default` shared-asset under
-// `packages/ui/src/components/shared-assets/banners/banner-dual-action-default.tsx`.
-// That kit file is a concrete template (no props, hard-coded copy), so
-// the Glaon wrap layer parameterizes its content (title / description /
-// actions / intent icon / dismissible) while preserving the kit's class
-// structure. Tokens flow through Tailwind v4 `@theme` (UUI `theme.css`)
-// and Glaon's brand override layer.
+// Glaon Banner — page-level announcement primitive. UUI's kit ships
+// only concrete shared-asset templates (`banner-dual-action-default`
+// + `banner-slim-default`) — no parametric primitive. Per the UUI
+// Source Rule's "no kit source" exception, Glaon hand-rolls the
+// component using those templates' class structures as canonical
+// reference and parameterises content + theme. Tokens flow through
+// Tailwind v4 `@theme` (UUI `theme.css`) and Glaon's brand override
+// layer.
+//
+// Maps Figma's `web-primitives-banner` axes 1:1:
+//   - `Type`:  text-field / single-action / dual-action / slim
+//   - `Theme`: default (light) / brand (dark navy)
+//
+// Distinct from Alert (#303) — Alert is in-flow inline status; Banner
+// is a page-level announcement strip pinned to the top / bottom of
+// the page. Distinct from Toast — Toast is a transient overlay.
+//
+// Usage:
+//
+//   <Banner
+//     type="dual-action"
+//     theme="default"
+//     title="We use third-party cookies in order to personalise your experience"
+//     description={<>Read our <a href="/cookies">Cookie Policy</a>.</>}
+//     primaryActionLabel="Allow"
+//     onPrimaryAction={acceptCookies}
+//     secondaryActionLabel="Decline"
+//     onSecondaryAction={declineCookies}
+//     onDismiss={hideBanner}
+//   />
 
-import type { FC, ReactNode } from 'react';
+import type { ChangeEvent, FC, ReactNode } from 'react';
 
-import { AlertCircle, AlertTriangle, CheckCircle, InfoCircle } from '@untitledui/icons';
+import { CheckVerified02 } from '@untitledui/icons';
 
-import { CloseButton } from '../base/buttons/close-button';
-
-// `@untitledui/icons` declares each icon's `Props` interface in a per-file
-// module that isn't re-exported, so deriving an exact type against the
-// raw imports trips TS4023. The icon picker (`icons/storybook.ts`) uses
-// the same `FC<any>` workaround for the same reason.
+// `@untitledui/icons` declares per-file icon types; type the slot
+// loosely so callers can pass any kit / custom icon component.
 //
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
 type IconComponent = FC<any>;
 
-export type BannerIntent = 'info' | 'success' | 'warning' | 'danger';
+export type BannerType = 'text-field' | 'single-action' | 'dual-action' | 'slim';
+export type BannerTheme = 'default' | 'brand';
+export type BannerInputType = 'email' | 'text' | 'url' | 'tel';
 
 export interface BannerProps {
-  /** Bold lead-in text. */
-  title: ReactNode;
-  /** Optional secondary line; rendered after the title. */
-  description?: ReactNode;
-  /** Severity / colour group for the leading icon. */
-  intent?: BannerIntent;
-  /** Override the default icon for the chosen intent. */
-  icon?: IconComponent;
   /**
-   * Action slot — typically one or two `<Button>` elements. Rendered to
-   * the right of the message on desktop, below it on mobile.
+   * Layout discriminator. Mirrors Figma's `Type` axis 1:1.
+   * @default 'single-action'
    */
-  actions?: ReactNode;
-  /** Render a close button at the top-right corner. */
-  dismissible?: boolean;
-  /** Fires when the close button is clicked. */
-  onDismiss?: () => void;
-  /** Accessible label for the close button. Defaults to "Dismiss". */
-  dismissLabel?: string;
-  /** Override the kit's outer container className. */
-  className?: string;
+  type?: BannerType | undefined;
+  /**
+   * Surface palette. Mirrors Figma's `Theme` axis. `default` is a
+   * light tray with a ring; `brand` is a dark navy fill.
+   * @default 'default'
+   */
+  theme?: BannerTheme | undefined;
+  /** Bold lead-in text. Always set. */
+  title: ReactNode;
+  /**
+   * Optional secondary copy. Use a ReactNode for inline links
+   * (`Read our <a>Cookie Policy</a>`). Ignored for `type='slim'`
+   * (slim renders title + inline link inline; pass the link inside
+   * `title`).
+   */
+  description?: ReactNode | undefined;
+  /**
+   * Override the leading icon. Defaults to the kit `CheckVerified02`
+   * glyph. Ignored for `type='slim'` (slim has no icon).
+   */
+  icon?: IconComponent | undefined;
+  /** Label for the primary CTA (right side). */
+  primaryActionLabel?: string | undefined;
+  /** Click handler for the primary CTA. */
+  onPrimaryAction?: (() => void) | undefined;
+  /**
+   * Label for the secondary CTA (left of the primary). Only renders
+   * for `type='dual-action'`.
+   */
+  secondaryActionLabel?: string | undefined;
+  /** Click handler for the secondary CTA. */
+  onSecondaryAction?: (() => void) | undefined;
+  /** Placeholder for the email/text input (`type='text-field'` only). */
+  inputPlaceholder?: string | undefined;
+  /** Native input type — drives mobile keyboard hint. @default 'email' */
+  inputType?: BannerInputType | undefined;
+  /** Controlled input value. Pair with `onInputChange`. */
+  inputValue?: string | undefined;
+  /** Initial input value for uncontrolled usage. */
+  defaultInputValue?: string | undefined;
+  /** Fires on every keystroke with the new string value. */
+  onInputChange?: ((value: string) => void) | undefined;
+  /**
+   * Accessible label for the input (forwarded as `aria-label`).
+   * Required when no visible label exists. @default 'Email'
+   */
+  inputAriaLabel?: string | undefined;
+  /** Click handler for the close X. Setting this surfaces the close button. */
+  onDismiss?: (() => void) | undefined;
+  /** Accessible label for the close X. @default 'Dismiss' */
+  dismissLabel?: string | undefined;
+  /** Tailwind override hook for the outer container. */
+  className?: string | undefined;
 }
 
-const intentIcons: Record<BannerIntent, IconComponent> = {
-  info: InfoCircle,
-  success: CheckCircle,
-  warning: AlertTriangle,
-  danger: AlertCircle,
+interface ThemeTokens {
+  container: string;
+  title: string;
+  description: string;
+  iconColor: string;
+  closeText: string;
+  closeHover: string;
+  primaryButton: string;
+  secondaryButton: string;
+  inputClass: string;
+  submitButton: string;
+}
+
+// Theme palettes — `default` mirrors the kit's
+// `bg-secondary` / `ring-secondary_alt` / `shadow-lg` shared-asset
+// vocabulary; `brand` swaps in dark-navy fill (`bg-utility-brand-700`)
+// with white text and lighter brand-200 accents per Figma's brand
+// banner reference.
+const themeTokens: Record<BannerTheme, ThemeTokens> = {
+  default: {
+    container: 'bg-secondary text-secondary ring-1 ring-inset ring-secondary_alt shadow-lg',
+    title: 'text-secondary',
+    description: 'text-tertiary',
+    iconColor: 'text-fg-brand-primary_alt',
+    closeText: 'text-fg-quaternary',
+    closeHover: 'hover:bg-primary_hover hover:text-fg-quaternary_hover',
+    primaryButton:
+      'bg-brand-solid text-white shadow-xs-skeuomorphic ring-1 ring-inset ring-transparent hover:bg-brand-solid_hover',
+    secondaryButton:
+      'bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-inset ring-primary hover:bg-primary_hover',
+    inputClass:
+      'bg-primary text-primary placeholder:text-placeholder ring-1 ring-inset ring-primary focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-fg-brand-primary',
+    submitButton:
+      'bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-inset ring-primary hover:bg-primary_hover',
+  },
+  brand: {
+    container: 'bg-utility-brand-700 text-white shadow-lg',
+    title: 'text-white',
+    description: 'text-utility-brand-200',
+    iconColor: 'text-utility-brand-200',
+    closeText: 'text-utility-brand-200',
+    closeHover: 'hover:bg-white/10 hover:text-white',
+    primaryButton:
+      'bg-white text-utility-brand-700 shadow-xs-skeuomorphic ring-1 ring-inset ring-transparent hover:bg-utility-brand-50',
+    secondaryButton: 'bg-transparent text-white ring-1 ring-inset ring-white/30 hover:bg-white/10',
+    inputClass:
+      'bg-utility-brand-800 text-white placeholder:text-utility-brand-200 ring-1 ring-inset ring-white/20 focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-white',
+    submitButton:
+      'bg-white text-utility-brand-700 shadow-xs-skeuomorphic ring-1 ring-inset ring-transparent hover:bg-utility-brand-50',
+  },
 };
 
-const intentIconColor: Record<BannerIntent, string> = {
-  info: 'text-fg-brand-primary_alt',
-  success: 'text-fg-success-primary',
-  warning: 'text-fg-warning-primary',
-  danger: 'text-fg-error-primary',
-};
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
 
+const buttonBase =
+  'inline-flex shrink-0 items-center justify-center rounded-md px-3 py-1.5 text-sm font-semibold whitespace-nowrap outline-focus-ring transition focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-50';
+
+function CloseX({
+  theme,
+  label,
+  onPress,
+  positioned,
+}: {
+  theme: BannerTheme;
+  label: string;
+  onPress: () => void;
+  positioned: 'absolute' | 'absolute-md-static';
+}) {
+  const tokens = themeTokens[theme];
+  const positionClass =
+    positioned === 'absolute' ? 'absolute top-2 right-2' : 'absolute top-2 right-2 md:static';
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onPress}
+      className={joinClasses(
+        positionClass,
+        'inline-flex size-8 shrink-0 items-center justify-center rounded-md outline-focus-ring transition focus-visible:outline-2 focus-visible:outline-offset-2',
+        tokens.closeText,
+        tokens.closeHover,
+      )}
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        className="size-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      >
+        <path d="M3 3l10 10M13 3L3 13" />
+      </svg>
+    </button>
+  );
+}
+
+/**
+ * Glaon Banner — page-level announcement strip. Single parametric
+ * primitive dispatching to the right layout via the `type` prop.
+ */
 export function Banner({
+  type = 'single-action',
+  theme = 'default',
   title,
   description,
-  intent = 'info',
   icon: IconOverride,
-  actions,
-  dismissible = false,
+  primaryActionLabel,
+  onPrimaryAction,
+  secondaryActionLabel,
+  onSecondaryAction,
+  inputPlaceholder = 'Enter your email',
+  inputType = 'email',
+  inputValue,
+  defaultInputValue,
+  onInputChange,
+  inputAriaLabel = 'Email',
   onDismiss,
   dismissLabel = 'Dismiss',
   className,
 }: BannerProps) {
-  const Icon = IconOverride ?? intentIcons[intent];
-  const iconColor = intentIconColor[intent];
+  const tokens = themeTokens[theme];
+  const Icon = IconOverride ?? CheckVerified02;
 
-  const containerClass =
-    'relative flex flex-col gap-4 rounded-xl bg-secondary p-4 shadow-lg ring-1 ring-secondary_alt md:flex-row md:items-center md:gap-3 md:py-3 md:pr-3 md:pl-5';
+  const hasPrimary =
+    primaryActionLabel !== undefined &&
+    primaryActionLabel.trim() !== '' &&
+    onPrimaryAction !== undefined;
+  const hasSecondary =
+    type === 'dual-action' &&
+    secondaryActionLabel !== undefined &&
+    secondaryActionLabel.trim() !== '' &&
+    onSecondaryAction !== undefined;
+  const hasDismiss = onDismiss !== undefined;
+
+  if (type === 'slim') {
+    return (
+      <div
+        role="status"
+        className={joinClasses(
+          'relative flex items-center gap-4 rounded-xl p-4 md:gap-3 md:px-12 md:py-3',
+          tokens.container,
+          className,
+        )}
+      >
+        <div className="flex w-0 flex-1 flex-col gap-0.5 md:flex-row md:justify-center md:gap-1.5 md:text-center">
+          <p
+            className={joinClasses('pr-8 text-sm font-semibold md:pr-0 md:truncate', tokens.title)}
+          >
+            {title}
+          </p>
+          {description !== undefined ? (
+            <p className={joinClasses('text-sm md:truncate', tokens.description)}>{description}</p>
+          ) : null}
+        </div>
+        {hasDismiss ? (
+          <CloseX theme={theme} label={dismissLabel} onPress={onDismiss} positioned="absolute" />
+        ) : null}
+      </div>
+    );
+  }
+
+  // text-field / single-action / dual-action share the icon + body
+  // layout. Action area + input slot are type-specific.
+  const inputProps: {
+    type: BannerInputType;
+    placeholder: string;
+    'aria-label': string;
+    className: string;
+    value?: string;
+    defaultValue?: string;
+    onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  } = {
+    type: inputType,
+    placeholder: inputPlaceholder,
+    'aria-label': inputAriaLabel,
+    className: joinClasses('h-9 w-full min-w-0 rounded-md px-3 text-sm md:w-64', tokens.inputClass),
+  };
+  if (inputValue !== undefined) inputProps.value = inputValue;
+  if (defaultInputValue !== undefined) inputProps.defaultValue = defaultInputValue;
+  if (onInputChange !== undefined) {
+    inputProps.onChange = (e: ChangeEvent<HTMLInputElement>) => {
+      onInputChange(e.target.value);
+    };
+  }
 
   return (
-    <div role="status" className={className ? `${containerClass} ${className}` : containerClass}>
-      <div className="flex flex-1 flex-col gap-3 md:w-0 md:flex-row md:items-center md:gap-2">
-        <Icon aria-hidden="true" className={`size-5 shrink-0 ${iconColor}`} />
-        <div className="flex flex-col gap-2 overflow-hidden lg:flex-row lg:gap-1.5">
-          <p className="pr-8 text-sm font-semibold text-secondary md:pr-0">{title}</p>
+    <div
+      role="status"
+      className={joinClasses(
+        'relative flex flex-col gap-4 rounded-xl p-4 md:flex-row md:items-center md:gap-3 md:py-3 md:pr-3 md:pl-5',
+        tokens.container,
+        className,
+      )}
+    >
+      <div className="flex flex-1 flex-col gap-3 md:w-0 md:flex-row md:items-center md:gap-3">
+        <Icon aria-hidden="true" className={joinClasses('size-5 shrink-0', tokens.iconColor)} />
+        <div className="flex flex-col gap-1 overflow-hidden lg:flex-row lg:gap-1.5">
+          <p
+            className={joinClasses('pr-8 text-sm font-semibold md:pr-0 md:truncate', tokens.title)}
+          >
+            {title}
+          </p>
           {description !== undefined ? (
-            <p className="text-sm text-tertiary">{description}</p>
+            <p className={joinClasses('text-sm md:truncate', tokens.description)}>{description}</p>
           ) : null}
         </div>
       </div>
-      {actions !== undefined || dismissible ? (
-        <div className="flex gap-2">
-          {actions !== undefined ? (
-            <div className="flex w-full flex-col-reverse gap-2 md:flex-row md:gap-3">{actions}</div>
-          ) : null}
-          {dismissible ? (
-            <div className="absolute top-2 right-2 flex shrink-0 items-center justify-center md:static">
-              <CloseButton
-                size="sm"
-                label={dismissLabel}
-                {...(onDismiss ? { onPress: onDismiss } : {})}
-              />
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+
+      <div className="flex items-center gap-2">
+        {type === 'text-field' ? (
+          <div className="flex w-full flex-col gap-2 md:flex-row md:items-center md:gap-2">
+            <input {...inputProps} />
+            {hasPrimary ? (
+              <button
+                type="button"
+                onClick={onPrimaryAction}
+                className={joinClasses(buttonBase, tokens.submitButton)}
+              >
+                {primaryActionLabel}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {(type === 'single-action' || type === 'dual-action') && (hasPrimary || hasSecondary) ? (
+          <div className="flex w-full flex-col-reverse gap-2 md:flex-row md:gap-3">
+            {hasSecondary ? (
+              <button
+                type="button"
+                onClick={onSecondaryAction}
+                className={joinClasses(buttonBase, tokens.secondaryButton)}
+              >
+                {secondaryActionLabel}
+              </button>
+            ) : null}
+            {hasPrimary ? (
+              <button
+                type="button"
+                onClick={onPrimaryAction}
+                className={joinClasses(buttonBase, tokens.primaryButton)}
+              >
+                {primaryActionLabel}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {hasDismiss ? (
+          <CloseX
+            theme={theme}
+            label={dismissLabel}
+            onPress={onDismiss}
+            positioned="absolute-md-static"
+          />
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/Banner/index.ts
+++ b/packages/ui/src/components/Banner/index.ts
@@ -1,1 +1,2 @@
-export { Banner, type BannerIntent, type BannerProps } from './Banner';
+export { Banner } from './Banner';
+export type { BannerInputType, BannerProps, BannerTheme, BannerType } from './Banner';


### PR DESCRIPTION
## Summary

Banner artık Figma `web-primitives-banner` `Type` × `Theme` axes'iyle bire bir eşleşen parametric primitive:

- **`type`** discriminator (4 layout): `text-field` (email input + submit), `single-action` (1 CTA), `dual-action` (2 CTA — cookie banner pattern), `slim` (48px-tall center-aligned strip).
- **`theme`** axis (2 surface): `default` (light tray + ring), `brand` (dark navy fill + white text).

Kit'te parametric primitive yok; sadece concrete `banner-dual-action-default` + `banner-slim-default` shared-asset'leri var. Glaon hand-rolled (UUI Source Rule "no kit source" istisnası — BadgeGroup / TopBar / SideNav / Notification pattern'i). Kit class structure'ı canonical reference olarak kullanılır.

## Migration

Eski Banner prop'ları kaldırıldı — yerine parametric API:

- **`intent`** (info / success / warning / danger) → kaldırıldı. Figma'da yok; severity gerekirse [Alert](?path=/docs/web-primitives-alert--docs) #303 (6-color matrix) kullanılır.
- **`actions: ReactNode`** free-form slot → kaldırıldı. Yerine `primaryActionLabel` / `onPrimaryAction` (+ `secondaryActionLabel` / `onSecondaryAction` for dual-action) — Alert pattern'i.
- **`dismissible: boolean`** → kaldırıldı. `onDismiss` set'lenmesi otomatik close X surface eder (Alert / Toast pattern'i).

Empty / whitespace `primaryActionLabel` ve `secondaryActionLabel` değerleri ilgili button'u otomatik hide ediyor — axe `button-name` hiç tripten geçmiyor (Alert #303 pattern'i).

## Scope

**In**

- `packages/ui/src/components/Banner/Banner.tsx` — parametric refactor, `type` / `theme` discriminator'lar
- `packages/ui/src/components/Banner/Banner.controls.ts` — yeni axis + slot prop'ları
- `packages/ui/src/components/Banner/Banner.stories.tsx` — Default + TextField + SingleAction + DualAction + Slim + Brand + Persistent + Types matrix + Themes matrix
- `packages/ui/src/components/Banner/Banner.mdx` — type matrix breakdown + theme açıklaması + a11y notes
- `packages/ui/src/components/Banner/index.ts` — type export'ları güncellendi (`BannerIntent` kaldırıldı, `BannerType` / `BannerTheme` / `BannerInputType` eklendi)

**Out**

- Severity axis (info/success/warning/danger) sürmüyor — Banner Figma'da sadece `default` / `brand` surface'i.
- Toast (#P16) / Alert (#303) / Notification (#303) primitive'lerine dokunmadık — farklı use-case'ler.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\`
- [x] \`pnpm --filter @glaon/ui lint\`
- [x] \`pnpm knip\`
- [x] \`pnpm --filter @glaon/ui exec vitest run\` — 93/93 prop-coverage assertion yeşil
- [x] \`pnpm --filter @glaon/ui build-storybook\` yeşil
- [ ] Storybook localhost:6006 — Banner sayfasında 4 type × 2 theme combinations seçilebilir; Types + Themes matrix story'leri tüm varyantları yan yana gösterir
- [ ] Figma Design tab — Banner \`parameters.design\` URL'i Figma sub-component'ine açılır
- [ ] Chromatic build yeşil — Banner canvas'ları type/theme genişlemesiyle değişir → baseline accept gerekir

Closes #305