### PR TITLE
feat(ui): dropdown primitive (menu trigger + sectioned items)

### DIFF
--- a/packages/ui/src/components/Dropdown/Dropdown.controls.ts
+++ b/packages/ui/src/components/Dropdown/Dropdown.controls.ts
@@ -1,0 +1,138 @@
+// `Dropdown.controls.ts` — single source of truth for Dropdown's
+// root-level prop matrix. Story (`Dropdown.stories.tsx`) imports the
+// spec and spreads it into `meta.args` / `meta.argTypes`; MDX docs
+// (`Dropdown.mdx`) reads the same spec via `<Controls />`.
+//
+// Note: Dropdown is a compound primitive — root-level props (open
+// state + `trigger`) live here; per-item / per-section props
+// (`label`, `icon`, `avatarUrl`, `selectionIndicator`, …) flow
+// through `react-docgen-typescript` because of the static-property
+// merge but belong on `<Dropdown.Item>` / `<Dropdown.Section>` /
+// `<Dropdown.Popover>` etc. The F6 prop-coverage gate accepts them
+// via the `excludeFromArgs` allowlist.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const triggerOptions = ['press', 'longPress'] as const;
+
+export const dropdownControls = {
+  defaultOpen: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Initial open state for uncontrolled usage. Set `true` for snapshot stories so Chromatic captures the open-popover state.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isOpen: {
+    type: 'boolean',
+    description:
+      "Controlled open state. Pair with `onOpenChange` to manage state outside the component. Usually unnecessary — RAC's `<MenuTrigger>` handles the click/keyboard contract by itself.",
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  onOpenChange: {
+    type: false,
+    action: 'open-changed',
+    description:
+      'Fires when the popover opens or closes (RAC `<MenuTrigger>` contract — receives the new boolean).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  trigger: {
+    type: 'inline-radio',
+    options: triggerOptions,
+    default: 'press',
+    description:
+      "Activation gesture. `press` (default) opens the menu on click / Space / Enter; `longPress` requires a 500 ms hold (mobile-friendly long-press menus). RAC's contract handles touch + keyboard for both.",
+    category: 'Behavior',
+  } satisfies ControlSpec<(typeof triggerOptions)[number]>,
+  children: {
+    type: false,
+    description:
+      'Compose with a focusable trigger child (`<Button>` / `<Avatar>` / `<Dropdown.DotsButton>`) and a `<Dropdown.Popover>` containing a `<Dropdown.Menu>` of `<Dropdown.Item>` rows. The kit auto-wires `aria-expanded` / `aria-controls` between trigger and menu.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+// Sub-component props (`Dropdown.Item`, `Dropdown.Popover`,
+// `Dropdown.Menu`, `Dropdown.Section`, `Dropdown.DotsButton`) flow
+// through `react-docgen-typescript` via the static-property merge
+// but belong on the children, not the root. The F6 prop-coverage
+// gate accepts them via this allowlist.
+export const dropdownExcludeFromArgs = defineExcludeFromArgs([
+  // Item-only
+  'label',
+  'addon',
+  'icon',
+  'avatarUrl',
+  'selectionIndicator',
+  'unstyled',
+  'onAction',
+  'textValue',
+  'href',
+  'target',
+  // Popover-only
+  'placement',
+  'offset',
+  'crossOffset',
+  'shouldFlip',
+  'arrowBoundaryOffset',
+  'containerPadding',
+  'shouldUpdatePosition',
+  'isEntering',
+  'isExiting',
+  // Menu-only
+  'items',
+  'selectionMode',
+  'selectedKeys',
+  'defaultSelectedKeys',
+  'disabledKeys',
+  'disallowEmptySelection',
+  'onSelectionChange',
+  'dependencies',
+  'autoFocus',
+  // Section-only
+  'title',
+  // DotsButton + AriaButton-forwarded
+  'onPress',
+  'onPressStart',
+  'onPressEnd',
+  'onPressUp',
+  'onPressChange',
+  'onHoverStart',
+  'onHoverEnd',
+  'onHoverChange',
+  'isDisabled',
+  'isPending',
+  'preventFocusOnPress',
+  'excludeFromTabOrder',
+  'form',
+  'formAction',
+  'formEncType',
+  'formMethod',
+  'formNoValidate',
+  'formTarget',
+  'name',
+  'value',
+  // RAC-forwarded
+  'aria-label',
+  'aria-labelledby',
+  'aria-describedby',
+  'aria-details',
+  'aria-haspopup',
+  'aria-expanded',
+  'aria-controls',
+  'aria-pressed',
+  'translate',
+  'slot',
+  'data-rac',
+  'id',
+  'key',
+  'type',
+  'rel',
+  'download',
+  'ping',
+  'referrerPolicy',
+  'routerOptions',
+  'className',
+  'style',
+] as const);

--- a/packages/ui/src/components/Dropdown/Dropdown.mdx
+++ b/packages/ui/src/components/Dropdown/Dropdown.mdx
@@ -1,0 +1,131 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as DropdownStories from './Dropdown.stories';
+
+<Meta of={DropdownStories} />
+
+# Dropdown
+
+Menu trigger + sectioned items primitive. Use Dropdown for action
+menus where the user picks one (or multiple) item(s) from a finite,
+visible list — TopBar user menu, table row context menu, toolbar
+filter dropdown, view settings, account switcher.
+
+The Glaon `<Dropdown>` is a thin re-export of the kit's `Dropdown`
+namespace (`packages/ui/src/components/base/dropdown/dropdown.tsx`).
+The kit provides keyboard navigation (Arrow / Enter / Escape /
+typeahead), focus management, and the `aria-expanded` /
+`aria-controls` wiring out of the box via react-aria-components'
+`<MenuTrigger>` + `<Menu>` + `<MenuItem>`.
+
+## When to use
+
+- TopBar user menu (avatar trigger + profile preview header + items
+  like `View profile` / `Settings` / `Sign out`).
+- Table row context menu (`...` overflow trigger + edit / archive /
+  delete items).
+- Toolbar filter dropdown (button trigger + checkbox-style multi-
+  select items).
+- View settings (button trigger + toggle indicators for `Auto-refresh`
+  / `Show archived` flags).
+- Account switcher (avatar trigger + avatar-group header showing
+  multiple connected accounts).
+
+## When NOT to use
+
+- **Form value picker** (single / multi value bound to a form field) → use [Select](?path=/docs/web-primitives-select--docs); Dropdown items are actions or toggles, not form values with a `selectedKey`.
+- **Generic anchored overlay** with arbitrary content → use [Popover](?path=/docs/web-primitives-popover--docs); Dropdown carries the WAI-ARIA `menu` role hierarchy.
+- **Peer-view switching** → use [Tabs](?path=/docs/web-primitives-tabs--docs).
+- **Modal confirmation** that requires user action before proceeding → use [Modal](?path=/docs/web-primitives-modal--docs).
+
+## Anatomy
+
+<Canvas of={DropdownStories.Default} />
+
+Compose with these slots:
+
+- **`<Dropdown>`** (alias for `<Dropdown.Root>`) — wraps the trigger and popover. Owns the open state.
+- **Trigger** — first focusable child (any `<Button>`, `<Avatar>`, or
+  `<Dropdown.DotsButton>` for the `...` overflow pattern).
+- **`<Dropdown.Popover>`** — popover container. Owns positioning
+  (`placement` / `offset` / `crossOffset`) and the entrance / exit
+  animations.
+- **`<Dropdown.Menu>`** — `<Menu>` list (RAC). Owns selection mode
+  (`selectionMode` / `selectedKeys` / `onSelectionChange`).
+- **`<Dropdown.Item>`** — `<MenuItem>` row. Slots: `label`,
+  `icon`, `avatarUrl`, `addon` (right-side text), `selectionIndicator`
+  (`'checkmark' | 'checkbox' | 'radio' | 'toggle' | 'none'`).
+- **`<Dropdown.Section>`** — grouped section. Pair with
+  `<Dropdown.SectionHeader>` for an eyebrow heading.
+- **`<Dropdown.Separator>`** — divider line between items.
+- **`<Dropdown.DotsButton>`** — pre-built `...` overflow button (use
+  for table row context menus).
+
+```tsx
+<Dropdown>
+  <Button iconTrailing={ChevronDown}>Options</Button>
+  <Dropdown.Popover>
+    <Dropdown.Menu>
+      <Dropdown.Item icon={Eye} label="View profile" />
+      <Dropdown.Item icon={Settings} label="Settings" />
+      <Dropdown.Separator />
+      <Dropdown.Item icon={LogOut} label="Sign out" />
+    </Dropdown.Menu>
+  </Dropdown.Popover>
+</Dropdown>
+```
+
+## Selection indicators
+
+`<Dropdown.Item selectionIndicator="...">` switches the visual
+indicator on the selected state:
+
+- **`checkmark`** (default) — single-select dropdown; ticks the
+  active row.
+- **`checkbox`** — multi-select dropdown (filter toolbar pattern).
+- **`radio`** — single-select with a leading radio dot (settings
+  groups).
+- **`toggle`** — boolean settings dropdown (each row is a flag
+  toggle; pair with `<Dropdown.Menu selectionMode="multiple">`).
+- **`none`** — no indicator (action menu items).
+
+Pair the indicator with `<Dropdown.Menu selectionMode="single">` /
+`'multiple'` so RAC's selection contract drives `aria-checked` /
+`aria-selected` on items.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The kit forwards RAC's `<MenuTrigger>` semantics: `role="menu"`
+  on the popover, `role="menuitem"` (or `menuitemcheckbox` /
+  `menuitemradio`) on items, `aria-expanded` / `aria-controls`
+  on the trigger, automatic focus return on close.
+- Keyboard contract: Space / Enter / Down Arrow opens the menu
+  (or activates the focused item); Up / Down Arrow navigates;
+  Home / End jump to first / last; type-ahead filters by first
+  letter; Escape closes; Tab moves out of the menu.
+- For icon-only triggers (`<Dropdown.DotsButton>` or icon-only
+  `<Button>`), always set `aria-label` so screen readers can
+  announce the trigger's purpose.
+- `selectionIndicator='checkbox'` / `'radio'` / `'toggle'` items
+  forward `aria-checked` to the `<MenuItem>` automatically — RAC
+  wires the role-specific semantics.
+- For `Dropdown.SectionHeader` (the eyebrow text above a group),
+  the kit renders a real `<header>` so screen readers announce the
+  group label without it being focusable.
+- Avoid placing form inputs inside a Dropdown menu — the menu role
+  doesn't expect `<input type="text">` children; use a [Popover](?path=/docs/web-primitives-popover--docs) for that case.
+
+## Related components
+
+- [Select](?path=/docs/web-primitives-select--docs) — form-input picker for single/multi value.
+- [Popover](?path=/docs/web-primitives-popover--docs) — generic anchored overlay with arbitrary content.
+- [Tabs](?path=/docs/web-primitives-tabs--docs) — peer-view switching.
+- [Modal](?path=/docs/web-primitives-modal--docs) — full-surface dialog for blocking decisions.

--- a/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
@@ -251,15 +251,22 @@ export const WithAvatarGroupHeader: Story = {
       </AriaButton>
       <Dropdown.Popover>
         <Dropdown.Menu>
-          <Dropdown.SectionHeader className="block px-3 pt-3 pb-2">
-            <div className="flex items-center gap-3">
-              <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
-              <div className="flex min-w-0 flex-col">
-                <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
-                <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
+          {/* RAC `<Header>` (SectionHeader) must live inside a
+              `<Section>` so axe `aria-required-children` accepts it
+              under the `role="menu"` parent. Without the Section
+              wrapper, axe flags `header[tabindex]` as a non-allowed
+              child of `role="menu"`. */}
+          <Dropdown.Section>
+            <Dropdown.SectionHeader className="block px-3 pt-3 pb-2">
+              <div className="flex items-center gap-3">
+                <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+                <div className="flex min-w-0 flex-col">
+                  <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
+                  <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
+                </div>
               </div>
-            </div>
-          </Dropdown.SectionHeader>
+            </Dropdown.SectionHeader>
+          </Dropdown.Section>
           <Dropdown.Separator />
           <Dropdown.Item icon={eyeIcon} label="View profile" />
           <Dropdown.Item icon={settingsIcon} label="Settings" />
@@ -350,15 +357,20 @@ export const OpenState: Story = {
       </AriaButton>
       <Dropdown.Popover>
         <Dropdown.Menu>
-          <Dropdown.SectionHeader className="block px-3 pt-3 pb-2">
-            <div className="flex items-center gap-3">
-              <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
-              <div className="flex min-w-0 flex-col">
-                <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
-                <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
+          {/* RAC `<Header>` (SectionHeader) must live inside a
+              `<Section>` for axe `aria-required-children` (see
+              WithAvatarGroupHeader story for the same fix). */}
+          <Dropdown.Section>
+            <Dropdown.SectionHeader className="block px-3 pt-3 pb-2">
+              <div className="flex items-center gap-3">
+                <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+                <div className="flex min-w-0 flex-col">
+                  <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
+                  <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
+                </div>
               </div>
-            </div>
-          </Dropdown.SectionHeader>
+            </Dropdown.SectionHeader>
+          </Dropdown.Section>
           <Dropdown.Separator />
           <Dropdown.Item icon={eyeIcon} label="View profile" addon="⌘P" />
           <Dropdown.Item icon={settingsIcon} label="Settings" addon="⌘," />

--- a/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 import { Eye, LogOut01, Settings01, User01 } from '@untitledui/icons';
+import { Button as AriaButton } from 'react-aria-components';
 
 import { defineControls } from '../_internal/controls';
 import { Avatar } from '../Avatar';
@@ -61,7 +62,6 @@ type Story = StoryObj<typeof Dropdown>;
 export const excludeFromArgs = dropdownExcludeFromArgs;
 
 export const Default: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">Options</Button>
@@ -79,7 +79,6 @@ export const Default: Story = {
 };
 
 export const WithIcons: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">Account</Button>
@@ -97,7 +96,6 @@ export const WithIcons: Story = {
 };
 
 export const WithAddons: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">Quick actions</Button>
@@ -119,7 +117,6 @@ const phoenixUrl = 'https://www.untitledui.com/images/avatars/phoenix-baker?fm=w
 const lanaUrl = 'https://www.untitledui.com/images/avatars/lana-steiner?fm=webp&q=80';
 
 export const WithAvatars: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">Assignee</Button>
@@ -135,7 +132,6 @@ export const WithAvatars: Story = {
 };
 
 export const WithSelectionCheckmark: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">Sort by</Button>
@@ -152,7 +148,6 @@ export const WithSelectionCheckmark: Story = {
 };
 
 export const WithSelectionCheckbox: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">Filter</Button>
@@ -169,7 +164,6 @@ export const WithSelectionCheckbox: Story = {
 };
 
 export const WithSelectionRadio: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">Theme</Button>
@@ -185,7 +179,6 @@ export const WithSelectionRadio: Story = {
 };
 
 export const WithSelectionToggle: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">View options</Button>
@@ -201,7 +194,6 @@ export const WithSelectionToggle: Story = {
 };
 
 export const WithSections: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">Workspace</Button>
@@ -231,7 +223,6 @@ export const WithSections: Story = {
 };
 
 export const WithDividers: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">Mixed</Button>
@@ -250,10 +241,14 @@ export const WithDividers: Story = {
 };
 
 export const WithAvatarGroupHeader: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
-      <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+      <AriaButton
+        aria-label="User menu for Olivia Rhye"
+        className="rounded-full outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+      >
+        <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+      </AriaButton>
       <Dropdown.Popover>
         <Dropdown.Menu>
           <Dropdown.SectionHeader className="block px-3 pt-3 pb-2">
@@ -278,7 +273,6 @@ export const WithAvatarGroupHeader: Story = {
 };
 
 export const IconTrigger: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Dropdown.DotsButton aria-label="More actions" />
@@ -294,17 +288,20 @@ export const IconTrigger: Story = {
   ),
 };
 
+// `<MenuTrigger>` (Dropdown root) needs a press-aware child to bind
+// the open/close handlers — a plain `<button>` or `<Avatar>` won't
+// activate the menu. Wrap the avatar in RAC's `<AriaButton>` so the
+// trigger contract works without forcing the Glaon `<Button>` chrome
+// (padding / ring / shadow) on the avatar visual.
 export const AvatarTrigger: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
-      <button
-        type="button"
+      <AriaButton
         aria-label="User menu for Olivia Rhye"
         className="rounded-full outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
       >
         <Avatar src={oliviaUrl} alt="Olivia Rhye" size="md" />
-      </button>
+      </AriaButton>
       <Dropdown.Popover>
         <Dropdown.Menu>
           <Dropdown.Item icon={eyeIcon} label="View profile" />
@@ -318,7 +315,6 @@ export const AvatarTrigger: Story = {
 };
 
 export const DisabledItem: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>
       <Button color="secondary">With disabled</Button>
@@ -329,6 +325,46 @@ export const DisabledItem: Story = {
           <Dropdown.Item id="archived" icon={userIcon} label="Archived (coming soon)" />
           <Dropdown.Separator />
           <Dropdown.Item id="logout" icon={logOutIcon} label="Sign out" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+// `OpenState` is the single story that renders with the popover
+// already open — it carries the canonical menu (avatar header +
+// sectioned items) so Chromatic's open-popover snapshot covers the
+// rich content. All other stories render the closed trigger only;
+// users click in the Storybook canvas to interact. See #316 for
+// the rationale (auto-open across all stories breaks the MDX docs
+// page when every overlay opens at once).
+export const OpenState: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <AriaButton
+        aria-label="User menu for Olivia Rhye"
+        className="rounded-full outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+      >
+        <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+      </AriaButton>
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.SectionHeader className="block px-3 pt-3 pb-2">
+            <div className="flex items-center gap-3">
+              <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
+                <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
+              </div>
+            </div>
+          </Dropdown.SectionHeader>
+          <Dropdown.Separator />
+          <Dropdown.Item icon={eyeIcon} label="View profile" addon="⌘P" />
+          <Dropdown.Item icon={settingsIcon} label="Settings" addon="⌘," />
+          <Dropdown.Item icon={userIcon} label="Switch account" />
+          <Dropdown.Separator />
+          <Dropdown.Item icon={logOutIcon} label="Sign out" />
         </Dropdown.Menu>
       </Dropdown.Popover>
     </Dropdown>

--- a/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,336 @@
+import type { FC } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { Eye, LogOut01, Settings01, User01 } from '@untitledui/icons';
+
+import { defineControls } from '../_internal/controls';
+import { Avatar } from '../Avatar';
+import { Button } from '../Button';
+import { Dropdown } from './Dropdown';
+import { dropdownControls, dropdownExcludeFromArgs } from './Dropdown.controls';
+
+const { args, argTypes } = defineControls(dropdownControls);
+
+// Cast `@untitledui/icons` exports to the kit's narrower
+// `FC<{ className?: string }>` shape — same workaround as
+// `icons/storybook.ts`. Per-icon Props interfaces aren't re-exported
+// from the package so direct typing trips TS4023.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+type IconComponent = FC<any>;
+const eyeIcon = Eye as IconComponent;
+const settingsIcon = Settings01 as IconComponent;
+const userIcon = User01 as IconComponent;
+const logOutIcon = LogOut01 as IconComponent;
+
+// Explicit `Meta<typeof Dropdown>` annotation (rather than
+// `satisfies`) keeps the kit's deep RAC `MenuTrigger` generic chains
+// out of the exported `meta` signature — `tsc --noEmit` runs with
+// `declaration: true`.
+const meta: Meta<typeof Dropdown> = {
+  title: 'Web Primitives/Dropdown',
+  component: Dropdown,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=web-primitives-dropdown',
+    },
+  },
+  args,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'flex-start',
+          height: 360,
+          padding: 24,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Dropdown>;
+
+export const excludeFromArgs = dropdownExcludeFromArgs;
+
+export const Default: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">Options</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.Item label="View profile" />
+          <Dropdown.Item label="Settings" />
+          <Dropdown.Item label="Keyboard shortcuts" />
+          <Dropdown.Separator />
+          <Dropdown.Item label="Sign out" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const WithIcons: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">Account</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.Item icon={eyeIcon} label="View profile" />
+          <Dropdown.Item icon={settingsIcon} label="Settings" />
+          <Dropdown.Item icon={userIcon} label="Switch account" />
+          <Dropdown.Separator />
+          <Dropdown.Item icon={logOutIcon} label="Sign out" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const WithAddons: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">Quick actions</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.Item icon={eyeIcon} label="View profile" addon="⌘P" />
+          <Dropdown.Item icon={settingsIcon} label="Settings" addon="⌘," />
+          <Dropdown.Item icon={userIcon} label="Switch account" addon="⌘⇧A" />
+          <Dropdown.Separator />
+          <Dropdown.Item icon={logOutIcon} label="Sign out" addon="⌘⇧Q" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+const oliviaUrl = 'https://www.untitledui.com/images/avatars/olivia-rhye?fm=webp&q=80';
+const phoenixUrl = 'https://www.untitledui.com/images/avatars/phoenix-baker?fm=webp&q=80';
+const lanaUrl = 'https://www.untitledui.com/images/avatars/lana-steiner?fm=webp&q=80';
+
+export const WithAvatars: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">Assignee</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.Item avatarUrl={oliviaUrl} label="Olivia Rhye" />
+          <Dropdown.Item avatarUrl={phoenixUrl} label="Phoenix Baker" />
+          <Dropdown.Item avatarUrl={lanaUrl} label="Lana Steiner" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const WithSelectionCheckmark: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">Sort by</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu selectionMode="single" defaultSelectedKeys={['name']}>
+          <Dropdown.Item id="name" label="Name" selectionIndicator="checkmark" />
+          <Dropdown.Item id="updated" label="Last updated" selectionIndicator="checkmark" />
+          <Dropdown.Item id="created" label="Date created" selectionIndicator="checkmark" />
+          <Dropdown.Item id="size" label="Size" selectionIndicator="checkmark" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const WithSelectionCheckbox: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">Filter</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu selectionMode="multiple" defaultSelectedKeys={['active', 'archived']}>
+          <Dropdown.Item id="active" label="Active" selectionIndicator="checkbox" />
+          <Dropdown.Item id="draft" label="Draft" selectionIndicator="checkbox" />
+          <Dropdown.Item id="archived" label="Archived" selectionIndicator="checkbox" />
+          <Dropdown.Item id="deleted" label="Deleted" selectionIndicator="checkbox" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const WithSelectionRadio: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">Theme</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu selectionMode="single" defaultSelectedKeys={['system']}>
+          <Dropdown.Item id="light" label="Light" selectionIndicator="radio" />
+          <Dropdown.Item id="dark" label="Dark" selectionIndicator="radio" />
+          <Dropdown.Item id="system" label="Match system" selectionIndicator="radio" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const WithSelectionToggle: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">View options</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu selectionMode="multiple" defaultSelectedKeys={['auto-refresh']}>
+          <Dropdown.Item id="auto-refresh" label="Auto-refresh" selectionIndicator="toggle" />
+          <Dropdown.Item id="archived" label="Show archived" selectionIndicator="toggle" />
+          <Dropdown.Item id="diff" label="Inline diff" selectionIndicator="toggle" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const WithSections: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">Workspace</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.Section>
+            <Dropdown.SectionHeader className="px-3 pt-2 pb-1 text-xs font-semibold text-tertiary uppercase">
+              Account
+            </Dropdown.SectionHeader>
+            <Dropdown.Item icon={eyeIcon} label="View profile" />
+            <Dropdown.Item icon={settingsIcon} label="Settings" />
+          </Dropdown.Section>
+          <Dropdown.Separator />
+          <Dropdown.Section>
+            <Dropdown.SectionHeader className="px-3 pt-2 pb-1 text-xs font-semibold text-tertiary uppercase">
+              Team
+            </Dropdown.SectionHeader>
+            <Dropdown.Item icon={userIcon} label="Invite colleagues" />
+            <Dropdown.Item icon={settingsIcon} label="Manage members" />
+          </Dropdown.Section>
+          <Dropdown.Separator />
+          <Dropdown.Item icon={logOutIcon} label="Sign out" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const WithDividers: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">Mixed</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.Item icon={eyeIcon} label="View profile" />
+          <Dropdown.Separator />
+          <Dropdown.Item icon={settingsIcon} label="Settings" />
+          <Dropdown.Item icon={userIcon} label="Team members" />
+          <Dropdown.Separator />
+          <Dropdown.Item icon={logOutIcon} label="Sign out" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const WithAvatarGroupHeader: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.SectionHeader className="block px-3 pt-3 pb-2">
+            <div className="flex items-center gap-3">
+              <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
+                <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
+              </div>
+            </div>
+          </Dropdown.SectionHeader>
+          <Dropdown.Separator />
+          <Dropdown.Item icon={eyeIcon} label="View profile" />
+          <Dropdown.Item icon={settingsIcon} label="Settings" />
+          <Dropdown.Item icon={userIcon} label="Switch account" />
+          <Dropdown.Separator />
+          <Dropdown.Item icon={logOutIcon} label="Sign out" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const IconTrigger: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Dropdown.DotsButton aria-label="More actions" />
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.Item icon={eyeIcon} label="View" />
+          <Dropdown.Item icon={settingsIcon} label="Edit" />
+          <Dropdown.Separator />
+          <Dropdown.Item icon={logOutIcon} label="Delete" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const AvatarTrigger: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <button
+        type="button"
+        aria-label="User menu for Olivia Rhye"
+        className="rounded-full outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2"
+      >
+        <Avatar src={oliviaUrl} alt="Olivia Rhye" size="md" />
+      </button>
+      <Dropdown.Popover>
+        <Dropdown.Menu>
+          <Dropdown.Item icon={eyeIcon} label="View profile" />
+          <Dropdown.Item icon={settingsIcon} label="Settings" />
+          <Dropdown.Separator />
+          <Dropdown.Item icon={logOutIcon} label="Sign out" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};
+
+export const DisabledItem: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Dropdown {...args}>
+      <Button color="secondary">With disabled</Button>
+      <Dropdown.Popover>
+        <Dropdown.Menu disabledKeys={['archived']}>
+          <Dropdown.Item id="active" icon={eyeIcon} label="View profile" />
+          <Dropdown.Item id="settings" icon={settingsIcon} label="Settings" />
+          <Dropdown.Item id="archived" icon={userIcon} label="Archived (coming soon)" />
+          <Dropdown.Separator />
+          <Dropdown.Item id="logout" icon={logOutIcon} label="Sign out" />
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
+  ),
+};

--- a/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
@@ -250,24 +250,24 @@ export const WithAvatarGroupHeader: Story = {
         <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
       </AriaButton>
       <Dropdown.Popover>
+        {/* Render the avatar profile preview as a sibling of <Menu>
+            (inside Popover but outside the menu role hierarchy) —
+            axe `aria-required-children` only validates `role="menu"`
+            descendants, and the kit's `<Avatar>` renders an
+            `<img>` that gets tabindex-bound by RAC's collection
+            machinery when placed inside Menu. Sibling layout keeps
+            the visual identical with proper a11y semantics. */}
+        <div
+          className="flex items-center gap-3 border-b border-secondary_alt px-3 py-3"
+          role="presentation"
+        >
+          <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+          <div className="flex min-w-0 flex-col">
+            <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
+            <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
+          </div>
+        </div>
         <Dropdown.Menu>
-          {/* RAC `<Header>` (SectionHeader) must live inside a
-              `<Section>` so axe `aria-required-children` accepts it
-              under the `role="menu"` parent. Without the Section
-              wrapper, axe flags `header[tabindex]` as a non-allowed
-              child of `role="menu"`. */}
-          <Dropdown.Section>
-            <Dropdown.SectionHeader className="block px-3 pt-3 pb-2">
-              <div className="flex items-center gap-3">
-                <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
-                <div className="flex min-w-0 flex-col">
-                  <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
-                  <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
-                </div>
-              </div>
-            </Dropdown.SectionHeader>
-          </Dropdown.Section>
-          <Dropdown.Separator />
           <Dropdown.Item icon={eyeIcon} label="View profile" />
           <Dropdown.Item icon={settingsIcon} label="Settings" />
           <Dropdown.Item icon={userIcon} label="Switch account" />
@@ -356,22 +356,22 @@ export const OpenState: Story = {
         <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
       </AriaButton>
       <Dropdown.Popover>
+        {/* Avatar profile preview as Menu sibling — see
+            WithAvatarGroupHeader story for the rationale (axe
+            `aria-required-children` rejects img[tabindex] under
+            role="menu"; sibling layout keeps the visual identical
+            with correct a11y semantics). */}
+        <div
+          className="flex items-center gap-3 border-b border-secondary_alt px-3 py-3"
+          role="presentation"
+        >
+          <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
+          <div className="flex min-w-0 flex-col">
+            <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
+            <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
+          </div>
+        </div>
         <Dropdown.Menu>
-          {/* RAC `<Header>` (SectionHeader) must live inside a
-              `<Section>` for axe `aria-required-children` (see
-              WithAvatarGroupHeader story for the same fix). */}
-          <Dropdown.Section>
-            <Dropdown.SectionHeader className="block px-3 pt-3 pb-2">
-              <div className="flex items-center gap-3">
-                <Avatar src={oliviaUrl} alt="Olivia Rhye" size="sm" />
-                <div className="flex min-w-0 flex-col">
-                  <span className="truncate text-sm font-semibold text-primary">Olivia Rhye</span>
-                  <span className="truncate text-xs text-tertiary">olivia@untitledui.com</span>
-                </div>
-              </div>
-            </Dropdown.SectionHeader>
-          </Dropdown.Section>
-          <Dropdown.Separator />
           <Dropdown.Item icon={eyeIcon} label="View profile" addon="⌘P" />
           <Dropdown.Item icon={settingsIcon} label="Settings" addon="⌘," />
           <Dropdown.Item icon={userIcon} label="Switch account" />

--- a/packages/ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,85 @@
+// Glaon Dropdown — menu trigger + sectioned items primitive. Thin
+// re-export of the kit's `Dropdown` namespace under
+// `packages/ui/src/components/base/dropdown/dropdown.tsx`. Per
+// CLAUDE.md's UUI Source Rule, the structural HTML/CSS, the
+// react-aria-components `<MenuTrigger>` + `<Menu>` + `<MenuItem>`
+// keyboard contract (Arrow / Enter / Escape / typeahead), and the
+// selection indicator matrix (checkmark / checkbox / radio / toggle)
+// come from the kit; Glaon's contribution is the wrap layer (Phase
+// 1.5 controls.ts + MDX + stories) and the callable namespace shape.
+//
+// Distinct from Select (P7): Select is a form-input picker for
+// single/multi value with a `selectedKey`; Dropdown is an action menu
+// with item handlers + optional selection-state indicators.
+//
+// Distinct from Popover (P13): Popover is a generic anchored overlay
+// with arbitrary content; Dropdown is a menu-pattern primitive with
+// the WAI-ARIA `menu` role hierarchy baked in.
+//
+// Maps Figma's `web-primitives-dropdown` axes:
+//   - Item:    Icon × Checkbox (selection indicator) × State × Divider
+//   - Header:  Avatar group / Header (compose via `Dropdown.SectionHeader`)
+//   - Trigger: Icon / Button / Avatar (compose as the first child of
+//             `<Dropdown />` — typically `<Button>`, `<Avatar>`, or
+//             `<Dropdown.DotsButton>`)
+//
+// Usage:
+//
+//   <Dropdown>
+//     <Button iconTrailing={ChevronDown}>Options</Button>
+//     <Dropdown.Popover>
+//       <Dropdown.Menu>
+//         <Dropdown.Item icon={Eye} label="View profile" />
+//         <Dropdown.Item icon={Settings} label="Settings" />
+//         <Dropdown.Separator />
+//         <Dropdown.Item icon={LogOut} label="Sign out" />
+//       </Dropdown.Menu>
+//     </Dropdown.Popover>
+//   </Dropdown>
+//
+// The Glaon `Dropdown` is a callable namespace — `<Dropdown>` is the
+// MenuTrigger root (alias for `Dropdown.Root` / kit's
+// `<MenuTrigger>`). Sub-components live as static properties:
+//
+//   Dropdown.Popover       — popover container (rounded-lg, shadow-lg)
+//   Dropdown.Menu          — <Menu> list (RAC)
+//   Dropdown.Section       — <MenuSection> grouped section
+//   Dropdown.SectionHeader — <Header> grouped section heading
+//   Dropdown.Item          — <MenuItem> with icon / avatar / addon /
+//                            selectionIndicator slots
+//   Dropdown.Separator     — divider line between items
+//   Dropdown.DotsButton    — pre-built `...` overflow trigger button
+
+import type { ComponentProps } from 'react';
+
+import { Dropdown as KitDropdown } from '../base/dropdown/dropdown';
+
+// Wrap the kit's `MenuTrigger` (`Dropdown.Root`) as a real callable
+// component so `Meta<typeof Dropdown>` resolves to a concrete React
+// component for Storybook docgen. The static properties inherit the
+// kit's sub-components verbatim — no behaviour change.
+function DropdownRoot(props: ComponentProps<typeof KitDropdown.Root>) {
+  return <KitDropdown.Root {...props} />;
+}
+
+type DropdownNamespace = typeof DropdownRoot & {
+  Root: typeof KitDropdown.Root;
+  Popover: typeof KitDropdown.Popover;
+  Menu: typeof KitDropdown.Menu;
+  Section: typeof KitDropdown.Section;
+  SectionHeader: typeof KitDropdown.SectionHeader;
+  Item: typeof KitDropdown.Item;
+  Separator: typeof KitDropdown.Separator;
+  DotsButton: typeof KitDropdown.DotsButton;
+};
+
+export const Dropdown: DropdownNamespace = Object.assign(DropdownRoot, {
+  Root: KitDropdown.Root,
+  Popover: KitDropdown.Popover,
+  Menu: KitDropdown.Menu,
+  Section: KitDropdown.Section,
+  SectionHeader: KitDropdown.SectionHeader,
+  Item: KitDropdown.Item,
+  Separator: KitDropdown.Separator,
+  DotsButton: KitDropdown.DotsButton,
+});

--- a/packages/ui/src/components/Dropdown/index.ts
+++ b/packages/ui/src/components/Dropdown/index.ts
@@ -1,0 +1,1 @@
+export { Dropdown } from './Dropdown';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,7 @@ export * from './components/Button';
 export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/Drawer';
+export * from './components/Dropdown';
 export * from './components/Input';
 export * from './components/List';
 export * from './components/Logo';


### PR DESCRIPTION
## Summary

Glaon Dropdown — kit'in `Dropdown` namespace'ini callable component olarak re-export eden Phase 1.5 conversion. Figma `web-primitives-dropdown` axes'iyle bire bir eşleşen 13 story.

Distinct from existing primitives:
- **vs Select (P7)**: Select form-input picker (`selectedKey` + form value); Dropdown action menu (item handlers + optional selection-state indicators).
- **vs Popover (P13)**: Popover generic anchored overlay (rich content); Dropdown menu-pattern primitive (WAI-ARIA menu role hierarchy baked in).
- **vs Tabs (P8)**: Tabs peer-view switcher; Dropdown menu trigger.

## Scope

**In**

- `packages/ui/src/components/Dropdown/Dropdown.tsx` — callable namespace wrapping kit's `Dropdown.Root` + static properties (Popover / Menu / Section / SectionHeader / Item / Separator / DotsButton).
- `Dropdown.controls.ts` — root MenuTrigger props (defaultOpen / isOpen / onOpenChange / trigger / children); item / popover / menu / section / dotsbutton props flow through docgen via static-property merge → `excludeFromArgs`.
- `Dropdown.mdx` — When to use / When NOT / Anatomy / Selection indicators / Variants / Props / A11y / Related.
- `Dropdown.stories.tsx` — 13 story:
  - **Default** + **WithIcons** + **WithAddons** + **WithAvatars** (item slots)
  - **WithSelectionCheckmark** / **WithSelectionCheckbox** / **WithSelectionRadio** / **WithSelectionToggle** (Figma `Checkbox` axis × kit `selectionIndicator`)
  - **WithSections** + **WithDividers** (header + separator)
  - **WithAvatarGroupHeader** (Figma `Type=Avatar group` TopBar user menu pattern)
  - **IconTrigger** (`Dropdown.DotsButton`) + **AvatarTrigger** (Figma `Type=Icon` / `Type=Avatar`)
  - **DisabledItem** (per-item via `disabledKeys`)
- `packages/ui/src/index.ts` barrel re-export

**Out**

- Submenu support (RAC `<SubmenuTrigger>` shipping ediyor; V1.1).
- Combobox-search filter (form-input pattern; ayrı primitive).
- Drag-to-select (pratik gerekçe yok).
- Auto-binding keyboard shortcuts (`addon` ile el ile gösteriliyor, V1.1 auto-binding).

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm knip`
- [x] `pnpm --filter @glaon/ui exec vitest run` — 102/102 prop-coverage assertion green
- [x] `pnpm --filter @glaon/ui build-storybook` green
- [ ] Storybook localhost:6006 — Dropdown sayfasında 13 story; defaultOpen story'leri snapshot-friendly (popover render edilir); selection indicators (checkmark / checkbox / radio / toggle) doğru görünür
- [ ] Figma Design tab — `parameters.design` URL'i Figma sub-component'ine açılır
- [ ] Chromatic build yeşil — yeni Dropdown baseline'ları accept gerekir
- [ ] A11y panel — RAC `MenuTrigger` keyboard contract (Arrow / Enter / Escape / Type-ahead) doğal olarak çalışır; `Dropdown.DotsButton` default `aria-label="Open menu"` taşır; AvatarTrigger story'sinde manuel `aria-label="User menu for Olivia Rhye"` örneği

Closes #312