### PR TITLE
feat(ui): logo chrome props (padding, radius, border, link, button)

### DIFF
--- a/packages/ui/src/components/Logo/Logo.controls.ts
+++ b/packages/ui/src/components/Logo/Logo.controls.ts
@@ -39,6 +39,36 @@ export const logoControls = {
       'Width of the rendered mark. Number → `px`; string → forwarded verbatim (`100%`, `4rem`). Height scales via the SVG `viewBox` aspect ratio. Leave empty for the SVG natural size.',
     category: 'Style',
   } satisfies ControlSpec<number | string>,
+  padding: {
+    type: 'text',
+    description:
+      'Wrapper padding. Number → `px`; string → forwarded verbatim (`8px`, `0.5rem`, `8px 12px`). Pair with `background` and `radius` for badge / chip presentations.',
+    category: 'Style',
+  } satisfies ControlSpec<number | string>,
+  radius: {
+    type: 'text',
+    description:
+      'Wrapper border-radius. Number → `px`; string → forwarded verbatim (`8px`, `9999px` for a circle). Typically combined with `padding` and `background`.',
+    category: 'Style',
+  } satisfies ControlSpec<number | string>,
+  border: {
+    type: 'text',
+    description:
+      'CSS `border` shorthand applied to the wrapper (`1px solid var(--color-secondary-alt)`, `2px solid currentColor`). Useful for outlined chip presentations.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  href: {
+    type: 'text',
+    description:
+      'Link destination. When set, the wrapper renders as an `<a>` so the entire mark becomes a click target (typical "home" link in a TopBar / SideNav). Mutually exclusive with `onPress`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onPress: {
+    type: false,
+    description:
+      'Click handler. When set, the wrapper renders as a `<button>` — use for menu triggers or programmatic actions rather than navigation. Mutually exclusive with `href`. Set per-story via `args.onPress` (the controls panel hides function props).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
   label: {
     type: 'text',
     default: 'Glaon',

--- a/packages/ui/src/components/Logo/Logo.mdx
+++ b/packages/ui/src/components/Logo/Logo.mdx
@@ -15,9 +15,12 @@ asset loader in the consuming app.
 ## When to use
 
 - **Top bar / header** — full `wordmark` on the marketing site,
-  `symbol` on the in-app top bar when horizontal space is tight.
+  `symbol` on the in-app top bar when horizontal space is tight. Pair
+  with `href="/"` so the entire mark becomes the home link.
 - **Auth screens** — `wordmark` centered above the login form.
 - **Splash / boot** — `symbol` for app icon style framing.
+- **Brand chips / tiles** — `symbol` with `padding`, `radius`, and
+  `background` to render a badge-style logo (favicon-on-card).
 - **Empty states** — `symbol` with `decorative` to anchor an empty
   panel without screen-reader noise.
 
@@ -43,6 +46,35 @@ The mark is composed of two visual elements:
 <Logo variant="wordmark" theme="light" size={240} />
 <Logo variant="symbol" theme="dark" background="var(--brand-700)" size={96} />
 ```
+
+## Chrome props
+
+`padding`, `radius`, and `border` style the wrapper around the SVG —
+useful for badge / chip presentations without authoring a separate
+container in the consuming page. Numbers are treated as `px`; strings
+forward verbatim (`'8px 12px'`, `'9999px'`, `'1px solid var(--color-secondary-alt)'`).
+
+```tsx
+<Logo variant="symbol" size={48} padding={12} radius="9999px" background="var(--brand-50)" />
+<Logo variant="wordmark" size={200} padding="12px 20px" radius={12} border="1px solid var(--color-secondary-alt)" />
+```
+
+## Link / button variants
+
+Set `href` to render the wrapper as an `<a>` so the entire mark
+becomes a click target — typical "home" link in a TopBar or SideNav.
+Set `onPress` instead when the logo opens a menu or triggers a
+programmatic action; the wrapper renders as a `<button type="button">`.
+The two props are mutually exclusive.
+
+```tsx
+<Logo variant="symbol" size={32} href="/" />
+<Logo variant="symbol" size={32} onPress={openBrandMenu} label="Open brand menu" />
+```
+
+Focusable variants always carry `aria-label` (defaults to `'Glaon'`)
+so screen readers announce the link / button — `decorative` is ignored
+when `href` or `onPress` is set.
 
 ## Variants
 
@@ -72,7 +104,13 @@ surface", regardless of which app-level theme is active.
 - Set `decorative` when the logo duplicates information already
   available to screen readers (a visible "Glaon" headline elsewhere
   on the page). The wrapper switches to `aria-hidden="true"` and
-  drops the `role`.
+  drops the `role`. Ignored when `href` or `onPress` is set —
+  focusable controls always need an accessible name.
+- `href` renders an `<a>`; `onPress` renders a `<button type="button">`.
+  Both carry `aria-label={label}` so axe `link-name` /
+  `button-name` stay green. The default `className` adds a focus ring
+  (`outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2`);
+  pass an explicit `className` to override.
 - Contrast: pair `theme="light"` with surfaces lighter than
   `var(--neutral-200)`; use `theme="dark"` for surfaces darker than
   `var(--brand-300)`. The Storybook **AllVariants** story is the

--- a/packages/ui/src/components/Logo/Logo.stories.tsx
+++ b/packages/ui/src/components/Logo/Logo.stories.tsx
@@ -51,6 +51,68 @@ export const Decorative: Story = {
   args: { variant: 'symbol', size: 96, decorative: true },
 };
 
+// Chrome — `padding` adds breathing room between the SVG and the
+// wrapper edge; pair with `background` for a tile-style presentation.
+export const Padded: Story = {
+  args: {
+    variant: 'symbol',
+    size: 64,
+    padding: 16,
+    background: 'var(--brand-50)',
+  },
+};
+
+// `radius` rounds the wrapper. Combine with `padding` and `background`
+// for a chip-style mark — useful for compact brand badges in cards
+// and list rows.
+export const Rounded: Story = {
+  args: {
+    variant: 'symbol',
+    size: 56,
+    padding: 14,
+    radius: '9999px',
+    background: 'var(--brand-50)',
+  },
+};
+
+// `border` adds a hairline outline around the wrapper. Mirrors the
+// TopBar treatment where the brand mark sits inside a thin neutral
+// frame for added definition on warm panels.
+export const Bordered: Story = {
+  args: {
+    variant: 'wordmark',
+    size: 200,
+    padding: '12px 20px',
+    radius: 12,
+    border: '1px solid var(--color-secondary-alt)',
+  },
+};
+
+// `href` turns the entire mark into an `<a>` — typical "home" link in
+// a TopBar / SideNav. Always carries `aria-label` so screen readers
+// announce the link target.
+export const AsLink: Story = {
+  args: {
+    variant: 'symbol',
+    size: 40,
+    href: '#home',
+    label: 'Glaon — go to home',
+  },
+};
+
+// `onPress` renders a `<button type="button">` instead — use when the
+// logo opens a menu or triggers a programmatic action. Mutually
+// exclusive with `href`. Inline noop here so the wrapper picks the
+// button branch; consumers wire a real handler.
+export const WithHandler: Story = {
+  args: {
+    variant: 'symbol',
+    size: 40,
+    label: 'Open brand menu',
+    onPress: () => undefined,
+  },
+};
+
 // Gallery — all four variants on their natural surfaces. Mirrors the
 // Brand Guideline placement grid so designers can verify pixel parity
 // against the Figma frame.

--- a/packages/ui/src/components/Logo/Logo.tsx
+++ b/packages/ui/src/components/Logo/Logo.tsx
@@ -17,7 +17,7 @@
 // follow-up adds Theme: Dark). `theme` here expresses contrast intent
 // against the immediate surface, not the global app theme.
 
-import type { CSSProperties } from 'react';
+import type { CSSProperties, MouseEventHandler } from 'react';
 
 export type LogoVariant = 'wordmark' | 'symbol';
 export type LogoTheme = 'light' | 'dark';
@@ -51,6 +51,36 @@ export interface LogoProps {
    * @default 'transparent'
    */
   background?: string;
+  /**
+   * Wrapper padding. Number → `px`; string → forwarded verbatim
+   * (`8px`, `0.5rem`, `8px 12px`). Useful when the logo sits inside
+   * a branded tile / chip and needs breathing room.
+   */
+  padding?: number | string;
+  /**
+   * Wrapper border-radius. Number → `px`; string → forwarded verbatim
+   * (`8px`, `9999px` for a circle, `0.5rem`). Pair with `padding` and
+   * `background` for badge- / chip-style logo presentations.
+   */
+  radius?: number | string;
+  /**
+   * Wrapper border. Pass any CSS `border` shorthand
+   * (`1px solid var(--color-secondary-alt)`, `2px solid currentColor`).
+   * Rendered as `style.border` on the wrapper.
+   */
+  border?: string;
+  /**
+   * Link destination. When set, the wrapper renders as an `<a>` so
+   * the entire mark becomes a click target (typical "home" link in
+   * a TopBar / SideNav). Mutually exclusive with `onPress`.
+   */
+  href?: string;
+  /**
+   * Click handler (`<button>` variant). Use when the logo opens a
+   * menu / triggers a programmatic action rather than navigating.
+   * Mutually exclusive with `href`.
+   */
+  onPress?: MouseEventHandler;
   /** Tailwind / className override hook for the wrapper. */
   className?: string;
   /**
@@ -61,7 +91,8 @@ export interface LogoProps {
   /**
    * Hide from assistive tech (sets `aria-hidden`). Use when the logo
    * is decorative — e.g. paired with a visible "Glaon" wordmark
-   * elsewhere on the page.
+   * elsewhere on the page. Ignored when `href` or `onPress` is set
+   * (link / button always need an accessible name).
    * @default false
    */
   decorative?: boolean;
@@ -126,6 +157,11 @@ export function Logo({
   theme = 'light',
   size,
   background = 'transparent',
+  padding,
+  radius,
+  border,
+  href,
+  onPress,
   className,
   label = 'Glaon',
   decorative = false,
@@ -135,14 +171,57 @@ export function Logo({
     color: bodyFill[theme],
     background,
     ...(size !== undefined ? { width: size } : {}),
+    ...(padding !== undefined ? { padding } : {}),
+    ...(radius !== undefined ? { borderRadius: radius } : {}),
+    ...(border !== undefined ? { border } : {}),
   };
+
+  const mark = variant === 'wordmark' ? <Wordmark /> : <Symbol />;
+
+  // Link / button variants always carry an accessible name (the link
+  // / button must be announced by screen readers regardless of
+  // `decorative` — focusable controls without a name fail axe
+  // `link-name` / `button-name`).
+  if (href !== undefined) {
+    return (
+      <a
+        href={href}
+        aria-label={label}
+        className={
+          className ?? 'outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2'
+        }
+        style={wrapperStyle}
+      >
+        {mark}
+      </a>
+    );
+  }
+
+  if (onPress !== undefined) {
+    return (
+      <button
+        type="button"
+        onClick={onPress}
+        aria-label={label}
+        className={
+          className ?? 'outline-focus-ring focus-visible:outline-2 focus-visible:outline-offset-2'
+        }
+        style={wrapperStyle}
+      >
+        {mark}
+      </button>
+    );
+  }
+
+  // Presentational variant — `<span>` with role="img" or
+  // aria-hidden depending on `decorative`.
   const a11yProps = decorative
     ? { 'aria-hidden': true as const }
     : { role: 'img' as const, 'aria-label': label };
 
   return (
     <span className={className} style={wrapperStyle} {...a11yProps}>
-      {variant === 'wordmark' ? <Wordmark /> : <Symbol />}
+      {mark}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Adds five wrapper props to `<Logo>`: `padding`, `radius`, `border` for chip / badge presentations; `href` and `onPress` to render the entire mark as an `<a>` or `<button type="button">` (typical TopBar home link or brand-menu trigger).

## Scope

**In**
- `Logo.tsx` — new props `padding`, `radius`, `border`, `href`, `onPress` (mutually exclusive). Render dispatcher returns `<a>` (when `href`), `<button type="button">` (when `onPress`), or the existing `<span>` (default).
- A11y — link / button variants always carry `aria-label={label}`; `decorative` is ignored when `href` / `onPress` is set (focusable controls always need a name). Default focus ring class added; consumer can override via `className`.
- `Logo.controls.ts` — five new control entries (Style + Behavior categories) with descriptions matching the prop docs.
- `Logo.mdx` — new "Chrome props" + "Link / button variants" sections; a11y note expanded for the link / button branches.
- `Logo.stories.tsx` — five new stories: `Padded`, `Rounded`, `Bordered`, `AsLink`, `WithHandler`. Existing matrix stories untouched.

**Out**
- Tailwind class-based chrome overrides (`paddingClassName`, etc.) — inline `style` only for this iteration, per issue scope boundary.
- Hover / animation effects — static prop expansion only.
- RN side (`PressableLogo`) — web-only; can be a follow-up if needed.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (102/102 assertions; new props covered)
- [x] `pnpm --filter @glaon/ui build-storybook` — clean build
- [ ] Storybook localhost:6006 — Logo page shows new controls (padding/radius/border/href in Controls panel; onPress hidden as function) and new stories render
- [ ] A11y — `AsLink` keyboard-reachable (Tab focus + visible ring); `WithHandler` announces "Open brand menu"
- [ ] Chromatic — new stories accepted into baseline; existing canvases byte-equal (props optional, undefined default)

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)