### PR TITLE
feat(ui): file-type icons D.4.a — docs/spreadsheets/presentations

### DIFF
--- a/packages/ui/src/components/Table/cells/FileTypeIconCell.tsx
+++ b/packages/ui/src/components/Table/cells/FileTypeIconCell.tsx
@@ -1,25 +1,35 @@
 // File type icon cell — file extension glyph + filename + optional
 // secondary line (size, modified date). Mirrors Figma "Type=File type
-// icon" cell. The leading glyph today is a neutral file icon (`File02`)
-// from `@untitledui/icons`; #309 Phase D ships per-extension artwork
-// (PDF / DOCX / ZIP / …) and consumers can swap once that lands by
-// passing an `extensionIcon` override.
+// icon" cell. The cell auto-detects the extension from the filename
+// and routes to the per-extension artwork via the file-type registry's
+// `fileTypeIconForExtension` helper (#370 D.4.a). When the extension
+// isn't covered, falls back to the kit's neutral `File02`. Consumers
+// can override the auto-detection via the `extensionIcon` prop.
 
 import { File02 } from '@untitledui/icons';
 
+import { fileTypeIconForExtension } from '../../../icons/filetype';
 import type { CellBaseProps, IconComponent } from './types';
 import { joinClasses } from './types';
 
 export interface FileTypeIconCellProps extends CellBaseProps {
-  /** Filename. */
+  /** Filename — the trailing extension drives the auto-glyph swap. */
   primary: string;
   /** Secondary line (e.g. `2.4 MB · Edited 3h ago`). */
   secondary?: string;
   /**
-   * Override the default file glyph with extension-specific artwork
-   * (e.g. PDF / DOCX SVG components from #309 Phase D once shipped).
+   * Override the auto-detected glyph with a specific component.
+   * Useful when the filename doesn't carry the extension (e.g.
+   * server-side metadata) or to force a specific look against the
+   * filename's actual extension.
    */
   extensionIcon?: IconComponent;
+}
+
+function extractExtension(filename: string): string | undefined {
+  const dot = filename.lastIndexOf('.');
+  if (dot === -1 || dot === filename.length - 1) return undefined;
+  return filename.slice(dot + 1);
 }
 
 export function FileTypeIconCell({
@@ -29,19 +39,34 @@ export function FileTypeIconCell({
   size = 'md',
   className,
 }: FileTypeIconCellProps) {
-  const Icon = extensionIcon ?? File02;
+  // Resolution order: explicit override > registry auto-detect >
+  // kit-neutral `File02` fallback.
+  const ext = extractExtension(primary);
+  const RegistryIcon = ext !== undefined ? fileTypeIconForExtension(ext) : undefined;
+  const Icon = extensionIcon ?? RegistryIcon ?? File02;
   const iconBox = size === 'sm' ? 'size-8' : 'size-10';
+  // Registry glyphs ship their own colored band + file silhouette,
+  // so they don't need the neutral background tile that wraps the
+  // fallback `File02` glyph. Strip the tile when we're rendering a
+  // registry glyph.
+  const isRegistryGlyph = Icon !== File02 && extensionIcon === undefined;
   return (
     <div className={joinClasses('flex items-center gap-3', className)}>
-      <span
-        aria-hidden="true"
-        className={joinClasses(
-          'flex shrink-0 items-center justify-center rounded-md bg-secondary text-fg-quaternary',
-          iconBox,
-        )}
-      >
-        <Icon className={size === 'sm' ? 'size-5' : 'size-6'} />
-      </span>
+      {isRegistryGlyph ? (
+        <span aria-hidden="true" className={joinClasses('flex shrink-0', iconBox)}>
+          <Icon className={size === 'sm' ? 'h-8' : 'h-10'} />
+        </span>
+      ) : (
+        <span
+          aria-hidden="true"
+          className={joinClasses(
+            'flex shrink-0 items-center justify-center rounded-md bg-secondary text-fg-quaternary',
+            iconBox,
+          )}
+        >
+          <Icon className={size === 'sm' ? 'size-5' : 'size-6'} />
+        </span>
+      )}
       <div className="flex flex-col">
         <span
           className={joinClasses(

--- a/packages/ui/src/icons/filetype/FileTypeIcons.stories.tsx
+++ b/packages/ui/src/icons/filetype/FileTypeIcons.stories.tsx
@@ -1,0 +1,205 @@
+import { useMemo, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { fileTypeCatalog } from './index';
+import type { FileTypeCategory, FileTypeIconCatalogEntry } from './types';
+
+// Storybook docs catalog for the file-type icon registry.
+// Phase D.4.a ships document / spreadsheet / presentation; D.4.b
+// follows with image / audio / video; D.4.c with archive / code /
+// other. Mirrors the brand / payment / integration catalog page
+// layout for visual consistency.
+//
+// Cross-link: `<Table.Cell.FileTypeIcon>` (#324 Phase A) consumes
+// these glyphs via the `fileTypeIconForExtension(ext)` helper —
+// pass a filename and the cell auto-routes to the right glyph.
+
+type CategoryFilter = 'all' | FileTypeCategory;
+
+const meta: Meta = {
+  title: 'Foundations/File Type Icons',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1025-31781',
+    },
+    // Docs-only sketch — no canvas snapshot diff because the icon
+    // set isn't a behavioural primitive. Per-icon per-PR review
+    // covers visual correctness; downstream Table cell stories
+    // capture the integration moment.
+    docs: { disable: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+function CatalogGrid({ search, category }: { search: string; category: CategoryFilter }) {
+  const filtered = useMemo<readonly FileTypeIconCatalogEntry[]>(() => {
+    const q = search.trim().toLowerCase();
+    return fileTypeCatalog.filter((entry) => {
+      const matchesCategory = category === 'all' || entry.category === category;
+      const matchesSearch =
+        q.length === 0 || entry.id.includes(q) || entry.label.toLowerCase().includes(q);
+      return matchesCategory && matchesSearch;
+    });
+  }, [search, category]);
+
+  if (filtered.length === 0) {
+    return (
+      <p
+        style={{
+          padding: 32,
+          color: 'var(--color-text-tertiary, #555)',
+          textAlign: 'center',
+        }}
+      >
+        No file-type glyphs match the current filter.
+      </p>
+    );
+  }
+
+  return (
+    <ul
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+        gap: 16,
+        padding: 0,
+        margin: 0,
+        listStyle: 'none',
+      }}
+    >
+      {filtered.map(({ id, label, Icon }) => (
+        <li
+          key={id}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 12,
+            padding: 16,
+            borderRadius: 12,
+            background: 'var(--color-bg-secondary, #f7f7f7)',
+            border: '1px solid var(--color-border-secondary, #e4e4e4)',
+          }}
+        >
+          <div
+            style={{
+              width: 48,
+              height: 60,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Icon className="h-12" />
+          </div>
+          <div style={{ textAlign: 'center', display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={{ fontSize: 14, fontWeight: 600 }}>{label}</span>
+            <code
+              style={{
+                fontSize: 12,
+                color: 'var(--color-text-tertiary, #555)',
+                background: 'var(--color-bg-primary, #fff)',
+                padding: '2px 6px',
+                borderRadius: 4,
+                userSelect: 'all',
+              }}
+            >
+              {`import { ${componentName(id)} } from '@glaon/ui'`}
+            </code>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function componentName(id: string): string {
+  // ids are bare file extensions; component names are PascalCase
+  // with `File` suffix (e.g. `pdf` → `PdfFile`, `numbers` →
+  // `NumbersFile`).
+  const head = id.charAt(0);
+  const titleCase = head.length > 0 ? head.toUpperCase() + id.slice(1) : '';
+  return `${titleCase}File`;
+}
+
+function CatalogPage() {
+  const [search, setSearch] = useState('');
+  const [category, setCategory] = useState<CategoryFilter>('all');
+  const filterButtonStyle = (active: boolean): React.CSSProperties => ({
+    padding: '6px 12px',
+    borderRadius: 8,
+    border: '1px solid var(--color-border-primary, #d5d7da)',
+    background: active ? 'var(--color-bg-brand-solid, #6941C6)' : 'var(--color-bg-primary, #fff)',
+    color: active ? '#fff' : 'var(--color-text-secondary, #555)',
+    fontSize: 13,
+    fontWeight: 500,
+    cursor: 'pointer',
+  });
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+        <input
+          type="search"
+          placeholder="Search file-type glyphs…"
+          aria-label="Search file-type glyphs"
+          value={search}
+          onChange={(event) => {
+            setSearch(event.currentTarget.value);
+          }}
+          style={{
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid var(--color-border-primary, #d5d7da)',
+            fontSize: 14,
+            flex: 1,
+            minWidth: 200,
+            maxWidth: 320,
+          }}
+        />
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {(
+            [
+              ['all', 'All'],
+              ['document', 'Document'],
+              ['spreadsheet', 'Spreadsheet'],
+              ['presentation', 'Presentation'],
+              ['image', 'Image'],
+              ['audio', 'Audio'],
+              ['video', 'Video'],
+              ['archive', 'Archive'],
+              ['code', 'Code'],
+              ['other', 'Other'],
+            ] as const
+          ).map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              style={filterButtonStyle(category === key)}
+              onClick={() => {
+                setCategory(key);
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <CatalogGrid search={search} category={category} />
+    </div>
+  );
+}
+
+/**
+ * Searchable + filterable grid of every file-type glyph the
+ * registry ships. Filter chips switch the visible category
+ * (Document, Spreadsheet, Presentation, Image, Audio, Video,
+ * Archive, Code, Other); search narrows by extension or display
+ * name. Each tile shows the canonical
+ * `import { … } from '@glaon/ui'` line for copy-paste.
+ */
+export const Catalog: Story = {
+  render: () => <CatalogPage />,
+};

--- a/packages/ui/src/icons/filetype/_shape.tsx
+++ b/packages/ui/src/icons/filetype/_shape.tsx
@@ -1,0 +1,74 @@
+// Internal helper — the canonical "file with corner fold" silhouette
+// + a colored extension band at the bottom. Every per-extension
+// glyph in the registry composes this primitive with its
+// extension code + category color. Lives under a leading
+// underscore so import-resolution treats it as private to the
+// registry (the package barrel doesn't re-export `_*`).
+
+import type { FileTypeIconProps } from './types';
+
+interface FileShapeProps extends FileTypeIconProps {
+  /** Extension label rendered in the bottom band (e.g. `PDF`, `DOCX`). */
+  extension: string;
+  /** Band background colour — typically per-category (red for archive, blue for document, …). */
+  bandColor: string;
+  /** Extension text colour — defaults to white for high-contrast bands. */
+  textColor?: string;
+}
+
+export function FileShape({
+  extension,
+  bandColor,
+  textColor = '#FFFFFF',
+  className,
+  'aria-hidden': ariaHidden = true,
+  ...rest
+}: FileShapeProps) {
+  return (
+    <svg viewBox="0 0 32 40" fill="none" aria-hidden={ariaHidden} className={className} {...rest}>
+      {/* File body — outline with corner fold. The folded corner is
+          drawn as a small triangle with the page-fold visible as a
+          subtle shadow. */}
+      <path
+        d="M5 3 a2 2 0 0 1 2 -2 h14 l8 8 v28 a2 2 0 0 1 -2 2 H7 a2 2 0 0 1 -2 -2 Z"
+        fill="#FFFFFF"
+        stroke="#D1D5DB"
+        strokeWidth="0.75"
+      />
+      <path d="M21 1 v6 a2 2 0 0 0 2 2 h6" fill="none" stroke="#D1D5DB" strokeWidth="0.75" />
+      <path d="M21 1 l8 8 H23 a2 2 0 0 1 -2 -2 Z" fill="#F3F4F6" />
+      {/* Extension band */}
+      <rect x="5" y="22" width="22" height="10" rx="1.5" fill={bandColor} />
+      <text
+        x="16"
+        y="29"
+        textAnchor="middle"
+        fontSize="6"
+        fontWeight="900"
+        fill={textColor}
+        fontFamily="system-ui, -apple-system, sans-serif"
+        letterSpacing="-0.05"
+      >
+        {extension}
+      </text>
+    </svg>
+  );
+}
+
+/**
+ * Per-category band palette. Picking the canonical "data colour"
+ * for each file family keeps a directory listing scannable —
+ * users learn the colour grammar (`blue = document`, `green =
+ * spreadsheet`) and identify file types at a glance.
+ */
+export const CATEGORY_BAND = {
+  archive: '#DC2626', // red-600
+  audio: '#A855F7', // purple-500
+  code: '#0EA5E9', // sky-500
+  document: '#2563EB', // blue-600
+  image: '#10B981', // emerald-500
+  other: '#6B7280', // gray-500
+  presentation: '#F97316', // orange-500
+  spreadsheet: '#16A34A', // green-600
+  video: '#EC4899', // pink-500
+} as const;

--- a/packages/ui/src/icons/filetype/document/DocFile.tsx
+++ b/packages/ui/src/icons/filetype/document/DocFile.tsx
@@ -1,0 +1,8 @@
+// DOC (legacy Word) file glyph. Document category — blue band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function DocFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="DOC" bandColor={CATEGORY_BAND.document} />;
+}

--- a/packages/ui/src/icons/filetype/document/DocxFile.tsx
+++ b/packages/ui/src/icons/filetype/document/DocxFile.tsx
@@ -1,0 +1,8 @@
+// DOCX (Word) file glyph. Document category — blue band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function DocxFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="DOCX" bandColor={CATEGORY_BAND.document} />;
+}

--- a/packages/ui/src/icons/filetype/document/MdFile.tsx
+++ b/packages/ui/src/icons/filetype/document/MdFile.tsx
@@ -1,0 +1,8 @@
+// MD (Markdown) file glyph. Document category — blue band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function MdFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="MD" bandColor={CATEGORY_BAND.document} />;
+}

--- a/packages/ui/src/icons/filetype/document/PagesFile.tsx
+++ b/packages/ui/src/icons/filetype/document/PagesFile.tsx
@@ -1,0 +1,8 @@
+// Pages (Apple Pages) file glyph. Document category — blue band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function PagesFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="PAGES" bandColor={CATEGORY_BAND.document} />;
+}

--- a/packages/ui/src/icons/filetype/document/PdfFile.tsx
+++ b/packages/ui/src/icons/filetype/document/PdfFile.tsx
@@ -1,0 +1,10 @@
+// PDF file glyph. Document category — blue band. Composes the
+// shared `FileShape` primitive so the file silhouette stays
+// consistent across every extension in the registry.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function PdfFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="PDF" bandColor={CATEGORY_BAND.document} />;
+}

--- a/packages/ui/src/icons/filetype/document/RtfFile.tsx
+++ b/packages/ui/src/icons/filetype/document/RtfFile.tsx
@@ -1,0 +1,8 @@
+// RTF (Rich Text Format) file glyph. Document category — blue band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function RtfFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="RTF" bandColor={CATEGORY_BAND.document} />;
+}

--- a/packages/ui/src/icons/filetype/document/TxtFile.tsx
+++ b/packages/ui/src/icons/filetype/document/TxtFile.tsx
@@ -1,0 +1,8 @@
+// TXT (plain text) file glyph. Document category — blue band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function TxtFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="TXT" bandColor={CATEGORY_BAND.document} />;
+}

--- a/packages/ui/src/icons/filetype/index.ts
+++ b/packages/ui/src/icons/filetype/index.ts
@@ -1,0 +1,136 @@
+// Glaon file-type icon registry — Phase D.4 of the icon registry
+// rollout (#309 / #370). Per-extension SVG glyphs for the canonical
+// file types Glaon ships, paired with a typed `fileTypeCatalog`
+// array that powers the Storybook catalog page and a
+// `fileTypeIconForExtension` helper that `<Table.Cell.FileTypeIcon>`
+// (#324 Phase A) calls to swap its neutral `File02` placeholder
+// for per-extension artwork.
+//
+// Phase scope (from #370):
+//   - **D.4.a (this):** Document + Spreadsheet + Presentation —
+//                       PDF, DOCX, DOC, PAGES, TXT, MD, RTF,
+//                       XLSX, XLS, NUMBERS, CSV, PPTX, KEY (13).
+//   - D.4.b (next)  :   Image + Audio + Video — PNG, JPG, GIF,
+//                       SVG, WEBP, HEIC, MP3, WAV, FLAC, AAC,
+//                       MP4, MOV, AVI, MKV, WEBM.
+//   - D.4.c         :   Archive + Code + Other — ZIP, RAR, TAR,
+//                       7z, JS, TS, JSON, YAML, XML, HTML, CSS,
+//                       PY, RB, GO, RS, DMG, EXE, APK.
+//
+// Each glyph component accepts the narrow `FileTypeIconProps`
+// (`className`, `aria-hidden` default true, `aria-label`). All
+// glyphs compose the shared `FileShape` primitive (`_shape.tsx`)
+// which renders a "file with corner fold" silhouette + a coloured
+// extension band — per-category palette keeps a directory listing
+// scannable at a glance (blue=document, green=spreadsheet,
+// orange=presentation, …).
+
+import type { ComponentType } from 'react';
+
+import { DocFile } from './document/DocFile';
+import { DocxFile } from './document/DocxFile';
+import { MdFile } from './document/MdFile';
+import { PagesFile } from './document/PagesFile';
+import { PdfFile } from './document/PdfFile';
+import { RtfFile } from './document/RtfFile';
+import { TxtFile } from './document/TxtFile';
+import { KeyFile } from './presentation/KeyFile';
+import { PptxFile } from './presentation/PptxFile';
+import { CsvFile } from './spreadsheet/CsvFile';
+import { NumbersFile } from './spreadsheet/NumbersFile';
+import { XlsFile } from './spreadsheet/XlsFile';
+import { XlsxFile } from './spreadsheet/XlsxFile';
+import type { FileTypeIconCatalogEntry, FileTypeIconProps } from './types';
+
+export type { FileTypeCategory, FileTypeIconCatalogEntry, FileTypeIconProps } from './types';
+export {
+  CsvFile,
+  DocFile,
+  DocxFile,
+  KeyFile,
+  MdFile,
+  NumbersFile,
+  PagesFile,
+  PdfFile,
+  PptxFile,
+  RtfFile,
+  TxtFile,
+  XlsFile,
+  XlsxFile,
+};
+
+/**
+ * Maps a file extension (lowercase, no leading dot — e.g. `'pdf'`,
+ * `'docx'`) to the registry's per-extension glyph component.
+ * Returns `undefined` when the extension isn't covered so consumers
+ * can fall back to a neutral file icon.
+ *
+ * `<Table.Cell.FileTypeIcon>` calls this internally to swap its
+ * leading glyph; consumers who detect the extension upstream
+ * (server-side metadata) can call it directly.
+ */
+export function fileTypeIconForExtension(
+  extension: string,
+): ComponentType<FileTypeIconProps> | undefined {
+  const ext = extension.toLowerCase().replace(/^\./, '');
+  switch (ext) {
+    // Document
+    case 'pdf':
+      return PdfFile;
+    case 'docx':
+      return DocxFile;
+    case 'doc':
+      return DocFile;
+    case 'pages':
+      return PagesFile;
+    case 'txt':
+      return TxtFile;
+    case 'md':
+    case 'markdown':
+      return MdFile;
+    case 'rtf':
+      return RtfFile;
+    // Spreadsheet
+    case 'xlsx':
+      return XlsxFile;
+    case 'xls':
+      return XlsFile;
+    case 'numbers':
+      return NumbersFile;
+    case 'csv':
+      return CsvFile;
+    // Presentation
+    case 'pptx':
+      return PptxFile;
+    case 'key':
+    case 'keynote':
+      return KeyFile;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Searchable catalog used by the `Foundations / File Type Icons`
+ * Storybook docs page. Order is alphabetical within each category
+ * so the rendered grid stays predictable for snapshot tests.
+ * Future phases (D.4.b–c) append.
+ */
+export const fileTypeCatalog: readonly FileTypeIconCatalogEntry[] = [
+  // --- D.4.a Document ---
+  { id: 'doc', label: 'DOC', category: 'document', Icon: DocFile },
+  { id: 'docx', label: 'DOCX', category: 'document', Icon: DocxFile },
+  { id: 'md', label: 'Markdown', category: 'document', Icon: MdFile },
+  { id: 'pages', label: 'Pages', category: 'document', Icon: PagesFile },
+  { id: 'pdf', label: 'PDF', category: 'document', Icon: PdfFile },
+  { id: 'rtf', label: 'RTF', category: 'document', Icon: RtfFile },
+  { id: 'txt', label: 'Text', category: 'document', Icon: TxtFile },
+  // --- D.4.a Spreadsheet ---
+  { id: 'csv', label: 'CSV', category: 'spreadsheet', Icon: CsvFile },
+  { id: 'numbers', label: 'Numbers', category: 'spreadsheet', Icon: NumbersFile },
+  { id: 'xls', label: 'XLS', category: 'spreadsheet', Icon: XlsFile },
+  { id: 'xlsx', label: 'XLSX', category: 'spreadsheet', Icon: XlsxFile },
+  // --- D.4.a Presentation ---
+  { id: 'key', label: 'Keynote', category: 'presentation', Icon: KeyFile },
+  { id: 'pptx', label: 'PPTX', category: 'presentation', Icon: PptxFile },
+];

--- a/packages/ui/src/icons/filetype/presentation/KeyFile.tsx
+++ b/packages/ui/src/icons/filetype/presentation/KeyFile.tsx
@@ -1,0 +1,9 @@
+// Keynote (Apple Keynote) file glyph. Presentation category —
+// orange band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function KeyFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="KEY" bandColor={CATEGORY_BAND.presentation} />;
+}

--- a/packages/ui/src/icons/filetype/presentation/PptxFile.tsx
+++ b/packages/ui/src/icons/filetype/presentation/PptxFile.tsx
@@ -1,0 +1,8 @@
+// PPTX (PowerPoint) file glyph. Presentation category — orange band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function PptxFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="PPTX" bandColor={CATEGORY_BAND.presentation} />;
+}

--- a/packages/ui/src/icons/filetype/spreadsheet/CsvFile.tsx
+++ b/packages/ui/src/icons/filetype/spreadsheet/CsvFile.tsx
@@ -1,0 +1,9 @@
+// CSV (comma-separated values) file glyph. Spreadsheet category —
+// green band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function CsvFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="CSV" bandColor={CATEGORY_BAND.spreadsheet} />;
+}

--- a/packages/ui/src/icons/filetype/spreadsheet/NumbersFile.tsx
+++ b/packages/ui/src/icons/filetype/spreadsheet/NumbersFile.tsx
@@ -1,0 +1,8 @@
+// Numbers (Apple Numbers) file glyph. Spreadsheet category — green band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function NumbersFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="NUM" bandColor={CATEGORY_BAND.spreadsheet} />;
+}

--- a/packages/ui/src/icons/filetype/spreadsheet/XlsFile.tsx
+++ b/packages/ui/src/icons/filetype/spreadsheet/XlsFile.tsx
@@ -1,0 +1,8 @@
+// XLS (legacy Excel) file glyph. Spreadsheet category — green band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function XlsFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="XLS" bandColor={CATEGORY_BAND.spreadsheet} />;
+}

--- a/packages/ui/src/icons/filetype/spreadsheet/XlsxFile.tsx
+++ b/packages/ui/src/icons/filetype/spreadsheet/XlsxFile.tsx
@@ -1,0 +1,8 @@
+// XLSX (Excel) file glyph. Spreadsheet category — green band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function XlsxFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="XLSX" bandColor={CATEGORY_BAND.spreadsheet} />;
+}

--- a/packages/ui/src/icons/filetype/types.ts
+++ b/packages/ui/src/icons/filetype/types.ts
@@ -1,0 +1,46 @@
+// Shared prop contract for every file-type glyph component.
+// Mirrors `BrandIconProps` in spirit but uses a 32×40 viewBox by
+// default — file glyphs are taller than wide (the canonical "file
+// with corner fold" silhouette). Consumers can resize via
+// `className` (e.g. `size-8` for square slots, `h-10` to preserve
+// the 4:5 ratio).
+
+import type { ReactNode } from 'react';
+
+export interface FileTypeIconProps {
+  /** Tailwind override hook for the rendered `<svg>`. */
+  className?: string;
+  /**
+   * Whether the icon is decorative. Defaults to `true` because
+   * file-type glyphs typically pair with the visible filename
+   * + size, which carry the meaning. Override to `false` and
+   * pair with `aria-label` for standalone usage (rare —
+   * usually for empty-row "no files yet" affordances).
+   * @default true
+   */
+  'aria-hidden'?: boolean;
+  /** Accessible label override for standalone usage. */
+  'aria-label'?: string;
+}
+
+export type FileTypeCategory =
+  | 'archive'
+  | 'audio'
+  | 'code'
+  | 'document'
+  | 'image'
+  | 'other'
+  | 'presentation'
+  | 'spreadsheet'
+  | 'video';
+
+export interface FileTypeIconCatalogEntry {
+  /** Stable identifier — kebab-case extension (e.g. `pdf`, `docx`). */
+  id: string;
+  /** Human-readable label rendered in the catalog grid. */
+  label: string;
+  /** Catalog category for filter chips. */
+  category: FileTypeCategory;
+  /** Component to render. */
+  Icon: (props: FileTypeIconProps) => ReactNode;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -39,6 +39,7 @@ export * from './components/TopBar';
 export * from './components/VerificationCodeInput';
 export * from './icons/brand';
 export * from './icons/emoji';
+export * from './icons/filetype';
 export * from './icons/integration';
 export * from './icons/payment';
 export * from './theme';


### PR DESCRIPTION
Phase D.4.a of #309 / #370. Adds 13 file-type glyphs (document / spreadsheet / presentation) plus wires Table.Cell.FileTypeIcon to consume per-extension artwork via the new fileTypeIconForExtension(ext) helper.

Coverage: PDF/DOCX/DOC/PAGES/TXT/MD/RTF (document, blue), XLSX/XLS/NUMBERS/CSV (spreadsheet, green), PPTX/KEY (presentation, orange).

- Shared FileShape primitive: silhouette + colored extension band per category palette.
- Table.Cell.FileTypeIcon auto-detects extension from filename, swaps to registry glyph, falls back to kit File02 when uncovered. extensionIcon override still wins.
- Foundations / File Type Icons searchable + category-filtered Storybook catalog.

Refs #309, #324, #370