### PR TITLE
feat(ui): payment icon registry D.2.d — regional rails

### DIFF
--- a/packages/ui/src/icons/payment/index.ts
+++ b/packages/ui/src/icons/payment/index.ts
@@ -10,13 +10,13 @@
 // Phase scope:
 //   - D.2.a (#377 ✓): Card networks — Visa, MasterCard, AMEX,
 //                     Discover, JCB, UnionPay.
-//   - **D.2.b (this):** Digital wallets — ApplePay, GooglePay,
-//                       SamsungPay, AmazonPay, PayPal, Venmo,
-//                       ShopPay, LinkPay.
-//   - D.2.c (next)  :   BNPL — Affirm, Afterpay, Klarna, Sezzle,
-//                       Zip, Splitit.
-//   - D.2.d         :   Regional rails — Alipay, WeChat,
-//                       MercadoPago, iDEAL, Bancontact, Sofort, …
+//   - D.2.b (#381 ✓): Digital wallets — ApplePay, GooglePay,
+//                     SamsungPay, AmazonPay, PayPal, Venmo,
+//                     ShopPay, LinkPay.
+//   - D.2.c (#384 ⏳): BNPL — Affirm, Afterpay, Klarna, Sezzle,
+//                     Zip, Splitit.
+//   - **D.2.d (this):** Regional rails — Alipay, WeChat Pay,
+//                       MercadoPago, iDEAL, Bancontact, SOFORT.
 //
 // Each glyph component accepts the narrow `PaymentIconProps`
 // (`className`, `aria-hidden` default true, `aria-label`). Payment
@@ -33,6 +33,12 @@ import { Jcb } from './networks/Jcb';
 import { Mastercard } from './networks/Mastercard';
 import { UnionPay } from './networks/UnionPay';
 import { Visa } from './networks/Visa';
+import { Alipay } from './regional/Alipay';
+import { Bancontact } from './regional/Bancontact';
+import { Ideal } from './regional/Ideal';
+import { MercadoPago } from './regional/MercadoPago';
+import { Sofort } from './regional/Sofort';
+import { WeChatPay } from './regional/WeChatPay';
 import { AmazonPay } from './wallets/AmazonPay';
 import { ApplePay } from './wallets/ApplePay';
 import { GooglePay } from './wallets/GooglePay';
