### PR TITLE
feat(ui): table phase C — parametric empty state

### DIFF
--- a/packages/ui/src/components/Table/Table.mdx
+++ b/packages/ui/src/components/Table/Table.mdx
@@ -70,6 +70,57 @@ Compose with these slots:
 </Table>
 ```
 
+## Empty state
+
+`<Table emptyState={…}>` auto-renders a fallback when the body has
+zero rows — pass `<Table.Empty />` for the canonical Glaon layout
+(icon tile + title + description + optional action button) or any
+custom ReactNode to override completely.
+
+```tsx
+<Table
+  aria-label="Team members"
+  emptyState={
+    <Table.Empty
+      icon={Users01}
+      title="No team members yet"
+      description="Invite collaborators to start building together."
+      action={{ label: 'Invite member', icon: Plus, onPress: openInviteModal }}
+    />
+  }
+>
+  <Table.Header>…</Table.Header>
+  <Table.Body items={rows}>{(row) => <Table.Row …/>}</Table.Body>
+</Table>
+```
+
+The wiring is context-based: `<Table emptyState={…}>` writes the
+node into a Glaon-internal context; the wrapped `<Table.Body>`
+reads it and forwards as RAC's `renderEmptyState` callback. Pass
+`renderEmptyState` directly on a body to override the root prop
+locally — useful when a single table surface has multiple bodies
+that each need a different empty fallback.
+
+`<Table.Empty>` itself is also exported as a sub-component, so the
+canonical layout works inside any custom `renderEmptyState`
+callback even without the root prop:
+
+```tsx
+<Table.Body
+  renderEmptyState={() => (
+    <Table.Empty title="Filtered out" description="Try widening the filter." />
+  )}
+>
+```
+
+A11y: `<Table.Empty>` renders with `role="status"` +
+`aria-live="polite"` so the message is announced when the table
+transitions from filled to empty. The optional action button is a
+real `<Button>` — keyboard reachable and screen-reader named.
+
+See [#326](https://github.com/toss-cengiz/glaon/issues/326) for the
+Phase C scope.
+
 ## Header label
 
 `Table.HeadLabel` is the canonical typography wrapper for column
@@ -79,11 +130,7 @@ table renders the same header treatment without consumers
 repeating the class set:
 
 ```tsx
