### PR TITLE
feat(ui): icon catalog Storybook page (foundations layer phase B)

### DIFF
--- a/packages/ui/src/icons/general/IconCatalog.stories.tsx
+++ b/packages/ui/src/icons/general/IconCatalog.stories.tsx
@@ -1,0 +1,221 @@
+import type { ComponentType, SVGProps } from 'react';
+import { useMemo, useState } from 'react';
+import * as UntitledIcons from '@untitledui/icons';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { groupByCategory } from './categories';
+
+// `Foundations / Icons / General` — searchable, categorised browser
+// over the entire `@untitledui/icons` export set (~1,179 glyphs at
+// the time of writing). Phase B of the icon registry rollout (#309)
+// — gives every UI contributor a single page to answer "which icon
+// name should I import?" without grepping node_modules. The curated
+// `storybookIcons` map (packages/ui/src/icons/storybook.ts) stays —
+// it powers component-story `select` controls and is intentionally
+// small. This catalog is the long-form companion.
+//
+// The catalog disables Chromatic snapshots (the icon set is
+// upstream + rendered live, so a baseline diff would break on every
+// kit bump that adds a glyph). Surface-level accessibility (search
+// input label, list semantics) still gets the Storybook a11y addon
+// gate.
+
+type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+const ALL_ICONS = Object.entries(UntitledIcons as Record<string, IconComponent>)
+  .filter(([, Icon]) => typeof Icon === 'function')
+  .sort(([a], [b]) => a.localeCompare(b));
+
+const ALL_ICON_NAMES = ALL_ICONS.map(([name]) => name);
+const TOTAL_COUNT = ALL_ICONS.length;
+const ICONS_BY_NAME = new Map<string, IconComponent>(ALL_ICONS);
+
+interface IconTileProps {
+  name: string;
+  Icon: IconComponent;
+}
+
+function IconTile({ name, Icon }: IconTileProps) {
+  const importLine = `import { ${name} } from '@untitledui/icons';`;
+
+  return (
+    <li
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 8,
+        padding: 12,
+        borderRadius: 12,
+        background: 'var(--color-bg-secondary, #f7f7f7)',
+        border: '1px solid var(--color-border-secondary, #e4e4e4)',
+        minHeight: 132,
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          width: 40,
+          height: 40,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--color-text-primary, #111)',
+        }}
+      >
+        <Icon className="size-8" />
+      </div>
+      <span
+        style={{
+          fontSize: 12,
+          fontWeight: 500,
+          color: 'var(--color-text-primary, #111)',
+          textAlign: 'center',
+          wordBreak: 'break-word',
+        }}
+      >
+        {name}
+      </span>
+      <code
+        title={importLine}
+        style={{
+          fontSize: 10,
+          color: 'var(--color-text-tertiary, #555)',
+          background: 'var(--color-bg-primary, #fff)',
+          padding: '2px 6px',
+          borderRadius: 4,
+          userSelect: 'all',
+          textAlign: 'center',
+          wordBreak: 'break-all',
+        }}
+      >
+        {importLine}
+      </code>
+    </li>
+  );
+}
+
+interface CategorySectionProps {
+  id: string;
+  label: string;
+  icons: readonly string[];
+}
+
+function CategorySection({ id, label, icons }: CategorySectionProps) {
+  if (icons.length === 0) return null;
+  return (
+    <section
+      aria-labelledby={`icon-cat-${id}`}
+      style={{ display: 'flex', flexDirection: 'column', gap: 12 }}
+    >
+      <header style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <h3
+          id={`icon-cat-${id}`}
+          style={{
+            fontSize: 14,
+            fontWeight: 600,
+            margin: 0,
+            color: 'var(--color-text-primary, #111)',
+          }}
+        >
+          {label}
+        </h3>
+        <span style={{ fontSize: 12, color: 'var(--color-text-tertiary, #555)' }}>
+          {icons.length}
+        </span>
+      </header>
+      <ul
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
+          gap: 12,
+          padding: 0,
+          margin: 0,
+          listStyle: 'none',
+        }}
+      >
+        {icons.map((name) => {
+          const Icon = ICONS_BY_NAME.get(name);
+          if (Icon === undefined) return null;
+          return <IconTile key={name} name={name} Icon={Icon} />;
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function CatalogPage() {
+  const [search, setSearch] = useState('');
+
+  const filteredNames = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (q.length === 0) return ALL_ICON_NAMES;
+    return ALL_ICON_NAMES.filter((name) => name.toLowerCase().includes(q));
+  }, [search]);
+
+  const groups = useMemo(() => groupByCategory(filteredNames), [filteredNames]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24, paddingBottom: 32 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <label
+          htmlFor="icon-catalog-search"
+          style={{ fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary, #444)' }}
+        >
+          Search
+        </label>
+        <input
+          id="icon-catalog-search"
+          type="search"
+          placeholder="e.g. arrow, alert, mail…"
+          value={search}
+          onChange={(event) => {
+            setSearch(event.currentTarget.value);
+          }}
+          style={{
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid var(--color-border-primary, #d5d7da)',
+            fontSize: 14,
+            width: '100%',
+            maxWidth: 360,
+          }}
+        />
+        <p style={{ fontSize: 12, color: 'var(--color-text-tertiary, #555)', margin: 0 }}>
+          {`Showing ${String(filteredNames.length)} of ${String(TOTAL_COUNT)} icons.`}
+          {search.trim().length > 0 && filteredNames.length === 0 ? (
+            <span style={{ marginLeft: 6 }}>{`No icons match "${search}".`}</span>
+          ) : null}
+        </p>
+      </div>
+      {groups.map(({ category, icons }) => (
+        <CategorySection key={category.id} id={category.id} label={category.label} icons={icons} />
+      ))}
+    </div>
+  );
+}
+
+const meta: Meta = {
+  title: 'Foundations/Icons/General',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=3463-407484',
+    },
+    docs: { disable: true },
+    chromatic: { disableSnapshot: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+/**
+ * Browse every icon `@untitledui/icons` exports. Type to filter by
+ * name (case-insensitive substring); each tile shows the canonical
+ * `import { Name } from '@untitledui/icons'` line for copy-paste.
+ * Categories are heuristic — see `categories.ts`.
+ */
+export const Catalog: Story = {
+  render: () => <CatalogPage />,
+};

--- a/packages/ui/src/icons/general/categories.ts
+++ b/packages/ui/src/icons/general/categories.ts
@@ -1,0 +1,198 @@
+// Heuristic category mapping for `@untitledui/icons` exports.
+//
+// The kit ships 1,179 icons as flat named exports (no semantic
+// metadata). The Figma "General UI icons" frame organises them into
+// ~19 sections; this file mirrors that organisation by matching the
+// export name against a prioritised list of regex patterns.
+//
+// Ordering matters: the first matching category wins, so put the most
+// specific predicates first (e.g. `Arrow*` before the catch-all
+// `General` bucket). Anything unmatched falls into `Other` so the
+// catalog never silently drops an icon.
+
+interface IconCategory {
+  /** Stable slug used for anchor links + sort order. */
+  id: string;
+  /** Human-readable label rendered in the catalog section header. */
+  label: string;
+  /** Returns `true` if `iconName` belongs to this category. */
+  matches: (iconName: string) => boolean;
+}
+
+const startsWith =
+  (...prefixes: readonly string[]) =>
+  (name: string): boolean =>
+    prefixes.some((p) => name.startsWith(p));
+
+const matchesAny =
+  (...patterns: readonly RegExp[]) =>
+  (name: string): boolean =>
+    patterns.some((p) => p.test(name));
+
+// Order: specific → broad. The first category whose `matches` returns
+// `true` claims the icon. A trailing `Other` bucket catches the rest.
+const ICON_CATEGORIES: readonly IconCategory[] = [
+  {
+    id: 'arrows',
+    label: 'Arrows',
+    matches: startsWith('Arrow', 'Chevron', 'Corner', 'FlipBackward', 'FlipForward', 'Switch'),
+  },
+  {
+    id: 'media-controls',
+    label: 'Media controls',
+    matches: matchesAny(
+      /^(Play|Pause|Stop|FastForward|Rewind|SkipBack|SkipForward|Repeat|Shuffle|Music|Album|Disc|Radio)/,
+    ),
+  },
+  {
+    id: 'editor',
+    label: 'Editor',
+    matches: matchesAny(
+      /^(Bold|Italic|Underline|Strikethrough|Heading|Type|Pen|Pencil|Eraser|Brush|Quote|Code|TextInput|TextAlign|Indent|Outdent|Subscript|Superscript|Highlighter|MagicWand|Paragraph|Spacing)/,
+    ),
+  },
+  {
+    id: 'charts',
+    label: 'Charts',
+    matches: matchesAny(
+      /^(Chart|BarChart|LineChart|PieChart|TrendUp|TrendDown|HorizontalBarChart|VerticalBars)/,
+    ),
+  },
+  {
+    id: 'time',
+    label: 'Time',
+    matches: matchesAny(/^(Clock|Calendar|Hourglass|AlarmClock|Watch|Timer)/),
+  },
+  {
+    id: 'weather',
+    label: 'Weather',
+    matches: matchesAny(
+      /^(Sun(?!set|rise)|Sunset|Sunrise|Moon|Cloud(?!Code|Off)|Rain|Snow|Wind|Lightning|Tornado|Umbrella|Thermometer|Stars|Hurricane|Droplet|Waves)/,
+    ),
+  },
+  {
+    id: 'security',
+    label: 'Security',
+    matches: matchesAny(/^(Lock|Unlock|Shield|Key(?!board)|Fingerprint|FaceId|Passcode|EyeOff)/),
+  },
+  {
+    id: 'finance',
+    label: 'Finance & eCommerce',
+    matches: matchesAny(
+      /^(Currency|Coins|Coin|Bitcoin|CreditCard|Wallet|Bank|Receipt|Tag(?!Off)|ShoppingCart|ShoppingBag|Cart|Gift|Sale|Pricing|Diamond|Percent|Calculator|Scales|Piggy|Trophy|Award|Medal)/,
+    ),
+  },
+  {
+    id: 'maps-travel',
+    label: 'Maps & travel',
+    matches: matchesAny(
+      /^(Map|Marker|Pin|Compass|Globe|Navigation|Plane|Train|Car|Bus|Road|Route|Walk|Run|Flag|Anchor|Sailboat|Truck|Bike|Tram|Rocket|LuggageBag|Passport|Trees|Tree)/,
+    ),
+  },
+  {
+    id: 'communication',
+    label: 'Communication',
+    matches: matchesAny(
+      /^(Mail|Message|Chat|Phone(?!book)|Inbox|Send|Reply|Forward|AtSign|Megaphone|Notification(?!Box)|Announcement|VoicemailEvelope)/,
+    ),
+  },
+  {
+    id: 'media-devices',
+    label: 'Media & devices',
+    matches: matchesAny(
+      /^(Volume|Speaker|Headphones|Microphone|Mic|Camera|Monitor|Tablet|Tv|Laptop|Mouse|Keyboard|Airpods|Airplay|Cast|Bluetooth|Battery|Wifi|Signal|Server|HardDrive|Disc|PowerButton|UsbFlashDrive|GamingPad|Joystick)/,
+    ),
+  },
+  {
+    id: 'images',
+    label: 'Images',
+    matches: matchesAny(/^(Image|Aperture|Crop|Flash|Gallery|FilmStrip|Camera|Frame)/),
+  },
+  {
+    id: 'files',
+    label: 'Files',
+    matches: matchesAny(/^(File|Folder|Archive|Briefcase|Drawer|Paperclip)/),
+  },
+  {
+    id: 'users',
+    label: 'Users',
+    matches: matchesAny(
+      /^(User(?!sCheck)|Users|Person|Profile|Face(?:Frown|Happy|Neutral|Sad|Smile|Wink|Content|Id|Hipster|Frownidiot)?$|Eye(?!Off)|Mood)/,
+    ),
+  },
+  {
+    id: 'layout',
+    label: 'Layout',
+    matches: matchesAny(
+      /^(Layout|Grid|Columns|Rows|Align|Distribute|Maximize|Minimize|Move|Reorder|Group|Frame|Drag|ContainerIcon|SidebarToggle|SidebarLeft|SidebarRight|MenuOpen|MenuClose|MenuFold)/,
+    ),
+  },
+  {
+    id: 'development',
+    label: 'Development',
+    matches: matchesAny(
+      /^(Code|Terminal|Bug|Branch|Git|Cpu|Brackets|Variable|Build|Container|Cube|Database|CloudCode)/,
+    ),
+  },
+  {
+    id: 'shapes',
+    label: 'Shapes',
+    matches: matchesAny(
+      /^(Square|Circle|Triangle|Hexagon|Octagon|Pentagon|Star|Heart|Cube|Sphere|Cylinder|Rhombus|Diamond)$/,
+    ),
+  },
+  {
+    id: 'alerts',
+    label: 'Alerts & feedback',
+    matches: matchesAny(
+      /^(Alert|Bell|InfoCircle|InfoHexagon|InfoOctagon|InfoSquare|HelpCircle|HelpHexagon|HelpOctagon|HelpSquare|AnnotationAlert|AnnotationInfo|AnnotationQuestion|QuestionMark|Notification(?!s$))/,
+    ),
+  },
+  {
+    id: 'general',
+    label: 'General',
+    matches: matchesAny(
+      /^(Plus|Minus|X(?:Close|Square|Circle)?$|Check|Search|Settings|Edit|Delete|Trash|Save|Refresh|Rotate|Filter|Sort|More|Menu|Home|Sliders|Lightbulb|Toggle|PowerButton|Magnet|Compass|Heart|Bookmark|Star|Flag|Eye|Wand|Tool|Wrench|Hammer|Scissors|Cursor|Hand|Click|Pointer|Tap|Touch|ToggleSwitch|UploadCloud|DownloadCloud|Loading|RefreshDouble|Award|Bookmark|Cog)/,
+    ),
+  },
+];
+
+function categorizeIcon(name: string): string {
+  for (const category of ICON_CATEGORIES) {
+    if (category.matches(name)) return category.id;
+  }
+  return 'other';
+}
+
+/** Group an iterable of icon names into ordered category buckets. */
+export function groupByCategory(names: readonly string[]): {
+  category: IconCategory | { id: 'other'; label: 'Other'; matches: () => false };
+  icons: readonly string[];
+}[] {
+  const buckets = new Map<string, string[]>();
+  for (const name of names) {
+    const id = categorizeIcon(name);
+    let bucket = buckets.get(id);
+    if (bucket === undefined) {
+      bucket = [];
+      buckets.set(id, bucket);
+    }
+    bucket.push(name);
+  }
+
+  const ordered: ReturnType<typeof groupByCategory> = [];
+  for (const category of ICON_CATEGORIES) {
+    const icons = buckets.get(category.id);
+    if (icons !== undefined && icons.length > 0) {
+      ordered.push({ category, icons });
+    }
+  }
+  const otherBucket = buckets.get('other');
+  if (otherBucket !== undefined && otherBucket.length > 0) {
+    ordered.push({
+      category: { id: 'other', label: 'Other', matches: () => false as const },
+      icons: otherBucket,
+    });
+  }
+  return ordered;
+}


### PR DESCRIPTION
## Summary

- Adds **`Foundations/Icons/General`** Storybook docs page — single browseable catalog over every icon `@untitledui/icons` exports (~1,179 today).
- Case-insensitive substring search + heuristic prefix-pattern category grouping (~20 buckets; unmatched icons fall into `Other`).
- Each tile renders the icon at 32px and shows the canonical `import { Name } from '@untitledui/icons'` line for copy-paste; counter at top reports `Showing N of <total>`.
- Phase B of [#309](https://github.com/toss-cengiz/glaon/issues/309). The curated `storybookIcons` map (component-story `select` controls) stays small + deliberate; this is the long-form companion.

## Scope

**In:**
- `packages/ui/src/icons/general/categories.ts` — heuristic prefix-pattern categorisation, exports only `groupByCategory` (the catalog's sole consumer).
- `packages/ui/src/icons/general/IconCatalog.stories.tsx` — story file, `Foundations/Icons/General` title, single `Catalog` story.
- Chromatic snapshot disabled for this story (`chromatic.disableSnapshot: true`) — the icon set is upstream + rendered live, so a baseline diff would break on every kit bump that adds a glyph.

**Out:**
- Phase A.2 (extend brand registry by 28 social platforms) — separate follow-up under #309.
- Phase C (FeaturedIcon MDX docs + country flag catalog) — separate follow-up.
- Phase D (App / Payment / Integration / File-type / Emoji collections) — five separate follow-ups.
- Curated `storybookIcons` rework — stays as the lean control map for component stories.
- Server-side / build-time tree-shaking heuristics — not needed; each icon is a separate UUI export.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check` — green.
- [x] `pnpm --filter @glaon/ui lint` — green.
- [x] `pnpm knip` — no orphans introduced.
- [x] `pnpm --filter @glaon/ui test` — 108/108 (F6 prop-coverage gate unchanged).
- [x] `pnpm exec prettier --check packages/ui/src/icons/general/` — clean.
- [ ] Reviewer: open Storybook (`pnpm --filter @glaon/ui storybook`), navigate to **Foundations / Icons / General**, verify the grid renders ~1,179 tiles grouped by category, search filters by name, copy-import-path is selectable per tile.
- [ ] CI green (Chromatic Figma signal + lint + type-check + audit + visual regression — catalog story is `disableSnapshot`'d so it should not appear in baselines).

Refs #309 — Phase B only. Phases A.2 / C / D remain open under the same tracking issue and ship as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)