### PR TITLE
feat(ui): payment icon registry D.2.a — card networks + Input swap

### DIFF
--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -22,6 +22,8 @@
 // need it.
 
 import { CreditCard02 } from '@untitledui/icons';
+
+import { paymentIconForBrand } from '../../icons/payment';
 import type {
   ChangeEventHandler,
   ClipboardEventHandler,
@@ -488,17 +490,18 @@ function PaymentInputVariant(props: InputProps) {
     [brand, isControlled, onChange],
   );
 
-  // V1 ships a single neutral credit-card glyph for every brand —
-  // visa / mastercard / amex / discover SVGs land in the BrandIcon
-  // registry (#309) and the variant will swap to per-brand artwork
-  // once that's merged. The inline glyph stays decorative
-  // (`aria-hidden`) until per-brand artwork lands; axe's
-  // `aria-prohibited-attr` rejects `aria-label` on a plain `<span>`
-  // without a role, so the detected brand surfaces only via the
-  // `onPaymentBrandDetected` callback for now.
+  // The leading glyph swaps to per-brand artwork via the payment
+  // registry's `paymentIconForBrand` helper (#368 D.2.a). When the
+  // detected brand is `unknown` the helper returns `undefined` and
+  // we fall back to the kit's neutral `CreditCard02`.
+  const BrandGlyph = paymentIconForBrand(brand);
   const leading = (
     <span aria-hidden="true" className="flex items-center pl-3 text-fg-quaternary">
-      <CreditCard02 className="size-5" />
+      {BrandGlyph !== undefined ? (
+        <BrandGlyph className="h-5" />
+      ) : (
+        <CreditCard02 className="size-5" />
+      )}
     </span>
   );
 

--- a/packages/ui/src/icons/payment/PaymentIcons.stories.tsx
+++ b/packages/ui/src/icons/payment/PaymentIcons.stories.tsx
@@ -1,0 +1,204 @@
+import { useMemo, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { paymentCatalog } from './index';
+import type { PaymentIconCatalogEntry } from './types';
+
+// Storybook docs catalog for the payment-icon registry.
+// Phase D.2.a of #309 ships the card-network tier (Visa,
+// MasterCard, AMEX, Discover, JCB, UnionPay); D.2.b–d follow with
+// digital wallets, BNPL, and regional rails. Mirrors the brand
+// + integration + emoji catalog page layout for visual consistency.
+//
+// Cross-link: `<Input variant="payment">` (#313) and
+// `<Table.Cell.PaymentIcon>` (#324 Phase A) consume these glyphs
+// via the `paymentIconForBrand(brand)` helper.
+
+type CategoryFilter = 'all' | PaymentIconCatalogEntry['category'];
+
+const meta: Meta = {
+  title: 'Foundations/Payment Icons',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1025-31781',
+    },
+    // Docs-only sketch — no canvas snapshot diff because the icon
+    // set isn't a behavioural primitive. Per-icon per-PR review
+    // covers visual correctness; downstream Input / Table stories
+    // capture the integration moment when the helper swaps the
+    // placeholder.
+    docs: { disable: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+function CatalogGrid({ search, category }: { search: string; category: CategoryFilter }) {
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return paymentCatalog.filter((entry) => {
+      const matchesCategory = category === 'all' || entry.category === category;
+      const matchesSearch =
+        q.length === 0 || entry.id.includes(q) || entry.label.toLowerCase().includes(q);
+      return matchesCategory && matchesSearch;
+    });
+  }, [search, category]);
+
+  if (filtered.length === 0) {
+    return (
+      <p
+        style={{
+          padding: 32,
+          color: 'var(--color-text-tertiary, #555)',
+          textAlign: 'center',
+        }}
+      >
+        No payment glyphs match the current filter.
+      </p>
+    );
+  }
+
+  return (
+    <ul
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+        gap: 16,
+        padding: 0,
+        margin: 0,
+        listStyle: 'none',
+      }}
+    >
+      {filtered.map(({ id, label, Icon }) => (
+        <li
+          key={id}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 12,
+            padding: 16,
+            borderRadius: 12,
+            background: 'var(--color-bg-secondary, #f7f7f7)',
+            border: '1px solid var(--color-border-secondary, #e4e4e4)',
+          }}
+        >
+          <div
+            style={{
+              width: 64,
+              height: 48,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Icon className="h-12" />
+          </div>
+          <div style={{ textAlign: 'center', display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={{ fontSize: 14, fontWeight: 600 }}>{label}</span>
+            <code
+              style={{
+                fontSize: 12,
+                color: 'var(--color-text-tertiary, #555)',
+                background: 'var(--color-bg-primary, #fff)',
+                padding: '2px 6px',
+                borderRadius: 4,
+                userSelect: 'all',
+              }}
+            >
+              {`import { ${componentName(id)} } from '@glaon/ui'`}
+            </code>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function componentName(id: string): string {
+  if (id === 'amex') return 'Amex';
+  if (id === 'jcb') return 'Jcb';
+  if (id === 'unionpay') return 'UnionPay';
+  return id
+    .split('-')
+    .map((part) => {
+      const head = part.charAt(0);
+      return head.length > 0 ? head.toUpperCase() + part.slice(1) : '';
+    })
+    .join('');
+}
+
+function CatalogPage() {
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState<CategoryFilter>('all');
+  const filterButtonStyle = (active: boolean): React.CSSProperties => ({
+    padding: '6px 12px',
+    borderRadius: 8,
+    border: '1px solid var(--color-border-primary, #d5d7da)',
+    background: active ? 'var(--color-bg-brand-solid, #6941C6)' : 'var(--color-bg-primary, #fff)',
+    color: active ? '#fff' : 'var(--color-text-secondary, #555)',
+    fontSize: 13,
+    fontWeight: 500,
+    cursor: 'pointer',
+  });
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+        <input
+          type="search"
+          placeholder="Search payment glyphs…"
+          aria-label="Search payment glyphs"
+          value={search}
+          onChange={(event) => {
+            setSearch(event.currentTarget.value);
+          }}
+          style={{
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid var(--color-border-primary, #d5d7da)',
+            fontSize: 14,
+            flex: 1,
+            minWidth: 200,
+            maxWidth: 320,
+          }}
+        />
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {(
+            [
+              ['all', 'All'],
+              ['networks', 'Networks'],
+              ['wallets', 'Wallets'],
+              ['bnpl', 'BNPL'],
+              ['regional', 'Regional'],
+            ] as const
+          ).map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              style={filterButtonStyle(category === key)}
+              onClick={() => {
+                setCategory(key);
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <CatalogGrid search={search} category={category} />
+    </div>
+  );
+}
+
+/**
+ * Searchable + filterable grid of every payment glyph the registry
+ * ships. Filter chips switch the visible tier (Networks, Wallets,
+ * BNPL, Regional); search narrows by id or display name. Each tile
+ * shows the canonical `import { … } from '@glaon/ui'` line for
+ * copy-paste.
+ */
+export const Catalog: Story = {
+  render: () => <CatalogPage />,
+};

--- a/packages/ui/src/icons/payment/index.ts
+++ b/packages/ui/src/icons/payment/index.ts
@@ -1,0 +1,85 @@
+// Glaon payment-icon registry — Phase D.2 of the icon registry
+// rollout (#309 / #368). Per-method SVG glyphs for the canonical
+// payment marks Glaon ships, paired with a typed `paymentCatalog`
+// array that powers the Storybook catalog page and a
+// `paymentIconForBrand` helper that `<Input variant="payment">`
+// (#313) and `<Table.Cell.PaymentIcon>` (#324 Phase A) call to
+// swap their neutral `CreditCard02` placeholder for per-brand
+// artwork.
+//
+// Phase scope:
+//   - **D.2.a (this) :** Card networks — Visa, MasterCard, AMEX,
+//                        Discover, JCB, UnionPay.
+//   - D.2.b (next)   :   Digital wallets — ApplePay, GooglePay,
+//                        SamsungPay, AmazonPay, PayPal, Venmo,
+//                        ShopPay, LinkPay.
+//   - D.2.c          :   BNPL — Affirm, Afterpay, Klarna, Sezzle,
+//                        Zip, Splitit.
+//   - D.2.d          :   Regional rails — Alipay, WeChat,
+//                        MercadoPago, iDEAL, Bancontact, Sofort, …
+//
+// Each glyph component accepts the narrow `PaymentIconProps`
+// (`className`, `aria-hidden` default true, `aria-label`). Payment
+// glyphs are inherently multi-colour and ship fixed brand fills
+// per each platform's brand spec — they do NOT inherit
+// `currentColor` because brand reproduction rules require the
+// canonical artwork on every surface.
+
+import type { ComponentType } from 'react';
+
+import { Amex } from './networks/Amex';
+import { Discover } from './networks/Discover';
+import { Jcb } from './networks/Jcb';
+import { Mastercard } from './networks/Mastercard';
+import { UnionPay } from './networks/UnionPay';
+import { Visa } from './networks/Visa';
+import type { PaymentBrand, PaymentIconCatalogEntry, PaymentIconProps } from './types';
+
+// `PaymentBrand` is owned by `<Input>` (#313) and re-exported from
+// the package barrel via that primitive — re-exporting it here too
+// would collide. Consumers `import { type PaymentBrand } from '@glaon/ui'`.
+export type { PaymentIconCatalogEntry, PaymentIconProps } from './types';
+export { Amex, Discover, Jcb, Mastercard, UnionPay, Visa };
+
+/**
+ * Maps a `PaymentBrand` (the auto-detected card brand from
+ * `<Input variant="payment">`) to the registry's per-brand glyph
+ * component. Returns `undefined` when the brand is unknown so
+ * consumers can fall back to a neutral credit-card icon.
+ *
+ * `<Input variant="payment">` calls this internally to swap its
+ * leading glyph; consumers who detect the brand upstream (server-
+ * side card-on-file rendering, etc.) can call it directly.
+ */
+export function paymentIconForBrand(
+  brand: PaymentBrand,
+): ComponentType<PaymentIconProps> | undefined {
+  switch (brand) {
+    case 'visa':
+      return Visa;
+    case 'mastercard':
+      return Mastercard;
+    case 'amex':
+      return Amex;
+    case 'discover':
+      return Discover;
+    case 'unknown':
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Searchable catalog used by the `Foundations / Payment Icons`
+ * Storybook docs page. Order is alphabetical within each category
+ * so the rendered grid stays predictable for snapshot tests.
+ * Future phases (D.2.b–d) append.
+ */
+export const paymentCatalog: readonly PaymentIconCatalogEntry[] = [
+  { id: 'amex', label: 'American Express', category: 'networks', Icon: Amex },
+  { id: 'discover', label: 'Discover', category: 'networks', Icon: Discover },
+  { id: 'jcb', label: 'JCB', category: 'networks', Icon: Jcb },
+  { id: 'mastercard', label: 'Mastercard', category: 'networks', Icon: Mastercard },
+  { id: 'unionpay', label: 'UnionPay', category: 'networks', Icon: UnionPay },
+  { id: 'visa', label: 'Visa', category: 'networks', Icon: Visa },
+];

--- a/packages/ui/src/icons/payment/networks/Amex.tsx
+++ b/packages/ui/src/icons/payment/networks/Amex.tsx
@@ -1,6 +1,9 @@
-// American Express (AMEX) card-network glyph. Ships fixed brand
-// fills — the canonical AMEX blue surface (`#006FCF`) with white
-// "AMERICAN EXPRESS" wordmark — per AMEX's brand-CTA spec.
+// American Express card-network glyph. Ships fixed brand fills —
+// canonical AMEX blue surface (`#006FCF`) with white "AMEX"
+// wordmark. Uses an SVG `<text>` wordmark for clean cross-platform
+// reproduction (the official kit ships AMERICAN EXPRESS in two
+// lines on full-size cards; the abbreviated AMEX is the canonical
+// compact form for icon slots like Glaon's payment-row glyph).
 
 import type { PaymentIconProps } from '../types';
 
@@ -8,10 +11,18 @@ export function Amex({ className, 'aria-hidden': ariaHidden = true, ...rest }: P
   return (
     <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
       <rect width="32" height="24" rx="3" fill="#006FCF" />
-      <path
-        d="M16 9 L18 9 L19 11 L20 9 L22 9 L20 13 L22 17 L20 17 L19 14.5 L18 17 L16 17 L14 13 Z M10.5 9 L13.5 9 L14 17 L12 17 L11.85 15.5 L10.15 15.5 L10 17 L8 17 Z M11 11 L10.4 14 L11.6 14 Z"
+      <text
+        x="16"
+        y="15.5"
+        textAnchor="middle"
+        fontSize="6"
+        fontWeight="900"
         fill="#FFFFFF"
-      />
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="0.3"
+      >
+        AMEX
+      </text>
     </svg>
   );
 }

--- a/packages/ui/src/icons/payment/networks/Amex.tsx
+++ b/packages/ui/src/icons/payment/networks/Amex.tsx
@@ -1,0 +1,17 @@
+// American Express (AMEX) card-network glyph. Ships fixed brand
+// fills — the canonical AMEX blue surface (`#006FCF`) with white
+// "AMERICAN EXPRESS" wordmark — per AMEX's brand-CTA spec.
+
+import type { PaymentIconProps } from '../types';
+
+export function Amex({ className, 'aria-hidden': ariaHidden = true, ...rest }: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#006FCF" />
+      <path
+        d="M16 9 L18 9 L19 11 L20 9 L22 9 L20 13 L22 17 L20 17 L19 14.5 L18 17 L16 17 L14 13 Z M10.5 9 L13.5 9 L14 17 L12 17 L11.85 15.5 L10.15 15.5 L10 17 L8 17 Z M11 11 L10.4 14 L11.6 14 Z"
+        fill="#FFFFFF"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/networks/Discover.tsx
+++ b/packages/ui/src/icons/payment/networks/Discover.tsx
@@ -1,6 +1,10 @@
 // Discover card-network glyph. Multi-color brand mark — ships
-// fixed brand fills (white surface + Discover orange wordmark
-// + the canonical orange circle) per Discover's brand-CTA spec.
+// fixed brand fills (white surface + Discover orange wordmark +
+// the canonical orange dot) per Discover's brand-CTA spec.
+// Uses a centred `<text>` wordmark with Discover's brand orange
+// accent dot replacing the `O`-as-globe in the official mark
+// (close enough for a 32×24 icon slot; full kit-art reproduces
+// the globe pictogram which doesn't read at this scale).
 
 import type { PaymentIconProps } from '../types';
 
@@ -12,11 +16,19 @@ export function Discover({
   return (
     <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
       <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
-      <path d="M0 16 L32 16 L32 21 a3 3 0 0 1 -3 3 L3 24 a3 3 0 0 1 -3 -3 Z" fill="#FF6000" />
-      <text x="6" y="14" fontSize="3" fontWeight="700" fill="#1F2937" fontFamily="system-ui">
+      <text
+        x="16"
+        y="14"
+        textAnchor="middle"
+        fontSize="3.6"
+        fontWeight="800"
+        fill="#1F2937"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="0.15"
+      >
         DISCOVER
       </text>
-      <circle cx="22" cy="12" r="2.6" fill="#FF6000" />
+      <circle cx="16" cy="18" r="1.8" fill="#FF6000" />
     </svg>
   );
 }

--- a/packages/ui/src/icons/payment/networks/Discover.tsx
+++ b/packages/ui/src/icons/payment/networks/Discover.tsx
@@ -1,0 +1,22 @@
+// Discover card-network glyph. Multi-color brand mark — ships
+// fixed brand fills (white surface + Discover orange wordmark
+// + the canonical orange circle) per Discover's brand-CTA spec.
+
+import type { PaymentIconProps } from '../types';
+
+export function Discover({
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
+      <path d="M0 16 L32 16 L32 21 a3 3 0 0 1 -3 3 L3 24 a3 3 0 0 1 -3 -3 Z" fill="#FF6000" />
+      <text x="6" y="14" fontSize="3" fontWeight="700" fill="#1F2937" fontFamily="system-ui">
+        DISCOVER
+      </text>
+      <circle cx="22" cy="12" r="2.6" fill="#FF6000" />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/networks/Jcb.tsx
+++ b/packages/ui/src/icons/payment/networks/Jcb.tsx
@@ -1,6 +1,7 @@
 // JCB card-network glyph. Multi-color brand mark — ships fixed
 // brand fills (the canonical white surface + tri-tone JCB blocks:
-// blue / red / green) per JCB's brand-CTA spec.
+// blue / red / green) per JCB's brand-CTA spec. Each colored
+// segment carries its respective letter centred via SVG `<text>`.
 
 import type { PaymentIconProps } from '../types';
 
@@ -8,16 +9,40 @@ export function Jcb({ className, 'aria-hidden': ariaHidden = true, ...rest }: Pa
   return (
     <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
       <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
-      <rect x="7" y="8" width="5" height="8" rx="1.5" fill="#0E4C96" />
-      <rect x="13.5" y="8" width="5" height="8" rx="1.5" fill="#E60039" />
-      <rect x="20" y="8" width="5" height="8" rx="1.5" fill="#00A55B" />
-      <text x="9" y="13.5" fontSize="2.5" fontWeight="700" fill="#FFFFFF" fontFamily="system-ui">
+      <rect x="6" y="6" width="6" height="12" rx="1.5" fill="#0E4C96" />
+      <rect x="13" y="6" width="6" height="12" rx="1.5" fill="#E60039" />
+      <rect x="20" y="6" width="6" height="12" rx="1.5" fill="#00A55B" />
+      <text
+        x="9"
+        y="14"
+        textAnchor="middle"
+        fontSize="5"
+        fontWeight="900"
+        fill="#FFFFFF"
+        fontFamily="system-ui, -apple-system, sans-serif"
+      >
         J
       </text>
-      <text x="15.5" y="13.5" fontSize="2.5" fontWeight="700" fill="#FFFFFF" fontFamily="system-ui">
+      <text
+        x="16"
+        y="14"
+        textAnchor="middle"
+        fontSize="5"
+        fontWeight="900"
+        fill="#FFFFFF"
+        fontFamily="system-ui, -apple-system, sans-serif"
+      >
         C
       </text>
-      <text x="22" y="13.5" fontSize="2.5" fontWeight="700" fill="#FFFFFF" fontFamily="system-ui">
+      <text
+        x="23"
+        y="14"
+        textAnchor="middle"
+        fontSize="5"
+        fontWeight="900"
+        fill="#FFFFFF"
+        fontFamily="system-ui, -apple-system, sans-serif"
+      >
         B
       </text>
     </svg>

--- a/packages/ui/src/icons/payment/networks/Jcb.tsx
+++ b/packages/ui/src/icons/payment/networks/Jcb.tsx
@@ -1,0 +1,25 @@
+// JCB card-network glyph. Multi-color brand mark — ships fixed
+// brand fills (the canonical white surface + tri-tone JCB blocks:
+// blue / red / green) per JCB's brand-CTA spec.
+
+import type { PaymentIconProps } from '../types';
+
+export function Jcb({ className, 'aria-hidden': ariaHidden = true, ...rest }: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
+      <rect x="7" y="8" width="5" height="8" rx="1.5" fill="#0E4C96" />
+      <rect x="13.5" y="8" width="5" height="8" rx="1.5" fill="#E60039" />
+      <rect x="20" y="8" width="5" height="8" rx="1.5" fill="#00A55B" />
+      <text x="9" y="13.5" fontSize="2.5" fontWeight="700" fill="#FFFFFF" fontFamily="system-ui">
+        J
+      </text>
+      <text x="15.5" y="13.5" fontSize="2.5" fontWeight="700" fill="#FFFFFF" fontFamily="system-ui">
+        C
+      </text>
+      <text x="22" y="13.5" fontSize="2.5" fontWeight="700" fill="#FFFFFF" fontFamily="system-ui">
+        B
+      </text>
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/networks/Mastercard.tsx
+++ b/packages/ui/src/icons/payment/networks/Mastercard.tsx
@@ -1,0 +1,23 @@
+// MasterCard card-network glyph. Multi-color brand mark — ships
+// fixed brand fills (the canonical interlocking red + yellow
+// circles + white surface) per MasterCard's brand-CTA spec.
+
+import type { PaymentIconProps } from '../types';
+
+export function Mastercard({
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
+      <circle cx="13" cy="12" r="5" fill="#EB001B" />
+      <circle cx="19" cy="12" r="5" fill="#F79E1B" />
+      <path
+        d="M16 7.5c1.16 1.04 1.92 2.7 1.92 4.5S17.16 15.46 16 16.5C14.84 15.46 14.08 13.8 14.08 12S14.84 8.54 16 7.5Z"
+        fill="#FF5F00"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/networks/UnionPay.tsx
+++ b/packages/ui/src/icons/payment/networks/UnionPay.tsx
@@ -1,0 +1,20 @@
+// UnionPay card-network glyph. Multi-color brand mark — ships
+// fixed brand fills (the canonical tri-tone red / blue / green
+// curved bands) per UnionPay's brand-CTA spec.
+
+import type { PaymentIconProps } from '../types';
+
+export function UnionPay({
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
+      <path d="M9 7 L13 7 L11.5 17 L7.5 17 Z" fill="#E21836" />
+      <path d="M14 7 L18 7 L16.5 17 L12.5 17 Z" fill="#00447C" />
+      <path d="M19 7 L23 7 L21.5 17 L17.5 17 Z" fill="#007B5F" />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/networks/UnionPay.tsx
+++ b/packages/ui/src/icons/payment/networks/UnionPay.tsx
@@ -1,6 +1,7 @@
 // UnionPay card-network glyph. Multi-color brand mark — ships
 // fixed brand fills (the canonical tri-tone red / blue / green
-// curved bands) per UnionPay's brand-CTA spec.
+// parallelograms with the UnionPay wordmark beneath) per
+// UnionPay's brand-CTA spec.
 
 import type { PaymentIconProps } from '../types';
 
@@ -12,9 +13,21 @@ export function UnionPay({
   return (
     <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
       <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
-      <path d="M9 7 L13 7 L11.5 17 L7.5 17 Z" fill="#E21836" />
-      <path d="M14 7 L18 7 L16.5 17 L12.5 17 Z" fill="#00447C" />
-      <path d="M19 7 L23 7 L21.5 17 L17.5 17 Z" fill="#007B5F" />
+      <path d="M11 4 L14 4 L11 14 L8 14 Z" fill="#E21836" />
+      <path d="M15 4 L18 4 L15 14 L12 14 Z" fill="#00447C" />
+      <path d="M19 4 L22 4 L19 14 L16 14 Z" fill="#007B5F" />
+      <text
+        x="16"
+        y="20"
+        textAnchor="middle"
+        fontSize="3.6"
+        fontWeight="800"
+        fill="#1F2937"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="0.1"
+      >
+        UnionPay
+      </text>
     </svg>
   );
 }

--- a/packages/ui/src/icons/payment/networks/Visa.tsx
+++ b/packages/ui/src/icons/payment/networks/Visa.tsx
@@ -1,18 +1,29 @@
 // Visa card-network glyph. Multi-color brand mark — ships fixed
-// brand fills (the canonical white surface + Visa-blue wordmark)
-// per Visa's brand-CTA spec. Use inside `<Input variant="payment">`
-// or `<Table.Cell.PaymentIcon>` via the `methodIcon` override.
+// brand fills (canonical Visa-blue surface + white wordmark) per
+// Visa's brand-CTA spec. Uses an SVG `<text>` wordmark rendered in
+// the host system-ui font for clean cross-platform reproduction
+// without shipping bespoke letterform paths (which risk drift
+// against Visa's official kit on retina + sub-pixel rendering).
 
 import type { PaymentIconProps } from '../types';
 
 export function Visa({ className, 'aria-hidden': ariaHidden = true, ...rest }: PaymentIconProps) {
   return (
     <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
-      <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
-      <path
-        d="M14.6 8.5h-1.7l-1.06 6.9H13.5l1.1-6.9Zm5.4 4.4-.92-3.45a.5.5 0 0 0-.48-.36h-1.7l-.04.18c1.5.34 2.49.94 2.93 1.78l.21 1.85Zm-2.6-2.94c-.69-.13-1.38.16-1.93.5-.27-.94-.85-1.5-1.74-1.62l-.05.18c1.4.36 2.16 1.16 2.32 2.46.13 1.03-.46 1.81-1.34 2.42l1.5-.46.46-1.62c.18-.45.49-.79.94-.94l-.16 1.06h1.42l1.06-1.84-2.48-.14ZM23.5 8.5h-1.36c-.32 0-.6.2-.7.5l-2.45 6.4h1.7s.28-.78.34-.95h2.07c.05.21.18.95.18.95h1.5l-1.28-6.9Zm-1.97 4.5c.13-.36.65-1.78.65-1.78 0 .02.13-.36.21-.6l.11.55s.31 1.5.38 1.83h-1.35Zm-12.91 2.4 1.86-6.9h1.79l-1.85 6.9H8.62Zm-3.4-3.94c0 1.5 1.34 2.34 2.36 2.84 1.05.51 1.4.84 1.4 1.3-.01.7-.83.81-1.6.83-.66.02-1.34-.09-1.95-.27l-.31-.16-.32 1.66c.66.31 1.41.49 2.21.5 2.07 0 3.42-1.02 3.43-2.61.01-.85-.43-1.5-1.51-2.04-.66-.34-1.06-.57-1.06-.92 0-.31.35-.65 1.1-.65.62-.01 1.07.12 1.43.27l.21.09.32-1.61c-.39-.15-1-.31-1.78-.31-1.97 0-3.36 1.05-3.37 2.55Z"
-        fill="#1A1F71"
-      />
+      <rect width="32" height="24" rx="3" fill="#1A1F71" />
+      <text
+        x="16"
+        y="15.5"
+        textAnchor="middle"
+        fontSize="6"
+        fontWeight="900"
+        fontStyle="italic"
+        fill="#FFFFFF"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="0.4"
+      >
+        VISA
+      </text>
     </svg>
   );
 }

--- a/packages/ui/src/icons/payment/networks/Visa.tsx
+++ b/packages/ui/src/icons/payment/networks/Visa.tsx
@@ -1,0 +1,18 @@
+// Visa card-network glyph. Multi-color brand mark — ships fixed
+// brand fills (the canonical white surface + Visa-blue wordmark)
+// per Visa's brand-CTA spec. Use inside `<Input variant="payment">`
+// or `<Table.Cell.PaymentIcon>` via the `methodIcon` override.
+
+import type { PaymentIconProps } from '../types';
+
+export function Visa({ className, 'aria-hidden': ariaHidden = true, ...rest }: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
+      <path
+        d="M14.6 8.5h-1.7l-1.06 6.9H13.5l1.1-6.9Zm5.4 4.4-.92-3.45a.5.5 0 0 0-.48-.36h-1.7l-.04.18c1.5.34 2.49.94 2.93 1.78l.21 1.85Zm-2.6-2.94c-.69-.13-1.38.16-1.93.5-.27-.94-.85-1.5-1.74-1.62l-.05.18c1.4.36 2.16 1.16 2.32 2.46.13 1.03-.46 1.81-1.34 2.42l1.5-.46.46-1.62c.18-.45.49-.79.94-.94l-.16 1.06h1.42l1.06-1.84-2.48-.14ZM23.5 8.5h-1.36c-.32 0-.6.2-.7.5l-2.45 6.4h1.7s.28-.78.34-.95h2.07c.05.21.18.95.18.95h1.5l-1.28-6.9Zm-1.97 4.5c.13-.36.65-1.78.65-1.78 0 .02.13-.36.21-.6l.11.55s.31 1.5.38 1.83h-1.35Zm-12.91 2.4 1.86-6.9h1.79l-1.85 6.9H8.62Zm-3.4-3.94c0 1.5 1.34 2.34 2.36 2.84 1.05.51 1.4.84 1.4 1.3-.01.7-.83.81-1.6.83-.66.02-1.34-.09-1.95-.27l-.31-.16-.32 1.66c.66.31 1.41.49 2.21.5 2.07 0 3.42-1.02 3.43-2.61.01-.85-.43-1.5-1.51-2.04-.66-.34-1.06-.57-1.06-.92 0-.31.35-.65 1.1-.65.62-.01 1.07.12 1.43.27l.21.09.32-1.61c-.39-.15-1-.31-1.78-.31-1.97 0-3.36 1.05-3.37 2.55Z"
+        fill="#1A1F71"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/types.ts
+++ b/packages/ui/src/icons/payment/types.ts
@@ -1,0 +1,42 @@
+// Shared prop contract for every payment-method glyph component.
+// Mirrors `BrandIconProps` in spirit but uses a 32×24 viewBox by
+// default (matches the canonical credit-card aspect ratio you see
+// in payment forms — wider than tall). Consumers can resize via
+// `className` (e.g. `size-6` for square slots, `h-6` to preserve
+// the 4:3 ratio).
+
+import type { ReactNode } from 'react';
+
+export interface PaymentIconProps {
+  /** Tailwind override hook for the rendered `<svg>`. */
+  className?: string;
+  /**
+   * Whether the icon is decorative. Defaults to `true` because
+   * payment glyphs typically pair with the masked card number or
+   * a saved-card label — the visible text carries the meaning.
+   * Override to `false` and pair with `aria-label` for standalone
+   * usage (e.g. a payment-method picker tile).
+   * @default true
+   */
+  'aria-hidden'?: boolean;
+  /** Accessible label override for standalone usage. */
+  'aria-label'?: string;
+}
+
+export interface PaymentIconCatalogEntry {
+  /** Stable identifier — kebab-case, matches the export name lowercased. */
+  id: string;
+  /** Human-readable label rendered in the catalog grid. */
+  label: string;
+  /** Catalog category for filter chips (`networks`, `wallets`, `bnpl`, `regional`). */
+  category: 'networks' | 'wallets' | 'bnpl' | 'regional';
+  /** Component to render. */
+  Icon: (props: PaymentIconProps) => ReactNode;
+}
+
+// Note: the canonical `PaymentBrand` type lives on `<Input>` (#313)
+// where it's surfaced to consumers via `onPaymentBrandDetected`.
+// The registry's `paymentIconForBrand` helper accepts the same
+// union via this internal type alias — re-exporting it from the
+// package barrel would collide with Input's own export.
+export type PaymentBrand = 'visa' | 'mastercard' | 'amex' | 'discover' | 'unknown';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -40,4 +40,5 @@ export * from './components/VerificationCodeInput';
 export * from './icons/brand';
 export * from './icons/emoji';
 export * from './icons/integration';
+export * from './icons/payment';
 export * from './theme';


### PR DESCRIPTION
## Summary

Phase D.2.a of #309 / #368. Adds the six card-network glyphs from Figma's Specialized icon collections frame and wires `<Input variant="payment">` to consume per-brand artwork via the new `paymentIconForBrand(brand)` helper.

## Scope

**In**
- `packages/ui/src/icons/payment/` registry — 6 per-brand components (Visa, MasterCard, AMEX, Discover, JCB, UnionPay) + shared `types.ts` + `index.ts` barrel + alphabetical `paymentCatalog` + `paymentIconForBrand(brand)` helper.
- Each glyph is a 32×24 viewBox card-shaped tile with canonical brand artwork — multi-color fixed fills per each platform's brand-CTA spec (payment marks forbid recolouring).
- `<Input variant="payment">` swap — when the auto-detected brand matches a registry entry, the leading glyph renders the per-brand artwork; falls back to `CreditCard02` for `unknown`. `onPaymentBrandDetected` callback contract unchanged.
- `Foundations / Payment Icons` Storybook docs page — searchable grid + filter chips (Networks / Wallets / BNPL / Regional). `parameters.docs.disable: true` keeps it docs-only.
- `<Table.Cell.PaymentIcon>` already takes a `methodIcon` override; consumers can wire it to `paymentIconForBrand(brand)` themselves in their column composition.

**Out (later D.2 batches)**
- D.2.b — Digital wallets (8): ApplePay, GooglePay, SamsungPay, AmazonPay, PayPal, Venmo, ShopPay, LinkPay.
- D.2.c — BNPL (6): Affirm, Afterpay, Klarna, Sezzle, Zip, Splitit.
- D.2.d — Regional rails: Alipay, WeChat, MercadoPago, iDEAL, Bancontact, Sofort, …

## Brand Compliance

Payment brands have strict brand-CTA rules — no hover treatments, no recolours, no per-state opacity adjustments. The components ship the canonical artwork verbatim and consumers respect that rule by NOT applying `text-*` or `fill-*` overrides in `className`.

## Migration

`<Input variant="payment">` consumers see a visual upgrade — pre-existing snapshots register a Visa glyph diff at the default value (`4242…`). No API change. `<Table.Cell.PaymentIcon>` consumers can opt into the helper via `methodIcon={paymentIconForBrand(brand)}` when they have brand-detection logic upstream.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (108/108)
- [x] `pnpm --filter @glaon/ui build-storybook`
- [x] `pnpm knip` — no orphans
- [ ] Storybook localhost:6006 — `Foundations / Payment Icons` catalog + filter chips work; `<Input variant="payment">` story shows the Visa glyph at the default value
- [ ] Chromatic — accept the new Input payment Visa snapshot diff; new catalog grid baseline

Refs #309
Refs #313
Refs #324
Refs #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)