-<Table.Head
-  id="role"
-  allowsSorting
-  tooltip="Default role assigned at invite time."
->
+<Table.Head id="role" allowsSorting tooltip="Default role assigned at invite time.">
   <Table.HeadLabel>Role</Table.HeadLabel>
 </Table.Head>
 ```

--- a/packages/ui/src/components/Table/Table.stories.tsx
+++ b/packages/ui/src/components/Table/Table.stories.tsx
@@ -1,4 +1,4 @@
-import { Edit01, Eye, Trash01 } from '@untitledui/icons';
+import { Edit01, Eye, Plus, Trash01, Users01 } from '@untitledui/icons';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 import { defineControls } from '../_internal/controls';
@@ -261,24 +261,85 @@ export const WithSelection: Story = {
   ),
 };
 
+// Phase C empty-state — `<Table emptyState={…}>` auto-wires
+// `renderEmptyState` on the body via context. `<Table.Empty>`
+// ships the canonical Glaon layout (icon tile + title +
+// description + optional action button).
 export const Empty: Story = {
   render: (args) => (
-    <Table {...args}>
+    <Table
+      {...args}
+      emptyState={
+        <Table.Empty
+          title="No devices yet"
+          description="Pair your first device to start automating."
+        />
+      }
+    >
       <Table.Header>
         <Table.Head id="name">Device</Table.Head>
         <Table.Head id="room">Room</Table.Head>
         <Table.Head id="status">Status</Table.Head>
       </Table.Header>
-      <Table.Body
-        renderEmptyState={() => (
-          <div className="flex flex-col items-center gap-2 px-6 py-10 text-center">
-            <p className="text-base font-semibold text-primary">No devices yet</p>
-            <p className="text-sm text-tertiary">Pair your first device to start automating.</p>
-          </div>
-        )}
-      >
-        {[]}
-      </Table.Body>
+      <Table.Body>{[]}</Table.Body>
+    </Table>
+  ),
+};
+
+// Empty state with action — domain-specific icon (`Users01`) +
+// CTA button (`onPress`) shows the canonical "fix this" affordance
+// for empty listings.
+export const EmptyWithAction: Story = {
+  render: (args) => (
+    <Table
+      {...args}
+      aria-label="Team members"
+      emptyState={
+        <Table.Empty
+          icon={Users01}
+          title="No team members yet"
+          description="Invite collaborators to start building together."
+          action={{
+            label: 'Invite member',
+            icon: Plus,
+            onPress: () => undefined,
+          }}
+        />
+      }
+    >
+      <Table.Header>
+        <Table.Head id="name">Name</Table.Head>
+        <Table.Head id="role">Role</Table.Head>
+        <Table.Head id="status">Status</Table.Head>
+      </Table.Header>
+      <Table.Body>{[]}</Table.Body>
+    </Table>
+  ),
+};
+
+// Custom empty-state node — pass any ReactNode to `emptyState` to
+// bypass the default `<Table.Empty>` layout (e.g. when the empty
+// case warrants an illustration or a multi-row layout the default
+// can't express).
+export const EmptyCustom: Story = {
+  render: (args) => (
+    <Table
+      {...args}
+      emptyState={
+        <div className="flex flex-col items-center gap-3 px-6 py-12 text-center">
+          <p className="text-2xl">🎉</p>
+          <p className="text-md font-semibold text-primary">Inbox zero!</p>
+          <p className="text-sm text-tertiary">
+            Treat yourself &mdash; there&apos;s nothing to triage.
+          </p>
+        </div>
+      }
+    >
+      <Table.Header>
+        <Table.Head id="subject">Subject</Table.Head>
+        <Table.Head id="from">From</Table.Head>
+      </Table.Header>
+      <Table.Body>{[]}</Table.Body>
     </Table>
   ),
 };

--- a/packages/ui/src/components/Table/Table.tsx
+++ b/packages/ui/src/components/Table/Table.tsx
@@ -55,7 +55,11 @@
 // sortable `Table.HeadLabel`, Phase C ships a parametric empty state,
 // and Phase D adds a per-row lead action column.
 
+import type { ComponentProps, ReactNode } from 'react';
+import { createContext, useContext } from 'react';
+
 import { Table as KitTable } from '../application/table/table';
+import { TableEmpty } from './parts/Empty';
 import { TableHeadLabel } from './parts/HeadLabel';
 import {
   ActionButtonsCell,
@@ -76,8 +80,16 @@ import {
 
 export { TableCard, TableRowActionsDropdown } from '../application/table/table';
 export * from './cells';
-export { TableHeadLabel };
+export { TableEmpty, TableHeadLabel };
+export type { TableEmptyAction, TableEmptyProps } from './parts/Empty';
 export type { TableHeadLabelProps } from './parts/HeadLabel';
+
+// Empty-state context — `<Table emptyState={…}>` writes the node;
+// the wrapped `<Table.Body>` reads it and forwards as
+// `renderEmptyState` so consumers don't need to hand-wire the
+// callback. Per-body `renderEmptyState` overrides the context if
+// both are set.
+const EmptyStateContext = createContext<ReactNode | undefined>(undefined);
 
 // The kit's `Table` is itself a namespace (`Table.Header`, `Table.Row`,
 // `Table.Cell`, …). Augment its static properties with the cell-type
@@ -121,12 +133,64 @@ const CellWithCellTypes: CellNamespace = Object.assign(KitTable.Cell, {
   SelectDropdown: SelectDropdownCell,
 });
 
-type TableNamespace = typeof KitTable & {
+// Glaon `<Table>` wraps the kit primitive to surface a root
+// `emptyState` prop — when set, the wrapped `<Table.Body>` reads it
+// from context and forwards as `renderEmptyState` so consumers don't
+// re-wire the callback per usage. Body-level `renderEmptyState`
+// overrides the root prop if both are passed.
+type KitTableProps = ComponentProps<typeof KitTable>;
+export interface TableProps extends Omit<KitTableProps, 'children'> {
+  /**
+   * Auto-rendered empty-state node when the body has zero rows.
+   * Pass `<Table.Empty …/>` for the canonical layout, or any custom
+   * ReactNode to override completely. Per-body `renderEmptyState`
+   * still wins if both are set.
+   */
+  emptyState?: ReactNode;
+  children?: ReactNode;
+}
+
+function TableRoot({ emptyState, children, ...props }: TableProps) {
+  return (
+    <EmptyStateContext.Provider value={emptyState}>
+      <KitTable {...props}>{children}</KitTable>
+    </EmptyStateContext.Provider>
+  );
+}
+
+type KitBodyProps = ComponentProps<typeof KitTable.Body>;
+function TableBodyWithEmpty(props: KitBodyProps) {
+  const contextEmpty = useContext(EmptyStateContext);
+  // Spread `renderEmptyState` conditionally — RAC's body type rejects
+  // an explicit `undefined` under `exactOptionalPropertyTypes`. Body-
+  // level `renderEmptyState` always wins; only fall back to context
+  // when the body didn't supply its own.
+  if (props.renderEmptyState !== undefined) {
+    return <KitTable.Body {...props} />;
+  }
+  if (contextEmpty !== undefined) {
+    return <KitTable.Body {...props} renderEmptyState={() => contextEmpty} />;
+  }
+  return <KitTable.Body {...props} />;
+}
+TableBodyWithEmpty.displayName = 'Table.Body';
+
+type TableNamespace = typeof TableRoot & {
+  Header: (typeof KitTable)['Header'];
+  Head: (typeof KitTable)['Head'];
+  Row: (typeof KitTable)['Row'];
+  Body: typeof TableBodyWithEmpty;
   Cell: CellNamespace;
   HeadLabel: typeof TableHeadLabel;
+  Empty: typeof TableEmpty;
 };
 
-export const Table: TableNamespace = Object.assign(KitTable, {
+export const Table: TableNamespace = Object.assign(TableRoot, {
+  Header: KitTable.Header,
+  Head: KitTable.Head,
+  Row: KitTable.Row,
+  Body: TableBodyWithEmpty,
   Cell: CellWithCellTypes,
   HeadLabel: TableHeadLabel,
+  Empty: TableEmpty,
 });

--- a/packages/ui/src/components/Table/index.ts
+++ b/packages/ui/src/components/Table/index.ts
@@ -1,3 +1,3 @@
-export { Table, TableCard, TableHeadLabel, TableRowActionsDropdown } from './Table';
-export type { TableHeadLabelProps } from './Table';
+export { Table, TableCard, TableEmpty, TableHeadLabel, TableRowActionsDropdown } from './Table';
+export type { TableEmptyAction, TableEmptyProps, TableHeadLabelProps, TableProps } from './Table';
 export * from './cells';

--- a/packages/ui/src/components/Table/parts/Empty.tsx
+++ b/packages/ui/src/components/Table/parts/Empty.tsx
@@ -1,0 +1,104 @@
+// Glaon Table.Empty — parametric empty-state primitive for table
+// bodies. Phase C of #323. The kit `<Table.Body>` accepts a
+// `renderEmptyState` callback; this sub-component is the canonical
+// Glaon UI for that callback (icon + title + description + action
+// button), so consumers don't re-implement the standard layout.
+//
+// The sibling `<Table emptyState={…}>` root prop (wired in
+// `Table.tsx`) auto-installs the supplied node as `renderEmptyState`
+// on the body — pass either `<Table.Empty …/>` or any custom node.
+//
+// Mirrors Figma's Tables-page empty-state frames
+// (https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=2218-469686).
+
+import type { FC, MouseEventHandler, ReactNode } from 'react';
+
+import { Inbox01 } from '@untitledui/icons';
+
+import { Button } from '../../Button';
+
+// `@untitledui/icons` declares per-file icon types; type the slot
+// loosely to match `storybookIcons` and the kit's `IconComponent`.
+//
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see comment above
+type IconComponent = FC<any>;
+
+export interface TableEmptyAction {
+  /** Visible label. */
+  label: string;
+  /** Click handler — renders a `<button>`. Mutually exclusive with `href`. */
+  onPress?: MouseEventHandler<HTMLButtonElement>;
+  /** Link destination — renders an `<a>`. Mutually exclusive with `onPress`. */
+  href?: string;
+  /** Optional leading icon (e.g. `Plus` for "Invite member"). */
+  icon?: IconComponent;
+}
+
+export interface TableEmptyProps {
+  /**
+   * Featured icon glyph rendered in a neutral tile above the title.
+   * Defaults to a generic inbox icon — pair the prop with a domain-
+   * specific glyph (`<Users01>` for team listings, `<File02>` for
+   * file pickers) for clearer empty-state communication.
+   */
+  icon?: IconComponent;
+  /** Headline text. */
+  title: string;
+  /** Optional body copy below the title. */
+  description?: string;
+  /** Optional action button. Provide either `onPress` or `href`. */
+  action?: TableEmptyAction;
+  /** Tailwind override hook for the wrapper. */
+  className?: string;
+  /** Slot for custom content rendered after the description (before the action). */
+  children?: ReactNode;
+}
+
+function joinClasses(...parts: (string | undefined | false | null)[]): string {
+  return parts.filter((p): p is string => Boolean(p)).join(' ');
+}
+
+/**
+ * Default empty-state UI for Glaon tables. Composes a featured icon
+ * tile, headline, optional body copy, optional CTA. `role="status"`
+ * + `aria-live="polite"` so the message is announced when the table
+ * transitions from filled to empty rather than landing silently.
+ */
+export function TableEmpty({
+  icon,
+  title,
+  description,
+  action,
+  className,
+  children,
+}: TableEmptyProps) {
+  const Icon = icon ?? Inbox01;
+
+  const buttonProps: Record<string, unknown> = { color: 'secondary', size: 'md' };
+  if (action !== undefined) {
+    if (action.icon !== undefined) buttonProps.iconLeading = action.icon;
+    if (action.onPress !== undefined) buttonProps.onClick = action.onPress;
+    if (action.href !== undefined) buttonProps.href = action.href;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={joinClasses('flex flex-col items-center gap-3 px-6 py-10 text-center', className)}
+    >
+      <span
+        aria-hidden="true"
+        className="flex size-12 items-center justify-center rounded-lg bg-secondary text-fg-quaternary"
+      >
+        <Icon className="size-6" />
+      </span>
+      <div className="flex flex-col gap-1">
+        <p className="text-md font-semibold text-primary">{title}</p>
+        {description !== undefined ? <p className="text-sm text-tertiary">{description}</p> : null}
+      </div>
+      {children}
+      {action !== undefined ? <Button {...buttonProps}>{action.label}</Button> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase C of #323. Adds a `Table.Empty` sub-component (canonical Glaon empty-state UI) and a `<Table emptyState={…}>` root prop that auto-wires `renderEmptyState` on the body via context — consumers can drop in either `<Table.Empty />` or any custom node without re-implementing the empty-row layout per usage.

## Scope

**In**
- `packages/ui/src/components/Table/parts/Empty.tsx` — `Table.Empty` sub-component (icon tile + title + description + optional action button). `role="status"` + `aria-live="polite"` so the message is announced when the table transitions from filled to empty. Default icon is `Inbox01`; consumers can swap via `icon` prop.
- `Table.tsx` — Glaon `<Table>` now wraps the kit primitive to surface the root `emptyState` prop. Wrapped `<Table.Body>` reads from `EmptyStateContext` and forwards as `renderEmptyState`. Body-level `renderEmptyState` overrides root.
- `Table.stories.tsx` — `Empty` upgraded to use `<Table.Empty>` + root `emptyState` prop. New `EmptyWithAction` (icon + CTA) + `EmptyCustom` (raw ReactNode escape hatch) stories.
- `Table.mdx` — Empty state section documenting the canonical pattern, the body-level override, and a11y semantics.

**Out (later phases of #323)**
- D: Lead-action column (#327) — checkbox/radio/toggle.
- E: Card chrome wrapper (#328).
- F: Mobile breakpoint + alternating fills (#329) — closes #323.

## Migration

`<Table.Body renderEmptyState={…}>` keeps working byte-equal — the context fallback only kicks in when `renderEmptyState` is omitted. `<Table.Empty>` and the root `emptyState` prop are opt-in. Existing Chromatic baselines for non-empty stories stay valid.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (108/108)
- [x] `pnpm --filter @glaon/ui build-storybook`
- [x] `pnpm knip` — no orphans
- [ ] Storybook localhost:6006 — Empty + EmptyWithAction + EmptyCustom render correctly; A11y panel reports `role="status"` + announcement timing
- [ ] Chromatic — new baselines accepted for the three empty stories; non-empty stories byte-equal

Closes #326
Refs #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)