### PR TITLE
fix(deps): drop :pinDevDependencies from Renovate extends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", ":semanticCommits"],
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests", ":semanticCommits"],
   "baseBranchPatterns": ["development"],
   "rangeStrategy": "replace",
   "timezone": "Europe/Istanbul",


### PR DESCRIPTION
## Summary

- Renovate'in `config:best-practices` preset'i içindeki `:pinDevDependencies` davranışını kaldırır. Repo'nun syncpack policy'si caret aralığı (`^x.y.z`) bekliyor; pin (`x.y.z`) ise her hafta `chore(deps): pin dependencies` PR'ı açıp `syncpack:lint` aşamasını düşürüyordu (örn. #335, #336).
- `config:best-practices` → `config:recommended` + `helpers:pinGitHubActionDigests` kombinasyonuna geçilir; GitHub Actions hash pinleme korunur, sadece pin-devdeps davranışı çıkar.
- #335 ve #336 takip eden adımda bu PR merge olduktan sonra kapatılır (immortal işaretli ama config değişiminden sonra yeniden doğmazlar).

## Scope

**In**
- `renovate.json` → `extends` listesi değiştirildi.

**Out**
- syncpack config'i veya policy'si (caret kuralı doğru kabul edildi).
- Mevcut Renovate `packageRules` (auto-merge, group, schedule) — değişmiyor.

## Test plan

- [ ] `commitlint`, `gitleaks`, `prettier` (lint-staged) geçer
- [ ] CI yeşile döner
- [ ] Bir sonraki Pazartesi Renovate çalıştığında pin PR'ı oluşmadığı doğrulanır (post-merge gözlem)

Closes #378