### PR TITLE
feat(ui): brand registry A.2.2 — 6 Tier-2 collaboration glyphs

### DIFF
--- a/packages/ui/src/components/SocialButton/SocialButton.tsx
+++ b/packages/ui/src/components/SocialButton/SocialButton.tsx
@@ -8,19 +8,20 @@
 // brand + style + label.
 //
 // Maps Figma's `web-primitives-social-button` axes 1:1:
-//   - `Social`:         apple / discord / dribbble / facebook / figma /
-//                       github / gitlab / google / linkedin / microsoft /
-//                       slack / twitter (12 — Phase A + A.2.1 Tier-1
-//                       auth providers)
+//   - `Social`:         apple / asana / atlassian / bitbucket / discord /
+//                       dribbble / facebook / figma / github / gitlab /
+//                       google / linkedin / microsoft / notion / slack /
+//                       telegram / trello / twitter (18 — Phase A +
+//                       A.2.1 Tier-1 auth + A.2.2 Tier-2 collaboration)
 //   - `Style`:          brand / black-outline / white-outline / icon-only (4)
 //   - `Supporting text`: "Continue with X" vs "X" (boolean)
 //   - `Size`:           sm / md / lg
 //
 // Brand glyphs come from the central registry under
 // `packages/ui/src/icons/brand/` (see #309). The registry phases in
-// the remaining 22 platforms — when Phase A.2.2 / A.2.3 land,
-// extend the `SocialBrand` union below and add a matching
-// `brandTokens` row per platform.
+// the remaining 16 platforms — when Phase A.2.3 lands, extend the
+// `SocialBrand` union below and add a matching `brandTokens` row
+// per platform.
 //
 // Usage:
 //
@@ -32,6 +33,9 @@ import type { MouseEventHandler, ReactNode } from 'react';
 
 import {
   Apple,
+  Asana,
+  Atlassian,
+  Bitbucket,
   Discord,
   Dribbble,
   Facebook,
@@ -41,13 +45,19 @@ import {
   Google,
   Linkedin,
   Microsoft,
+  Notion,
   Slack,
+  Telegram,
+  Trello,
   Twitter,
   type BrandIconProps,
 } from '../../icons/brand';
 
 export type SocialBrand =
   | 'apple'
+  | 'asana'
+  | 'atlassian'
+  | 'bitbucket'
   | 'discord'
   | 'dribbble'
   | 'facebook'
@@ -57,7 +67,10 @@ export type SocialBrand =
   | 'google'
   | 'linkedin'
   | 'microsoft'
+  | 'notion'
   | 'slack'
+  | 'telegram'
+  | 'trello'
   | 'twitter';
 export type SocialStyle = 'brand' | 'black-outline' | 'white-outline' | 'icon-only';
 export type SocialSize = 'sm' | 'md' | 'lg';
@@ -205,6 +218,54 @@ const brandTokens: Record<SocialBrand, BrandTokens> = {
     // Google + Microsoft "white surface" pattern.
     brandClass: 'bg-primary text-secondary ring-1 ring-inset ring-primary hover:bg-primary_hover',
     Glyph: Slack,
+  },
+  // --- Phase A.2.2 — Tier-2 collaboration platforms ---
+  notion: {
+    label: 'Notion',
+    // Notion's brand-CTA convention is white surface + black text;
+    // the single-colour `N` glyph follows currentColor so it reads
+    // dark against the white bg. Same pattern as Google / Microsoft.
+    brandClass: 'bg-primary text-secondary ring-1 ring-inset ring-primary hover:bg-primary_hover',
+    Glyph: Notion,
+  },
+  trello: {
+    label: 'Trello',
+    // Trello's brand-blue is `#0079BF` — closest Glaon utility
+    // token is `utility-blue-700`. The two-list-stack glyph reads
+    // white against that surface.
+    brandClass: 'bg-utility-blue-700 text-white hover:bg-utility-blue-800',
+    Glyph: Trello,
+  },
+  asana: {
+    label: 'Asana',
+    // Asana ships a multi-colour three-dot mark (red / coral /
+    // orange triad). Keep on white so the warm-toned fills don't
+    // collide with a coloured bg.
+    brandClass: 'bg-primary text-secondary ring-1 ring-inset ring-primary hover:bg-primary_hover',
+    Glyph: Asana,
+  },
+  atlassian: {
+    label: 'Atlassian',
+    // Atlassian ships a multi-colour blue-gradient mark — the
+    // canonical chevron pair. White surface + dark text label
+    // keeps the gradient blue legible.
+    brandClass: 'bg-primary text-secondary ring-1 ring-inset ring-primary hover:bg-primary_hover',
+    Glyph: Atlassian,
+  },
+  bitbucket: {
+    label: 'Bitbucket',
+    // Bitbucket sits under the Atlassian brand bar — same surface
+    // treatment so the multi-colour bucket glyph reads correctly.
+    brandClass: 'bg-primary text-secondary ring-1 ring-inset ring-primary hover:bg-primary_hover',
+    Glyph: Bitbucket,
+  },
+  telegram: {
+    label: 'Telegram',
+    // Telegram's brand-CTA convention is a circular blue surface
+    // (`#229ED9`); `utility-blue-700` is the closest Glaon token.
+    // The white paper-plane glyph inherits via `currentColor`.
+    brandClass: 'bg-utility-blue-700 text-white hover:bg-utility-blue-800',
+    Glyph: Telegram,
   },
 };
 

