### PR TITLE
feat(ui): button group primitive (segmented control)

### DIFF
--- a/packages/ui/src/components/ButtonGroup/ButtonGroup.controls.ts
+++ b/packages/ui/src/components/ButtonGroup/ButtonGroup.controls.ts
@@ -1,0 +1,73 @@
+// `ButtonGroup.controls.ts` — single source of truth for ButtonGroup's
+// variant matrix. Story (`ButtonGroup.stories.tsx`) imports the spec
+// and spreads it into `meta.args` / `meta.argTypes`; MDX docs
+// (`ButtonGroup.mdx`) reads the same spec via `<Controls />`.
+//
+// The control set covers the *root* (`<ButtonGroup>`) props only.
+// `<ButtonGroup.Item>` props are documented in MDX and exercised
+// through dedicated stories — Storybook's controls panel binds to
+// the parametric `meta.component`, and exposing item props at root
+// level would conflict with the per-item compose pattern.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md'] as const;
+
+export const buttonGroupControls = {
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale. `sm` (h-9) for dense filter bars; `md` (h-10, default) for primary view toggles.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  defaultValue: {
+    type: 'text',
+    default: 'day',
+    description:
+      'Initial selected item value (uncontrolled). The matching `<ButtonGroup.Item value="…">` renders pressed on first paint. Pair with `value` + `onChange` for controlled state instead.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  value: {
+    type: 'text',
+    description:
+      'Controlled selected value. Pair with `onChange` to manage state outside the component. Use sparingly — uncontrolled `defaultValue` is enough for most filter bars.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      "Disable every segment in the group. Per-item `isDisabled` still cascades — this prop only sharpens, it can't enable an item the group has disabled.",
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  'aria-label': {
+    type: 'text',
+    default: 'Date range',
+    description:
+      'Accessible label for the group landmark (e.g. "Date range", "View mode"). Required when icon-only items are used so screen readers announce the group purpose.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  onChange: {
+    type: false,
+    action: 'changed',
+    description:
+      'Fires with the next selected value when the user picks a different segment. Required for controlled usage (paired with `value`).',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  children: {
+    type: false,
+    description:
+      'Compose with `<ButtonGroup.Item>` rows. Item props (`value`, `iconLeading`, `iconOnly`, `dot`, `isDisabled`, `aria-label`) are documented in the MDX page; story examples cover each axis.',
+    category: 'Content',
+  } satisfies ControlSpec<unknown>,
+} as const;
+
+export const buttonGroupExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/ButtonGroup/ButtonGroup.mdx
+++ b/packages/ui/src/components/ButtonGroup/ButtonGroup.mdx
@@ -1,0 +1,122 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as ButtonGroupStories from './ButtonGroup.stories';
+
+<Meta of={ButtonGroupStories} />
+
+# ButtonGroup
+
+Segmented control for picking exactly one option out of a small,
+known set. Use it where the choice should stay on screen — date
+range filters, view-mode toggles, status sweeps — so users see the
+full set of options without opening a menu.
+
+## When to use
+
+- **Date range filters** — Day / Week / Month / Year on a dashboard.
+- **View toggles** — List / Grid / Map for a result set.
+- **Status sweeps** — All / Active / Archived on a list page.
+- **Property selectors** — Imperial / Metric, Light / Dark.
+
+## When NOT to use
+
+- More than ~5 options → use [Tabs](?path=/docs/web-primitives-tabs--docs)
+  or a `<Select>`. Segmented controls scale badly past five segments.
+- The choice opens different content panels → use **Tabs** (the
+  panels are the affordance, not the segments).
+- Each segment performs a different action (no "selected" state) →
+  this is V1.1 ("action-group" mode); for now, lay out separate
+  `<Button>` instances side by side.
+- Multi-select (multiple segments active at once) → V1.1; use
+  `<Checkbox>` group or chips today.
+
+## Anatomy
+
+<Canvas of={ButtonGroupStories.Default} />
+
+The group is a compound component: a parent `<ButtonGroup>` shares
+the rounded outer ring and a flat surface; each `<ButtonGroup.Item>`
+is a segment with three visual modes (label only, leading icon +
+label, status dot + label, icon only). The selected segment receives
+a "pressed" treatment (`bg-secondary`); unselected segments keep the
+neutral surface and pick up `bg-primary_hover` on pointer entry.
+
+```tsx
+<ButtonGroup defaultValue="week" aria-label="Date range">
+  <ButtonGroup.Item value="day">Day</ButtonGroup.Item>
+  <ButtonGroup.Item value="week">Week</ButtonGroup.Item>
+  <ButtonGroup.Item value="month">Month</ButtonGroup.Item>
+  <ButtonGroup.Item value="year">Year</ButtonGroup.Item>
+</ButtonGroup>
+```
+
+## Selection modes
+
+V1 ships **single-select only**. Either pick the controlled flow:
+
+```tsx
+const [view, setView] = useState('list');
+
+<ButtonGroup value={view} onChange={setView} aria-label="View mode">
+  <ButtonGroup.Item value="list" iconLeading={ListIcon}>List</ButtonGroup.Item>
+  <ButtonGroup.Item value="grid" iconLeading={GridIcon}>Grid</ButtonGroup.Item>
+</ButtonGroup>
+```
+
+…or hand state off to the component with `defaultValue` and read the
+selection through `onChange` only. Mixing both (`value` + `defaultValue`)
+is not supported — `value` always wins when defined.
+
+## Item variants
+
+Each `<ButtonGroup.Item>` exposes these visual axes (mirrors Figma's
+`Icon` axis on the base button group cell):
+
+- **Label only** — pass children, omit `iconLeading` and `dot`.
+- **Leading icon + label** — set `iconLeading` to a component icon.
+- **Dot + label** — set `dot` (`gray` / `brand` / `success` /
+  `warning` / `error`) for a status-prefixed segment.
+- **Icon only** — set `iconLeading` and `iconOnly`. Always pair with
+  `aria-label` so axe `button-name` stays green.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+The controls panel below covers the **root** (`<ButtonGroup>`) props.
+`<ButtonGroup.Item>` props are documented above (and exercised through
+the variant stories) — the controls panel binds to a single component,
+so per-item knobs live in the dedicated stories rather than as
+top-level controls.
+
+<Controls />
+
+## Accessibility
+
+- Wrapper renders as `<div role="group">` with the consumer's
+  `aria-label` ("Date range", "View mode") so the group is announced
+  as a unit.
+- Each segment is a native `<button type="button">` with
+  `aria-pressed={isSelected}` — the toggle-button pattern. V1 uses Tab
+  to move between segments and Enter / Space to pick; arrow-key roving
+  focus is a V1.1 follow-up.
+- Icon-only segments **must** carry `aria-label`. The wrap forwards it
+  onto the button so screen readers announce "View as grid" instead
+  of an unnamed icon.
+- Disabled segments lose pointer events and contrast (`opacity-50`).
+  When the group itself is disabled, every segment inherits the
+  disabled state — per-item `isDisabled` cannot un-disable.
+- Selected segment is z-raised (`z-10`) so its 1px corners overlap the
+  divider lines cleanly without clipping; focus ring lifts even higher
+  (`focus-visible:z-10`) so it doesn't get trimmed by neighbours.
+
+## Related components
+
+- [Tabs](?path=/docs/web-primitives-tabs--docs) — when each segment
+  opens a different content panel.
+- [Button](?path=/docs/web-primitives-button--docs) — when each
+  control performs an action (no "pressed" persistence).
+- [Select](?path=/docs/web-primitives-select--docs) — when the option
+  set is large or only the chosen value matters at rest.

--- a/packages/ui/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/ui/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,0 +1,224 @@
+import { Calendar, Grid01, List, Map01 } from '@untitledui/icons';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { ButtonGroup } from './ButtonGroup';
+import { buttonGroupControls, buttonGroupExcludeFromArgs } from './ButtonGroup.controls';
+
+const { args, argTypes } = defineControls(buttonGroupControls);
+
+// Explicit `Meta<typeof ButtonGroup>` annotation (rather than
+// `satisfies`) keeps the Object.assign namespace shape out of the
+// exported `meta` signature — `tsc --noEmit` runs with
+// `declaration: true`.
+//
+// Phase 1.5: `args` + `argTypes` come from `ButtonGroup.controls.ts`;
+// `tags: ['autodocs']` is omitted because `ButtonGroup.mdx` replaces
+// the docs tab.
+const meta: Meta<typeof ButtonGroup> = {
+  title: 'Web Primitives/ButtonGroup',
+  component: ButtonGroup,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=16-399',
+    },
+  },
+  args,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div style={{ padding: 24 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonGroup>;
+
+export const excludeFromArgs = buttonGroupExcludeFromArgs;
+
+export const Default: Story = {
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <ButtonGroup.Item value="day">Day</ButtonGroup.Item>
+      <ButtonGroup.Item value="week">Week</ButtonGroup.Item>
+      <ButtonGroup.Item value="month">Month</ButtonGroup.Item>
+      <ButtonGroup.Item value="year">Year</ButtonGroup.Item>
+    </ButtonGroup>
+  ),
+};
+
+// `iconLeading` precedes the label — useful when the icon adds
+// recognition (calendar / clock / view-mode glyphs).
+export const WithIcons: Story = {
+  args: { defaultValue: 'list', 'aria-label': 'View mode' },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <ButtonGroup.Item value="list" iconLeading={List}>
+        List
+      </ButtonGroup.Item>
+      <ButtonGroup.Item value="grid" iconLeading={Grid01}>
+        Grid
+      </ButtonGroup.Item>
+      <ButtonGroup.Item value="map" iconLeading={Map01}>
+        Map
+      </ButtonGroup.Item>
+    </ButtonGroup>
+  ),
+};
+
+// `dot` prefixes the label with a status colour — segmented filters
+// for ticket / project status sweeps. The dot is purely decorative
+// (`aria-hidden`), so the label still carries semantic meaning.
+export const WithDots: Story = {
+  args: { defaultValue: 'active', 'aria-label': 'Project status filter' },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <ButtonGroup.Item value="active" dot="success">
+        Active
+      </ButtonGroup.Item>
+      <ButtonGroup.Item value="paused" dot="warning">
+        Paused
+      </ButtonGroup.Item>
+      <ButtonGroup.Item value="archived" dot="gray">
+        Archived
+      </ButtonGroup.Item>
+    </ButtonGroup>
+  ),
+};
+
+// `iconOnly` strips the visible label — the segment becomes a
+// compact toolbar-style toggle. Each item must carry `aria-label`
+// so axe `button-name` stays green and screen readers announce the
+// segment purpose.
+export const IconOnly: Story = {
+  args: { defaultValue: 'list', 'aria-label': 'View mode' },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <ButtonGroup.Item value="list" iconLeading={List} iconOnly aria-label="View as list">
+        List
+      </ButtonGroup.Item>
+      <ButtonGroup.Item value="grid" iconLeading={Grid01} iconOnly aria-label="View as grid">
+        Grid
+      </ButtonGroup.Item>
+      <ButtonGroup.Item value="map" iconLeading={Map01} iconOnly aria-label="View as map">
+        Map
+      </ButtonGroup.Item>
+    </ButtonGroup>
+  ),
+};
+
+// `isDisabled` on the parent cascades to every segment. Use for
+// transient states ("loading filters from server") or guarded UI.
+export const Disabled: Story = {
+  args: { defaultValue: 'week', isDisabled: true, 'aria-label': 'Date range (loading)' },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <ButtonGroup.Item value="day">Day</ButtonGroup.Item>
+      <ButtonGroup.Item value="week">Week</ButtonGroup.Item>
+      <ButtonGroup.Item value="month">Month</ButtonGroup.Item>
+      <ButtonGroup.Item value="year">Year</ButtonGroup.Item>
+    </ButtonGroup>
+  ),
+};
+
+// Per-segment `isDisabled` while the rest of the group stays
+// interactive. Useful for licence-gated views or temporarily
+// unavailable filters (e.g. "Year" pending data backfill).
+export const DisabledItem: Story = {
+  args: { defaultValue: 'day', 'aria-label': 'Date range' },
+  render: (args) => (
+    <ButtonGroup {...args}>
+      <ButtonGroup.Item value="day">Day</ButtonGroup.Item>
+      <ButtonGroup.Item value="week">Week</ButtonGroup.Item>
+      <ButtonGroup.Item value="month">Month</ButtonGroup.Item>
+      <ButtonGroup.Item value="year" isDisabled>
+        Year
+      </ButtonGroup.Item>
+    </ButtonGroup>
+  ),
+};
+
+// Side-by-side size matrix — the `sm` rail (h-9) for dense
+// filter-bar contexts, `md` (h-10) for primary view toggles.
+export const Sizes: Story = {
+  args: { 'aria-label': 'Date range' },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <ButtonGroup {...args} size="sm" defaultValue="day">
+        <ButtonGroup.Item value="day" iconLeading={Calendar}>
+          Day
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="week" iconLeading={Calendar}>
+          Week
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="month" iconLeading={Calendar}>
+          Month
+        </ButtonGroup.Item>
+      </ButtonGroup>
+      <ButtonGroup {...args} size="md" defaultValue="week">
+        <ButtonGroup.Item value="day" iconLeading={Calendar}>
+          Day
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="week" iconLeading={Calendar}>
+          Week
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="month" iconLeading={Calendar}>
+          Month
+        </ButtonGroup.Item>
+      </ButtonGroup>
+    </div>
+  ),
+};
+
+// All four item visual modes (label / icon+label / dot+label /
+// icon-only) on the same `md` size so designers can verify pixel
+// parity against the Figma `_Button group base` cell matrix.
+export const Variants: Story = {
+  args: { 'aria-label': 'Variant gallery' },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <ButtonGroup defaultValue="b" aria-label="Label only">
+        <ButtonGroup.Item value="a">Day</ButtonGroup.Item>
+        <ButtonGroup.Item value="b">Week</ButtonGroup.Item>
+        <ButtonGroup.Item value="c">Month</ButtonGroup.Item>
+      </ButtonGroup>
+      <ButtonGroup defaultValue="b" aria-label="Leading icon + label">
+        <ButtonGroup.Item value="a" iconLeading={Calendar}>
+          Day
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="b" iconLeading={Calendar}>
+          Week
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="c" iconLeading={Calendar}>
+          Month
+        </ButtonGroup.Item>
+      </ButtonGroup>
+      <ButtonGroup defaultValue="b" aria-label="Dot + label">
+        <ButtonGroup.Item value="a" dot="success">
+          Active
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="b" dot="warning">
+          Paused
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="c" dot="gray">
+          Archived
+        </ButtonGroup.Item>
+      </ButtonGroup>
+      <ButtonGroup defaultValue="b" aria-label="Icon only">
+        <ButtonGroup.Item value="a" iconLeading={List} iconOnly aria-label="List">
+          List
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="b" iconLeading={Grid01} iconOnly aria-label="Grid">
+          Grid
+        </ButtonGroup.Item>
+        <ButtonGroup.Item value="c" iconLeading={Map01} iconOnly aria-label="Map">
+          Map
+        </ButtonGroup.Item>
+      </ButtonGroup>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/ui/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,262 @@
+// Glaon ButtonGroup — segmented-control primitive. The kit doesn't
+// ship a generic `ButtonGroup`, so under the UUI Source Rule's
+// "no kit source" exception (see CLAUDE.md), Glaon hand-rolls a
+// parameterised wrap using kit surface vocabulary as canonical
+// reference (`bg-primary` segment, `ring-primary` shared outer ring,
+// `bg-secondary` "pressed" treatment for the selected segment).
+//
+// Figma reference: Design System → Button groups
+// (https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=16-399).
+//
+// Use case: date range picker (Day / Week / Month / Year), view toggle
+// (List / Grid), filter set (All / Active / Archived). Single-select
+// only in V1 — multi-select / action-group / per-item href live in a
+// V1.1 follow-up issue.
+//
+// Compound API mirrors the Tabs / Dropdown pattern — root + nested
+// item, both exposed on a static-property namespace so consumers
+// compose inline:
+//
+//   <ButtonGroup defaultValue="day" aria-label="Date range">
+//     <ButtonGroup.Item value="day">Day</ButtonGroup.Item>
+//     <ButtonGroup.Item value="week">Week</ButtonGroup.Item>
+//   </ButtonGroup>
+//
+// A11y model: the wrapper is `role="group"` (toggle-button pattern)
+// rather than `role="radiogroup"` because V1 doesn't ship arrow-key
+// roving focus — Tab moves through each segment, Enter / Space picks
+// it. Each segment carries `aria-pressed={isSelected}`.
+
+'use client';
+
+import { createContext, useCallback, useContext, useState, type FC, type ReactNode } from 'react';
+
+// `@untitledui/icons` declares per-file icon types; type the slot
+// loosely to match `storybookIcons` and the kit's `IconComponent`.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+type IconComponent = FC<any>;
+
+export type ButtonGroupSize = 'sm' | 'md';
+export type ButtonGroupDot = 'gray' | 'brand' | 'success' | 'warning' | 'error';
+
+interface ButtonGroupContextValue {
+  size: ButtonGroupSize;
+  selectedValue: string | undefined;
+  onSelect: (value: string) => void;
+  isGroupDisabled: boolean;
+}
+
+const ButtonGroupContext = createContext<ButtonGroupContextValue | null>(null);
+
+function useButtonGroupContext(): ButtonGroupContextValue {
+  const ctx = useContext(ButtonGroupContext);
+  if (!ctx) {
+    throw new Error('ButtonGroup.Item must be used inside <ButtonGroup>.');
+  }
+  return ctx;
+}
+
+function joinClasses(...parts: (string | undefined | false | null)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+export interface ButtonGroupProps {
+  /** Visual scale. @default 'md' */
+  size?: ButtonGroupSize;
+  /**
+   * Currently-selected item value (controlled). Pair with `onChange`.
+   * Leave undefined for uncontrolled usage and use `defaultValue`.
+   */
+  value?: string;
+  /** Initial selected value for uncontrolled usage. */
+  defaultValue?: string;
+  /** Fires when the user picks a different item. */
+  onChange?: (value: string) => void;
+  /**
+   * Disable the entire group. Individual items can still set their
+   * own `isDisabled` to override per-segment.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Accessible label for the group landmark (e.g. "Date range",
+   * "View mode"). Required when icon-only items are used so screen
+   * readers announce the group purpose.
+   */
+  'aria-label'?: string;
+  /** Tailwind override hook for the wrapper. */
+  className?: string;
+  /** Compose with `<ButtonGroup.Item>` rows. */
+  children: ReactNode;
+}
+
+function ButtonGroupRoot({
+  size = 'md',
+  value: controlledValue,
+  defaultValue,
+  onChange,
+  isDisabled = false,
+  'aria-label': ariaLabel,
+  className,
+  children,
+}: ButtonGroupProps) {
+  const [internalValue, setInternalValue] = useState<string | undefined>(defaultValue);
+  const isControlled = controlledValue !== undefined;
+  const selectedValue = isControlled ? controlledValue : internalValue;
+
+  const handleSelect = useCallback(
+    (next: string) => {
+      if (!isControlled) {
+        setInternalValue(next);
+      }
+      onChange?.(next);
+    },
+    [isControlled, onChange],
+  );
+
+  return (
+    <ButtonGroupContext.Provider
+      value={{ size, selectedValue, onSelect: handleSelect, isGroupDisabled: isDisabled }}
+    >
+      <div
+        role="group"
+        aria-label={ariaLabel}
+        className={joinClasses(
+          'inline-flex h-max rounded-lg bg-primary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset',
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </ButtonGroupContext.Provider>
+  );
+}
+
+export interface ButtonGroupItemProps {
+  /** Stable value identifying this item — flows back via parent `onChange`. */
+  value: string;
+  /** Visible label. Optional when `iconOnly` is true (use `aria-label` then). */
+  children?: ReactNode;
+  /** Leading icon component (e.g. from `@untitledui/icons`). */
+  iconLeading?: IconComponent;
+  /**
+   * Render only the icon — no text label. Pair with `aria-label` so
+   * the segment is announced (axe `button-name`).
+   * @default false
+   */
+  iconOnly?: boolean;
+  /**
+   * Status dot prefix (e.g. green for "active"). Mutually exclusive
+   * with `iconLeading` — pick the affordance that matches the data.
+   */
+  dot?: ButtonGroupDot;
+  /**
+   * Disable this single segment. The parent group's `isDisabled`
+   * still cascades — this prop only sharpens, it can't enable.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /** A11y override for icon-only segments. */
+  'aria-label'?: string;
+}
+
+interface SegmentSizeStyle {
+  base: string;
+  padded: string;
+  iconOnly: string;
+  icon: string;
+  dot: string;
+}
+
+const sizeStyles: Record<ButtonGroupSize, SegmentSizeStyle> = {
+  sm: {
+    base: 'gap-1.5 text-sm font-semibold',
+    padded: 'h-9 px-3',
+    iconOnly: 'size-9',
+    icon: 'size-4',
+    dot: 'size-1.5',
+  },
+  md: {
+    base: 'gap-2 text-sm font-semibold',
+    padded: 'h-10 px-3.5',
+    iconOnly: 'size-10',
+    icon: 'size-5',
+    dot: 'size-2',
+  },
+};
+
+const dotColors: Record<ButtonGroupDot, string> = {
+  gray: 'bg-fg-quaternary',
+  brand: 'bg-brand-solid',
+  success: 'bg-fg-success-primary',
+  warning: 'bg-fg-warning-primary',
+  error: 'bg-fg-error-primary',
+};
+
+// Selected: muted-pressed treatment (`bg-secondary`) — closer to the
+// kit's "active" tab fill than to a brand call-to-action, which suits
+// segmented filters where the group itself is the focus, not a single
+// segment shouting for attention.
+//
+// Divider: each non-first segment carries a 1px left border that
+// "shares" with the previous segment's right edge via `-ml-px` so the
+// outer ring stays a clean 1px. Selected segment is z-raised so its
+// corners overlap the divider rather than getting clipped.
+function ButtonGroupItem({
+  value,
+  children,
+  iconLeading: LeadingIcon,
+  iconOnly = false,
+  dot,
+  isDisabled = false,
+  'aria-label': ariaLabel,
+}: ButtonGroupItemProps) {
+  const { size, selectedValue, onSelect, isGroupDisabled } = useButtonGroupContext();
+  const isSelected = selectedValue === value;
+  const disabled = isDisabled || isGroupDisabled;
+  const sizes = sizeStyles[size];
+
+  return (
+    <button
+      type="button"
+      aria-pressed={isSelected}
+      aria-label={iconOnly ? ariaLabel : undefined}
+      disabled={disabled}
+      onClick={() => {
+        onSelect(value);
+      }}
+      className={joinClasses(
+        'relative inline-flex items-center justify-center whitespace-nowrap outline-focus-ring transition',
+        'focus-visible:z-10 focus-visible:outline-2 focus-visible:-outline-offset-2',
+        'first:rounded-l-[7px] last:rounded-r-[7px]',
+        '[&:not(:first-child)]:-ml-px [&:not(:first-child)]:border-l [&:not(:first-child)]:border-primary',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        sizes.base,
+        iconOnly ? sizes.iconOnly : sizes.padded,
+        isSelected
+          ? 'z-10 bg-secondary text-primary'
+          : 'bg-primary text-secondary hover:bg-primary_hover hover:text-secondary_hover',
+      )}
+    >
+      {dot !== undefined ? (
+        <span
+          aria-hidden="true"
+          className={joinClasses('shrink-0 rounded-full', sizes.dot, dotColors[dot])}
+        />
+      ) : null}
+      {LeadingIcon !== undefined ? (
+        <LeadingIcon className={joinClasses('shrink-0', sizes.icon)} aria-hidden="true" />
+      ) : null}
+      {iconOnly ? null : children}
+    </button>
+  );
+}
+
+type ButtonGroupNamespace = typeof ButtonGroupRoot & {
+  Item: typeof ButtonGroupItem;
+};
+
+export const ButtonGroup: ButtonGroupNamespace = Object.assign(ButtonGroupRoot, {
+  Item: ButtonGroupItem,
+});

--- a/packages/ui/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/ui/src/components/ButtonGroup/ButtonGroup.tsx
@@ -123,7 +123,16 @@ function ButtonGroupRoot({
         role="group"
         aria-label={ariaLabel}
         className={joinClasses(
-          'inline-flex h-max rounded-lg bg-primary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset',
+          // `w-fit` blocks the cross-axis stretch a parent flex column
+          // would otherwise apply (`align-items: stretch` on `inline-flex`
+          // children still expands them in the cross-axis), which used
+          // to paint the wrapper's empty surface as a long line right of
+          // the segments. The outer ring is owned by each segment's own
+          // `border` (see `ButtonGroupItem` below) — keeping the ring on
+          // the wrapper hid the selected segment's top / bottom edges
+          // because child backgrounds always paint over a parent's
+          // `box-shadow: inset`.
+          'inline-flex h-max w-fit rounded-lg shadow-xs-skeuomorphic',
           className,
         )}
       >
@@ -229,8 +238,15 @@ function ButtonGroupItem({
       className={joinClasses(
         'relative inline-flex items-center justify-center whitespace-nowrap outline-focus-ring transition',
         'focus-visible:z-10 focus-visible:outline-2 focus-visible:-outline-offset-2',
-        'first:rounded-l-[7px] last:rounded-r-[7px]',
-        '[&:not(:first-child)]:-ml-px [&:not(:first-child)]:border-l [&:not(:first-child)]:border-primary',
+        // Each segment owns a full `border` instead of relying on the
+        // wrapper's `ring-inset` — that way the selected segment's
+        // `bg-secondary` can't paint over the wrapper's top / bottom
+        // ring. Adjacent segments collapse their shared edge with
+        // `-ml-px` so the visible result is still a single 1px frame
+        // around the group. First / last segments round to match the
+        // wrapper's `rounded-lg`.
+        'border border-primary first:rounded-l-lg last:rounded-r-lg',
+        '[&:not(:first-child)]:-ml-px',
         'disabled:cursor-not-allowed disabled:opacity-50',
         sizes.base,
         iconOnly ? sizes.iconOnly : sizes.padded,

--- a/packages/ui/src/components/ButtonGroup/index.ts
+++ b/packages/ui/src/components/ButtonGroup/index.ts
@@ -1,0 +1,7 @@
+export { ButtonGroup } from './ButtonGroup';
+export type {
+  ButtonGroupDot,
+  ButtonGroupItemProps,
+  ButtonGroupProps,
+  ButtonGroupSize,
+} from './ButtonGroup';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,6 +10,7 @@ export * from './components/BadgeGroup';
 export * from './components/Banner';
 export * from './components/Breadcrumb';
 export * from './components/Button';
+export * from './components/ButtonGroup';
 export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/Drawer';


### PR DESCRIPTION
## Summary

Adds `<ButtonGroup>` + `<ButtonGroup.Item>` compound primitive for single-select segmented controls — date range filters (Day / Week / Month / Year), view-mode toggles (List / Grid / Map), status sweeps (All / Active / Archived). Hand-rolled per the UUI Source Rule's "no kit source" exception (the kit ships no generic ButtonGroup); the wrap re-uses kit surface vocabulary so the result sits naturally next to `<Button>` and `<Tabs>`.

## Scope

**In**
- New `packages/ui/src/components/ButtonGroup/` — `ButtonGroup.tsx`, `ButtonGroup.controls.ts`, `ButtonGroup.mdx`, `ButtonGroup.stories.tsx`, `index.ts`.
- `packages/ui/src/index.ts` — barrel export.
- Compound API: `<ButtonGroup>` (root, controlled or uncontrolled) + `<ButtonGroup.Item>` (segment with `value`, `iconLeading`, `iconOnly`, `dot`, `isDisabled`, `aria-label`).
- Sizes `sm` (h-9) / `md` (h-10) match Figma `_Button group base` cell matrix.
- A11y: `role="group"` wrapper + native `<button>` segments with `aria-pressed`. Tab moves between segments; Enter / Space picks. Disabled state cascades from group → segment.
- 8 stories: `Default`, `WithIcons`, `WithDots`, `IconOnly`, `Disabled`, `DisabledItem`, `Sizes`, `Variants`. F6 prop-coverage gate green (105/105).

**Out**
- Multi-select / action-group / per-item `href` — V1.1 (separate issue).
- Vertical orientation — Figma is horizontal-only; future issue if needed.
- Arrow-key roving focus (radiogroup pattern) — V1.1 nice-to-have per issue scope.
- RN counterpart — web-only this iteration.

## Design notes

- Selected segment uses the muted-pressed treatment (`bg-secondary`) rather than a brand call-to-action — fits filter-bar contexts where the group is the focus, not a single segment.
- Items share a single 1px outer ring; non-first segments draw a left border with `-ml-px` overlap so the ring stays clean. Selected segment is z-raised so its corners overlap the divider rather than getting clipped.
- `iconOnly` strips the visible label but keeps `children` as the API hint — the visual is icon-only, the test surface still binds the human-readable name through `aria-label`.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (105/105)
- [x] `pnpm --filter @glaon/ui build-storybook` — clean
- [x] `pnpm knip` — no orphans
- [ ] CI story-tests (Playwright + axe) — local browsers not installed; CI exercises
- [ ] Storybook localhost:6006 — ButtonGroup page renders all 8 stories; segments keyboard-reachable; selected highlighted; controls panel surfaces root props
- [ ] A11y panel — `role="group"` wrapper named; icon-only items announce `aria-label`; disabled segments don't trap focus
- [ ] Chromatic — new baselines accepted; existing stories byte-equal (new component, no shared overlap)

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)