### PR TITLE
fix(ui): overlay stories — single openstate per primitive (#316)

### DIFF
--- a/packages/ui/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.stories.tsx
@@ -98,7 +98,6 @@ export const Default: Story = {
 };
 
 export const SideRight: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Drawer {...args}>
       <Drawer.Trigger>
@@ -122,7 +121,6 @@ export const SideRight: Story = {
 };
 
 export const SideLeft: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Drawer {...args}>
       <Drawer.Trigger>
@@ -146,7 +144,6 @@ export const SideLeft: Story = {
 };
 
 export const SideTop: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Drawer {...args}>
       <Drawer.Trigger>
@@ -170,7 +167,6 @@ export const SideTop: Story = {
 };
 
 export const SideBottom: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Drawer {...args}>
       <Drawer.Trigger>
@@ -263,7 +259,6 @@ export const Persistent: Story = {
 };
 
 export const SizeFull: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Drawer {...args}>
       <Drawer.Trigger>
@@ -284,6 +279,44 @@ export const SizeFull: Story = {
         <Drawer.Footer>
           <Button color="primary" size="sm">
             Done
+          </Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  ),
+};
+
+// `OpenState` is the single story that renders with the drawer
+// already open — Chromatic's open-drawer snapshot lives here. All
+// other stories render the closed trigger button so the MDX docs
+// page stays readable when every story renders side by side.
+// See #316 for the rationale.
+export const OpenState: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button color="secondary" size="sm">
+          Open drawer
+        </Button>
+      </Drawer.Trigger>
+      <Drawer.Content>
+        <Drawer.Header>
+          <h2 className="text-lg font-semibold text-primary">Settings</h2>
+          <p className="text-sm text-tertiary">Tweak the defaults for this workspace.</p>
+        </Drawer.Header>
+        <Drawer.Body>
+          <p className="text-sm text-secondary">
+            Drawer content sits in a slide-in panel. Use it for forms, filters, or any flow where
+            the user needs context from the page behind the panel.
+          </p>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Button color="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button color="primary" size="sm">
+            Save
           </Button>
         </Drawer.Footer>
       </Drawer.Content>

--- a/packages/ui/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.stories.tsx
@@ -286,12 +286,15 @@ export const SizeFull: Story = {
   ),
 };
 
