### PR TITLE
feat(ui): featured-icon storybook docs (foundations phase C)

### DIFF
--- a/packages/ui/src/components/foundations/featured-icon/FeaturedIcon.mdx
+++ b/packages/ui/src/components/foundations/featured-icon/FeaturedIcon.mdx
@@ -1,0 +1,123 @@
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
+
+import * as FeaturedIconStories from './FeaturedIcon.stories';
+
+<Meta of={FeaturedIconStories} />
+
+# Featured Icon
+
+Iconographic chip used to anchor a piece of UI to a semantic meaning —
+the round / squircle frame around an icon you see on Alerts,
+Notifications, empty-state panels, and dashboard tiles. FeaturedIcon
+owns its own size, colour, and theme treatment; consumers only supply
+the inner glyph.
+
+This page documents the kit-raw primitive that ships under
+`packages/ui/src/components/foundations/featured-icon/`. It is not yet
+publicly exported through `@glaon/ui`'s barrel — components like
+`Alert` and `Notification` consume it directly today. Promotion to a
+publicly-exported wrap is a separate concern (UUI Source Rule); this
+page is scoped to documenting the existing internal surface.
+
+## When to use
+
+- **Alert / Notification icon slot** — match `theme="light"` with the
+  matching `color` (`error`, `warning`, `success`, `brand`, `gray`).
+- **Empty-state panel** — pair `theme="modern"` with a larger size
+  (`lg` or `xl`) to anchor a "no data" message.
+- **Dashboard tile** — `theme="modern-neue"` provides a raised chip
+  on a primary surface; `xl` reads as a hero glyph.
+- **Marketing / branded sections** — `theme="gradient"` or
+  `theme="dark"` give richer visual weight; reserve for hero areas,
+  not chrome.
+
+## When NOT to use
+
+- **Inline icon next to text** → use `@untitledui/icons` directly,
+  no chip frame.
+- **Pure decorative bullet** → `<DotIcon>` (sibling foundation
+  primitive) is lighter weight.
+- **Brand glyph next to a button label** → use the brand registry
+  (`@glaon/ui` `Apple`, `Google`, `Figma`, …) — those carry
+  brand-correct colour fills and don't want a semantic theme.
+
+## Anatomy
+
+<Canvas of={FeaturedIconStories.Default} />
+
+The chip wraps any icon component or React node. Glyph sizing flows
+from the chip's `size` prop — a `sm` chip auto-scales the inner glyph
+to 16px, `md` to 20px, `lg` to 24px, `xl` to 28px.
+
+```tsx
+import { FeaturedIcon } from '@glaon/ui/components/foundations/featured-icon';
+import { Lightbulb02 } from '@untitledui/icons';
+
+<FeaturedIcon icon={Lightbulb02} theme="light" color="brand" size="md" />;
+```
+
+## Variants
+
+### Themes
+
+<Canvas of={FeaturedIconStories.ThemeMatrix} />
+
+Six themes ship with the kit. Pair with the surrounding surface:
+
+- **`light`** — tinted background, low visual weight. Default for
+  dense UI (alerts, list rows).
+- **`modern`** — raised chip on the primary surface. Use for
+  dashboard tiles and settings groups.
+- **`modern-neue`** — softer raise with a subtle inner shadow. Use
+  for elevated content panels.
+- **`outline`** — stroked frame, hollow background. Reserved for
+  marketing sections that need negative space.
+- **`gradient`** — bold gradient fill. Marketing / hero only.
+- **`dark`** — dark fill against light surfaces. Marketing / hero
+  only.
+
+### Colours × themes
+
+<Canvas of={FeaturedIconStories.ColorMatrix} />
+
+Five semantic colours map to Glaon's brand + state palette. Pick the
+colour by **meaning**, not visual weight — `error` always means
+"something went wrong" regardless of theme.
+
+### Sizes
+
+<Canvas of={FeaturedIconStories.SizeScale} />
+
+Four sizes (32 / 40 / 48 / 56 px). The size also controls the inner
+glyph's stroke width on `sm` to keep optical balance — don't try to
+override.
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The chip itself is decorative and rendered as a `<div>` with no ARIA
+  role; the surrounding component (Alert, Notification, …) is
+  responsible for the announceable label.
+- The inner glyph carries `data-icon` and inherits `currentColor`
+  from the chip's text colour for single-colour icons. Brand glyphs
+  (multi-colour) shipped through the brand registry retain their
+  fixed brand fills regardless of theme.
+- If you use FeaturedIcon stand-alone (rare), wrap it in an element
+  with the right ARIA semantics — `<button>`, `<a>`, or a labelled
+  `<div role="img" aria-label="…">`.
+
+## Related
+
+- [`Alert`](?path=/docs/web-primitives-alert--docs) and
+  [`Notification`](?path=/docs/web-primitives-notification--docs) —
+  the most common consumers; both wire FeaturedIcon to their colour
+  prop automatically.
+- [Brand Icons](?path=/docs/foundations-brand-icons--catalog) —
+  brand glyphs (Apple, Google, Figma, …) you'd pass to `icon` for
+  social-context featured chips.
+- [Icons / General](?path=/docs/foundations-icons-general--catalog) —
+  full `@untitledui/icons` browser; pick a glyph here, then wire it
+  through `icon`.