--- a/packages/ui/src/icons/brand/Asana.tsx
+++ b/packages/ui/src/icons/brand/Asana.tsx
@@ -1,0 +1,18 @@
+// Asana three-dot mark. Multi-color brand glyph — ships fixed
+// brand fills (the canonical red / coral / orange triad) so unlike
+// single-colour brand glyphs this does NOT inherit `currentColor`.
+// Place on a contrasting surface — the SocialButton wrap pairs it
+// with `bg-primary` (white) so the warm-toned mark reads against
+// light bg.
+
+import type { BrandIconProps } from './types';
+
+export function Asana({ className, 'aria-hidden': ariaHidden = true, ...rest }: BrandIconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <circle cx="12" cy="15.94" r="5.5" fill="#F06A6A" />
+      <circle cx="6.5" cy="6.94" r="5.5" fill="#F06A6A" opacity="0.85" />
+      <circle cx="17.5" cy="6.94" r="5.5" fill="#F06A6A" opacity="0.85" />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/brand/Atlassian.tsx
+++ b/packages/ui/src/icons/brand/Atlassian.tsx
@@ -1,0 +1,39 @@
+// Atlassian chevron mark — the two-mountain-peak glyph used across
+// Atlassian properties (Jira, Confluence, Trello brand bar etc.).
+// Multi-color brand glyph — ships fixed brand fills (Atlassian's
+// canonical blue gradient) so this does NOT inherit `currentColor`.
+// Place on a white or neutral surface so the gradient blue reads.
+
+import type { BrandIconProps } from './types';
+
+export function Atlassian({
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}: BrandIconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <defs>
+        <linearGradient
+          id="atlassian-grad"
+          x1="11.85"
+          y1="11.49"
+          x2="6.49"
+          y2="20.78"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0" stopColor="#0052CC" />
+          <stop offset="0.92" stopColor="#2684FF" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M7.12 11.41a.55.55 0 0 0-.93.16L.05 23.81a.57.57 0 0 0 .51.81h8.41a.55.55 0 0 0 .51-.31c1.81-3.74.71-9.43-2.36-12.9Z"
+        fill="url(#atlassian-grad)"
+      />
+      <path
+        d="M11.55.5a12.4 12.4 0 0 0-.72 12.25l4.13 8.26a.57.57 0 0 0 .51.31h8.41a.57.57 0 0 0 .51-.81S13.07.79 12.49.51a.46.46 0 0 0-.94-.01Z"
+        fill="#2684FF"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/brand/Bitbucket.tsx
+++ b/packages/ui/src/icons/brand/Bitbucket.tsx
@@ -1,0 +1,38 @@
+// Bitbucket bucket glyph. Multi-color brand mark — ships fixed
+// brand fills (Atlassian's blue gradient + the white bucket-band)
+// so this does NOT inherit `currentColor`. Pairs with white or
+// neutral surfaces so the gradient reads cleanly.
+
+import type { BrandIconProps } from './types';
+
+export function Bitbucket({
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}: BrandIconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <defs>
+        <linearGradient
+          id="bitbucket-grad"
+          x1="22.03"
+          y1="9.86"
+          x2="11.43"
+          y2="18.04"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.18" stopColor="#0052CC" />
+          <stop offset="1" stopColor="#2684FF" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M.778 1.213a.768.768 0 0 0-.768.892l3.263 19.81c.084.5.515.868 1.022.873H19.95a.772.772 0 0 0 .77-.646l3.27-20.03a.768.768 0 0 0-.768-.891zM14.52 14.563H9.418L8.04 7.351h7.7z"
+        fill="#2684FF"
+      />
+      <path
+        d="M22.943 7.351h-7.207l-1.222 7.212H9.418l-5.895 6.997c.187.16.425.249.671.252H19.95a.772.772 0 0 0 .77-.646Z"
+        fill="url(#bitbucket-grad)"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/brand/Notion.tsx
+++ b/packages/ui/src/icons/brand/Notion.tsx
@@ -1,0 +1,20 @@
+// Notion `N` glyph (the simplified mark used in social-share / auth
+// contexts; the full `Notion` wordmark is a separate asset). Single-
+// colour via `currentColor`. The brand surface treatment in
+// SocialButton uses Notion's white + black canonical pairing.
+
+import type { BrandIconProps } from './types';
+
+export function Notion({ className, 'aria-hidden': ariaHidden = true, ...rest }: BrandIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden={ariaHidden}
+      className={className}
+      {...rest}
+    >
+      <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L17.86 1.968c-.42-.326-.981-.7-2.055-.607L3.01 2.295c-.466.046-.56.28-.374.466l1.823 1.447Zm.793 3.08v13.904c0 .747.373 1.027 1.214.98l14.523-.84c.841-.046.935-.56.935-1.167V6.354c0-.606-.233-.933-.748-.886l-15.177.887c-.56.047-.747.327-.747.933Zm14.337.745c.093.42 0 .84-.42.888l-.7.14v10.264c-.608.327-1.168.514-1.635.514-.748 0-.935-.234-1.495-.933l-4.577-7.186v6.952L12.21 19l.001 0s0 .84-1.168.84l-3.222.186c-.093-.186 0-.653.327-.746l.84-.234V9.854L7.822 9.76c-.094-.42.14-1.026.793-1.073l3.456-.233 4.764 7.279V9.295l-1.215-.139c-.093-.514.28-.887.747-.933l3.222-.187Z" />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/brand/Telegram.tsx
+++ b/packages/ui/src/icons/brand/Telegram.tsx
@@ -1,0 +1,20 @@
+// Telegram paper-plane glyph. Single-colour via `currentColor`.
+// Telegram's brand-CTA convention is a circular blue surface
+// (`#229ED9` ≈ `utility-blue-700`) with a white plane glyph; the
+// SocialButton wrap applies the surface treatment.
+
+import type { BrandIconProps } from './types';
+
+export function Telegram({ className, 'aria-hidden': ariaHidden = true, ...rest }: BrandIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden={ariaHidden}
+      className={className}
+      {...rest}
+    >
+      <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0Zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/brand/Trello.tsx
+++ b/packages/ui/src/icons/brand/Trello.tsx
@@ -1,0 +1,20 @@
+// Trello board glyph — the canonical two-list-stack inside a rounded
+// rectangle frame. Single-colour via `currentColor`. SocialButton
+// surface treatment uses Trello's brand-blue (`#0079BF` ≈
+// `utility-blue-700`) so the white-on-blue glyph reads correctly.
+
+import type { BrandIconProps } from './types';
+
+export function Trello({ className, 'aria-hidden': ariaHidden = true, ...rest }: BrandIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden={ariaHidden}
+      className={className}
+      {...rest}
+    >
+      <path d="M21.147 0H2.853A2.86 2.86 0 0 0 0 2.853v18.294A2.86 2.86 0 0 0 2.853 24h18.294A2.86 2.86 0 0 0 24 21.147V2.853A2.86 2.86 0 0 0 21.147 0ZM10.42 18.231a.93.93 0 0 1-.93.93H4.34a.93.93 0 0 1-.93-.93V4.34a.93.93 0 0 1 .93-.93h5.151a.93.93 0 0 1 .93.93v13.891Zm10.17-6.196a.93.93 0 0 1-.93.93h-5.15a.93.93 0 0 1-.93-.93V4.34a.93.93 0 0 1 .93-.93h5.15a.93.93 0 0 1 .93.93v7.696Z" />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/brand/index.ts
+++ b/packages/ui/src/icons/brand/index.ts
@@ -7,11 +7,11 @@
 //   - Phase A     (#322 ✓): Apple, Dribbble, Facebook, Figma,
 //                            Google, Twitter — six platforms
 //                            consumed by the original `<SocialButton>`.
-//   - Phase A.2.1 (this) :  GitHub, GitLab, Microsoft, LinkedIn,
+//   - Phase A.2.1 (#372 ✓): GitHub, GitLab, Microsoft, LinkedIn,
 //                            Discord, Slack — Tier-1 auth providers.
-//   - Phase A.2.2 (next) :  Notion, Trello, Asana, Atlassian,
+//   - Phase A.2.2 (this) :  Notion, Trello, Asana, Atlassian,
 //                            Bitbucket, Telegram — collaboration.
-//   - Phase A.2.3 (long) :  AngelList, Clubhouse, Dropbox, Medium,
+//   - Phase A.2.3 (next) :  AngelList, Clubhouse, Dropbox, Medium,
 //                            Pinterest, Reddit, Snapchat, Spotify,
 //                            Stack Overflow, Tumblr, TikTok, Twitch,
 //                            Vimeo, WhatsApp, YouTube, …
@@ -24,6 +24,9 @@
 // spec — they're never recoloured.
 
 import { Apple } from './Apple';
+import { Asana } from './Asana';
+import { Atlassian } from './Atlassian';
+import { Bitbucket } from './Bitbucket';
 import { Discord } from './Discord';
 import { Dribbble } from './Dribbble';
 import { Facebook } from './Facebook';
@@ -33,13 +36,19 @@ import { Gitlab } from './Gitlab';
 import { Google } from './Google';
 import { Linkedin } from './Linkedin';
 import { Microsoft } from './Microsoft';
+import { Notion } from './Notion';
 import { Slack } from './Slack';
+import { Telegram } from './Telegram';
+import { Trello } from './Trello';
 import { Twitter } from './Twitter';
 import type { BrandIconCatalogEntry } from './types';
 
 export type { BrandIconCatalogEntry, BrandIconProps } from './types';
 export {
   Apple,
+  Asana,
+  Atlassian,
+  Bitbucket,
   Discord,
   Dribbble,
   Facebook,
@@ -49,7 +58,10 @@ export {
   Google,
   Linkedin,
   Microsoft,
+  Notion,
   Slack,
+  Telegram,
+  Trello,
   Twitter,
 };
 
@@ -61,6 +73,9 @@ export {
  */
 export const brandCatalog: readonly BrandIconCatalogEntry[] = [
   { id: 'apple', label: 'Apple', Icon: Apple },
+  { id: 'asana', label: 'Asana', Icon: Asana },
+  { id: 'atlassian', label: 'Atlassian', Icon: Atlassian },
+  { id: 'bitbucket', label: 'Bitbucket', Icon: Bitbucket },
   { id: 'discord', label: 'Discord', Icon: Discord },
   { id: 'dribbble', label: 'Dribbble', Icon: Dribbble },
   { id: 'facebook', label: 'Facebook', Icon: Facebook },
@@ -70,6 +85,9 @@ export const brandCatalog: readonly BrandIconCatalogEntry[] = [
   { id: 'google', label: 'Google', Icon: Google },
   { id: 'linkedin', label: 'LinkedIn', Icon: Linkedin },
   { id: 'microsoft', label: 'Microsoft', Icon: Microsoft },
+  { id: 'notion', label: 'Notion', Icon: Notion },
   { id: 'slack', label: 'Slack', Icon: Slack },
+  { id: 'telegram', label: 'Telegram', Icon: Telegram },
+  { id: 'trello', label: 'Trello', Icon: Trello },
   { id: 'twitter', label: 'Twitter / X', Icon: Twitter },
 ];


### PR DESCRIPTION
## Summary

Second batch of #309 Phase A.2 (sub-issue #365). Adds six Tier-2 collaboration platform glyphs to the registry plus matching `SocialBrand` union + `brandTokens` rows on `<SocialButton>`: **Notion, Trello, Asana, Atlassian, Bitbucket, Telegram**.

## Scope

**In**
- Six `<Platform>.tsx` files in `packages/ui/src/icons/brand/` — 24×24 viewBox SVGs following the Phase A pattern. Single-colour glyphs (Notion, Trello, Telegram) inherit `currentColor`; multi-colour glyphs (Asana, Atlassian, Bitbucket) ship fixed brand fills per platform spec.
- `brandCatalog` array updated (alphabetical) — 12 → 18 entries.
- `<SocialButton>` `SocialBrand` union expanded from 12 → 18 platforms; matching `brandTokens` rows define each brand's surface treatment per the platform's brand-CTA guidelines.

**Out (next A.2 batch)**
- A.2.3 — Tier-3 long tail (AngelList, Clubhouse, Dropbox, Medium, Pinterest, Reddit, Snapchat, Spotify, Stack Overflow, Tumblr, TikTok, Twitch, Vimeo, WhatsApp, YouTube + remaining Figma frame entries).

## Migration

`<SocialButton brand="notion">` etc. just works. Existing consumers (Phase A + A.2.1 brands) keep rendering byte-equal — the union expansion is purely additive.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (108/108)
- [x] `pnpm --filter @glaon/ui build-storybook`
- [x] `pnpm knip` — no orphans
- [ ] Storybook localhost:6006 — `Foundations / Brand Icons` catalog shows 18 tiles with search; `<SocialButton brand=…>` controls panel includes the new brands
- [ ] Chromatic — new baselines accepted (catalog grid)

Refs #309
Refs #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)