@@ -48,20 +54,26 @@ import type { PaymentBrand, PaymentIconCatalogEntry, PaymentIconProps } from './
 // would collide. Consumers `import { type PaymentBrand } from '@glaon/ui'`.
 export type { PaymentIconCatalogEntry, PaymentIconProps } from './types';
 export {
+  Alipay,
   AmazonPay,
   Amex,
   ApplePay,
+  Bancontact,
   Discover,
   GooglePay,
+  Ideal,
   Jcb,
   LinkPay,
   Mastercard,
+  MercadoPago,
   PayPal,
   SamsungPay,
   ShopPay,
+  Sofort,
   UnionPay,
   Venmo,
   Visa,
+  WeChatPay,
 };
 
 /**
@@ -115,4 +127,11 @@ export const paymentCatalog: readonly PaymentIconCatalogEntry[] = [
   { id: 'samsung-pay', label: 'Samsung Pay', category: 'wallets', Icon: SamsungPay },
   { id: 'shop-pay', label: 'Shop Pay', category: 'wallets', Icon: ShopPay },
   { id: 'venmo', label: 'Venmo', category: 'wallets', Icon: Venmo },
+  // --- D.2.d Regional rails ---
+  { id: 'alipay', label: 'Alipay', category: 'regional', Icon: Alipay },
+  { id: 'bancontact', label: 'Bancontact', category: 'regional', Icon: Bancontact },
+  { id: 'ideal', label: 'iDEAL', category: 'regional', Icon: Ideal },
+  { id: 'mercado-pago', label: 'Mercado Pago', category: 'regional', Icon: MercadoPago },
+  { id: 'sofort', label: 'SOFORT', category: 'regional', Icon: Sofort },
+  { id: 'wechat-pay', label: 'WeChat Pay', category: 'regional', Icon: WeChatPay },
 ];

--- a/packages/ui/src/icons/payment/regional/Alipay.tsx
+++ b/packages/ui/src/icons/payment/regional/Alipay.tsx
@@ -1,0 +1,26 @@
+// Alipay regional-rail glyph. Multi-color brand mark — ships fixed
+// brand fills (canonical Alipay-blue surface + white "支付宝" or
+// "Alipay" wordmark) per Alipay's brand-CTA spec. We use the
+// Latin "Alipay" wordmark for international payment forms.
+
+import type { PaymentIconProps } from '../types';
+
+export function Alipay({ className, 'aria-hidden': ariaHidden = true, ...rest }: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#1677FF" />
+      <text
+        x="16"
+        y="16"
+        textAnchor="middle"
+        fontSize="6"
+        fontWeight="800"
+        fill="#FFFFFF"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="-0.05"
+      >
+        Alipay
+      </text>
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/regional/Bancontact.tsx
+++ b/packages/ui/src/icons/payment/regional/Bancontact.tsx
@@ -1,0 +1,40 @@
+// Bancontact (Belgian banking rail) glyph. Multi-color brand
+// mark — ships fixed brand fills (canonical white surface +
+// blue + yellow "Bancontact" wordmark) per Bancontact's brand-CTA
+// spec.
+
+import type { PaymentIconProps } from '../types';
+
+export function Bancontact({
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
+      <text
+        x="11"
+        y="15.5"
+        fontSize="4.6"
+        fontWeight="800"
+        fill="#005AC2"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="-0.1"
+      >
+        Banc
+      </text>
+      <text
+        x="20"
+        y="15.5"
+        fontSize="4.6"
+        fontWeight="800"
+        fill="#FFD800"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="-0.1"
+      >
+        ontact
+      </text>
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/regional/Ideal.tsx
+++ b/packages/ui/src/icons/payment/regional/Ideal.tsx
@@ -1,0 +1,25 @@
+// iDEAL (Dutch banking rail) glyph. Multi-color brand mark —
+// ships fixed brand fills (canonical white surface + iDEAL-pink
+// "iDEAL" wordmark) per the iDEAL brand-CTA spec.
+
+import type { PaymentIconProps } from '../types';
+
+export function Ideal({ className, 'aria-hidden': ariaHidden = true, ...rest }: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
+      <text
+        x="16"
+        y="16"
+        textAnchor="middle"
+        fontSize="6.4"
+        fontWeight="800"
+        fill="#CC0066"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="-0.1"
+      >
+        iDEAL
+      </text>
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/regional/MercadoPago.tsx
+++ b/packages/ui/src/icons/payment/regional/MercadoPago.tsx
@@ -1,0 +1,41 @@
+// Mercado Pago regional-rail glyph. Multi-color brand mark —
+// ships fixed brand fills (canonical Mercado-blue surface + white
+// "Mercado Pago" wordmark) per Mercado's brand-CTA spec.
+
+import type { PaymentIconProps } from '../types';
+
+export function MercadoPago({
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#00B1EA" />
+      <text
+        x="16"
+        y="11.5"
+        textAnchor="middle"
+        fontSize="3.6"
+        fontWeight="800"
+        fill="#FFFFFF"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="-0.05"
+      >
+        Mercado
+      </text>
+      <text
+        x="16"
+        y="17.5"
+        textAnchor="middle"
+        fontSize="3.6"
+        fontWeight="800"
+        fill="#FFE600"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="-0.05"
+      >
+        Pago
+      </text>
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/regional/Sofort.tsx
+++ b/packages/ui/src/icons/payment/regional/Sofort.tsx
@@ -1,0 +1,26 @@
+// SOFORT (Klarna's German bank-redirect rail) glyph. Multi-color
+// brand mark — ships fixed brand fills (canonical white surface +
+// pink "SOFORT" wordmark) per Klarna's brand-CTA spec for the
+// SOFORT sub-brand.
+
+import type { PaymentIconProps } from '../types';
+
+export function Sofort({ className, 'aria-hidden': ariaHidden = true, ...rest }: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#FFFFFF" stroke="#D1D5DB" strokeWidth="0.5" />
+      <text
+        x="16"
+        y="16"
+        textAnchor="middle"
+        fontSize="6"
+        fontWeight="900"
+        fill="#EE5C82"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="-0.1"
+      >
+        SOFORT
+      </text>
+    </svg>
+  );
+}

--- a/packages/ui/src/icons/payment/regional/WeChatPay.tsx
+++ b/packages/ui/src/icons/payment/regional/WeChatPay.tsx
@@ -1,0 +1,29 @@
+// WeChat Pay regional-rail glyph. Multi-color brand mark — ships
+// fixed brand fills (canonical WeChat-green surface + white
+// "WeChat Pay" wordmark) per Tencent's brand-CTA spec.
+
+import type { PaymentIconProps } from '../types';
+
+export function WeChatPay({
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}: PaymentIconProps) {
+  return (
+    <svg viewBox="0 0 32 24" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      <rect width="32" height="24" rx="3" fill="#07C160" />
+      <text
+        x="16"
+        y="16"
+        textAnchor="middle"
+        fontSize="4.4"
+        fontWeight="800"
+        fill="#FFFFFF"
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="-0.05"
+      >
+        WeChat Pay
+      </text>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Phase D.2.d of #309 / #368 — final D.2 batch. Adds 6 regional payment-rail glyphs: **Alipay, WeChat Pay, MercadoPago, iDEAL, Bancontact, SOFORT**.

## Scope

**In**
- `packages/ui/src/icons/payment/regional/` — 6 per-platform components (32×24 wordmark tiles, fixed brand fills per each platform's brand-CTA spec).
- `paymentCatalog` updated — `regional` sub-section appended.
- The existing `Foundations / Payment Icons` Storybook page's "Regional" filter chip now routes these glyphs.

## D.2 Coverage Summary

After this PR + #384 (D.2.c BNPL) merge, the payment registry covers:

| Tier | Count | Status |
|---|---|---|
| Networks (D.2.a) | 6 | ✓ #377 merged |
| Wallets (D.2.b) | 8 | ✓ #381 merged |
| BNPL (D.2.c) | 6 | ⏳ #384 in flight |
| **Regional (D.2.d, this)** | 6 | ⏳ this PR |

Total: **26 payment glyphs**. D.2 (#368) closes once both D.2.c and this batch merge.

## Migration

Pure additive — no consumer surface changes. `paymentIconForBrand(brand)` helper unchanged (regional rails aren't auto-detected from card-number regex; consumer-selected at checkout).

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` — F6 prop-coverage gate green (108/108)
- [x] `pnpm --filter @glaon/ui build-storybook`
- [x] `pnpm knip` — no orphans
- [ ] Storybook localhost:6006 — `Foundations / Payment Icons` "Regional" filter shows 6 tiles; copy-paste import snippets work
- [ ] Chromatic — new baselines accepted

Refs #309
Refs #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)