--- a/packages/ui/src/components/foundations/featured-icon/FeaturedIcon.stories.tsx
+++ b/packages/ui/src/components/foundations/featured-icon/FeaturedIcon.stories.tsx
@@ -1,0 +1,236 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { Lightbulb02 } from '@untitledui/icons';
+
+import { FeaturedIcon } from './featured-icon';
+
+// `Foundations/Featured Icon` — Storybook surface for the kit-raw
+// FeaturedIcon primitive. Phase C of the icon registry rollout
+// (#309): document the theme × color × size matrix so consumers
+// (Alert, Notification, Modal, future device tiles) reach for the
+// right combination without spelunking the kit source.
+//
+// FeaturedIcon ships as raw UUI source under `components/foundations/`
+// (no Glaon wrap layer yet — see UUI Source Rule). Promotion to a
+// publicly-exported wrapped primitive is a separate concern; this
+// PR is docs-only. Stories therefore import the kit component
+// directly and live alongside the source file.
+
+const themes = ['light', 'gradient', 'dark', 'outline', 'modern', 'modern-neue'] as const;
+const colors = ['brand', 'gray', 'success', 'warning', 'error'] as const;
+const sizes = ['sm', 'md', 'lg', 'xl'] as const;
+
+// Explicit `Meta<typeof FeaturedIcon>` annotation rather than
+// `satisfies` keeps Storybook csf-internal types out of the exported
+// `meta` signature — `tsc --noEmit` runs with `declaration: true`,
+// and the kit-source primitive's prop interface isn't exported.
+const meta: Meta<typeof FeaturedIcon> = {
+  title: 'Foundations/Featured Icon',
+  component: FeaturedIcon,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1025-31781',
+    },
+  },
+  args: {
+    icon: Lightbulb02,
+    size: 'md',
+    theme: 'light',
+    color: 'brand',
+  },
+  argTypes: {
+    icon: {
+      control: false,
+      description:
+        'Icon component or React node rendered inside the chip. Pair with `@untitledui/icons` or the brand registry; the FeaturedIcon owns sizing and colour treatment.',
+      table: { category: 'Content' },
+    },
+    size: {
+      control: 'inline-radio',
+      options: sizes,
+      description:
+        'Outer chip size. `sm` = 32px, `md` = 40px, `lg` = 48px, `xl` = 56px. Inner glyph scales accordingly.',
+      table: { category: 'Style' },
+    },
+    theme: {
+      control: 'select',
+      options: themes,
+      description:
+        'Visual treatment. `light` (tinted background) and `modern` (raised on a primary surface) are the most common; `dark`, `gradient`, `outline`, `modern-neue` ship for richer marketing / dashboard contexts.',
+      table: { category: 'Style' },
+    },
+    color: {
+      control: 'inline-radio',
+      options: colors,
+      description:
+        'Semantic colour role. Pairs with the surrounding context: `brand` for primary affordances, `success`/`warning`/`error` for state-bound messages, `gray` for neutral framing.',
+      table: { category: 'Style' },
+    },
+    className: {
+      control: false,
+      description: 'Tailwind override hook for the outer chip.',
+      table: { category: 'Style' },
+    },
+    children: {
+      control: false,
+      description:
+        'Optional decorative content rendered alongside the glyph (e.g. a small status dot). Rare; prefer composition outside the chip.',
+      table: { category: 'Content' },
+    },
+  },
+} satisfies Meta<typeof FeaturedIcon>;
+
+export default meta;
+type Story = StoryObj<typeof FeaturedIcon>;
+
+/**
+ * Default rendering with the controls panel wired up — toggle
+ * `theme`, `color`, and `size` to compare combinations.
+ */
+export const Default: Story = {};
+
+/**
+ * Every theme rendered side by side at the canonical `md` size with
+ * the `brand` colour. Use this to pick a theme by visual weight,
+ * then narrow colour + size in the controls panel above.
+ */
+export const ThemeMatrix: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Six themes the kit ships. `light` is the everyday default; `modern` and `modern-neue` add a raised chip for dashboards; `dark`, `gradient`, and `outline` lean into branded marketing surfaces.',
+      },
+    },
+  },
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 24,
+        alignItems: 'center',
+      }}
+    >
+      {themes.map((theme) => (
+        <div
+          key={theme}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 8,
+            padding: 12,
+          }}
+        >
+          <FeaturedIcon icon={Lightbulb02} theme={theme} color="brand" size="md" />
+          <code style={{ fontSize: 12, color: 'var(--color-text-tertiary, #555)' }}>{theme}</code>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * Theme × colour matrix at the canonical `md` size. Surfaces every
+ * supported pairing so a contributor can spot which combinations the
+ * kit already styles (e.g. `outline` × `error`) without wiring an
+ * ad-hoc story.
+ */
+export const ColorMatrix: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Theme rows × colour columns. The chip carries semantic meaning, so prefer matching the colour to the surrounding context (an alert in error state pairs with `color="error"`, etc.).',
+      },
+    },
+  },
+  render: () => (
+    <table
+      style={{
+        borderCollapse: 'collapse',
+      }}
+    >
+      <thead>
+        <tr>
+          <th
+            style={{
+              padding: 12,
+              textAlign: 'left',
+              fontSize: 12,
+              color: 'var(--color-text-tertiary, #555)',
+            }}
+          >
+            theme \ color
+          </th>
+          {colors.map((color) => (
+            <th
+              key={color}
+              style={{
+                padding: 12,
+                textAlign: 'center',
+                fontSize: 12,
+                color: 'var(--color-text-tertiary, #555)',
+              }}
+            >
+              {color}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {themes.map((theme) => (
+          <tr key={theme}>
+            <td
+              style={{
+                padding: 12,
+                fontSize: 12,
+                color: 'var(--color-text-tertiary, #555)',
+              }}
+            >
+              <code>{theme}</code>
+            </td>
+            {colors.map((color) => (
+              <td key={color} style={{ padding: 12, textAlign: 'center' }}>
+                <FeaturedIcon icon={Lightbulb02} theme={theme} color={color} size="md" />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+};
+
+/**
+ * Size scale at a fixed `light × brand` treatment. Sizes step in
+ * 8px increments — pair `sm` with inline labels, `xl` with empty
+ * states or hero panels.
+ */
+export const SizeScale: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: 24,
+        alignItems: 'center',
+      }}
+    >
+      {sizes.map((size) => (
+        <div
+          key={size}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <FeaturedIcon icon={Lightbulb02} theme="light" color="brand" size={size} />
+          <code style={{ fontSize: 12, color: 'var(--color-text-tertiary, #555)' }}>{size}</code>
+        </div>
+      ))}
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

- Adds **`Foundations/Featured Icon`** — Storybook stories + MDX docs for the kit-raw FeaturedIcon primitive used by `Alert`, `Notification`, and (future) dashboard tiles.
- Documents the full prop matrix: **6 themes** × **5 semantic colors** × **4 sizes**.
- Phase C of [#309](https://github.com/toss-cengiz/glaon/issues/309). Country flag catalog (the other half of Phase C) deferred to a follow-up — runtime CDN dependency raises CSP + architectural questions that deserve their own resolution.

## Scope

**In:**
- `packages/ui/src/components/foundations/featured-icon/FeaturedIcon.stories.tsx` — Stories: `Default` (controls-driven), `ThemeMatrix` (6 themes side by side), `ColorMatrix` (theme × color grid), `SizeScale`.
- `packages/ui/src/components/foundations/featured-icon/FeaturedIcon.mdx` — Narrative docs: when to use, when not to, anatomy, variants (themes / colors / sizes), prop reference (`<Controls />`), accessibility notes, related foundations links (Alert, Notification, brand registry, icon catalog).
- Stories use the explicit `Meta<typeof FeaturedIcon>` annotation pattern (matches Card.stories) — `satisfies` triggers TS4023 because the kit-raw primitive's prop interface isn't exported.

**Out:**
- **Country flag catalog** — defers to follow-up under #309. UUI ships flags via `https://www.untitledui.com/images/flags/...` CDN. Adopting that creates a runtime cross-origin dependency that conflicts with the addon's restrictive CSP (`default-src 'self'`); choosing between CDN whitelist, npm flag library (`flag-icons`), or self-hosted SVGs is its own architectural call.
- FeaturedIcon promotion to a Glaon-wrapped public primitive — separate concern under the UUI Source Rule. This PR only adds docs to the existing kit-raw internal primitive.
- Controls.ts split — overkill for a docs-only addition to a kit-raw component (F6 prop-coverage gate excludes lowercase `foundations/` folders); inline argTypes in the story.
- DotIcon docs — sibling foundation primitive, separate scope.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check` — green.
- [x] `pnpm --filter @glaon/ui lint` — green.
- [x] `pnpm --filter @glaon/ui test` — 108/108 (F6 prop-coverage gate unchanged).
- [x] `pnpm knip` — no orphans.
- [x] `pnpm exec prettier --check packages/ui/src/components/foundations/featured-icon/` — clean.
- [ ] Reviewer: open Storybook (`pnpm --filter @glaon/ui storybook`), navigate to **Foundations / Featured Icon**, verify the four stories render, controls panel toggles theme / color / size live, MDX page links resolve.
- [ ] CI green (Chromatic Figma signal + lint + type-check + audit + visual regression — four new stories will appear in baseline accept).

Refs #309 — Phase C (FeaturedIcon docs only). Phases A.2 (extended brand registry), C.2 (country flags), and D (app / payment / integration / file-type / emoji collections) remain open under the same tracking issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)