-// `OpenState` is the single story that renders with the drawer
-// already open — Chromatic's open-drawer snapshot lives here. All
-// other stories render the closed trigger button so the MDX docs
-// page stays readable when every story renders side by side.
-// See #316 for the rationale.
+// `OpenState` carries the open-drawer snapshot for Chromatic. We
+// also opt this story OUT of the MDX `<Stories>` docs block via
+// `parameters.docs.disable: true` — without it, the docs page
+// renders the full-side drawer alongside the other stories,
+// covering everything beside it. The Storybook navigator still
+// lists the story for direct browsing + Chromatic snapshots
+// continue to capture it. See #316 for the rationale.
 export const OpenState: Story = {
+  parameters: { docs: { disable: true } },
   args: { defaultOpen: true },
   render: (args) => (
     <Drawer {...args}>

--- a/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.stories.tsx
@@ -338,14 +338,15 @@ export const DisabledItem: Story = {
   ),
 };
 
-// `OpenState` is the single story that renders with the popover
-// already open — it carries the canonical menu (avatar header +
-// sectioned items) so Chromatic's open-popover snapshot covers the
-// rich content. All other stories render the closed trigger only;
-// users click in the Storybook canvas to interact. See #316 for
-// the rationale (auto-open across all stories breaks the MDX docs
-// page when every overlay opens at once).
+// `OpenState` carries the open-popover snapshot for Chromatic
+// (avatar header + sectioned items). Opted OUT of the MDX
+// `<Stories>` docs block via `parameters.docs.disable: true` —
+// without it, the docs page would render an open dropdown
+// alongside other stories. The Storybook navigator still lists
+// the story for direct browsing + Chromatic still snapshots it.
+// See #316 for the rationale.
 export const OpenState: Story = {
+  parameters: { docs: { disable: true } },
   args: { defaultOpen: true },
   render: (args) => (
     <Dropdown {...args}>

--- a/packages/ui/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui/src/components/Modal/Modal.stories.tsx
@@ -87,7 +87,6 @@ export const Default: Story = {
 };
 
 export const SizeSm: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Modal {...args}>
       <Modal.Trigger>
@@ -113,7 +112,6 @@ export const SizeSm: Story = {
 };
 
 export const SizeMd: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Modal {...args}>
       <Modal.Trigger>
@@ -139,7 +137,6 @@ export const SizeMd: Story = {
 };
 
 export const SizeLg: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Modal {...args}>
       <Modal.Trigger>
@@ -165,7 +162,6 @@ export const SizeLg: Story = {
 };
 
 export const SizeFull: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Modal {...args}>
       <Modal.Trigger>
@@ -226,7 +222,6 @@ export const WithForm: Story = {
 };
 
 export const Scrollable: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Modal {...args}>
       <Modal.Trigger>
@@ -299,7 +294,6 @@ export const Persistent: Story = {
 };
 
 export const Confirmation: Story = {
-  args: { defaultOpen: true },
   render: (args) => (
     <Modal {...args}>
       <Modal.Trigger>
@@ -318,6 +312,44 @@ export const Confirmation: Story = {
           </Button>
           <Button color="primary-destructive" size="sm">
             Delete
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+// `OpenState` is the single story that renders with the modal already
+// open — Chromatic's open-modal snapshot lives here. All other stories
+// render the closed trigger button so the MDX docs page stays
+// readable when every story renders side by side. See #316 for the
+// rationale (auto-open across all stories breaks the docs surface
+// when multiple modals overlap).
+export const OpenState: Story = {
+  args: { defaultOpen: true },
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Open modal
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.Header>
+          <h2 className="text-lg font-semibold text-primary">Confirm action</h2>
+          <p className="text-sm text-tertiary">This will permanently apply the change.</p>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">
+            Modals are focus-trapped overlays for blocking decisions or short multi-step flows.
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button color="primary" size="sm">
+            Confirm
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/packages/ui/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui/src/components/Modal/Modal.stories.tsx
@@ -319,13 +319,15 @@ export const Confirmation: Story = {
   ),
 };
 
-// `OpenState` is the single story that renders with the modal already
-// open — Chromatic's open-modal snapshot lives here. All other stories
-// render the closed trigger button so the MDX docs page stays
-// readable when every story renders side by side. See #316 for the
-// rationale (auto-open across all stories breaks the docs surface
-// when multiple modals overlap).
+// `OpenState` carries the open-modal snapshot for Chromatic. We
+// also opt this story OUT of the MDX `<Stories>` docs block via
+// `parameters.docs.disable: true` — without it, the docs page
+// renders the full-viewport modal alongside the other stories,
+// covering everything below it. The Storybook navigator still
+// lists the story for direct browsing + Chromatic snapshots
+// continue to capture it. See #316 for the rationale.
 export const OpenState: Story = {
+  parameters: { docs: { disable: true } },
   args: { defaultOpen: true },
   render: (args) => (
     <Modal {...args}>

--- a/packages/ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/src/components/Popover/Popover.stories.tsx
@@ -167,13 +167,13 @@ export const WithRichContent: Story = {
   ),
 };
 
-// `OpenState` is the single story that renders with the popover
-// already open — Chromatic's open-popover snapshot lives here. All
-// other stories render the closed trigger button so the MDX docs
-// page stays readable when every story renders side by side. See
-// #316 for the rationale (auto-open across all stories breaks the
-// docs surface when multiple popovers overlap).
+// `OpenState` carries the open-popover snapshot for Chromatic. We
+// also opt this story OUT of the MDX `<Stories>` docs block via
+// `parameters.docs.disable: true` — keeps docs page readable +
+// Storybook navigator + Chromatic still see the story. See #316
+// for the rationale.
 export const OpenState: Story = {
+  parameters: { docs: { disable: true } },
   args: { defaultOpen: true },
   render: (args) => (
     <Popover {...args}>

--- a/packages/ui/src/components/Popover/Popover.stories.tsx
+++ b/packages/ui/src/components/Popover/Popover.stories.tsx
@@ -167,19 +167,26 @@ export const WithRichContent: Story = {
   ),
 };
 
-export const DefaultOpen: Story = {
+// `OpenState` is the single story that renders with the popover
+// already open — Chromatic's open-popover snapshot lives here. All
+// other stories render the closed trigger button so the MDX docs
+// page stays readable when every story renders side by side. See
+// #316 for the rationale (auto-open across all stories breaks the
+// docs surface when multiple popovers overlap).
+export const OpenState: Story = {
   args: { defaultOpen: true },
   render: (args) => (
     <Popover {...args}>
       <Popover.Trigger>
         <Button color="secondary" size="sm">
-          Default-open
+          Open popover
         </Button>
       </Popover.Trigger>
       <Popover.Content>
         <div className="w-64 p-4">
-          <p className="text-sm text-secondary">
-            Useful for snapshotting the open state in Chromatic.
+          <p className="text-sm font-semibold text-primary">Popover title</p>
+          <p className="mt-1 text-sm text-secondary">
+            Popovers are click-triggered overlays for richer content than a tooltip.
           </p>
         </div>
       </Popover.Content>

--- a/packages/ui/src/components/Tooltip/Tooltip.controls.ts
+++ b/packages/ui/src/components/Tooltip/Tooltip.controls.ts
@@ -87,9 +87,9 @@ export const tooltipControls = {
   } satisfies ControlSpec<boolean>,
   defaultOpen: {
     type: 'boolean',
-    default: true,
+    default: false,
     description:
-      'Initial open state for uncontrolled usage. Story canvases default to `true` so the tooltip is visible without manual hover during snapshot capture.',
+      'Initial open state for uncontrolled usage. The dedicated `OpenState` story sets this to `true` so Chromatic captures the open-tooltip snapshot; other stories render the closed trigger so the MDX docs page stays readable when all stories render side by side.',
     category: 'Behavior',
   } satisfies ControlSpec<boolean>,
   offset: {

--- a/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -171,12 +171,13 @@ export const SlowDelay: Story = {
   ),
 };
 
-// `OpenState` is the single story that renders with the tooltip
-// already open — Chromatic's open-tooltip snapshot lives here. All
-// other stories render the closed trigger so the MDX docs page
-// stays readable when every story renders side by side (otherwise
-// 11 tooltips stack and overlap). See #316 for the rationale.
+// `OpenState` carries the open-tooltip snapshot for Chromatic. We
+// also opt this story OUT of the MDX `<Stories>` docs block via
+// `parameters.docs.disable: true` — keeps docs page readable +
+// Storybook navigator + Chromatic still see the story. See #316
+// for the rationale.
 export const OpenState: Story = {
+  parameters: { docs: { disable: true } },
   args: { defaultOpen: true, title: 'Tooltip text' },
   render: (args) => (
     <Tooltip {...args}>

--- a/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -135,7 +135,7 @@ export const Right: Story = {
 };
 
 export const Disabled: Story = {
-  args: { isDisabled: true, defaultOpen: false },
+  args: { isDisabled: true },
   render: (args) => (
     <Tooltip {...args}>
       <Button color="secondary" size="sm">
@@ -161,11 +161,27 @@ export const LongContent: Story = {
 };
 
 export const SlowDelay: Story = {
-  args: { delay: 1200, defaultOpen: false },
+  args: { delay: 1200 },
   render: (args) => (
     <Tooltip {...args}>
       <Button color="secondary" size="sm">
         Hover (1.2s delay)
+      </Button>
+    </Tooltip>
+  ),
+};
+
+// `OpenState` is the single story that renders with the tooltip
+// already open — Chromatic's open-tooltip snapshot lives here. All
+// other stories render the closed trigger so the MDX docs page
+// stays readable when every story renders side by side (otherwise
+// 11 tooltips stack and overlap). See #316 for the rationale.
+export const OpenState: Story = {
+  args: { defaultOpen: true, title: 'Tooltip text' },
+  render: (args) => (
+    <Tooltip {...args}>
+      <Button color="secondary" size="sm">
+        Hovered
       </Button>
     </Tooltip>
   ),


### PR DESCRIPTION
## Summary

Apply the Dropdown PR #315 pattern to **Modal / Drawer / Popover / Tooltip** — the four overlay primitives whose MDX docs pages were unreadable when every story rendered with its overlay auto-opened. Closes #316.

Each primitive now has:
- Closed-trigger stories (one per visual variant: sizes / sides / placements / etc.) — user clicks to open in Storybook canvas.
- A single dedicated **`OpenState`** story with `defaultOpen: true` carrying canonical content for Chromatic open-state snapshot coverage.

## Per-primitive changes

**Modal** (6 stories): drop \`defaultOpen: true\` from \`SizeSm\` / \`SizeMd\` / \`SizeLg\` / \`SizeFull\` / \`Scrollable\` / \`Confirmation\` → add \`OpenState\` (header + body + cancel/confirm footer).

**Drawer** (5 stories): drop \`defaultOpen: true\` from \`SideRight\` / \`SideLeft\` / \`SideTop\` / \`SideBottom\` / \`SizeFull\` → add \`OpenState\` (right-side + header/body/footer).

**Popover** (1 story): rename existing \`DefaultOpen\` to \`OpenState\` + enrich content (title + description).

**Tooltip** (controls + stories): flip \`Tooltip.controls.ts\` \`defaultOpen\` default \`true → false\` (was tooltip-cloud on docs page); drop redundant explicit \`defaultOpen: false\` from \`Disabled\` / \`SlowDelay\`; add \`OpenState\` story.

## Chromatic coverage shift

- Closed-trigger snapshots: capture trigger button / icon / avatar styles (visual regression for trigger chrome).
- \`OpenState\` snapshots (1 per primitive): capture open-overlay content (visual regression for header / body / actions / placement).

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\`
- [x] \`pnpm --filter @glaon/ui lint\`
- [x] \`pnpm knip\`
- [x] \`pnpm --filter @glaon/ui exec vitest run\` — 102/102 prop-coverage assertions green
- [x] \`pnpm --filter @glaon/ui build-storybook\` green
- [ ] Storybook localhost:6006 — Modal / Drawer / Popover / Tooltip docs pages readable; each has 1 \`OpenState\` story rendering open + N closed-trigger stories
- [ ] Chromatic build — 4 open-state baselines + N closed-trigger baselines change; accept as new baseline

Closes #316