### PR TITLE
feat(ui): table phase F — dividers + mobile (closes #323)

### DIFF
--- a/packages/ui/src/components/Table/Table.controls.ts
+++ b/packages/ui/src/components/Table/Table.controls.ts
@@ -8,6 +8,7 @@ import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls'
 
 const sizeOptions = ['sm', 'md'] as const;
 const selectionModeOptions = ['none', 'single', 'multiple'] as const;
+const dividersOptions = ['divider-line', 'alternating-fills'] as const;
 
 export const tableControls = {
   'aria-label': {
@@ -32,6 +33,14 @@ export const tableControls = {
       '`none` (default) for read-only data, `single` for radio-style row selection, `multiple` for checkbox column with optional select-all in the header.',
     category: 'Behavior',
   } satisfies ControlSpec<(typeof selectionModeOptions)[number]>,
+  dividers: {
+    type: 'inline-radio',
+    options: dividersOptions,
+    default: 'divider-line',
+    description:
+      'Row separator treatment. `divider-line` (default) draws a 1px hairline between rows; `alternating-fills` zebra-stripes by painting every even row with `bg-secondary`. Use the latter for dense numeric grids where the eye benefits from a row-band.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof dividersOptions)[number]>,
   onRowAction: {
     type: false,
     action: 'row-action',

--- a/packages/ui/src/components/Table/Table.mdx
+++ b/packages/ui/src/components/Table/Table.mdx
@@ -70,6 +70,49 @@ Compose with these slots:
 </Table>
 ```
 
+## Dividers + mobile (Phase F)
+
+`dividers` controls the row separator treatment:
+
+- `'divider-line'` (default) — a 1px hairline between rows; the
+  kit's standard treatment.
+- `'alternating-fills'` — every even row picks up `bg-secondary`,
+  giving a zebra band that helps the eye track values across dense
+  numeric grids. Mirrors Figma's Tables-page `Dividers=Alternating
+  fills` axis.
+
+```tsx
+<Table dividers="alternating-fills" aria-label="Sales">
+  …
+</Table>
+```
+
+**Mobile column hiding** is consumer-driven via Tailwind responsive
+utilities on the matching `<Table.Head>` + `<Table.Cell>` pair —
+drop the high-bandwidth columns at narrow breakpoints rather than
+wrapping every cell:
+
+```tsx
+<Table.Head id="lastSeen" className="hidden md:table-cell">
+  <Table.HeadLabel>Last seen</Table.HeadLabel>
+</Table.Head>
+…
+<Table.Cell className="hidden md:table-cell">{row.lastSeen}</Table.Cell>
+```
+
+V1 ships this as a **convention**, not a Glaon prop — column-
+priority rules are context-specific (which column drops depends on
+the data), so a `data-priority` axis + container-query layer would
+prescribe more than the API can deliver. A follow-up issue can add
+the helper if a clear default emerges.
+
+The `Mobile` story uses Storybook's viewport addon (`mobile1`
+preset) to demonstrate the responsive shift. The `AlternatingFills`
+story renders the zebra-stripe variant.
+
+See [#329](https://github.com/toss-cengiz/glaon/issues/329) for the
+Phase F scope.
+
 ## Card chrome
 
 `Table.Card.{Root, Header, Filters, Pagination}` wraps a table in

--- a/packages/ui/src/components/Table/Table.stories.tsx
+++ b/packages/ui/src/components/Table/Table.stories.tsx
@@ -1117,3 +1117,102 @@ export const EmptyWithChrome: Story = {
     </Table.Card>
   ),
 };
+
+// === Phase F — dividers + mobile ===========================================
+//
+// `dividers='alternating-fills'` zebra-stripes rows for dense
+// numeric grids. Mobile column hiding is consumer-driven via
+// Tailwind responsive utilities on `<Table.Head>` / `<Table.Cell>`
+// — drop the high-bandwidth columns at narrow breakpoints rather
+// than wrapping every cell.
+
+// `dividers='alternating-fills'` — even rows pick up `bg-secondary`
+// so the eye can track values across wide tables. Compare against
+// `Default` (the kit's `divider-line` treatment) for the canonical
+// contrast pair.
+export const AlternatingFills: Story = {
+  args: { dividers: 'alternating-fills' },
+  render: (args) => (
+    <Table {...args}>
+      <Table.Header>
+        <Table.Head id="name">
+          <Table.HeadLabel>Device</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="room">
+          <Table.HeadLabel>Room</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="status">
+          <Table.HeadLabel>Status</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="lastSeen">
+          <Table.HeadLabel>Last seen</Table.HeadLabel>
+        </Table.Head>
+      </Table.Header>
+      <Table.Body>
+        {devices.map((device) => (
+          <Table.Row key={device.id} id={device.id}>
+            <Table.Cell>
+              <span className="font-medium text-primary">{device.name}</span>
+            </Table.Cell>
+            <Table.Cell>{device.room}</Table.Cell>
+            <Table.Cell>{statusBadge(device.status)}</Table.Cell>
+            <Table.Cell>{device.lastSeen}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  ),
+};
+
+// Mobile responsive — drop secondary columns at narrow breakpoints
+// using Tailwind's `hidden sm:table-cell` utility on the matching
+// `<Table.Head>` + `<Table.Cell>` pair. Open Storybook's viewport
+// addon (mobile preset) to see the effect; on a desktop viewport
+// every column stays visible.
+//
+// V1 ships this as a **convention** rather than a Glaon prop because
+// column-priority rules are deeply context-specific (which columns
+// drop vs. stay depends on the data). A `data-priority` axis +
+// container query layer can land in a follow-up if a one-size-fits-
+// all default emerges.
+export const Mobile: Story = {
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+    docs: {
+      description: {
+        story:
+          "Mobile-friendly table — secondary columns hide below `sm` via Tailwind `hidden sm:table-cell`. Use Storybook's viewport addon to switch between mobile / desktop and watch columns drop / re-appear.",
+      },
+    },
+  },
+  render: () => (
+    <Table aria-label="Devices (responsive)">
+      <Table.Header>
+        <Table.Head id="name">
+          <Table.HeadLabel>Device</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="room" className="hidden sm:table-cell">
+          <Table.HeadLabel>Room</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="status">
+          <Table.HeadLabel>Status</Table.HeadLabel>
+        </Table.Head>
+        <Table.Head id="lastSeen" className="hidden md:table-cell">
+          <Table.HeadLabel>Last seen</Table.HeadLabel>
+        </Table.Head>
+      </Table.Header>
+      <Table.Body>
+        {devices.map((device) => (
+          <Table.Row key={device.id} id={device.id}>
+            <Table.Cell>
+              <span className="font-medium text-primary">{device.name}</span>
+            </Table.Cell>
+            <Table.Cell className="hidden sm:table-cell">{device.room}</Table.Cell>
+            <Table.Cell>{statusBadge(device.status)}</Table.Cell>
+            <Table.Cell className="hidden md:table-cell">{device.lastSeen}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  ),
+};

--- a/packages/ui/src/components/Table/Table.tsx
+++ b/packages/ui/src/components/Table/Table.tsx
@@ -155,7 +155,18 @@ const CellWithCellTypes: CellNamespace = Object.assign(KitTable.Cell, {
 // re-wire the callback per usage. Body-level `renderEmptyState`
 // overrides the root prop if both are passed.
 type KitTableProps = ComponentProps<typeof KitTable>;
-export interface TableProps extends Omit<KitTableProps, 'children'> {
+
+/**
+ * Row-divider treatment. Mirrors Figma's Tables-page `Dividers`
+ * axis. `divider-line` (default) renders a 1px hairline between
+ * rows; `alternating-fills` zebra-stripes the rows by painting
+ * every even `<tr>` with `bg-secondary`. Use `alternating-fills`
+ * for dense numeric grids where the eye benefits from a row-band
+ * to track values across columns.
+ */
+export type TableDividers = 'divider-line' | 'alternating-fills';
+
+export interface TableProps extends Omit<KitTableProps, 'children' | 'className'> {
   /**
    * Auto-rendered empty-state node when the body has zero rows.
    * Pass `<Table.Empty …/>` for the canonical layout, or any custom
@@ -163,13 +174,30 @@ export interface TableProps extends Omit<KitTableProps, 'children'> {
    * still wins if both are set.
    */
   emptyState?: ReactNode;
+  /** @default 'divider-line' */
+  dividers?: TableDividers;
+  className?: string;
   children?: ReactNode;
 }
 
-function TableRoot({ emptyState, children, ...props }: TableProps) {
+function TableRoot({ emptyState, dividers, className, children, ...props }: TableProps) {
+  // Phase F: zebra-stripe rows via Tailwind's `[& tbody …]` arbitrary
+  // child selector when `dividers='alternating-fills'`. The kit
+  // forwards `className` onto the underlying `<table>` element so the
+  // selector resolves through the rendered DOM. `divider-line` (the
+  // default) keeps the kit's bottom-border-per-row treatment.
+  const dividerClass =
+    dividers === 'alternating-fills' ? '[&_tbody_tr:nth-child(even)]:bg-secondary' : undefined;
+  const mergedClass = [dividerClass, className].filter(Boolean).join(' ') || undefined;
   return (
     <EmptyStateContext.Provider value={emptyState}>
-      <KitTable {...props}>{children}</KitTable>
+      {mergedClass !== undefined ? (
+        <KitTable {...props} className={mergedClass}>
+          {children}
+        </KitTable>
+      ) : (
+        <KitTable {...props}>{children}</KitTable>
+      )}
     </EmptyStateContext.Provider>
   );
 }

--- a/packages/ui/src/components/Table/index.ts
+++ b/packages/ui/src/components/Table/index.ts
@@ -17,6 +17,7 @@ export type {
   LeadActionRadioProps,
   LeadActionToggleProps,
   TableCardPaginationProps,
+  TableDividers,
   TableEmptyAction,
   TableEmptyProps,
   TableHeadLabelProps,


### PR DESCRIPTION
## Summary

Final phase of #323. Adds `dividers: 'divider-line' | 'alternating-fills'` prop on `<Table>` for Figma's `Dividers` axis, and ships mobile column-hiding as a documented Tailwind responsive convention (not a Glaon prop).

## Scope

**In**
- `Table.tsx` — `dividers` prop on `TableProps`. `'divider-line'` (default) is byte-equal to current behaviour; `'alternating-fills'` paints every even `<tr>` with `bg-secondary` via Tailwind's `[&_tbody_tr:nth-child(even)]:bg-secondary` arbitrary child selector. The `className` flows through to the kit `<AriaTable>` element so the selector resolves.
- `Table.controls.ts` — `dividers` control entry.
- `Table.stories.tsx` — `AlternatingFills` (zebra-striped Default), `Mobile` (uses Storybook viewport addon's `mobile1` preset to demonstrate column-hiding via Tailwind `hidden sm:table-cell`).
- `Table.mdx` — Dividers + mobile section explaining both axes and the rationale for the responsive convention vs a built-in prop.
- `index.ts` — exports `TableDividers` type.

**Out (deferred to a follow-up)**
- `data-priority` axis + container-query layer for mobile column hiding — V1 ships the Tailwind utility convention because column-priority rules are context-specific. A `data-priority` helper lands if a one-size-fits-all default emerges.
- Stacked-card mobile layout (`mobileLayout='stacked'`) — separate scope; the convention works on most listings.

## Closes #323

Every Phase A–F sub-issue is now merged:
- #324 — Phase A: cell-type sub-component catalog
- #330 — Phase B: HeadLabel + sort/tooltip pattern
- #333 — Phase C: parametric empty state
- #334 — Phase D: lead-action column primitives
- #360 — Phase E: Card chrome wrapper
- **this PR** — Phase F: dividers + mobile

Table now ships full Figma parity from the Tables-page frame: 14 cell-type sub-components, HeadLabel sortable indicator, parametric empty state (`<Table emptyState=…>`), lead-action column variants (Checkbox / Radio / Toggle), Card chrome wrapper (`<Table.Card>` + Header + Filters + Pagination), dividers + mobile.

## Migration

`dividers` defaults to `'divider-line'` — current behaviour byte-equal. The mobile pattern is opt-in. Existing Chromatic baselines stay valid.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (108/108)
- [x] `pnpm --filter @glaon/ui build-storybook`
- [x] `pnpm knip` — no orphans
- [ ] Storybook localhost:6006 — `AlternatingFills` shows zebra stripes; `Mobile` viewport switch toggles column visibility; existing stories byte-equal
- [ ] Chromatic — new baselines accepted; existing stories byte-equal

Closes #329
Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)