### PR TITLE
feat(ui): table phase D — lead-action column primitives

### DIFF
--- a/packages/ui/src/components/Table/Table.mdx
+++ b/packages/ui/src/components/Table/Table.mdx
@@ -121,6 +121,63 @@ real `<Button>` — keyboard reachable and screen-reader named.
 See [#326](https://github.com/toss-cengiz/glaon/issues/326) for the
 Phase C scope.
 
+## Lead action column
+
+`Table.LeadAction.{Checkbox|Radio|Toggle}` ships the three lead-
+column controls from Figma's `Table cell lead action` frame
+(`Property 1` axis). When to use each:
+
+- **Checkbox** — external-state multi-select. The kit's
+  `<Table selectionMode="multiple">` already auto-renders the
+  canonical multi-select checkbox column; reach for
+  `Table.LeadAction.Checkbox` only when the row's selection state
+  lives outside RAC (e.g. server-paginated dataset where the
+  selected ids are owned by a TanStack Query hook).
+- **Radio** — single-select. The kit's `selectionMode="single"`
+  renders a checkbox glyph that's functionally radio-correct but
+  visually wrong; this primitive draws the canonical radio shape.
+  Group radios across rows by sharing the same `name`.
+- **Toggle** — per-row independent boolean state. NOT a "selection"
+  semantic — each row's state is independent. Canonical use case:
+  feature flag tables, integration enable / disable lists.
+
+Compose into the first `<Table.Cell>` of every row (and matching
+`<Table.Head>` so the column is announced to screen readers — use
+`<span className="sr-only">…</span>` since the visible header is
+typically blank):
+
+```tsx
+<Table aria-label="Integrations">
+  <Table.Header>
+    <Table.Head id="enabled"><span className="sr-only">Enabled</span></Table.Head>
+    <Table.Head id="name"><Table.HeadLabel>Integration</Table.HeadLabel></Table.Head>
+  </Table.Header>
+  <Table.Body items={integrations}>
+    {(row) => (
+      <Table.Row id={row.id}>
+        <Table.Cell>
+          <Table.LeadAction.Toggle
+            value={enabled.has(row.id)}
+            onChange={(next) => toggle(row.id, next)}
+            ariaLabel={`Enable ${row.name}`}
+          />
+        </Table.Cell>
+        <Table.Cell>{row.name}</Table.Cell>
+      </Table.Row>
+    )}
+  </Table.Body>
+</Table>
+```
+
+A11y: every variant requires `ariaLabel`. Checkbox / Radio render
+via Glaon `<Checkbox>` / native radio input; Toggle wraps Glaon
+`<Switch>`. Each forwards `aria-label` onto the underlying input so
+axe `button-name` / `label` / `aria-input-field-name` stay green.
+
+See [#327](https://github.com/toss-cengiz/glaon/issues/327) for the
+Phase D scope; the Phase D.2 follow-up will wire a root `actionType`
+prop that auto-renders the lead column without consumer composition.
+
 ## Header label
 
 `Table.HeadLabel` is the canonical typography wrapper for column

--- a/packages/ui/src/components/Table/Table.stories.tsx
+++ b/packages/ui/src/components/Table/Table.stories.tsx
@@ -1,5 +1,6 @@
 import { Edit01, Eye, Plus, Trash01, Users01 } from '@untitledui/icons';
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { useState } from 'react';
 
 import { defineControls } from '../_internal/controls';
 import { Badge } from '../Badge';
@@ -722,4 +723,207 @@ export const SalesMetrics: Story = {
       </Table.Body>
     </Table>
   ),
+};
+
+// === Phase D — lead action column ========================================
+//
+// `Table.LeadAction.{Checkbox|Radio|Toggle}` ships the three
+// lead-column controls from Figma's `Table cell lead action` frame.
+// The kit's `<Table selectionMode="multiple">` already handles the
+// canonical multi-select checkbox column; reach for `LeadAction`
+// when you need radio (single-select with the right glyph), toggle
+// (per-row independent boolean state), or external state for the
+// checkbox column.
+
+interface IntegrationRow {
+  id: string;
+  name: string;
+  description: string;
+}
+
+const integrations: IntegrationRow[] = [
+  { id: 'github', name: 'GitHub', description: 'Sync issues + PRs as Glaon devices.' },
+  { id: 'slack', name: 'Slack', description: 'Forward events to a channel.' },
+  { id: 'pagerduty', name: 'PagerDuty', description: 'Page on-call when a device fails.' },
+];
+
+// `LeadAction.Toggle` — per-row independent boolean state.
+// Canonical use case: feature flag / integration enable list.
+export const WithToggleColumn: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Lead-column `<Switch>` for per-row enable / disable. Independent state per row — no group selection semantics.',
+      },
+    },
+  },
+  render: () => {
+    const ToggleStory = () => {
+      const [enabled, setEnabled] = useState(new Set(['github']));
+      const toggle = (id: string) => {
+        const next = new Set(enabled);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        setEnabled(next);
+      };
+      return (
+        <Table aria-label="Integrations">
+          <Table.Header>
+            <Table.Head id="enabled">
+              <span className="sr-only">Enabled</span>
+            </Table.Head>
+            <Table.Head id="name">
+              <Table.HeadLabel>Integration</Table.HeadLabel>
+            </Table.Head>
+            <Table.Head id="description">
+              <Table.HeadLabel>Description</Table.HeadLabel>
+            </Table.Head>
+          </Table.Header>
+          <Table.Body>
+            {integrations.map((row) => (
+              <Table.Row key={row.id} id={row.id}>
+                <Table.Cell>
+                  <Table.LeadAction.Toggle
+                    value={enabled.has(row.id)}
+                    onChange={() => {
+                      toggle(row.id);
+                    }}
+                    ariaLabel={`Enable ${row.name}`}
+                  />
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="font-medium text-primary">{row.name}</span>
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="text-tertiary">{row.description}</span>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      );
+    };
+    return <ToggleStory />;
+  },
+};
+
+// `LeadAction.Radio` — single-select tables. Group radios across
+// rows by sharing the same `name`.
+export const WithRadioSelection: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Lead-column native radio. Picks exactly one row at a time; canonical "default config" selector pattern.',
+      },
+    },
+  },
+  render: () => {
+    const RadioStory = () => {
+      const [selected, setSelected] = useState('slack');
+      return (
+        <Table aria-label="Default integration">
+          <Table.Header>
+            <Table.Head id="selected">
+              <span className="sr-only">Default</span>
+            </Table.Head>
+            <Table.Head id="name">
+              <Table.HeadLabel>Integration</Table.HeadLabel>
+            </Table.Head>
+            <Table.Head id="description">
+              <Table.HeadLabel>Description</Table.HeadLabel>
+            </Table.Head>
+          </Table.Header>
+          <Table.Body>
+            {integrations.map((row) => (
+              <Table.Row key={row.id} id={row.id}>
+                <Table.Cell>
+                  <Table.LeadAction.Radio
+                    name="default-integration"
+                    formValue={row.id}
+                    value={selected === row.id}
+                    onChange={() => {
+                      setSelected(row.id);
+                    }}
+                    ariaLabel={`Set ${row.name} as default`}
+                  />
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="font-medium text-primary">{row.name}</span>
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="text-tertiary">{row.description}</span>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      );
+    };
+    return <RadioStory />;
+  },
+};
+
+// `LeadAction.Checkbox` — externally-controlled checkbox column.
+// Reach for it when RAC's built-in `selectionMode="multiple"` doesn't
+// fit (e.g. server-paginated dataset where the selection set lives
+// outside the table). For pure RAC selection prefer the kit prop.
+export const WithCheckboxColumn: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Externally-controlled lead-column checkbox. Use when RAC `selectionMode="multiple"` doesn\'t fit (e.g. server-paginated rows where the selection set is owned by a query hook).',
+      },
+    },
+  },
+  render: () => {
+    const CheckboxStory = () => {
+      const [selected, setSelected] = useState(new Set(['github']));
+      const toggle = (id: string) => {
+        const next = new Set(selected);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        setSelected(next);
+      };
+      return (
+        <Table aria-label="Bulk-action integrations">
+          <Table.Header>
+            <Table.Head id="selected">
+              <span className="sr-only">Select</span>
+            </Table.Head>
+            <Table.Head id="name">
+              <Table.HeadLabel>Integration</Table.HeadLabel>
+            </Table.Head>
+            <Table.Head id="description">
+              <Table.HeadLabel>Description</Table.HeadLabel>
+            </Table.Head>
+          </Table.Header>
+          <Table.Body>
+            {integrations.map((row) => (
+              <Table.Row key={row.id} id={row.id}>
+                <Table.Cell>
+                  <Table.LeadAction.Checkbox
+                    value={selected.has(row.id)}
+                    onChange={() => {
+                      toggle(row.id);
+                    }}
+                    ariaLabel={`Select ${row.name}`}
+                  />
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="font-medium text-primary">{row.name}</span>
+                </Table.Cell>
+                <Table.Cell>
+                  <span className="text-tertiary">{row.description}</span>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      );
+    };
+    return <CheckboxStory />;
+  },
 };

--- a/packages/ui/src/components/Table/Table.tsx
+++ b/packages/ui/src/components/Table/Table.tsx
@@ -61,6 +61,7 @@ import { createContext, useContext } from 'react';
 import { Table as KitTable } from '../application/table/table';
 import { TableEmpty } from './parts/Empty';
 import { TableHeadLabel } from './parts/HeadLabel';
+import { LeadAction } from './parts/LeadAction';
 import {
   ActionButtonsCell,
   ActionDropdownCell,
@@ -79,6 +80,12 @@ import {
 } from './cells';
 
 export { TableCard, TableRowActionsDropdown } from '../application/table/table';
+export { LeadActionCheckbox, LeadActionRadio, LeadActionToggle } from './parts/LeadAction';
+export type {
+  LeadActionCheckboxProps,
+  LeadActionRadioProps,
+  LeadActionToggleProps,
+} from './parts/LeadAction';
 export * from './cells';
 export { TableEmpty, TableHeadLabel };
 export type { TableEmptyAction, TableEmptyProps } from './parts/Empty';
@@ -183,6 +190,7 @@ type TableNamespace = typeof TableRoot & {
   Cell: CellNamespace;
   HeadLabel: typeof TableHeadLabel;
   Empty: typeof TableEmpty;
+  LeadAction: typeof LeadAction;
 };
 
 export const Table: TableNamespace = Object.assign(TableRoot, {
@@ -193,4 +201,5 @@ export const Table: TableNamespace = Object.assign(TableRoot, {
   Cell: CellWithCellTypes,
   HeadLabel: TableHeadLabel,
   Empty: TableEmpty,
+  LeadAction,
 });

--- a/packages/ui/src/components/Table/index.ts
+++ b/packages/ui/src/components/Table/index.ts
@@ -1,3 +1,20 @@
-export { Table, TableCard, TableEmpty, TableHeadLabel, TableRowActionsDropdown } from './Table';
-export type { TableEmptyAction, TableEmptyProps, TableHeadLabelProps, TableProps } from './Table';
+export {
+  LeadActionCheckbox,
+  LeadActionRadio,
+  LeadActionToggle,
+  Table,
+  TableCard,
+  TableEmpty,
+  TableHeadLabel,
+  TableRowActionsDropdown,
+} from './Table';
+export type {
+  LeadActionCheckboxProps,
+  LeadActionRadioProps,
+  LeadActionToggleProps,
+  TableEmptyAction,
+  TableEmptyProps,
+  TableHeadLabelProps,
+  TableProps,
+} from './Table';
 export * from './cells';

--- a/packages/ui/src/components/Table/parts/LeadAction.tsx
+++ b/packages/ui/src/components/Table/parts/LeadAction.tsx
@@ -1,0 +1,179 @@
+// Glaon Table.LeadAction — lead-column control primitives for table
+// rows. Phase D of #323. Three sub-components mirror Figma's `Table
+// cell lead action` frame ([node 10501:17313](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=10501-17313))
+// `Property 1` axis: Checkbox / Radio / Toggle.
+//
+// Use cases:
+//   - **Checkbox** — multi-select bulk-action listings. The kit
+//     `<Table selectionMode="multiple">` already auto-renders a
+//     checkbox column; reach for `Table.LeadAction.Checkbox` only
+//     when you need a custom-controlled checkbox column (e.g. when
+//     selection state lives outside RAC).
+//   - **Radio** — single-select tables (pick one default config /
+//     primary card / etc.). The kit's `selectionMode="single"` ships
+//     a checkbox glyph that's functionally radio-correct but visually
+//     wrong; this primitive renders the canonical radio shape.
+//   - **Toggle** — independent per-row enable / disable (feature flag
+//     tables, integration toggles). Not a "selection" semantic;
+//     each row's state is independent.
+//
+// Compose into the first `<Table.Cell>` of every row (and matching
+// `<Table.Head>` so the column is announced to screen readers):
+//
+//   <Table.Header>
+//     <Table.Head id="enabled">
+//       <span className="sr-only">Enabled</span>
+//     </Table.Head>
+//     <Table.Head id="name">Integration</Table.Head>
+//   </Table.Header>
+//   <Table.Body items={integrations}>
+//     {(row) => (
+//       <Table.Row id={row.id}>
+//         <Table.Cell>
+//           <Table.LeadAction.Toggle
+//             value={enabled.has(row.id)}
+//             onChange={(next) => toggle(row.id, next)}
+//             ariaLabel={`Enable ${row.name}`}
+//           />
+//         </Table.Cell>
+//         <Table.Cell>{row.name}</Table.Cell>
+//       </Table.Row>
+//     )}
+//   </Table.Body>
+
+import { Switch as GlaonSwitch } from '../../Switch';
+import { Checkbox } from '../../Checkbox';
+
+interface LeadActionBaseProps {
+  /** Required accessible label — the lead column has no visible header text. */
+  ariaLabel: string;
+  /** Disable interaction. */
+  isDisabled?: boolean;
+  /** Tailwind override hook. */
+  className?: string;
+}
+
+export interface LeadActionCheckboxProps extends LeadActionBaseProps {
+  /** Controlled selection state. */
+  value: boolean;
+  /** Fires with the next selection state. */
+  onChange?: (next: boolean) => void;
+  /** Render as indeterminate (e.g. partial group selection). */
+  isIndeterminate?: boolean;
+}
+
+/**
+ * Lead-column checkbox — wraps the kit `<Checkbox>` (RAC-backed)
+ * with controlled `value` / `onChange` semantics. Use when the
+ * row's selection state lives outside RAC (e.g. paired with a
+ * server-paginated dataset where RAC's `<Table selectionMode>`
+ * doesn't fit). For pure RAC multi-select, prefer
+ * `<Table selectionMode="multiple">` — the kit auto-renders the
+ * checkbox column for you.
+ */
+export function LeadActionCheckbox({
+  value,
+  onChange,
+  isIndeterminate,
+  isDisabled,
+  ariaLabel,
+  className,
+}: LeadActionCheckboxProps) {
+  const checkboxProps: Record<string, unknown> = {
+    'aria-label': ariaLabel,
+    isSelected: value,
+    size: 'md',
+  };
+  if (onChange !== undefined) checkboxProps.onChange = onChange;
+  if (isIndeterminate !== undefined) checkboxProps.isIndeterminate = isIndeterminate;
+  if (isDisabled !== undefined) checkboxProps.isDisabled = isDisabled;
+  if (className !== undefined) checkboxProps.className = className;
+  return <Checkbox {...checkboxProps} />;
+}
+
+export interface LeadActionRadioProps extends LeadActionBaseProps {
+  /** Whether this radio is selected. */
+  value: boolean;
+  /** Fires when this radio is selected. */
+  onChange?: () => void;
+  /** Form-group name — radios in the same group share `name`. */
+  name: string;
+  /** Native form value forwarded to the underlying `<input>`. */
+  formValue: string;
+}
+
+/**
+ * Lead-column radio — native `<input type="radio">` styled to match
+ * Glaon's radio surface. Group radios across rows by sharing the
+ * same `name`; `onChange` fires when this row's radio becomes the
+ * group's active selection.
+ */
+export function LeadActionRadio({
+  value,
+  onChange,
+  name,
+  formValue,
+  isDisabled,
+  ariaLabel,
+  className,
+}: LeadActionRadioProps) {
+  return (
+    <span className={`relative inline-flex ${className ?? ''}`}>
+      <input
+        type="radio"
+        name={name}
+        value={formValue}
+        checked={value}
+        disabled={isDisabled}
+        aria-label={ariaLabel}
+        onChange={() => onChange?.()}
+        className="size-5 cursor-pointer accent-fg-brand-primary disabled:cursor-not-allowed disabled:opacity-50"
+      />
+    </span>
+  );
+}
+
+export interface LeadActionToggleProps extends LeadActionBaseProps {
+  /** Controlled toggle state. */
+  value: boolean;
+  /** Fires with the next state. */
+  onChange?: (next: boolean) => void;
+}
+
+/**
+ * Lead-column toggle — Glaon `<Switch>` with controlled `value` /
+ * `onChange` semantics. Use for per-row independent boolean state
+ * (feature flag tables, integration enable / disable).
+ */
+export function LeadActionToggle({
+  value,
+  onChange,
+  isDisabled,
+  ariaLabel,
+  className,
+}: LeadActionToggleProps) {
+  // The kit `Switch` (RAC `Toggle`) takes `aria-label` + `isSelected`
+  // + `onChange`. Keep the contract symmetric across LeadAction.*.
+  const switchProps: Record<string, unknown> = {
+    'aria-label': ariaLabel,
+    isSelected: value,
+  };
+  if (onChange !== undefined) {
+    switchProps.onChange = (next: boolean) => {
+      onChange(next);
+    };
+  }
+  if (isDisabled !== undefined) switchProps.isDisabled = isDisabled;
+  if (className !== undefined) switchProps.className = className;
+  return <GlaonSwitch {...switchProps} />;
+}
+
+/**
+ * Namespace bundle so consumers compose `<Table.LeadAction.Toggle>`
+ * etc. matching the rest of the Table sub-component conventions.
+ */
+export const LeadAction = {
+  Checkbox: LeadActionCheckbox,
+  Radio: LeadActionRadio,
+  Toggle: LeadActionToggle,
+};


### PR DESCRIPTION
## Summary

Phase D V1 of #323. Adds `Table.LeadAction.{Checkbox|Radio|Toggle}` sub-components for the three lead-column controls from Figma's `Table cell lead action` frame. Each variant is a thin composition wrap over an existing primitive (Checkbox / native radio / Switch) with controlled `value` / `onChange` semantics + required `ariaLabel`.

## Scope

**In**
- `packages/ui/src/components/Table/parts/LeadAction.tsx` — three sub-components (`LeadActionCheckbox`, `LeadActionRadio`, `LeadActionToggle`) plus a namespace bundle exposed as `Table.LeadAction.*`. Lowercase `parts/` folder excludes the file from the F6 prop-coverage gate's component discovery.
- `Table.tsx` + `index.ts` — namespace augmentation + barrel re-exports for the new sub-components and their props.
- `Table.stories.tsx` — three new stories: `WithToggleColumn`, `WithRadioSelection`, `WithCheckboxColumn`. Each uses `useState` to model realistic external-state ownership patterns.
- `Table.mdx` — Lead action column section explaining when to reach for each variant vs the kit's built-in `selectionMode`.

**Out (deferred to Phase D.2 follow-up)**
- Root `actionType: 'checkbox' | 'radio' | 'toggle'` prop that auto-renders the lead column without consumer composition (parallel to Phase C's `emptyState` pattern). V1 keeps composition explicit so consumers learn the API; the orchestration helper lands in a follow-up issue.
- GLAON PATCH on the kit's Table source to swap Checkbox → Radio when `selectionMode="single"` — V1's `Table.LeadAction.Radio` is the explicit-composition workaround.

**Out (later phases of #323)**
- E: Card chrome wrapper (#328).
- F: Mobile breakpoint + alternating fills (#329) — closes #323.

## Migration

Every sub-component is opt-in. Existing tables (with or without `selectionMode`) keep rendering byte-equal. New consumers can mix `LeadAction.*` columns with regular cell-types (`Table.Cell.Avatar`, etc.) without conflict.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (108/108)
- [x] `pnpm --filter @glaon/ui build-storybook`
- [x] `pnpm knip` — no orphans
- [ ] Storybook localhost:6006 — WithToggleColumn / WithRadioSelection / WithCheckboxColumn render correctly; A11y panel reports labelled inputs
- [ ] Chromatic — new baselines accepted; existing stories byte-equal

Closes #327
Refs #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)