### PR TITLE
feat(ui): textarea tags-inner variant (multi-value chip input)

### DIFF
--- a/packages/ui/src/components/Textarea/Textarea.controls.ts
+++ b/packages/ui/src/components/Textarea/Textarea.controls.ts
@@ -7,8 +7,18 @@ import type { ControlSpec } from '../_internal/controls';
 import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
 
 const sizeOptions = ['sm', 'md'] as const;
+const variantOptions = ['default', 'tags-inner'] as const;
+type TagSeparator = 'Enter' | ',' | ' ';
 
 export const textareaControls = {
+  variant: {
+    type: 'inline-radio',
+    options: variantOptions,
+    default: 'default',
+    description:
+      'Layout. `default` renders the kit textarea verbatim. `tags-inner` splits the surface into a chip list + typing area for multi-value capture (mail recipients, tag clouds). Tags-only props (`tags`, `defaultTags`, `onTagsChange`, `addTagOn`) are ignored when `variant` stays `default`.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof variantOptions)[number]>,
   label: {
     type: 'text',
     default: 'Description',
@@ -144,6 +154,32 @@ export const textareaControls = {
     description: 'Tailwind override hook for the native `<textarea>` element itself.',
     category: 'Style',
   } satisfies ControlSpec<string>,
+  tags: {
+    type: 'object',
+    description:
+      "Controlled chip list (`variant='tags-inner'`). Pair with `onTagsChange` to manage state outside the field.",
+    category: 'Behavior',
+  } satisfies ControlSpec<string[]>,
+  defaultTags: {
+    type: 'object',
+    description:
+      'Initial chip list for uncontrolled `tags-inner` usage. Storybook\'s `object` control accepts a JSON array (`["alice@example.com", "bob@example.com"]`).',
+    category: 'Behavior',
+  } satisfies ControlSpec<string[]>,
+  onTagsChange: {
+    type: false,
+    action: 'tags-changed',
+    description:
+      'Fires with the next chip list when chips are added (Enter / comma / paste) or removed (Backspace / X). Required for controlled `tags` usage.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  addTagOn: {
+    type: 'object',
+    default: ['Enter', ','] satisfies TagSeparator[],
+    description:
+      "Keys that confirm the current text into a chip. Defaults to `['Enter', ',']`. Add `' '` for whitespace-as-separator (tag clouds), drop `,` to allow commas inside a single tag (rare). Storybook's `object` control accepts a JSON array.",
+    category: 'Behavior',
+  } satisfies ControlSpec<TagSeparator[]>,
   ref: {
     type: false,
     description: 'Forwarded ref to the kit `<TextField>` wrapper.',

--- a/packages/ui/src/components/Textarea/Textarea.mdx
+++ b/packages/ui/src/components/Textarea/Textarea.mdx
@@ -22,6 +22,7 @@ line — descriptions, comments, free-form notes.
 - **Single-line capture** → use [Input](?path=/docs/web-primitives-input--docs); a Textarea on a single-line value wastes vertical space and confuses keyboard users (Enter inserts a newline instead of submitting).
 - **Code / monospaced editing** → out of scope for Phase 1; queue a Phase 2 CodeEditor primitive.
 - **Rich text with formatting toolbars** → out of scope; queue a Phase 2 RichText primitive.
+- **Single-value picker from a fixed list** → `<Select>`. The `tags-inner` variant exists for free-form multi-value capture, not for constrained option sets.
 
 ## Anatomy
 
@@ -41,6 +42,38 @@ caption that re-styles to red when `isInvalid` is true.
   isRequired
 />
 ```
+
+## Tags inner variant
+
+`variant="tags-inner"` swaps the multi-line capture surface for a
+chip-based multi-value input. Each confirmed value becomes a `<Badge>`
+chip rendered above the typing area; the surrounding container shares
+the same focus ring + invalid styling as the default Textarea.
+
+```tsx
+<Textarea
+  variant="tags-inner"
+  label="Recipients"
+  placeholder="Add an email and press Enter…"
+  defaultTags={['alice@example.com']}
+  onTagsChange={(tags) => setRecipients(tags)}
+  addTagOn={['Enter', ',']}
+/>
+```
+
+Keyboard contract:
+
+- **Enter** / **,** (or any subset configured via `addTagOn`) confirms
+  the current text into a new chip and clears the input.
+- **Backspace** on an empty input pops the last chip — typical
+  chip-input UX so keyboard users prune mistakes without reaching
+  for the X button.
+- **Paste** with the configured separator (e.g. comma-separated email
+  list) splits on the first non-Enter token and bulk-adds.
+
+State is fully controlled (`tags` + `onTagsChange`) or uncontrolled
+(`defaultTags`). Mixing the two is unsupported — `tags` always wins
+when defined. Duplicate values are dropped silently.
 
 ## Variants
 
@@ -68,6 +101,13 @@ caption that re-styles to red when `isInvalid` is true.
   can rely on `rows` plus content scroll instead. Don't disable
   resize via CSS without a strong reason — it removes a useful
   affordance.
+- For `variant="tags-inner"`: every chip is a `<Badge>` with an X
+  remove button (`aria-label="Remove …"`); the chip list is wrapped
+  in `<ul role="list">` so screen readers announce it as a list.
+  The typing area inherits `aria-invalid` / `aria-required` /
+  `aria-describedby` so the same hint / error contract holds — a
+  screen reader hears "Recipients, required, 2 items, edit text"
+  followed by the hint when the field is focused.
 
 ## Related components
 

--- a/packages/ui/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/ui/src/components/Textarea/Textarea.stories.tsx
@@ -87,3 +87,79 @@ export const Sizes: Story = {
     </div>
   ),
 };
+
+// `variant='tags-inner'` swaps the multi-line capture surface for a
+// chip-based multi-value input. Confirm a tag with Enter / comma;
+// Backspace on the empty input pops the last chip.
+export const TagsInner: Story = {
+  args: {
+    variant: 'tags-inner',
+    label: 'Recipients',
+    placeholder: 'Add an email and press Enter…',
+    hint: 'Confirm with Enter or comma. Backspace removes the last chip.',
+  },
+};
+
+// Initial chip list rendered via `defaultTags` (uncontrolled). Use
+// for forms that hydrate from server state on mount.
+export const TagsInnerWithValues: Story = {
+  args: {
+    variant: 'tags-inner',
+    label: 'Tags',
+    placeholder: 'Add a tag…',
+    defaultTags: ['design-system', 'phase-1', 'ui'],
+  },
+};
+
+// Combine `tags-inner` with `isInvalid` to surface form validation —
+// the surface ring re-styles red and the hint inherits error styling
+// (the kit's `HintText` flips colour automatically). axe verifies
+// `aria-invalid` + `aria-describedby` plumb through to the typing
+// area below the chips.
+export const TagsInnerWithError: Story = {
+  args: {
+    variant: 'tags-inner',
+    label: 'Recipients',
+    placeholder: 'Add an email…',
+    defaultTags: ['marketing@example.com'],
+    isInvalid: true,
+    hint: 'At least one engineering recipient is required.',
+  },
+};
+
+// `addTagOn` set to `[',']` confirms only on commas — useful for
+// CSV-style input where Enter should drop a newline (e.g. multi-line
+// addresses, paragraph-separated keywords).
+export const TagsInnerComma: Story = {
+  args: {
+    variant: 'tags-inner',
+    label: 'Keywords',
+    placeholder: 'Type a keyword and press , …',
+    defaultTags: ['monorepo'],
+    addTagOn: [','],
+  },
+};
+
+// Side-by-side variant gallery so designers can verify the two
+// surfaces look like family members — same ring + focus + invalid
+// affordances, just two different content layouts.
+export const Variants: Story = {
+  parameters: { controls: { exclude: ['variant', 'label', 'placeholder', 'defaultTags'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <Textarea
+        {...args}
+        variant="default"
+        label="Default — free-form description"
+        placeholder="Tell us a bit about yourself…"
+      />
+      <Textarea
+        {...args}
+        variant="tags-inner"
+        label="Tags inner — multi-value capture"
+        placeholder="Add a tag and press Enter…"
+        defaultTags={['frontend', 'tooling']}
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/Textarea/Textarea.tsx
+++ b/packages/ui/src/components/Textarea/Textarea.tsx
@@ -1,14 +1,425 @@
-// Glaon Textarea — thin wrap around the Untitled UI kit `TextArea`
-// source under `packages/ui/src/components/base/textarea/textarea.tsx`.
-// Per CLAUDE.md's UUI Source Rule, the structural HTML/CSS, focus /
-// invalid / disabled state matrix, and resize-handle styling come from
-// the kit; Glaon's contribution is the wrap layer (token override via
-// `theme.css` + `glaon-overrides.css`, prop API consistency, Figma
-// `parameters.design` mapping in the story).
+// Glaon Textarea — wraps the Untitled UI kit `TextArea` source under
+// `packages/ui/src/components/base/textarea/textarea.tsx` for the
+// default variant, and adds a hand-rolled `tags-inner` variant for the
+// chip-based multi-value input pattern from the Figma `Inputs` page
+// (https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=85-1269).
 //
-// We surface the kit's casing (`TextArea`) under the Glaon name
-// `Textarea` (one capital A) to match common React/web idiom while
-// keeping the kit re-export clean. `TextAreaBase` stays as-is for
-// consumers that want the unwrapped primitive.
+// Per CLAUDE.md's UUI Source Rule, the kit handles the structural
+// HTML/CSS, focus / invalid / disabled state matrix, and resize-handle
+// styling for the default variant; Glaon's contribution is the wrap
+// layer (token override via `theme.css` + `glaon-overrides.css`, prop
+// API consistency, Figma `parameters.design` mapping in stories).
+//
+// `tags-inner` falls under the "no kit source" exception — the kit
+// ships no multi-value chip input pattern. We hand-roll a layout that
+// mirrors the kit textarea surface (`bg-primary` rounded ring with the
+// same focus / invalid affordances) and renders Glaon `<Badge>` chips
+// at the top, with the typing area underneath. Keyboard contract:
+//
+//   - `Enter` / `,` / ` ` (configurable via `addTagOn`) confirms the
+//     current text into a new chip and clears the input.
+//   - `Backspace` on an empty input removes the last chip.
+//   - `paste` splits on the first separator in `addTagOn` ↦ bulk add.
 
-export { TextArea as Textarea, TextAreaBase } from '../base/textarea/textarea';
+import type {
+  ChangeEventHandler,
+  ClipboardEventHandler,
+  FocusEventHandler,
+  KeyboardEventHandler,
+  ReactNode,
+  Ref,
+} from 'react';
+import { useCallback, useId, useRef, useState } from 'react';
+import { TextField as AriaTextField } from 'react-aria-components';
+
+import { HintText } from '../base/input/hint-text';
+import { Label } from '../base/input/label';
+import { Badge } from '../Badge';
+import { TextArea as KitTextArea } from '../base/textarea/textarea';
+
+export { TextAreaBase } from '../base/textarea/textarea';
+
+export type TextareaSize = 'sm' | 'md';
+export type TextareaVariant = 'default' | 'tags-inner';
+
+/**
+ * Keyboard tokens that confirm the current text into a chip. The
+ * default set covers the most common patterns — Enter (deliberate
+ * confirm) and comma (paste-friendly). Add `' '` for whitespace-as-
+ * separator behaviour (typical for tag clouds), drop comma to allow
+ * commas inside a single tag value (rare).
+ */
+export type TextareaTagSeparator = 'Enter' | ',' | ' ';
+
+export interface TextareaProps {
+  /**
+   * Layout variant. `default` (the only Phase 1 mode until now) renders
+   * the kit textarea verbatim. `tags-inner` splits the surface into a
+   * chip list + typing area for multi-value capture (e.g. mail
+   * recipients, tag clouds).
+   * @default 'default'
+   */
+  variant?: TextareaVariant;
+  /** Visible label rendered above the field. */
+  label?: string;
+  /** Helper text rendered below the field — re-styles red when `isInvalid`. */
+  hint?: ReactNode;
+  /** Inline tooltip trigger appended to the label (info icon). */
+  tooltip?: string;
+  /** Visual scale. */
+  size?: TextareaSize;
+  /** Native `<textarea rows>` (default variant) / starting line count (tags-inner). */
+  rows?: number;
+  /** Native `<textarea cols>`. */
+  cols?: number;
+  /** Placeholder shown in the typing area when empty. */
+  placeholder?: string;
+  /** Surface validation error styling (red border + ring). */
+  isInvalid?: boolean;
+  /** Block all interaction. */
+  isDisabled?: boolean;
+  /** Selectable / copyable but the value can't be edited. */
+  isReadOnly?: boolean;
+  /** Mark the field as required (forwards `aria-required`). */
+  isRequired?: boolean;
+  /** Hide the visual `*` next to the label without dropping `aria-required`. */
+  hideRequiredIndicator?: boolean;
+  /** Controlled value (default variant). */
+  value?: string;
+  /** Initial value (default variant). */
+  defaultValue?: string;
+  /** Form field name forwarded to the native textarea. */
+  name?: string;
+  /** Fires on every keystroke with the new string value (default variant). */
+  onChange?: (value: string) => void;
+  /** Fires when focus leaves the field. */
+  onBlur?: FocusEventHandler;
+  /** Fires when focus enters the field. */
+  onFocus?: FocusEventHandler;
+  /** Tailwind override hook for the outer wrapper. */
+  className?: string;
+  /** Tailwind override hook for the native `<textarea>`. */
+  textAreaClassName?: string;
+  /** Forwarded ref to the kit `<TextField>` wrapper (default variant). */
+  ref?: Ref<HTMLDivElement>;
+  /** Forwarded ref to the underlying `<textarea>` element. */
+  textAreaRef?: Ref<HTMLTextAreaElement>;
+
+  // --- tags-inner only ---
+
+  /** Controlled chip list (tags-inner). Pair with `onTagsChange`. */
+  tags?: readonly string[];
+  /** Initial chip list (tags-inner, uncontrolled). */
+  defaultTags?: readonly string[];
+  /** Fires with the next chip list when chips are added or removed. */
+  onTagsChange?: (tags: string[]) => void;
+  /**
+   * Keys that confirm the current text into a chip. Defaults to
+   * `['Enter', ',']`.
+   * @default ['Enter', ',']
+   */
+  addTagOn?: readonly TextareaTagSeparator[];
+}
+
+const DEFAULT_TAG_SEPARATORS: readonly TextareaTagSeparator[] = ['Enter', ','];
+
+function joinClasses(...parts: (string | undefined | false | null)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+// Surface mirrors the kit's `TextAreaBase` so the tags-inner container
+// reads as a Textarea family member. Focus + invalid styles via
+// `:focus-within` so the parent `<div>` carries the visual state.
+const tagsInnerSurface =
+  'flex w-full flex-col gap-2 rounded-lg bg-primary text-primary shadow-xs ring-1 ring-primary ring-inset transition focus-within:ring-2 focus-within:ring-brand placeholder:text-placeholder';
+const tagsInnerSizes: Record<TextareaSize, string> = {
+  sm: 'p-3 text-sm',
+  md: 'px-3.5 py-3 text-md',
+};
+const tagsInnerInvalid = 'ring-error_subtle focus-within:ring-2 focus-within:ring-error';
+const tagsInnerDisabled = 'cursor-not-allowed opacity-50';
+
+export function Textarea({
+  variant = 'default',
+  // tags-inner-only props (unused on default — destructure them out
+  // so the rest spread doesn't carry them onto the kit textarea).
+  tags,
+  defaultTags,
+  onTagsChange,
+  addTagOn = DEFAULT_TAG_SEPARATORS,
+  ...common
+}: TextareaProps) {
+  if (variant === 'default') {
+    return <KitDefaultTextarea {...common} />;
+  }
+
+  const tagsProps: Pick<TagsInnerProps, 'tags' | 'defaultTags' | 'onTagsChange' | 'addTagOn'> = {
+    addTagOn,
+  };
+  if (tags !== undefined) tagsProps.tags = tags;
+  if (defaultTags !== undefined) tagsProps.defaultTags = defaultTags;
+  if (onTagsChange !== undefined) tagsProps.onTagsChange = onTagsChange;
+
+  return <TagsInnerTextarea {...common} {...tagsProps} />;
+}
+
+type CommonProps = Omit<
+  TextareaProps,
+  'variant' | 'tags' | 'defaultTags' | 'onTagsChange' | 'addTagOn'
+>;
+
+// `KitTextArea` declares its props with strict (non-undefined-tolerant)
+// optional shapes; since our wrap allows callers to pass `undefined`
+// to opt out, we spread conditionally so we never hand the kit an
+// explicit `undefined` for an optional prop.
+function KitDefaultTextarea(props: CommonProps) {
+  // The kit accepts a wider `ClassNameOrFunction` type than our
+  // string-only wrap; re-typing here would force every consumer to
+  // know that. Spread conditionally so we never hand the kit an
+  // explicit `undefined` for an optional prop (the kit's
+  // `exactOptionalPropertyTypes` typing rejects that).
+  const passthrough: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(props)) {
+    if (value !== undefined) passthrough[key] = value;
+  }
+  return <KitTextArea {...passthrough} />;
+}
+
+interface TagsInnerProps extends CommonProps {
+  tags?: readonly string[];
+  defaultTags?: readonly string[];
+  onTagsChange?: (tags: string[]) => void;
+  addTagOn?: readonly TextareaTagSeparator[];
+}
+
+function TagsInnerTextarea(props: TagsInnerProps) {
+  const {
+    label,
+    hint,
+    tooltip,
+    size = 'md',
+    rows,
+    cols,
+    placeholder,
+    isInvalid = false,
+    isDisabled = false,
+    isReadOnly = false,
+    isRequired = false,
+    hideRequiredIndicator = false,
+    name,
+    className,
+    textAreaClassName,
+    onBlur,
+    onFocus,
+    ref,
+    textAreaRef,
+    tags: controlledTags,
+    defaultTags,
+    onTagsChange,
+    addTagOn = DEFAULT_TAG_SEPARATORS,
+  } = props;
+
+  const [uncontrolledTags, setUncontrolledTags] = useState<string[]>(() =>
+    defaultTags !== undefined ? [...defaultTags] : [],
+  );
+  const isControlled = controlledTags !== undefined;
+  const currentTags: readonly string[] = isControlled ? controlledTags : uncontrolledTags;
+  const innerTextAreaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [draftValue, setDraftValue] = useState('');
+  const hintId = useId();
+
+  const setTextAreaRef = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      innerTextAreaRef.current = node;
+      if (typeof textAreaRef === 'function') {
+        textAreaRef(node);
+      } else if (textAreaRef !== undefined && textAreaRef !== null) {
+        (textAreaRef as { current: HTMLTextAreaElement | null }).current = node;
+      }
+    },
+    [textAreaRef],
+  );
+
+  const updateTags = useCallback(
+    (next: string[]) => {
+      if (!isControlled) {
+        setUncontrolledTags(next);
+      }
+      onTagsChange?.(next);
+    },
+    [isControlled, onTagsChange],
+  );
+
+  const commitDraft = useCallback(
+    (raw: string) => {
+      const cleaned = raw.trim();
+      if (cleaned.length === 0) return;
+      if (currentTags.includes(cleaned)) {
+        setDraftValue('');
+        return;
+      }
+      updateTags([...currentTags, cleaned]);
+      setDraftValue('');
+    },
+    [currentTags, updateTags],
+  );
+
+  const removeTag = useCallback(
+    (tagToRemove: string) => {
+      updateTags(currentTags.filter((t) => t !== tagToRemove));
+    },
+    [currentTags, updateTags],
+  );
+
+  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback(
+    (event) => {
+      if (isReadOnly || isDisabled) return;
+
+      const keyToken: TextareaTagSeparator | undefined =
+        event.key === 'Enter'
+          ? 'Enter'
+          : event.key === ','
+            ? ','
+            : event.key === ' '
+              ? ' '
+              : undefined;
+      if (keyToken !== undefined && addTagOn.includes(keyToken)) {
+        event.preventDefault();
+        commitDraft(draftValue);
+        return;
+      }
+
+      // Backspace on an empty draft pops the last chip — typical
+      // chip-input UX; lets keyboard users prune mistakes without
+      // reaching for the X button.
+      if (event.key === 'Backspace' && draftValue.length === 0 && currentTags.length > 0) {
+        event.preventDefault();
+        const next = [...currentTags];
+        next.pop();
+        updateTags(next);
+      }
+    },
+    [addTagOn, commitDraft, currentTags, draftValue, isDisabled, isReadOnly, updateTags],
+  );
+
+  const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = useCallback(
+    (event) => {
+      if (isReadOnly || isDisabled) return;
+      const pasted = event.clipboardData.getData('text');
+      const bulkDelimiter = addTagOn.find((s) => s !== 'Enter');
+      if (bulkDelimiter === undefined || !pasted.includes(bulkDelimiter)) {
+        return;
+      }
+      event.preventDefault();
+      const additions = pasted
+        .split(bulkDelimiter)
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0 && !currentTags.includes(part));
+      if (additions.length === 0) return;
+      const dedupedAdditions = additions.filter(
+        (entry, index, all) => all.indexOf(entry) === index,
+      );
+      updateTags([...currentTags, ...dedupedAdditions]);
+      setDraftValue('');
+    },
+    [addTagOn, currentTags, isDisabled, isReadOnly, updateTags],
+  );
+
+  const handleDraftChange: ChangeEventHandler<HTMLTextAreaElement> = useCallback((event) => {
+    setDraftValue(event.currentTarget.value);
+  }, []);
+
+  const surfaceClass = joinClasses(
+    tagsInnerSurface,
+    tagsInnerSizes[size],
+    isInvalid && tagsInnerInvalid,
+    isDisabled && tagsInnerDisabled,
+  );
+
+  // Build the AriaTextField props object conditionally to avoid handing
+  // RAC explicit `undefined` for an optional prop (exactOptionalPropertyTypes).
+  // RAC's TextField generics for the render-prop `className` resist a
+  // narrow object literal type here, so we type the bag as `unknown`
+  // and cast on the spread.
+  const fieldProps: Record<string, unknown> = {
+    isInvalid,
+    isDisabled,
+    isReadOnly,
+    isRequired,
+    className: joinClasses(
+      'group flex h-max w-full flex-col items-start justify-start gap-1.5',
+      className,
+    ),
+  };
+  if (name !== undefined) fieldProps.name = name;
+  if (ref !== undefined) fieldProps.ref = ref;
+  if (onBlur !== undefined) fieldProps.onBlur = onBlur;
+  if (onFocus !== undefined) fieldProps.onFocus = onFocus;
+
+  return (
+    <AriaTextField {...fieldProps}>
+      {label !== undefined && (
+        <Label
+          isRequired={hideRequiredIndicator ? !hideRequiredIndicator : isRequired}
+          {...(tooltip !== undefined ? { tooltip } : {})}
+        >
+          {label}
+        </Label>
+      )}
+
+      <div
+        className={surfaceClass}
+        onClick={(event) => {
+          if (event.target === event.currentTarget) {
+            innerTextAreaRef.current?.focus();
+          }
+        }}
+      >
+        {currentTags.length > 0 && (
+          <ul className="flex flex-wrap gap-1.5" role="list">
+            {currentTags.map((tag) => (
+              <li key={tag}>
+                <Badge
+                  size={size}
+                  color="gray"
+                  icon="close"
+                  onClose={() => {
+                    removeTag(tag);
+                  }}
+                >
+                  {tag}
+                </Badge>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <textarea
+          ref={setTextAreaRef}
+          rows={rows ?? 1}
+          {...(cols !== undefined ? { cols } : {})}
+          {...(currentTags.length === 0 && placeholder !== undefined ? { placeholder } : {})}
+          value={draftValue}
+          onChange={handleDraftChange}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          disabled={isDisabled}
+          readOnly={isReadOnly}
+          aria-invalid={isInvalid}
+          aria-required={isRequired}
+          {...(hint !== undefined ? { 'aria-describedby': hintId } : {})}
+          className={joinClasses(
+            'w-full resize-none border-0 bg-transparent text-current outline-hidden focus:outline-hidden placeholder:text-placeholder',
+            textAreaClassName,
+          )}
+        />
+      </div>
+
+      {hint !== undefined && (
+        <HintText id={hintId} isInvalid={isInvalid} size={size}>
+          {hint}
+        </HintText>
+      )}
+    </AriaTextField>
+  );
+}

--- a/packages/ui/src/components/Textarea/Textarea.tsx
+++ b/packages/ui/src/components/Textarea/Textarea.tsx
@@ -22,7 +22,6 @@
 //   - `paste` splits on the first separator in `addTagOn` ↦ bulk add.
 
 import type {
-  ChangeEventHandler,
   ClipboardEventHandler,
   FocusEventHandler,
   KeyboardEventHandler,
@@ -30,7 +29,7 @@ import type {
   Ref,
 } from 'react';
 import { useCallback, useId, useRef, useState } from 'react';
-import { TextField as AriaTextField } from 'react-aria-components';
+import { TextArea as AriaTextArea, TextField as AriaTextField } from 'react-aria-components';
 
 import { HintText } from '../base/input/hint-text';
 import { Label } from '../base/input/label';
@@ -325,10 +324,6 @@ function TagsInnerTextarea(props: TagsInnerProps) {
     [addTagOn, currentTags, isDisabled, isReadOnly, updateTags],
   );
 
-  const handleDraftChange: ChangeEventHandler<HTMLTextAreaElement> = useCallback((event) => {
-    setDraftValue(event.currentTarget.value);
-  }, []);
-
   const surfaceClass = joinClasses(
     tagsInnerSurface,
     tagsInnerSizes[size],
@@ -340,12 +335,17 @@ function TagsInnerTextarea(props: TagsInnerProps) {
   // RAC explicit `undefined` for an optional prop (exactOptionalPropertyTypes).
   // RAC's TextField generics for the render-prop `className` resist a
   // narrow object literal type here, so we type the bag as `unknown`
-  // and cast on the spread.
+  // and cast on the spread. Drive `value` + `onChange` at the field
+  // level so RAC binds the label / aria-describedby plumbing to
+  // `<AriaTextArea>` automatically — a plain `<textarea>` falls outside
+  // RAC's scan and trips axe `label-title-only`.
   const fieldProps: Record<string, unknown> = {
     isInvalid,
     isDisabled,
     isReadOnly,
     isRequired,
+    value: draftValue,
+    onChange: setDraftValue,
     className: joinClasses(
       'group flex h-max w-full flex-col items-start justify-start gap-1.5',
       className,
@@ -383,6 +383,7 @@ function TagsInnerTextarea(props: TagsInnerProps) {
                   size={size}
                   color="gray"
                   icon="close"
+                  closeLabel={`Remove ${tag}`}
                   onClose={() => {
                     removeTag(tag);
                   }}
@@ -394,19 +395,13 @@ function TagsInnerTextarea(props: TagsInnerProps) {
           </ul>
         )}
 
-        <textarea
+        <AriaTextArea
           ref={setTextAreaRef}
           rows={rows ?? 1}
           {...(cols !== undefined ? { cols } : {})}
           {...(currentTags.length === 0 && placeholder !== undefined ? { placeholder } : {})}
-          value={draftValue}
-          onChange={handleDraftChange}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
-          disabled={isDisabled}
-          readOnly={isReadOnly}
-          aria-invalid={isInvalid}
-          aria-required={isRequired}
           {...(hint !== undefined ? { 'aria-describedby': hintId } : {})}
           className={joinClasses(
             'w-full resize-none border-0 bg-transparent text-current outline-hidden focus:outline-hidden placeholder:text-placeholder',

--- a/packages/ui/src/components/Textarea/index.ts
+++ b/packages/ui/src/components/Textarea/index.ts
@@ -1,1 +1,7 @@
 export { Textarea, TextAreaBase } from './Textarea';
+export type {
+  TextareaProps,
+  TextareaSize,
+  TextareaTagSeparator,
+  TextareaVariant,
+} from './Textarea';


### PR DESCRIPTION
## Summary

Adds `variant: 'default' | 'tags-inner'` to `<Textarea>`. The new `tags-inner` variant splits the surface into a `<Badge>` chip list above a typing area for multi-value capture (mail recipients, tag clouds, keyword lists). Hand-rolled per the UUI Source Rule's "no kit source" exception — the kit ships no multi-value chip input pattern — but mirrors the kit textarea's surface, focus, and invalid affordances so the two variants read as family members.

## Scope

**In**
- `Textarea.tsx` — wraps the kit textarea for `variant='default'` (byte-equal pass-through). For `variant='tags-inner'`, hand-rolled layout with chip list (`<ul role="list">` of `<Badge icon="close">`s) over a native `<textarea>`. Keyboard: Enter / comma confirm, Backspace on empty pops last, Paste with separator bulk-adds.
- `Textarea.controls.ts` — new entries: `variant`, `tags`, `defaultTags`, `onTagsChange`, `addTagOn`.
- `Textarea.mdx` — new "Tags inner variant" section with code sample + keyboard contract, expanded a11y notes for chip list semantics.
- `Textarea.stories.tsx` — 5 new stories: `TagsInner`, `TagsInnerWithValues`, `TagsInnerWithError`, `TagsInnerComma`, `Variants`.
- State: controlled (`tags` + `onTagsChange`) or uncontrolled (`defaultTags`); duplicates dropped silently.

**Out**
- Combobox-style autocomplete (typing → suggestion dropdown) — V1.1 separate issue.
- Drag-to-reorder chips — V1.2.
- Per-tag color / icon (e.g. `success` / `archived` chip variants) — Phase 2.
- Email / format validation per tag — consumer-orchestrated.
- Input parametric variants (the `tags-inner` Input counterpart shares this pattern; tracked in #313 separately).

## Migration

`variant` defaults to `'default'`, every new prop is optional + undefined-default. Existing Textarea consumers render byte-equal — only added stories will appear in Chromatic baseline.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (105/105)
- [x] `pnpm --filter @glaon/ui build-storybook`
- [ ] Storybook localhost:6006 — Textarea page shows variant control with `default` / `tags-inner`; 5 new stories render correctly; chips add via Enter / comma; Backspace on empty pops last; X removes a specific chip
- [ ] A11y panel — chip list announced as list; each X button has `aria-label="Remove …"`; typing area inherits `aria-invalid` + `aria-required` + `aria-describedby`
- [ ] Chromatic — new baselines accepted; existing canvases byte-equal (`variant='default'` is the new default)

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)