### PR TITLE
feat(ui): table phase B — HeadLabel typography wrapper + canonical sort/tooltip pattern

### DIFF
--- a/packages/ui/src/components/Table/Table.mdx
+++ b/packages/ui/src/components/Table/Table.mdx
@@ -70,6 +70,39 @@ Compose with these slots:
 </Table>
 ```
 
+## Header label
+
+`Table.HeadLabel` is the canonical typography wrapper for column
+header labels — `font-semibold` + `text-secondary` on a
+single-line span. Drop it inside any `<Table.Head>` so every Glaon
+table renders the same header treatment without consumers
+repeating the class set:
+
+```tsx
+<Table.Head
+  id="role"
+  allowsSorting
+  tooltip="Default role assigned at invite time."
+>
+  <Table.HeadLabel>Role</Table.HeadLabel>
+</Table.Head>
+```
+
+The structural plumbing already lives on `<Table.Head>`:
+
+- **`allowsSorting`** — opts the column into the sort affordance.
+  RAC renders the chevron-selector when no direction is active and
+  swaps to an up / down arrow when the column is the active sort
+  target. `aria-sort` on the `<th>` flows automatically.
+- **`tooltip`** — adds a `?` icon next to the label. Hover or focus
+  opens the kit `<Tooltip>` so the help text is keyboard-reachable
+  without clutter.
+
+The `HeaderLabelStates` story renders the Figma `_Table header label`
+frame's five Arrow / Help-icon variations side by side so designers
+can verify pixel parity. See [#325](https://github.com/toss-cengiz/glaon/issues/325)
+for the Phase B scope.
+
 ## Cell-type catalog
 
 `Table.Cell` is the kit's `<gridcell>` wrapper; in addition to raw

--- a/packages/ui/src/components/Table/Table.stories.tsx
+++ b/packages/ui/src/components/Table/Table.stories.tsx
@@ -116,14 +116,16 @@ export const WithSortableHeader: Story = {
     <Table {...args}>
       <Table.Header>
         <Table.Head id="name" allowsSorting>
-          Device
+          <Table.HeadLabel>Device</Table.HeadLabel>
         </Table.Head>
         <Table.Head id="room" allowsSorting>
-          Room
+          <Table.HeadLabel>Room</Table.HeadLabel>
         </Table.Head>
-        <Table.Head id="status">Status</Table.Head>
+        <Table.Head id="status">
+          <Table.HeadLabel>Status</Table.HeadLabel>
+        </Table.Head>
         <Table.Head id="lastSeen" allowsSorting>
-          Last seen
+          <Table.HeadLabel>Last seen</Table.HeadLabel>
         </Table.Head>
       </Table.Header>
       <Table.Body>
@@ -137,6 +139,99 @@ export const WithSortableHeader: Story = {
             <Table.Cell>{device.lastSeen}</Table.Cell>
           </Table.Row>
         ))}
+      </Table.Body>
+    </Table>
+  ),
+};
+
+// `Table.HeadLabel` + `tooltip` prop on `<Table.Head>` — the kit
+// renders a `?` icon next to the label that opens the help tooltip
+// on hover / focus. Pair with `allowsSorting` for "this column can
+// be sorted, here's what it means" affordances.
+export const WithHelpIcon: Story = {
+  render: (args) => (
+    <Table {...args}>
+      <Table.Header>
+        <Table.Head id="name">
+          <Table.HeadLabel>Device</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head
+          id="room"
+          allowsSorting
+          tooltip="The room the device is paired with — change in device settings."
+        >
+          <Table.HeadLabel>Room</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head
+          id="status"
+          tooltip="Online means the device responded within the last 5 minutes."
+        >
+          <Table.HeadLabel>Status</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="lastSeen" allowsSorting>
+          <Table.HeadLabel>Last seen</Table.HeadLabel>
+        </Table.Head>
+      </Table.Header>
+      <Table.Body>
+        {devices.map((device) => (
+          <Table.Row key={device.id} id={device.id}>
+            <Table.Cell>
+              <span className="font-medium text-primary">{device.name}</span>
+            </Table.Cell>
+            <Table.Cell>{device.room}</Table.Cell>
+            <Table.Cell>{statusBadge(device.status)}</Table.Cell>
+            <Table.Cell>{device.lastSeen}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  ),
+};
+
+// Header label gallery — Figma `Arrow` axis variants (none /
+// chevron-selector / down-arrow / up-arrow) shown in a single
+// canvas so designers can verify pixel parity. RAC renders the
+// chevron-selector when `allowsSorting` is set but no direction is
+// active, and an `ArrowDown` (rotated 180° for ascending) when the
+// column matches the table's `sortDescriptor`. The `sorted` column
+// in this story shows the descending state.
+export const HeaderLabelStates: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Header label states — plain / sortable (chevron) / sorted (arrow) / with tooltip / sorted + tooltip.',
+      },
+    },
+  },
+  args: { sortDescriptor: { column: 'sorted', direction: 'descending' as const } },
+  render: (args) => (
+    <Table {...args} aria-label="Header label states">
+      <Table.Header>
+        <Table.Head id="plain">
+          <Table.HeadLabel>Plain label</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="sortable" allowsSorting>
+          <Table.HeadLabel>Sortable</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="sorted" allowsSorting>
+          <Table.HeadLabel>Sorted</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="tooltip" tooltip="Inline help text — hover or focus to read.">
+          <Table.HeadLabel>With tooltip</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="combo" allowsSorting tooltip="Sortable column with extra context.">
+          <Table.HeadLabel>Combo</Table.HeadLabel>
+        </Table.Head>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row id="r1">
+          <Table.Cell>—</Table.Cell>
+          <Table.Cell>—</Table.Cell>
+          <Table.Cell>—</Table.Cell>
+          <Table.Cell>—</Table.Cell>
+          <Table.Cell>—</Table.Cell>
+        </Table.Row>
       </Table.Body>
     </Table>
   ),

--- a/packages/ui/src/components/Table/Table.tsx
+++ b/packages/ui/src/components/Table/Table.tsx
@@ -56,6 +56,7 @@
 // and Phase D adds a per-row lead action column.
 
 import { Table as KitTable } from '../application/table/table';
+import { TableHeadLabel } from './parts/HeadLabel';
 import {
   ActionButtonsCell,
   ActionDropdownCell,
@@ -75,6 +76,8 @@ import {
 
 export { TableCard, TableRowActionsDropdown } from '../application/table/table';
 export * from './cells';
+export { TableHeadLabel };
+export type { TableHeadLabelProps } from './parts/HeadLabel';
 
 // The kit's `Table` is itself a namespace (`Table.Header`, `Table.Row`,
 // `Table.Cell`, …). Augment its static properties with the cell-type
@@ -120,8 +123,10 @@ const CellWithCellTypes: CellNamespace = Object.assign(KitTable.Cell, {
 
 type TableNamespace = typeof KitTable & {
   Cell: CellNamespace;
+  HeadLabel: typeof TableHeadLabel;
 };
 
 export const Table: TableNamespace = Object.assign(KitTable, {
   Cell: CellWithCellTypes,
+  HeadLabel: TableHeadLabel,
 });

--- a/packages/ui/src/components/Table/index.ts
+++ b/packages/ui/src/components/Table/index.ts
@@ -1,2 +1,3 @@
-export { Table, TableCard, TableRowActionsDropdown } from './Table';
+export { Table, TableCard, TableHeadLabel, TableRowActionsDropdown } from './Table';
+export type { TableHeadLabelProps } from './Table';
 export * from './cells';

--- a/packages/ui/src/components/Table/parts/HeadLabel.tsx
+++ b/packages/ui/src/components/Table/parts/HeadLabel.tsx
@@ -1,0 +1,48 @@
+// Glaon Table.HeadLabel — typography wrapper for column header
+// labels. Phase B of #323. The kit `<Table.Head>` already handles
+// the structural plumbing (the sortable chevron / arrow comes from
+// `allowsSorting` on the `<Column>`, the `?` help-icon comes from
+// the `tooltip` prop). HeadLabel is the canonical way to wrap the
+// visible label text so every Glaon table renders the same
+// `font-semibold` + `text-secondary` typography without consumers
+// repeating the class set per cell.
+//
+// Usage:
+//
+//   <Table.Head id="role" allowsSorting tooltip="Default role assigned at invite time.">
+//     <Table.HeadLabel>Role</Table.HeadLabel>
+//   </Table.Head>
+//
+// The `tooltip` + `allowsSorting` props live on `<Table.Head>` and
+// the kit already renders them inline with the children — we don't
+// re-implement either in HeadLabel.
+
+import type { ReactNode } from 'react';
+
+export interface TableHeadLabelProps {
+  /** Tailwind override hook. */
+  className?: string;
+  /** Visible label text. */
+  children: ReactNode;
+}
+
+function joinClasses(...parts: (string | undefined | false | null)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+/**
+ * Typography wrapper for column header labels — `font-semibold` +
+ * `text-secondary` on a single-line span. Drop inside a
+ * `<Table.Head>` to align with Figma's `_Table header label`
+ * frame. Combine with the host `<Table.Head>`'s `tooltip` prop and
+ * `allowsSorting` to surface the help-icon and sort affordance.
+ */
+export function TableHeadLabel({ className, children }: TableHeadLabelProps) {
+  return (
+    <span
+      className={joinClasses('whitespace-nowrap text-sm font-semibold text-secondary', className)}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/ui/src/components/application/table/table.tsx
+++ b/packages/ui/src/components/application/table/table.tsx
@@ -198,7 +198,18 @@ const TableHead = ({ className, tooltip, label, children, ...props }: TableHeadP
 
                     {tooltip && (
                         <Tooltip title={tooltip} placement="top">
-                            <TooltipTrigger className="cursor-pointer text-fg-quaternary transition duration-100 ease-linear hover:text-fg-quaternary_hover focus:text-fg-quaternary_hover">
+                            {/* GLAON PATCH (re-apply on upgrade): the kit's
+                                icon-only TooltipTrigger has no accessible
+                                name, so axe `button-name` fires on every
+                                `<Table.Head tooltip="…">`. Mirror the patch
+                                we already apply on `Input`'s tooltip
+                                trigger — use the tooltip text itself as the
+                                button's `aria-label` until the kit ships a
+                                default. */}
+                            <TooltipTrigger
+                                aria-label={tooltip}
+                                className="cursor-pointer text-fg-quaternary transition duration-100 ease-linear hover:text-fg-quaternary_hover focus:text-fg-quaternary_hover"
+                            >
                                 <HelpCircle className="size-4" />
                             </TooltipTrigger>
                         </Tooltip>


### PR DESCRIPTION
## Summary

Phase B of #323. The kit `<Table.Head>` already handles the sort indicator (`allowsSorting`) and the inline help-icon tooltip (`tooltip`); Phase B adds `Table.HeadLabel` — a thin typography wrapper that gives every Glaon column header the same `font-semibold` + `text-secondary` treatment without consumers repeating the class set per cell. The MDX makes the canonical sort + tooltip composition explicit so future consumers don't reinvent the pattern.

## Scope

**In**
- `packages/ui/src/components/Table/parts/HeadLabel.tsx` — typography wrapper; lowercase `parts/` folder excludes it from the F6 prop-coverage gate's component discovery (same convention as Phase A's `cells/`).
- `Table.tsx` — augments `Table` namespace with `HeadLabel` static property.
- `Table.stories.tsx` — `WithSortableHeader` upgraded to use `Table.HeadLabel`; new `WithHelpIcon` story (`tooltip` on `<Table.Head>`); new `HeaderLabelStates` gallery covering Figma's `_Table header label` Arrow / Help-icon variants (plain / sortable / sorted / tooltip / sortable+tooltip) side by side.
- `Table.mdx` — Header label section documenting the canonical pattern: `<Table.HeadLabel>` for typography, kit-level `allowsSorting` for sort indicator, kit-level `tooltip` for help icon.

**Out (later phases of #323)**
- C: Parametric empty state (#326).
- D: Lead-action column (#327).
- E: Card chrome wrapper (#328).
- F: Mobile breakpoint + alternating fills (#329).

## Migration

`<Table.Head>{text}</Table.Head>` keeps working byte-equal; `Table.HeadLabel` is opt-in. Existing Chromatic baselines for stories that don't use HeadLabel stay valid.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (108/108)
- [x] `pnpm --filter @glaon/ui build-storybook`
- [x] `pnpm knip` — no orphans
- [ ] Storybook localhost:6006 — `Web Primitives / Table` page lists HeaderLabelStates + WithHelpIcon; sorted column shows arrow; help icon opens tooltip on hover/focus; A11y panel green
- [ ] Chromatic — new baselines accepted; existing Default / WithSelection / Empty / Loading / Compact stories byte-equal

Closes #325
Refs #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)