### PR TITLE
feat(ui): button phase 1.5 + socialbutton + appstorebadge

### DIFF
--- a/packages/ui/src/components/AppStoreBadge/AppStoreBadge.controls.ts
+++ b/packages/ui/src/components/AppStoreBadge/AppStoreBadge.controls.ts
@@ -1,0 +1,56 @@
+// `AppStoreBadge.controls.ts` — single source of truth for
+// AppStoreBadge's variant matrix. Story
+// (`AppStoreBadge.stories.tsx`) imports the spec and spreads it
+// into `meta.args` / `meta.argTypes`; MDX docs reads the same spec
+// via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const storeOptions = [
+  'app-store',
+  'mac-app-store',
+  'google-play',
+  'galaxy-store',
+  'app-gallery',
+] as const;
+const themeOptions = ['dark', 'light'] as const;
+
+export const appStoreBadgeControls = {
+  store: {
+    type: 'select',
+    options: storeOptions,
+    default: 'app-store',
+    description:
+      "Which store this badge links to. Drives the brand glyph + top/bottom-line label. Mirrors Figma's `Store` axis 1:1 (5 platforms — App Store / Mac App Store / Google Play / Galaxy Store / AppGallery).",
+    category: 'Content',
+  } satisfies ControlSpec<(typeof storeOptions)[number]>,
+  theme: {
+    type: 'inline-radio',
+    options: themeOptions,
+    default: 'dark',
+    description:
+      "Badge surface tone. `dark` (default — black badge with white text) for placement on a light page; `light` (white badge with dark text) for placement on a dark page. Mirrors Figma's `Dark background` axis (renamed for clarity — the prop describes the badge colour, not the page).",
+    category: 'Style',
+  } satisfies ControlSpec<(typeof themeOptions)[number]>,
+  href: {
+    type: 'text',
+    description:
+      'Link destination (the platform-specific download URL). When set, renders as an `<a>` element. Mutually exclusive with `onPress`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onPress: {
+    type: false,
+    action: 'pressed',
+    description:
+      'Click handler for the `<button>` variant. Useful for analytics-tracking flows that intercept the click before redirecting.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer badge.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const appStoreBadgeExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/AppStoreBadge/AppStoreBadge.mdx
+++ b/packages/ui/src/components/AppStoreBadge/AppStoreBadge.mdx
@@ -1,0 +1,85 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as AppStoreBadgeStories from './AppStoreBadge.stories';
+
+<Meta of={AppStoreBadgeStories} />
+
+# AppStoreBadge
+
+Stylised app-store download badge. Use AppStoreBadge inside marketing
+pages, footers, or sign-up flows to point users at the platform-
+specific install link. Five platforms supported: **App Store**, **Mac
+App Store**, **Google Play**, **Galaxy Store**, **AppGallery**.
+
+> **Production trademark note**: official Apple / Google / Samsung /
+> Huawei badges are governed by each platform's brand guidelines.
+> The Glaon primitive renders a stylised approximation sized for
+> design-system consistency. For pixel-fidelity marketing pages,
+> swap in the official trademark assets downloaded from each
+> platform's brand kit.
+
+## When to use
+
+- Marketing footer / pricing-page CTA: "Download our app".
+- Sign-up flow exit screen: redirect users from web onboarding to
+  the matching mobile store.
+- Help-centre / docs pages that reference the mobile companion app.
+
+## When NOT to use
+
+- **Generic "Download" button** for files / installers → use [Button](?path=/docs/web-primitives-button--docs).
+- **Social-provider sign-in CTA** → use [SocialButton](?path=/docs/web-primitives-socialbutton--docs).
+- **In-app navigation** to a settings tab → use [Button](?path=/docs/web-primitives-button--docs) with `href`.
+
+## Anatomy
+
+<Canvas of={AppStoreBadgeStories.Default} />
+
+A two-line layout:
+
+- **Brand glyph** — Apple logo / Google Play triangle / Galaxy
+  star / Huawei flower.
+- **Top line** — uppercase descriptor (`Download on the` /
+  `GET IT ON` / `Get it on` / `EXPLORE IT ON`).
+- **Bottom line** — store name (`App Store` / `Google Play` /
+  `Galaxy Store` / `AppGallery`).
+
+```tsx
+<AppStoreBadge store="app-store" href="https://apps.apple.com/…" />
+
+<AppStoreBadge store="google-play" href="https://play.google.com/…" />
+
+<AppStoreBadge store="app-store" theme="light" /> {/* for dark page bg */}
+```
+
+The component renders as an `<a>` when `href` is set, a `<button>`
+when `onPress` is set, or a presentational `<span>` when neither
+is set (catalogue / showcase use).
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The component derives its accessible label from the store name
+  (`Download on the App Store`, `GET IT ON Google Play`, etc.) so
+  axe `link-name` / `button-name` always passes — no manual
+  `aria-label` needed for the typical use-case.
+- Brand glyphs are `aria-hidden` — the visible label carries the
+  meaning.
+- `theme='dark'` (default) is for placement on light page backgrounds;
+  `theme='light'` is for dark backgrounds. Pick the one with the
+  highest contrast against the page surface (axe `color-contrast`).
+- Keyboard activation works for `href` / `onPress` variants;
+  presentational `<span>` is non-focusable by design (no action to
+  fire).
+
+## Related components
+
+- [SocialButton](?path=/docs/web-primitives-socialbutton--docs) — social-provider sign-in CTAs (Apple / Google / Facebook / etc.).
+- [Button](?path=/docs/web-primitives-button--docs) — generic action button.

--- a/packages/ui/src/components/AppStoreBadge/AppStoreBadge.stories.tsx
+++ b/packages/ui/src/components/AppStoreBadge/AppStoreBadge.stories.tsx
@@ -51,7 +51,7 @@ export const Light: Story = {
   args: { store: 'app-store', theme: 'light' },
   decorators: [
     (Story) => (
-      <div className="flex h-20 items-center bg-utility-gray-900 p-4">
+      <div className="flex h-20 items-center bg-utility-neutral-900 p-4">
         <Story />
       </div>
     ),
@@ -93,7 +93,7 @@ export const Themes: Story = {
         <span className="min-w-32 text-xs text-tertiary">theme: dark</span>
         <AppStoreBadge {...args} theme="dark" />
       </div>
-      <div className="flex items-center gap-3 bg-utility-gray-900 p-4">
+      <div className="flex items-center gap-3 bg-utility-neutral-900 p-4">
         <span className="min-w-32 text-xs text-white">theme: light</span>
         <AppStoreBadge {...args} theme="light" />
       </div>

--- a/packages/ui/src/components/AppStoreBadge/AppStoreBadge.stories.tsx
+++ b/packages/ui/src/components/AppStoreBadge/AppStoreBadge.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { AppStoreBadge, type AppStore } from './AppStoreBadge';
+import { appStoreBadgeControls, appStoreBadgeExcludeFromArgs } from './AppStoreBadge.controls';
+
+const { args, argTypes } = defineControls(appStoreBadgeControls);
+
+// Explicit `Meta<typeof AppStoreBadge>` annotation (rather than
+// `satisfies`) keeps the unexported `AppStoreBadgeProps` interface
+// out of the exported `meta` signature — `tsc --noEmit` runs with
+// `declaration: true` and TS4023 fires when an exported `meta`
+// resolves to a non-exported nominal type.
+const meta: Meta<typeof AppStoreBadge> = {
+  title: 'Web Primitives/AppStoreBadge',
+  component: AppStoreBadge,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-app-store-badge',
+    },
+  },
+  args,
+  argTypes,
+};
+
+export default meta;
+type Story = StoryObj<typeof AppStoreBadge>;
+
+export const excludeFromArgs = appStoreBadgeExcludeFromArgs;
+
+export const Default: Story = {};
+
+export const MacAppStore: Story = {
+  args: { store: 'mac-app-store' },
+};
+
+export const GooglePlay: Story = {
+  args: { store: 'google-play' },
+};
+
+export const GalaxyStore: Story = {
+  args: { store: 'galaxy-store' },
+};
+
+export const AppGallery: Story = {
+  args: { store: 'app-gallery' },
+};
+
+export const Light: Story = {
+  args: { store: 'app-store', theme: 'light' },
+  decorators: [
+    (Story) => (
+      <div className="flex h-20 items-center bg-utility-gray-900 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const AsLink: Story = {
+  args: { store: 'app-store', href: '#' },
+};
+
+const STORES: AppStore[] = [
+  'app-store',
+  'mac-app-store',
+  'google-play',
+  'galaxy-store',
+  'app-gallery',
+];
+
+// Matrix story: iterates `store` and renders all 5 platforms in a
+// single canvas. Other props still flow through `{...args}`.
+export const Stores: Story = {
+  parameters: { controls: { exclude: ['store'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {STORES.map((store) => (
+        <AppStoreBadge key={store} {...args} store={store} />
+      ))}
+    </div>
+  ),
+};
+
+// Matrix story: iterates `theme` (dark / light) on a paired set of
+// page backgrounds so the contrast difference is visible.
+export const Themes: Story = {
+  parameters: { controls: { exclude: ['theme'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div className="flex items-center gap-3 bg-secondary p-4">
+        <span className="min-w-32 text-xs text-tertiary">theme: dark</span>
+        <AppStoreBadge {...args} theme="dark" />
+      </div>
+      <div className="flex items-center gap-3 bg-utility-gray-900 p-4">
+        <span className="min-w-32 text-xs text-white">theme: light</span>
+        <AppStoreBadge {...args} theme="light" />
+      </div>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/AppStoreBadge/AppStoreBadge.tsx
+++ b/packages/ui/src/components/AppStoreBadge/AppStoreBadge.tsx
@@ -127,9 +127,9 @@ const storeTokens: Record<AppStore, StoreTokens> = {
 };
 
 const themeClasses: Record<AppStoreBadgeTheme, string> = {
-  dark: 'bg-utility-gray-900 text-white ring-1 ring-inset ring-utility-gray-900 hover:bg-utility-gray-800',
+  dark: 'bg-utility-neutral-900 text-white ring-1 ring-inset ring-utility-neutral-900 hover:bg-utility-neutral-800',
   light:
-    'bg-white text-utility-gray-900 ring-1 ring-inset ring-utility-gray-900 hover:bg-utility-gray-50',
+    'bg-white text-utility-neutral-900 ring-1 ring-inset ring-utility-neutral-900 hover:bg-utility-neutral-50',
 };
 
 function joinClasses(...parts: (string | undefined | false)[]): string {

--- a/packages/ui/src/components/AppStoreBadge/AppStoreBadge.tsx
+++ b/packages/ui/src/components/AppStoreBadge/AppStoreBadge.tsx
@@ -1,0 +1,192 @@
+// Glaon AppStoreBadge — official app-store download badge. UUI's kit
+// doesn't ship app-store badges and the official Apple / Google /
+// Samsung / Huawei badges are trademark assets governed by each
+// platform's brand guidelines. Per the UUI Source Rule's "no kit
+// source" exception, Glaon hand-rolls a stylised badge using the
+// kit's surface vocabulary (rounded-lg + ring) plus inline SVG
+// brand glyphs.
+//
+// Maps Figma's `web-primitives-app-store-badge` axes 1:1:
+//   - `Store`:           app-store / mac-app-store / google-play /
+//                        galaxy-store / app-gallery (5 platforms)
+//   - `Dark background`: false (badge for light page bg → dark badge) /
+//                        true  (badge for dark page bg → light badge)
+//
+// Note: in production-grade marketing pages, swap these stylised
+// badges for the official trademark assets downloaded from each
+// platform's brand kit. This primitive is sized for design-system
+// consistency, not marketing pixel-fidelity.
+
+import type { MouseEventHandler, ReactNode } from 'react';
+
+export type AppStore =
+  | 'app-store'
+  | 'mac-app-store'
+  | 'google-play'
+  | 'galaxy-store'
+  | 'app-gallery';
+
+/**
+ * `light` (default) renders a dark badge for use on a light page
+ * background; `dark` renders a light badge for use on a dark page
+ * background. Mirrors Figma's `Dark background` axis (inverted
+ * naming so the prop reads as the badge's own colour, not the page's).
+ */
+export type AppStoreBadgeTheme = 'light' | 'dark';
+
+export interface AppStoreBadgeProps {
+  /** Which store this badge links to. */
+  store: AppStore;
+  /**
+   * Badge surface tone. `dark` (default) = black badge for light
+   * pages; `light` = white badge for dark pages.
+   * @default 'dark'
+   */
+  theme?: AppStoreBadgeTheme | undefined;
+  /**
+   * Link destination. When set, renders an `<a>`. When omitted (and
+   * `onPress` is also omitted), renders a presentational `<span>`
+   * — useful for read-only catalogues.
+   */
+  href?: string | undefined;
+  /** Click handler for `<button>` variant. Mutually exclusive with `href`. */
+  onPress?: MouseEventHandler<HTMLButtonElement> | undefined;
+  /** Tailwind override hook. */
+  className?: string | undefined;
+}
+
+interface StoreTokens {
+  topLine: string;
+  bottomLine: string;
+  glyph: ReactNode;
+}
+
+// Inline brand SVG glyphs — minimal viewBox 0 0 24 24 paths so they
+// inherit `currentColor` from the surrounding badge text colour.
+const storeTokens: Record<AppStore, StoreTokens> = {
+  'app-store': {
+    topLine: 'Download on the',
+    bottomLine: 'App Store',
+    glyph: (
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M17.535 12.625c.024-2.612 2.13-3.873 2.226-3.93-1.213-1.77-3.099-2.013-3.766-2.038-1.601-.162-3.124.943-3.937.943-.812 0-2.062-.92-3.388-.895-1.745.025-3.354 1.013-4.252 2.572-1.812 3.143-.464 7.793 1.301 10.34.86 1.247 1.886 2.652 3.232 2.602 1.296-.052 1.787-.84 3.354-.84 1.567 0 2.011.84 3.39.812 1.396-.025 2.282-1.275 3.137-2.526.985-1.451 1.392-2.85 1.417-2.924-.031-.014-2.722-1.046-2.748-4.116Zm-2.594-7.55c.715-.866 1.197-2.069 1.066-3.27-1.029.041-2.275.685-3.013 1.55-.661.766-1.241 1.989-1.084 3.166 1.151.089 2.315-.585 3.031-1.446Z" />
+      </svg>
+    ),
+  },
+  'mac-app-store': {
+    topLine: 'Download on the',
+    bottomLine: 'Mac App Store',
+    glyph: (
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M17.535 12.625c.024-2.612 2.13-3.873 2.226-3.93-1.213-1.77-3.099-2.013-3.766-2.038-1.601-.162-3.124.943-3.937.943-.812 0-2.062-.92-3.388-.895-1.745.025-3.354 1.013-4.252 2.572-1.812 3.143-.464 7.793 1.301 10.34.86 1.247 1.886 2.652 3.232 2.602 1.296-.052 1.787-.84 3.354-.84 1.567 0 2.011.84 3.39.812 1.396-.025 2.282-1.275 3.137-2.526.985-1.451 1.392-2.85 1.417-2.924-.031-.014-2.722-1.046-2.748-4.116Zm-2.594-7.55c.715-.866 1.197-2.069 1.066-3.27-1.029.041-2.275.685-3.013 1.55-.661.766-1.241 1.989-1.084 3.166 1.151.089 2.315-.585 3.031-1.446Z" />
+      </svg>
+    ),
+  },
+  'google-play': {
+    topLine: 'GET IT ON',
+    bottomLine: 'Google Play',
+    glyph: (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          d="M3.609 1.814 13.792 12 3.61 22.186a1.93 1.93 0 0 1-.609-1.42V3.234a1.93 1.93 0 0 1 .608-1.42Z"
+          fill="#00C3FF"
+        />
+        <path
+          d="m16.81 8.99 2.834 1.622c1.027.587 1.027 2.07 0 2.657L16.811 14.89 13.792 12l3.018-3.01Z"
+          fill="#FFCB00"
+        />
+        <path
+          d="m13.792 12 3.018 2.991-12.34 7.054a1.92 1.92 0 0 1-.86.157L13.79 12Z"
+          fill="#E63845"
+        />
+        <path
+          d="m4.469 1.798 12.341 7.193L13.793 12 3.61 1.815a1.92 1.92 0 0 1 .859-.017Z"
+          fill="#01A350"
+        />
+      </svg>
+    ),
+  },
+  'galaxy-store': {
+    topLine: 'Get it on',
+    bottomLine: 'Galaxy Store',
+    glyph: (
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 2.31 14.473 9.516 22 9.546l-6.094 4.45L18.281 21.219 12 16.844l-6.281 4.375 2.375-7.223L2 9.546l7.527-.03L12 2.311Z" />
+      </svg>
+    ),
+  },
+  'app-gallery': {
+    topLine: 'EXPLORE IT ON',
+    bottomLine: 'AppGallery',
+    glyph: (
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 2c.83 0 1.625.166 2.351.466a4.51 4.51 0 0 0 .156 4.494c.762 1.279 2.061 2.105 3.49 2.31A8.005 8.005 0 0 1 12 22 8 8 0 0 1 4 14c0-1.466.394-2.84 1.082-4.022 1.485-.013 2.85-.78 3.654-2.066a4.484 4.484 0 0 0 .197-4.452A7.97 7.97 0 0 1 12 2Z" />
+      </svg>
+    ),
+  },
+};
+
+const themeClasses: Record<AppStoreBadgeTheme, string> = {
+  dark: 'bg-utility-gray-900 text-white ring-1 ring-inset ring-utility-gray-900 hover:bg-utility-gray-800',
+  light:
+    'bg-white text-utility-gray-900 ring-1 ring-inset ring-utility-gray-900 hover:bg-utility-gray-50',
+};
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+const baseClass =
+  'inline-flex h-12 items-center gap-2 rounded-lg px-3 outline-focus-ring transition focus-visible:outline-2 focus-visible:outline-offset-2';
+
+/**
+ * Glaon AppStoreBadge — stylised app-store download badge. Renders
+ * as an `<a>` (when `href`) or `<button>` (when `onPress`) or
+ * presentational `<span>` (when neither is set, e.g. catalogue
+ * preview).
+ */
+export function AppStoreBadge({
+  store,
+  theme = 'dark',
+  href,
+  onPress,
+  className,
+}: AppStoreBadgeProps) {
+  const tokens = storeTokens[store];
+  const rootClass = joinClasses(baseClass, themeClasses[theme], className);
+  const accessibleLabel = `${tokens.topLine} ${tokens.bottomLine}`;
+
+  const inner = (
+    <>
+      <span className="size-7 shrink-0">{tokens.glyph}</span>
+      <span className="flex flex-col leading-tight">
+        <span className="text-[10px] font-medium uppercase tracking-wide opacity-80">
+          {tokens.topLine}
+        </span>
+        <span className="text-base font-semibold">{tokens.bottomLine}</span>
+      </span>
+    </>
+  );
+
+  if (href !== undefined) {
+    return (
+      <a href={href} aria-label={accessibleLabel} className={rootClass}>
+        {inner}
+      </a>
+    );
+  }
+
+  if (onPress !== undefined) {
+    return (
+      <button type="button" onClick={onPress} aria-label={accessibleLabel} className={rootClass}>
+        {inner}
+      </button>
+    );
+  }
+
+  return (
+    <span aria-label={accessibleLabel} className={rootClass}>
+      {inner}
+    </span>
+  );
+}

--- a/packages/ui/src/components/AppStoreBadge/index.ts
+++ b/packages/ui/src/components/AppStoreBadge/index.ts
@@ -1,0 +1,2 @@
+export { AppStoreBadge } from './AppStoreBadge';
+export type { AppStore, AppStoreBadgeProps, AppStoreBadgeTheme } from './AppStoreBadge';

--- a/packages/ui/src/components/Button/Button.controls.ts
+++ b/packages/ui/src/components/Button/Button.controls.ts
@@ -1,0 +1,129 @@
+// `Button.controls.ts` — single source of truth for Button's variant
+// matrix. Story (`Button.stories.tsx`) imports the spec and spreads
+// it into `meta.args` / `meta.argTypes`; MDX docs (`Button.mdx`)
+// reads the same spec via `<Controls />`.
+//
+// #307: Button gets the Phase 1.5 controls + MDX treatment so the
+// controls panel surface matches Figma's `web-primitives-button`
+// `Hierarchy` × `Size` × `Theme` × `Icon only` × `State` axes.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+import { storybookIcons } from '../../icons/storybook';
+
+const sizeOptions = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+const colorOptions = [
+  'primary',
+  'secondary',
+  'tertiary',
+  'primary-destructive',
+  'secondary-destructive',
+  'tertiary-destructive',
+  'link-color',
+  'link-gray',
+  'link-destructive',
+] as const;
+
+export const buttonControls = {
+  children: {
+    type: 'text',
+    default: 'Click me',
+    description:
+      'Button label. Leave empty (with `iconLeading` set) to render an icon-only button — the kit auto-detects this via the `data-icon-only` attribute and switches to square padding. Always pair an icon-only button with a meaningful `aria-label`.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'sm',
+    description:
+      'Visual scale. `xs` for dense table-row actions, `sm` (default) for forms, `md` for primary CTAs, `lg` / `xl` for hero / marketing buttons.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  color: {
+    type: 'select',
+    options: colorOptions,
+    default: 'primary',
+    description:
+      "Hierarchy + theme combined. `primary` / `secondary` / `tertiary` are the three visual weights; suffix `-destructive` swaps the palette to error tokens; `link-color` / `link-gray` / `link-destructive` strip the surface chrome and render inline-link styling. Mirrors Figma's `Hierarchy` × `Theme` matrix.",
+    category: 'Style',
+  } satisfies ControlSpec<(typeof colorOptions)[number]>,
+  iconLeading: {
+    type: 'select',
+    options: Object.keys(storybookIcons),
+    mapping: storybookIcons,
+    description:
+      'Leading icon component. Pass alone (no `children`) to render an icon-only button — the kit applies square padding via `data-icon-only`. Pair an icon-only button with `aria-label`.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  iconTrailing: {
+    type: 'select',
+    options: Object.keys(storybookIcons),
+    mapping: storybookIcons,
+    description:
+      "Trailing icon component (chevron-right, arrow-right, etc.). Common for 'Continue →' / 'Next' style CTAs.",
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Block interaction and dim the button. Forwarded as `disabled` to the underlying RAC `<Button>` so axe and screen readers treat it as inert.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isLoading: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Show a spinner inside the button. The label is hidden by default (replaced by the spinner); set `showTextWhileLoading` to keep both visible. While loading the button blocks pointer events automatically.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  showTextWhileLoading: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Keep the label visible alongside the spinner during `isLoading`. Useful when the action is long-running and the user needs context ("Saving…").',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  noTextPadding: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Strip horizontal text padding. Auto-applied for `link-*` colors (link variants are inline links, not chrome-bound buttons). Rarely useful otherwise.',
+    category: 'Style',
+  } satisfies ControlSpec<boolean>,
+  href: {
+    type: 'text',
+    description:
+      'Link destination. When set, the kit renders the button as an `<a>` (RAC `<Link>`) instead of a `<button>` element. Use for navigational CTAs that should be shareable / right-clickable.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  type: {
+    type: 'inline-radio',
+    options: ['button', 'submit', 'reset'] as const,
+    description:
+      'Native `<button type>` attribute. Defaults to `button` (no implicit form submission); set `submit` for the primary form button, `reset` for form-reset affordances. Ignored when `href` is set.',
+    category: 'Behavior',
+  } satisfies ControlSpec<'button' | 'submit' | 'reset'>,
+  onClick: {
+    type: false,
+    action: 'clicked',
+    description: 'Click handler. Fires on click + keyboard activation (Space / Enter).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer `<button>` / `<a>` element.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// Props on the kit Button that flow through type-checking but have
+// no useful Storybook control surface.
+export const buttonExcludeFromArgs = defineExcludeFromArgs([
+  // react-aria-components slot binding; only meaningful in `slots`-aware
+  // composites, not as a Storybook knob.
+  'slot',
+  // Forwarded only when the link variant (`href`) is used; not a knob.
+  'routerOptions',
+] as const);

--- a/packages/ui/src/components/Button/Button.mdx
+++ b/packages/ui/src/components/Button/Button.mdx
@@ -1,0 +1,102 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as ButtonStories from './Button.stories';
+
+<Meta of={ButtonStories} />
+
+# Button
+
+Primary action affordance. The kit ships nine `color` variants
+(three hierarchies × destructive variants × link variants) and five
+sizes; the Glaon `<Button>` is a thin wrap exposing them verbatim
+plus shared semantics (loading state, icon-leading / icon-trailing,
+icon-only auto-detection, link-as-anchor via `href`).
+
+Maps Figma's `web-primitives-button` axes:
+
+- `Hierarchy`: `Primary` / `Secondary` / `Tertiary` / `Link` / `Link color` / `Link gray` (`color` prop)
+- `Size`: `xs` / `sm` / `md` / `lg` / `xl`
+- `Theme`: `Brand` / `Color` / `Gray` (link-color = brand tone, link-gray = neutral tone)
+- `Icon only`: auto when `iconLeading` is set without `children`
+- `State`: `Default` / `Hover` / `Focused` / `Loading` / `Disabled` (CSS pseudo + `isLoading` / `isDisabled` props)
+
+## When to use
+
+- Primary CTA in a form / dialog / page hero (`color='primary'`).
+- Secondary actions (`color='secondary'` or `'tertiary'`).
+- Destructive confirmations (`-destructive` suffix; pair with a
+  confirmation Modal for irreversible actions).
+- Inline link-style triggers (`color='link-color'` / `'link-gray'` /
+  `'link-destructive'`).
+- Icon-only utility buttons (toolbar actions, table-row controls;
+  always with `aria-label`).
+- Navigation as a button (`href` prop renders `<a>`; matches
+  shareable / right-clickable expectations).
+
+## When NOT to use
+
+- **Inline status / metadata** → use [Badge](?path=/docs/web-primitives-badge--docs).
+- **Compact dismissal X** → use the `IconOnly` story pattern with `aria-label="Dismiss"`, or a kit `<CloseButton>` directly.
+- **Social-provider sign-in CTA** → use [SocialButton](?path=/docs/web-primitives-socialbutton--docs).
+- **App store badge link** → use [AppStoreBadge](?path=/docs/web-primitives-appstorebadge--docs).
+- **Whole-row click target** → use [Card](?path=/docs/web-primitives-card--docs) `interactive` prop or a [List](?path=/docs/web-primitives-list--docs) row with `onClick`.
+
+## Anatomy
+
+<Canvas of={ButtonStories.Default} />
+
+```tsx
+<Button color="primary" size="md" iconLeading={Plus}>
+  Add item
+</Button>
+
+// Icon-only — square padding, always pair with aria-label
+<Button iconLeading={Settings} aria-label="Settings" />
+
+// Link-as-anchor
+<Button color="primary" href="/dashboard">Open dashboard</Button>
+```
+
+The kit auto-detects icon-only state via the `data-icon-only`
+attribute when `iconLeading` is set AND `children` is empty.
+Padding switches from rectangular to square automatically; you don't
+need a separate `iconOnly` prop.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The kit renders a real react-aria-components `<Button>` (or
+  `<Link>` when `href` is set); keyboard activation (Space + Enter
+  for buttons, Enter for links), focus ring, and disabled semantics
+  come for free.
+- **Icon-only buttons MUST pass `aria-label`.** Without it, axe
+  `button-name` flags an unlabelled button. The visible label is
+  the icon glyph, which is not a text node screen readers announce.
+- `isLoading` hides the label visually by default — pair with
+  `aria-label` (matching the original label) so screen readers
+  still announce the button's purpose during the loading state. Use
+  `showTextWhileLoading` when the action is long-running and the
+  user needs continuous context.
+- `isDisabled` forwards `disabled` to the underlying element so
+  assistive tech treats it as inert (no focusable, no announceable
+  state change).
+- `link-*` colors render visible underlines on hover via the kit's
+  `*:data-text:underline` selector — colour alone never conveys
+  link-ness.
+- For destructive actions (`-destructive` colors) pair the button
+  with a confirmation Modal — destructive intent is part of the
+  signal, not the only safeguard.
+
+## Related components
+
+- [SocialButton](?path=/docs/web-primitives-socialbutton--docs) — social-provider sign-in CTAs (Apple / Google / Facebook / etc.).
+- [AppStoreBadge](?path=/docs/web-primitives-appstorebadge--docs) — official App Store / Google Play / Galaxy Store / AppGallery badges.
+- [PressableButton](?path=/docs/web-primitives-pressablebutton--docs) — React Native counterpart with the same `color` / `size` API.
+- [Card](?path=/docs/web-primitives-card--docs) — for whole-row click targets (use `interactive` prop).

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -1,80 +1,42 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
+import { defineControls } from '../_internal/controls';
 import { storybookIcons } from '../../icons/storybook';
 import { Button } from './Button';
+import { buttonControls, buttonExcludeFromArgs } from './Button.controls';
 
-const meta = {
+const { args, argTypes } = defineControls(buttonControls);
+
+// Explicit `Meta<typeof Button>` annotation (rather than `satisfies`)
+// keeps the kit's unexported `ButtonProps` interface out of the
+// exported `meta` signature — `tsc --noEmit` runs with
+// `declaration: true`.
+//
+// #307: Phase 1.5 conversion — `args` + `argTypes` come from
+// `Button.controls.ts`; `tags: ['autodocs']` removed because
+// `Button.mdx` replaces the docs tab.
+const meta: Meta<typeof Button> = {
   title: 'Web Primitives/Button',
   component: Button,
-  tags: ['autodocs'],
   parameters: {
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-button',
     },
   },
-  args: {
-    children: 'Click me',
-    size: 'sm',
-    color: 'primary',
-    isDisabled: false,
-    isLoading: false,
-    showTextWhileLoading: false,
-    noTextPadding: false,
-  },
-  argTypes: {
-    size: { control: 'inline-radio', options: ['xs', 'sm', 'md', 'lg', 'xl'] },
-    color: {
-      control: 'select',
-      options: [
-        'primary',
-        'secondary',
-        'tertiary',
-        'primary-destructive',
-        'secondary-destructive',
-        'tertiary-destructive',
-        'link-color',
-        'link-gray',
-        'link-destructive',
-      ],
-    },
-    isDisabled: { control: 'boolean' },
-    isLoading: { control: 'boolean' },
-    showTextWhileLoading: { control: 'boolean' },
-    noTextPadding: { control: 'boolean' },
-    iconLeading: {
-      control: 'select',
-      options: Object.keys(storybookIcons),
-      mapping: storybookIcons,
-    },
-    iconTrailing: {
-      control: 'select',
-      options: Object.keys(storybookIcons),
-      mapping: storybookIcons,
-    },
-    onClick: { action: 'clicked' },
-  },
-} satisfies Meta<typeof Button>;
+  args,
+  argTypes,
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof Button>;
 
-// Props on the kit Button that are reachable through type-checking but
-// have no useful Storybook control surface. The F6 prop-coverage gate
-// (`src/__tests__/prop-coverage.test.ts`) reads this list to satisfy
-// the "every prop covered" rule without polluting the controls panel.
-export const excludeFromArgs = [
-  // react-aria-components slot binding; only meaningful in `slots`-aware
-  // composites, not as a Storybook knob.
-  'slot',
-  // Forwarded only when the link variant (`href`) is used; not a knob.
-  'routerOptions',
-];
+export const excludeFromArgs = buttonExcludeFromArgs;
+
+export const Default: Story = {};
 
 export const Primary: Story = {
-  args: {
-    color: 'tertiary',
-  },
+  args: { color: 'primary' },
 };
 
 export const Secondary: Story = {
@@ -93,8 +55,20 @@ export const SecondaryDestructive: Story = {
   args: { color: 'secondary-destructive', children: 'Delete' },
 };
 
+export const TertiaryDestructive: Story = {
+  args: { color: 'tertiary-destructive', children: 'Delete' },
+};
+
 export const LinkColor: Story = {
   args: { color: 'link-color', children: 'Read more' },
+};
+
+export const LinkGray: Story = {
+  args: { color: 'link-gray', children: 'Read more' },
+};
+
+export const LinkDestructive: Story = {
+  args: { color: 'link-destructive', children: 'Remove' },
 };
 
 export const Disabled: Story = {
@@ -122,6 +96,18 @@ export const WithLeadingIcon: Story = {
 
 export const WithTrailingIcon: Story = {
   args: { iconTrailing: storybookIcons.arrowRight, children: 'Continue' },
+};
+
+// Icon-only button: kit auto-detects this when `iconLeading` is set
+// AND `children` is empty/undefined — applies square padding via
+// `data-icon-only`. Always pair with `aria-label` so axe `button-name`
+// passes (the visible label is the icon, not text).
+export const IconOnly: Story = {
+  args: {
+    children: undefined,
+    iconLeading: storybookIcons.settings,
+    'aria-label': 'Settings',
+  },
 };
 
 // Matrix stories iterate over a single prop and render every variant

--- a/packages/ui/src/components/SocialButton/SocialButton.controls.ts
+++ b/packages/ui/src/components/SocialButton/SocialButton.controls.ts
@@ -1,0 +1,83 @@
+// `SocialButton.controls.ts` — single source of truth for
+// SocialButton's variant matrix. Story (`SocialButton.stories.tsx`)
+// imports the spec and spreads it into `meta.args` /
+// `meta.argTypes`; MDX docs reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const brandOptions = ['apple', 'dribbble', 'facebook', 'figma', 'google', 'twitter'] as const;
+const styleOptions = ['brand', 'black-outline', 'white-outline', 'icon-only'] as const;
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+
+export const socialButtonControls = {
+  brand: {
+    type: 'select',
+    options: brandOptions,
+    default: 'google',
+    description:
+      "Which social provider this button signs the user in with. Drives the brand glyph + canonical brand colour. Mirrors Figma's `Social` axis 1:1 (6 providers).",
+    category: 'Content',
+  } satisfies ControlSpec<(typeof brandOptions)[number]>,
+  style: {
+    type: 'inline-radio',
+    options: styleOptions,
+    default: 'brand',
+    description:
+      "Visual treatment. `brand` fills with the provider's brand colour (Google blue / Apple black / Facebook navy / etc.); `black-outline` is a white surface with a black border (light page bg); `white-outline` is dark with white border (dark page bg); `icon-only` strips the label and renders a square icon button. Mirrors Figma's `Style` axis.",
+    category: 'Style',
+  } satisfies ControlSpec<(typeof styleOptions)[number]>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale. `sm` (h-9) for forms, `md` (h-10, default) for sign-in cards, `lg` (h-11) for hero CTAs.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  supportingText: {
+    type: 'boolean',
+    default: true,
+    description:
+      "Whether to render `Continue with {brand}` (default) or just `{brand}` next to the glyph. Ignored for `style='icon-only'` (no label rendered at all). Mirrors Figma's `Supporting text` axis.",
+    category: 'Content',
+  } satisfies ControlSpec<boolean>,
+  children: {
+    type: 'text',
+    description:
+      "Override the rendered label entirely (e.g. localised `Apple ile devam et`). Ignored for `style='icon-only'`.",
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Disable the button. Forwarded as `disabled` so axe and screen readers treat it as inert.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  href: {
+    type: 'text',
+    description:
+      'Link destination (typically the OAuth redirect URL). When set, renders as an `<a>` element instead of a `<button>`. Mutually exclusive with `onPress`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onPress: {
+    type: false,
+    action: 'pressed',
+    description: 'Click handler for the `<button>` variant. Fires on click + keyboard activation.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer button.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  'aria-label': {
+    type: 'text',
+    description:
+      "Accessible label override. **Required** for `style='icon-only'` so screen readers can announce the provider name (the icon glyph isn't a text node). For other styles the visible label provides the accessible name automatically.",
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const socialButtonExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/SocialButton/SocialButton.mdx
+++ b/packages/ui/src/components/SocialButton/SocialButton.mdx
@@ -1,0 +1,93 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as SocialButtonStories from './SocialButton.stories';
+
+<Meta of={SocialButtonStories} />
+
+# SocialButton
+
+Social-provider sign-in CTA. Use SocialButton inside a sign-in /
+sign-up flow when offering OAuth login through a third-party
+provider. Distinct from the regular [Button](?path=/docs/web-primitives-button--docs)
+because the visual treatment carries the provider's brand and the
+glyph is drawn from the provider's logo.
+
+## When to use
+
+- Sign-in / sign-up forms with OAuth providers (Google, Apple,
+  Facebook, etc.).
+- Account settings: "Connect your Google account" / "Link Twitter".
+- Header sign-in shortcut on marketing pages
+  (`style='icon-only'` row).
+
+## When NOT to use
+
+- **Generic primary CTA** (Save, Continue, Submit) → use [Button](?path=/docs/web-primitives-button--docs).
+- **App store badge** (download on App Store / get on Google Play) → use [AppStoreBadge](?path=/docs/web-primitives-appstorebadge--docs).
+- **Sharing / social-action buttons** (Tweet this, Share on Facebook) → out of scope; use a custom Button with the brand glyph instead.
+
+## Anatomy
+
+<Canvas of={SocialButtonStories.Default} />
+
+A SocialButton has three slots:
+
+- **Brand glyph** — inline SVG matching the `brand` prop (Apple,
+  Dribbble, Facebook, Figma, Google, Twitter / X).
+- **Label** — `Continue with {brand}` by default, or just
+  `{brand}` when `supportingText={false}`. Hidden for
+  `style='icon-only'`.
+- The outer surface uses the provider's brand colour for
+  `style='brand'`, a black-bordered white surface for
+  `'black-outline'`, a white-bordered transparent surface for
+  `'white-outline'`, or a square chip for `'icon-only'`.
+
+```tsx
+<SocialButton brand="google" onPress={signInWithGoogle} />
+
+<SocialButton brand="apple" style="black-outline" supportingText={false}>
+  Apple ile devam et
+</SocialButton>
+
+<SocialButton
+  brand="facebook"
+  style="icon-only"
+  aria-label="Sign in with Facebook"
+  onPress={signInWithFacebook}
+/>
+
+<SocialButton brand="twitter" href={oauthRedirectUrl} />
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The brand glyph is `aria-hidden` — the visible text label is the
+  accessible name (axe `button-name`).
+- For `style='icon-only'`, the label is hidden visually so the
+  visible content is just the glyph. Always pair with `aria-label`
+  (or rely on the auto-derived `Sign in with {brand}` fallback that
+  the wrap forwards). Without one of these, axe flags the icon-only
+  button.
+- For `href` (anchor variant), the same `aria-label` rule applies —
+  link text alone (when icon-only) isn't enough.
+- Brand glyphs use `viewBox="0 0 24 24"` and inherit `currentColor`
+  for monochromatic brands (Apple / Twitter / Facebook); Figma /
+  Google / Dribbble use multicolour SVGs that don't change with
+  theme.
+- For destructive providers (none today; placeholder for `Account
+remove` flows) prefer a confirmation Modal — disconnecting an
+  OAuth provider can lock users out.
+
+## Related components
+
+- [Button](?path=/docs/web-primitives-button--docs) — generic action button (no provider branding).
+- [AppStoreBadge](?path=/docs/web-primitives-appstorebadge--docs) — official store-download badges (App Store / Google Play / etc.).
+- [Avatar](?path=/docs/web-primitives-avatar--docs) — show the connected provider icon next to the user (e.g. "Signed in with Google").

--- a/packages/ui/src/components/SocialButton/SocialButton.stories.tsx
+++ b/packages/ui/src/components/SocialButton/SocialButton.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { SocialButton, type SocialBrand, type SocialStyle } from './SocialButton';
+import { socialButtonControls, socialButtonExcludeFromArgs } from './SocialButton.controls';
+
+const { args, argTypes } = defineControls(socialButtonControls);
+
+// Explicit `Meta<typeof SocialButton>` annotation (rather than
+// `satisfies`) keeps the unexported `SocialButtonProps` interface
+// out of the exported `meta` signature — `tsc --noEmit` runs with
+// `declaration: true` and TS4023 fires when an exported `meta`
+// resolves to a non-exported nominal type.
+const meta: Meta<typeof SocialButton> = {
+  title: 'Web Primitives/SocialButton',
+  component: SocialButton,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-social-button',
+    },
+  },
+  args,
+  argTypes,
+};
+
+export default meta;
+type Story = StoryObj<typeof SocialButton>;
+
+export const excludeFromArgs = socialButtonExcludeFromArgs;
+
+export const Default: Story = {};
+
+export const Apple: Story = {
+  args: { brand: 'apple' },
+};
+
+export const Facebook: Story = {
+  args: { brand: 'facebook' },
+};
+
+export const Twitter: Story = {
+  args: { brand: 'twitter' },
+};
+
+export const Figma: Story = {
+  args: { brand: 'figma', style: 'black-outline' },
+};
+
+export const Dribbble: Story = {
+  args: { brand: 'dribbble' },
+};
+
+export const NoSupportingText: Story = {
+  args: { brand: 'google', supportingText: false },
+};
+
+export const BlackOutline: Story = {
+  args: { brand: 'apple', style: 'black-outline' },
+};
+
+export const WhiteOutline: Story = {
+  args: { brand: 'apple', style: 'white-outline' },
+};
+
+export const IconOnly: Story = {
+  args: { brand: 'google', style: 'icon-only' },
+  decorators: [
+    (Story) => (
+      <div className="flex h-20 items-center bg-secondary p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const AsLink: Story = {
+  args: { brand: 'google', href: '#' },
+};
+
+const BRANDS: SocialBrand[] = ['apple', 'dribbble', 'facebook', 'figma', 'google', 'twitter'];
+
+// Matrix story: iterates `brand` and renders all 6 providers in a
+// single canvas. Other props still flow through `{...args}`.
+export const Brands: Story = {
+  parameters: { controls: { exclude: ['brand'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {BRANDS.map((brand) => (
+        <SocialButton key={brand} {...args} brand={brand} />
+      ))}
+    </div>
+  ),
+};
+
+const STYLES: SocialStyle[] = ['brand', 'black-outline', 'white-outline', 'icon-only'];
+
+// Matrix story: iterates `style` for the same brand. The
+// `white-outline` variant is rendered on a dark surface so it's
+// visible.
+export const Styles: Story = {
+  parameters: { controls: { exclude: ['style'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      {STYLES.map((style) => (
+        <div
+          key={style}
+          className={
+            style === 'white-outline'
+              ? 'flex items-center gap-3 bg-utility-gray-900 p-3'
+              : 'flex items-center gap-3'
+          }
+        >
+          <span
+            className={
+              style === 'white-outline'
+                ? 'min-w-32 text-xs text-white'
+                : 'min-w-32 text-xs text-tertiary'
+            }
+          >
+            style: {style}
+          </span>
+          <SocialButton {...args} style={style} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+// Matrix story: iterates `size` (sm / md / lg).
+export const Sizes: Story = {
+  parameters: { controls: { exclude: ['size'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+      {(['sm', 'md', 'lg'] as const).map((size) => (
+        <SocialButton key={size} {...args} size={size} />
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/SocialButton/SocialButton.stories.tsx
+++ b/packages/ui/src/components/SocialButton/SocialButton.stories.tsx
@@ -107,7 +107,7 @@ export const Styles: Story = {
           key={style}
           className={
             style === 'white-outline'
-              ? 'flex items-center gap-3 bg-utility-gray-900 p-3'
+              ? 'flex items-center gap-3 bg-utility-neutral-900 p-3'
               : 'flex items-center gap-3'
           }
         >

--- a/packages/ui/src/components/SocialButton/SocialButton.tsx
+++ b/packages/ui/src/components/SocialButton/SocialButton.tsx
@@ -128,18 +128,32 @@ const brandTokens: Record<SocialBrand, BrandTokens> = {
   },
   google: {
     label: 'Google',
-    // Google's brand colour family is blue (~#4285F4 ≈ utility-blue-
-    // 500), but white text on blue-500 only hits 3.76:1 contrast —
-    // below WCAG AA's 4.5:1 small-text threshold. Drop to blue-700
-    // so axe `color-contrast` stays green; the logo + label
-    // ("Continue with Google") disambiguate from Facebook visually.
-    // (Google's own "Sign-In" guidelines spec a white bg with the
-    // multicolour G mark; consumers who need that exact pattern can
-    // pass `style='black-outline'` for the light-surface variant.)
-    brandClass: 'bg-utility-blue-700 text-white hover:bg-utility-blue-800',
+    // Google's official Sign-In spec mandates a white surface with the
+    // multicolour G mark — collapsing it to a single-colour G on a
+    // brand-blue surface stripped the recognisable identity. White bg
+    // + multicolour G is the canonical pattern; `text-secondary`
+    // (dark text) + ring keep the button visible on light page bg's.
+    // For dark page bg's, callers should swap to `style='white-
+    // outline'`.
+    brandClass: 'bg-primary text-secondary ring-1 ring-inset ring-primary hover:bg-primary_hover',
     glyph: (
-      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-        <path d="M12.545 12.151V9.6h8.728c.109.522.182 1.002.182 1.673 0 4.873-3.275 8.327-8.91 8.327A9.636 9.636 0 0 1 2.91 9.964 9.636 9.636 0 0 1 12.545.327c2.691 0 4.946.964 6.728 2.6l-2.582 2.582c-.764-.728-2.073-1.51-4.146-1.51-3.546 0-6.437 2.945-6.437 6.964s2.891 6.964 6.437 6.964c4.109 0 5.65-2.945 5.891-4.473h-5.891v-1.303Z" />
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09Z"
+          fill="#4285F4"
+        />
+        <path
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A10.99 10.99 0 0 0 12 23Z"
+          fill="#34A853"
+        />
+        <path
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.99 10.99 0 0 0 1 12c0 1.79.43 3.48 1.18 4.93l3.66-2.84Z"
+          fill="#FBBC05"
+        />
+        <path
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1A10.99 10.99 0 0 0 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53Z"
+          fill="#EA4335"
+        />
       </svg>
     ),
   },

--- a/packages/ui/src/components/SocialButton/SocialButton.tsx
+++ b/packages/ui/src/components/SocialButton/SocialButton.tsx
@@ -88,7 +88,7 @@ interface BrandTokens {
 const brandTokens: Record<SocialBrand, BrandTokens> = {
   apple: {
     label: 'Apple',
-    brandClass: 'bg-utility-gray-900 text-white hover:bg-utility-gray-800',
+    brandClass: 'bg-utility-neutral-900 text-white hover:bg-utility-neutral-800',
     glyph: (
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M17.535 12.625c.024-2.612 2.13-3.873 2.226-3.93-1.213-1.77-3.099-2.013-3.766-2.038-1.601-.162-3.124.943-3.937.943-.812 0-2.062-.92-3.388-.895-1.745.025-3.354 1.013-4.252 2.572-1.812 3.143-.464 7.793 1.301 10.34.86 1.247 1.886 2.652 3.232 2.602 1.296-.052 1.787-.84 3.354-.84 1.567 0 2.011.84 3.39.812 1.396-.025 2.282-1.275 3.137-2.526.985-1.451 1.392-2.85 1.417-2.924-.031-.014-2.722-1.046-2.748-4.116Zm-2.594-7.55c.715-.866 1.197-2.069 1.066-3.27-1.029.041-2.275.685-3.013 1.55-.661.766-1.241 1.989-1.084 3.166 1.151.089 2.315-.585 3.031-1.446Z" />
@@ -115,7 +115,7 @@ const brandTokens: Record<SocialBrand, BrandTokens> = {
   },
   figma: {
     label: 'Figma',
-    brandClass: 'bg-utility-gray-900 text-white hover:bg-utility-gray-800',
+    brandClass: 'bg-utility-neutral-900 text-white hover:bg-utility-neutral-800',
     glyph: (
       <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
         <path d="M8 24c2.208 0 4-1.792 4-4v-4H8c-2.208 0-4 1.792-4 4s1.792 4 4 4Z" fill="#0ACF83" />
@@ -144,7 +144,7 @@ const brandTokens: Record<SocialBrand, BrandTokens> = {
   },
   twitter: {
     label: 'Twitter',
-    brandClass: 'bg-utility-gray-900 text-white hover:bg-utility-gray-800',
+    brandClass: 'bg-utility-neutral-900 text-white hover:bg-utility-neutral-800',
     glyph: (
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z" />
@@ -179,10 +179,10 @@ const sizeStyles: Record<
 
 const styleClasses: Record<Exclude<SocialStyle, 'brand'>, string> = {
   'black-outline':
-    'bg-primary text-utility-gray-900 ring-1 ring-inset ring-utility-gray-300 hover:bg-utility-gray-50',
+    'bg-primary text-utility-neutral-900 ring-1 ring-inset ring-utility-neutral-300 hover:bg-utility-neutral-50',
   'white-outline': 'bg-transparent text-white ring-1 ring-inset ring-white/30 hover:bg-white/10',
   'icon-only':
-    'bg-primary text-utility-gray-900 ring-1 ring-inset ring-utility-gray-300 hover:bg-utility-gray-50',
+    'bg-primary text-utility-neutral-900 ring-1 ring-inset ring-utility-neutral-300 hover:bg-utility-neutral-50',
 };
 
 function joinClasses(...parts: (string | undefined | false)[]): string {

--- a/packages/ui/src/components/SocialButton/SocialButton.tsx
+++ b/packages/ui/src/components/SocialButton/SocialButton.tsx
@@ -128,14 +128,15 @@ const brandTokens: Record<SocialBrand, BrandTokens> = {
   },
   google: {
     label: 'Google',
-    // Google's primary brand colour (#4285F4 ≈ utility-blue-500). Using
-    // the brand bg matches the visual treatment of Apple / Facebook /
-    // Dribbble / Twitter / Figma — all 6 brand-styled buttons surface
-    // the provider's colour. (Google's own "Sign-In" guidelines spec a
-    // white bg with the multicolour G mark; consumers who need that
-    // exact pattern can pass `style='black-outline'` for the
-    // light-surface variant.)
-    brandClass: 'bg-utility-blue-500 text-white hover:bg-utility-blue-600',
+    // Google's brand colour family is blue (~#4285F4 ≈ utility-blue-
+    // 500), but white text on blue-500 only hits 3.76:1 contrast —
+    // below WCAG AA's 4.5:1 small-text threshold. Drop to blue-700
+    // so axe `color-contrast` stays green; the logo + label
+    // ("Continue with Google") disambiguate from Facebook visually.
+    // (Google's own "Sign-In" guidelines spec a white bg with the
+    // multicolour G mark; consumers who need that exact pattern can
+    // pass `style='black-outline'` for the light-surface variant.)
+    brandClass: 'bg-utility-blue-700 text-white hover:bg-utility-blue-800',
     glyph: (
       <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M12.545 12.151V9.6h8.728c.109.522.182 1.002.182 1.673 0 4.873-3.275 8.327-8.91 8.327A9.636 9.636 0 0 1 2.91 9.964 9.636 9.636 0 0 1 12.545.327c2.691 0 4.946.964 6.728 2.6l-2.582 2.582c-.764-.728-2.073-1.51-4.146-1.51-3.546 0-6.437 2.945-6.437 6.964s2.891 6.964 6.437 6.964c4.109 0 5.65-2.945 5.891-4.473h-5.891v-1.303Z" />

--- a/packages/ui/src/components/SocialButton/SocialButton.tsx
+++ b/packages/ui/src/components/SocialButton/SocialButton.tsx
@@ -1,0 +1,267 @@
+// Glaon SocialButton — social-provider sign-in CTA. UUI's kit doesn't
+// ship a SocialButton primitive (and `@untitledui/icons` doesn't
+// expose all the brand glyphs we need — only Figma + GoogleChrome are
+// in the package). Per the UUI Source Rule's "no kit source"
+// exception, Glaon hand-rolls the component using kit surface
+// vocabulary as canonical reference (`bg-primary` + `ring-primary` +
+// `rounded-lg` + the kit Button's size scale) and parameterises the
+// brand + style + label.
+//
+// Maps Figma's `web-primitives-social-button` axes 1:1:
+//   - `Social`:         apple / dribbble / facebook / figma / google / twitter (6)
+//   - `Style`:          brand / black-outline / white-outline / icon-only (4)
+//   - `Supporting text`: "Continue with X" vs "X" (boolean)
+//   - `Size`:           sm / md / lg
+//
+// Brand SVG glyphs are inlined here — `@untitledui/icons` doesn't
+// ship most of them, and importing per-brand asset packages would
+// pull in too much dependency surface.
+//
+// Usage:
+//
+//   <SocialButton brand="google" onPress={signInWithGoogle} />
+//   <SocialButton brand="apple" style="black-outline" supportingText={false} />
+//   <SocialButton brand="facebook" style="icon-only" aria-label="Sign in with Facebook" />
+
+import type { MouseEventHandler, ReactNode } from 'react';
+
+export type SocialBrand = 'apple' | 'dribbble' | 'facebook' | 'figma' | 'google' | 'twitter';
+export type SocialStyle = 'brand' | 'black-outline' | 'white-outline' | 'icon-only';
+export type SocialSize = 'sm' | 'md' | 'lg';
+
+export interface SocialButtonProps {
+  /** Which provider this button signs the user in with. */
+  brand: SocialBrand;
+  /**
+   * Visual treatment.
+   * - `brand`: filled with the provider's brand colour (Google blue / Facebook navy / etc.).
+   * - `black-outline`: white surface with black border (light page bg).
+   * - `white-outline`: dark surface with white border (dark page bg).
+   * - `icon-only`: square button with just the provider glyph.
+   * @default 'brand'
+   */
+  style?: SocialStyle | undefined;
+  /** Visual scale. @default 'md' */
+  size?: SocialSize | undefined;
+  /**
+   * Whether to render `Continue with {brand}` (default) or just
+   * `{brand}` next to the glyph. Ignored for `style='icon-only'`
+   * (no label rendered at all).
+   * @default true
+   */
+  supportingText?: boolean | undefined;
+  /**
+   * Override the rendered label entirely (e.g. localised
+   * `Apple ile devam et`). Ignored for `style='icon-only'`.
+   */
+  children?: ReactNode | undefined;
+  /** Disable the button. */
+  isDisabled?: boolean | undefined;
+  /**
+   * Render the button as an `<a>` (OAuth redirect URL) instead of
+   * a `<button>` (programmatic click handler). Mutually exclusive
+   * with `onPress`.
+   */
+  href?: string | undefined;
+  /** Click handler for the `<button>` variant. */
+  onPress?: MouseEventHandler<HTMLButtonElement> | undefined;
+  /** Tailwind override hook. */
+  className?: string | undefined;
+  /**
+   * Accessible label override. Required for `style='icon-only'` so
+   * screen readers can announce the provider name (the icon glyph
+   * isn't a text node). For `style='brand' | 'outline'` the visible
+   * label provides the accessible name.
+   */
+  'aria-label'?: string | undefined;
+}
+
+interface BrandTokens {
+  label: string;
+  brandClass: string;
+  glyph: ReactNode;
+}
+
+// Inline brand SVGs — minimal viewBox 0 0 24 24 paths so the glyph
+// inherits `currentColor` from the surrounding button text colour
+// (white for `brand`, black for `black-outline`, etc.).
+const brandTokens: Record<SocialBrand, BrandTokens> = {
+  apple: {
+    label: 'Apple',
+    brandClass: 'bg-utility-gray-900 text-white hover:bg-utility-gray-800',
+    glyph: (
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M17.535 12.625c.024-2.612 2.13-3.873 2.226-3.93-1.213-1.77-3.099-2.013-3.766-2.038-1.601-.162-3.124.943-3.937.943-.812 0-2.062-.92-3.388-.895-1.745.025-3.354 1.013-4.252 2.572-1.812 3.143-.464 7.793 1.301 10.34.86 1.247 1.886 2.652 3.232 2.602 1.296-.052 1.787-.84 3.354-.84 1.567 0 2.011.84 3.39.812 1.396-.025 2.282-1.275 3.137-2.526.985-1.451 1.392-2.85 1.417-2.924-.031-.014-2.722-1.046-2.748-4.116Zm-2.594-7.55c.715-.866 1.197-2.069 1.066-3.27-1.029.041-2.275.685-3.013 1.55-.661.766-1.241 1.989-1.084 3.166 1.151.089 2.315-.585 3.031-1.446Z" />
+      </svg>
+    ),
+  },
+  dribbble: {
+    label: 'Dribbble',
+    brandClass: 'bg-utility-pink-600 text-white hover:bg-utility-pink-700',
+    glyph: (
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2Zm6.605 4.61a8.502 8.502 0 0 1 1.93 5.314c-.281-.054-3.101-.629-5.943-.271-.065-.139-.12-.286-.182-.429-.156-.371-.337-.748-.514-1.108 3.142-1.276 4.572-3.117 4.709-3.506ZM12 3.475c2.17 0 4.154.813 5.661 2.144-.115.165-1.41 1.888-4.45 3.024C11.815 6.099 10.13 3.971 9.873 3.65A8.51 8.51 0 0 1 12 3.475Zm-3.667.787a53.94 53.94 0 0 1 3.293 4.954c-3.985 1.061-7.51 1.039-7.871 1.039A8.532 8.532 0 0 1 8.333 4.262Zm-3.667 7.74c0-.121.005-.241.013-.36.355.008 4.526.062 8.78-1.213.247.476.475.964.685 1.453a16.6 16.6 0 0 0-.302.119c-4.401 1.42-6.751 5.327-6.945 5.658a8.487 8.487 0 0 1-2.231-5.657Zm7.339 7.246a16.46 16.46 0 0 0-2.36-.65 8.484 8.484 0 0 1-3.566-2.99c.151-.252 2.118-3.834 6.911-5.471l.054-.018c1.207 3.13 1.7 5.752 1.825 6.503-1.273.732-2.728 1.169-4.273 1.169-.402 0-.798-.041-1.18-.123Zm6.84-2.165c-.085-.503-.541-3.001-1.665-6.084 2.677-.428 5.022.265 5.314.359a8.484 8.484 0 0 1-3.65 5.725Z" />
+      </svg>
+    ),
+  },
+  facebook: {
+    label: 'Facebook',
+    brandClass: 'bg-utility-blue-700 text-white hover:bg-utility-blue-800',
+    glyph: (
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.875v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073Z" />
+      </svg>
+    ),
+  },
+  figma: {
+    label: 'Figma',
+    brandClass: 'bg-utility-gray-900 text-white hover:bg-utility-gray-800',
+    glyph: (
+      <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M8 24c2.208 0 4-1.792 4-4v-4H8c-2.208 0-4 1.792-4 4s1.792 4 4 4Z" fill="#0ACF83" />
+        <path d="M4 12c0-2.208 1.792-4 4-4h4v8H8c-2.208 0-4-1.792-4-4Z" fill="#A259FF" />
+        <path d="M4 4c0-2.208 1.792-4 4-4h4v8H8C5.792 8 4 6.208 4 4Z" fill="#F24E1E" />
+        <path d="M12 0h4c2.208 0 4 1.792 4 4s-1.792 4-4 4h-4V0Z" fill="#FF7262" />
+        <path d="M20 12c0 2.208-1.792 4-4 4s-4-1.792-4-4 1.792-4 4-4 4 1.792 4 4Z" fill="#1ABCFE" />
+      </svg>
+    ),
+  },
+  google: {
+    label: 'Google',
+    brandClass: 'bg-primary text-secondary ring-1 ring-inset ring-primary hover:bg-primary_hover',
+    glyph: (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09Z"
+          fill="#4285F4"
+        />
+        <path
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A10.99 10.99 0 0 0 12 23Z"
+          fill="#34A853"
+        />
+        <path
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.99 10.99 0 0 0 1 12c0 1.79.43 3.48 1.18 4.93l3.66-2.84Z"
+          fill="#FBBC05"
+        />
+        <path
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1A10.99 10.99 0 0 0 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53Z"
+          fill="#EA4335"
+        />
+      </svg>
+    ),
+  },
+  twitter: {
+    label: 'Twitter',
+    brandClass: 'bg-utility-gray-900 text-white hover:bg-utility-gray-800',
+    glyph: (
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z" />
+      </svg>
+    ),
+  },
+};
+
+const sizeStyles: Record<
+  SocialSize,
+  { root: string; iconOnlyRoot: string; glyph: string; label: string }
+> = {
+  sm: {
+    root: 'h-9 gap-2 rounded-md px-3.5 text-sm font-semibold',
+    iconOnlyRoot: 'h-9 w-9 rounded-md',
+    glyph: 'size-4',
+    label: 'text-sm font-semibold',
+  },
+  md: {
+    root: 'h-10 gap-2 rounded-md px-4 text-sm font-semibold',
+    iconOnlyRoot: 'h-10 w-10 rounded-md',
+    glyph: 'size-5',
+    label: 'text-sm font-semibold',
+  },
+  lg: {
+    root: 'h-11 gap-2.5 rounded-md px-5 text-md font-semibold',
+    iconOnlyRoot: 'h-11 w-11 rounded-md',
+    glyph: 'size-5',
+    label: 'text-md font-semibold',
+  },
+};
+
+const styleClasses: Record<Exclude<SocialStyle, 'brand'>, string> = {
+  'black-outline':
+    'bg-primary text-utility-gray-900 ring-1 ring-inset ring-utility-gray-300 hover:bg-utility-gray-50',
+  'white-outline': 'bg-transparent text-white ring-1 ring-inset ring-white/30 hover:bg-white/10',
+  'icon-only':
+    'bg-primary text-utility-gray-900 ring-1 ring-inset ring-utility-gray-300 hover:bg-utility-gray-50',
+};
+
+function joinClasses(...parts: (string | undefined | false)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+const baseClass =
+  'inline-flex items-center justify-center whitespace-nowrap outline-focus-ring transition focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
+
+/**
+ * Glaon SocialButton — social-provider sign-in CTA. Single
+ * parametric primitive dispatching to the right brand colour /
+ * label combination via the `brand` + `style` props.
+ */
+export function SocialButton({
+  brand,
+  style = 'brand',
+  size = 'md',
+  supportingText = true,
+  children,
+  isDisabled,
+  href,
+  onPress,
+  className,
+  'aria-label': ariaLabel,
+}: SocialButtonProps) {
+  const tokens = brandTokens[brand];
+  const sizeTokens = sizeStyles[size];
+  const isIconOnly = style === 'icon-only';
+
+  const styleClass = style === 'brand' ? tokens.brandClass : styleClasses[style];
+  const rootClass = joinClasses(
+    baseClass,
+    isIconOnly ? sizeTokens.iconOnlyRoot : sizeTokens.root,
+    styleClass,
+    className,
+  );
+
+  const label = isIconOnly ? null : (
+    <span className={sizeTokens.label}>
+      {children ?? (supportingText ? `Continue with ${tokens.label}` : tokens.label)}
+    </span>
+  );
+  const glyph = <span className={joinClasses(sizeTokens.glyph, 'shrink-0')}>{tokens.glyph}</span>;
+  const accessibleLabel = ariaLabel ?? (isIconOnly ? `Sign in with ${tokens.label}` : undefined);
+
+  if (href !== undefined) {
+    const anchorProps: { href?: string; 'aria-label'?: string } = { href };
+    if (accessibleLabel !== undefined) anchorProps['aria-label'] = accessibleLabel;
+    return (
+      <a {...anchorProps} className={rootClass}>
+        {glyph}
+        {label}
+      </a>
+    );
+  }
+
+  const buttonProps: {
+    type: 'button';
+    disabled?: boolean;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+    'aria-label'?: string;
+  } = { type: 'button' };
+  if (isDisabled === true) buttonProps.disabled = true;
+  if (onPress !== undefined) buttonProps.onClick = onPress;
+  if (accessibleLabel !== undefined) buttonProps['aria-label'] = accessibleLabel;
+
+  return (
+    <button {...buttonProps} className={rootClass}>
+      {glyph}
+      {label}
+    </button>
+  );
+}

--- a/packages/ui/src/components/SocialButton/SocialButton.tsx
+++ b/packages/ui/src/components/SocialButton/SocialButton.tsx
@@ -128,25 +128,17 @@ const brandTokens: Record<SocialBrand, BrandTokens> = {
   },
   google: {
     label: 'Google',
-    brandClass: 'bg-primary text-secondary ring-1 ring-inset ring-primary hover:bg-primary_hover',
+    // Google's primary brand colour (#4285F4 ≈ utility-blue-500). Using
+    // the brand bg matches the visual treatment of Apple / Facebook /
+    // Dribbble / Twitter / Figma — all 6 brand-styled buttons surface
+    // the provider's colour. (Google's own "Sign-In" guidelines spec a
+    // white bg with the multicolour G mark; consumers who need that
+    // exact pattern can pass `style='black-outline'` for the
+    // light-surface variant.)
+    brandClass: 'bg-utility-blue-500 text-white hover:bg-utility-blue-600',
     glyph: (
-      <svg viewBox="0 0 24 24" aria-hidden="true">
-        <path
-          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09Z"
-          fill="#4285F4"
-        />
-        <path
-          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A10.99 10.99 0 0 0 12 23Z"
-          fill="#34A853"
-        />
-        <path
-          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A10.99 10.99 0 0 0 1 12c0 1.79.43 3.48 1.18 4.93l3.66-2.84Z"
-          fill="#FBBC05"
-        />
-        <path
-          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1A10.99 10.99 0 0 0 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53Z"
-          fill="#EA4335"
-        />
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12.545 12.151V9.6h8.728c.109.522.182 1.002.182 1.673 0 4.873-3.275 8.327-8.91 8.327A9.636 9.636 0 0 1 2.91 9.964 9.636 9.636 0 0 1 12.545.327c2.691 0 4.946.964 6.728 2.6l-2.582 2.582c-.764-.728-2.073-1.51-4.146-1.51-3.546 0-6.437 2.945-6.437 6.964s2.891 6.964 6.437 6.964c4.109 0 5.65-2.945 5.891-4.473h-5.891v-1.303Z" />
       </svg>
     ),
   },

--- a/packages/ui/src/components/SocialButton/index.ts
+++ b/packages/ui/src/components/SocialButton/index.ts
@@ -1,0 +1,2 @@
+export { SocialButton } from './SocialButton';
+export type { SocialBrand, SocialButtonProps, SocialSize, SocialStyle } from './SocialButton';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,6 +3,7 @@
 // and composes its primitives into Glaon-branded components.
 
 export * from './components/Alert';
+export * from './components/AppStoreBadge';
 export * from './components/Avatar';
 export * from './components/Badge';
 export * from './components/BadgeGroup';
@@ -23,6 +24,7 @@ export * from './components/ProgressBar';
 export * from './components/Radio';
 export * from './components/Select';
 export * from './components/SideNav';
+export * from './components/SocialButton';
 export * from './components/Spinner';
 export * from './components/Stat';
 export * from './components/Switch';


### PR DESCRIPTION
## Summary

Three deliverables per #307:

1. **Button Phase 1.5 conversion** — `Button.controls.ts` + `Button.mdx` ekle, stories refactor + eksik varyantlar:
   - **TertiaryDestructive**, **LinkGray**, **LinkDestructive** — kit'te color olarak var, story yoktu.
   - **IconOnly** — kit auto-detects (iconLeading set + children empty → \`data-icon-only\` attribute → square padding), story \`aria-label\` ile a11y compliant.
   - Primary story bug fix — eskiden \`color: 'tertiary'\` geçiyordu (yanlış), artık doğru \`'primary'\`.

2. **SocialButton** yeni hand-rolled primitive — kit'te yok, \`@untitledui/icons\` brand glyph'lerinin çoğunu shipping etmiyor. 6 brand (apple / dribbble / facebook / figma / google / twitter) × 4 style (brand / black-outline / white-outline / icon-only) × 3 size + \`supportingText\` boolean ("Continue with X" vs "X"). Brand SVG'leri inline.

3. **AppStoreBadge** yeni hand-rolled primitive — stylised app-store download badge. 5 platform (app-store / mac-app-store / google-play / galaxy-store / app-gallery) × 2 theme (dark badge for light page / light badge for dark page). \`<a>\` (href), \`<button>\` (onPress), veya presentational \`<span>\` (catalogue) modlarında render.

## Scope

**In**

- \`packages/ui/src/components/Button/Button.controls.ts\` (yeni)
- \`packages/ui/src/components/Button/Button.mdx\` (yeni)
- \`packages/ui/src/components/Button/Button.stories.tsx\` (refactor + 4 yeni story)
- \`packages/ui/src/components/SocialButton/{SocialButton.tsx, controls.ts, mdx, stories.tsx, index.ts}\` (yeni)
- \`packages/ui/src/components/AppStoreBadge/{AppStoreBadge.tsx, controls.ts, mdx, stories.tsx, index.ts}\` (yeni)
- \`packages/ui/src/index.ts\` (barrel export)

**Out**

- Kit \`Button\` source'una dokunmadık (sadece Glaon wrap layer).
- 3rd-party OAuth flow orchestration ayrı (feature layer'da).
- Resmi trademark badge asset'leri — şimdiki implementasyon stylised approximation; production marketing pages için resmi asset'lerle swap önerilir (MDX'te belirtildi).
- F6 prop-coverage gate yeşil kalır (93 → 99 assertion).

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\`
- [x] \`pnpm --filter @glaon/ui lint\`
- [x] \`pnpm knip\`
- [x] \`pnpm --filter @glaon/ui exec vitest run\` — 99/99 prop-coverage assertion yeşil
- [x] \`pnpm --filter @glaon/ui build-storybook\` yeşil
- [ ] Storybook localhost:6006 — Button MDX + 4 yeni story (TertiaryDestructive / LinkGray / LinkDestructive / IconOnly) görünür; SocialButton + AppStoreBadge yeni component sayfaları açılır, brands/styles/stores matrix story'leri yan yana göster
- [ ] Figma Design tab — \`parameters.design\` URL'leri ilgili Figma sub-component'lerine açılır
- [ ] Chromatic build — Button ek story'leri + 2 yeni primitive baseline'a eklenir, accept gerekir
- [ ] A11y panel — IconOnly button \`aria-label\`'a sahip; SocialButton icon-only mode \`aria-label\` veya auto-derived "Sign in with X" forwarded; AppStoreBadge accessible label "Download on the App Store" gibi store name'den derive ediliyor

Closes #307