### PR TITLE
feat(ui): file-type icons D.4.b — image/audio/video glyphs

### DIFF
--- a/packages/ui/src/icons/filetype/FileTypeIcons.stories.tsx
+++ b/packages/ui/src/icons/filetype/FileTypeIcons.stories.tsx
@@ -119,7 +119,9 @@ function CatalogGrid({ search, category }: { search: string; category: CategoryF
 function componentName(id: string): string {
   // ids are bare file extensions; component names are PascalCase
   // with `File` suffix (e.g. `pdf` → `PdfFile`, `numbers` →
-  // `NumbersFile`).
+  // `NumbersFile`). Identifiers can't begin with a digit, so the
+  // 7z archive ships as `SevenZipFile`.
+  if (id === '7z') return 'SevenZipFile';
   const head = id.charAt(0);
   const titleCase = head.length > 0 ? head.toUpperCase() + id.slice(1) : '';
   return `${titleCase}File`;

--- a/packages/ui/src/icons/filetype/archive/RarFile.tsx
+++ b/packages/ui/src/icons/filetype/archive/RarFile.tsx
@@ -1,0 +1,8 @@
+// RAR archive file glyph. Archive category — red band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function RarFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="RAR" bandColor={CATEGORY_BAND.archive} />;
+}

--- a/packages/ui/src/icons/filetype/archive/SevenZipFile.tsx
+++ b/packages/ui/src/icons/filetype/archive/SevenZipFile.tsx
@@ -1,0 +1,10 @@
+// 7z archive file glyph. Archive category — red band.
+// Component name is `SevenZipFile` because identifiers can't begin
+// with a digit; the catalog id stays `7z` for extension matching.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function SevenZipFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="7Z" bandColor={CATEGORY_BAND.archive} />;
+}

--- a/packages/ui/src/icons/filetype/archive/TarFile.tsx
+++ b/packages/ui/src/icons/filetype/archive/TarFile.tsx
@@ -1,0 +1,9 @@
+// TAR archive file glyph (covers .tar, .tar.gz, .tgz aliases).
+// Archive category — red band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function TarFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="TAR" bandColor={CATEGORY_BAND.archive} />;
+}

--- a/packages/ui/src/icons/filetype/archive/ZipFile.tsx
+++ b/packages/ui/src/icons/filetype/archive/ZipFile.tsx
@@ -1,0 +1,8 @@
+// ZIP archive file glyph. Archive category — red band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function ZipFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="ZIP" bandColor={CATEGORY_BAND.archive} />;
+}

--- a/packages/ui/src/icons/filetype/audio/AacFile.tsx
+++ b/packages/ui/src/icons/filetype/audio/AacFile.tsx
@@ -1,0 +1,8 @@
+// AAC audio file glyph. Audio category — purple band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function AacFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="AAC" bandColor={CATEGORY_BAND.audio} />;
+}

--- a/packages/ui/src/icons/filetype/audio/FlacFile.tsx
+++ b/packages/ui/src/icons/filetype/audio/FlacFile.tsx
@@ -1,0 +1,8 @@
+// FLAC audio file glyph. Audio category — purple band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function FlacFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="FLAC" bandColor={CATEGORY_BAND.audio} />;
+}

--- a/packages/ui/src/icons/filetype/audio/Mp3File.tsx
+++ b/packages/ui/src/icons/filetype/audio/Mp3File.tsx
@@ -1,0 +1,8 @@
+// MP3 audio file glyph. Audio category — purple band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function Mp3File(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="MP3" bandColor={CATEGORY_BAND.audio} />;
+}

--- a/packages/ui/src/icons/filetype/audio/WavFile.tsx
+++ b/packages/ui/src/icons/filetype/audio/WavFile.tsx
@@ -1,0 +1,8 @@
+// WAV audio file glyph. Audio category — purple band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function WavFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="WAV" bandColor={CATEGORY_BAND.audio} />;
+}

--- a/packages/ui/src/icons/filetype/code/CssFile.tsx
+++ b/packages/ui/src/icons/filetype/code/CssFile.tsx
@@ -1,0 +1,8 @@
+// CSS file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function CssFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="CSS" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/GoFile.tsx
+++ b/packages/ui/src/icons/filetype/code/GoFile.tsx
@@ -1,0 +1,8 @@
+// Go source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function GoFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="GO" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/HtmlFile.tsx
+++ b/packages/ui/src/icons/filetype/code/HtmlFile.tsx
@@ -1,0 +1,8 @@
+// HTML file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function HtmlFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="HTML" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/JsFile.tsx
+++ b/packages/ui/src/icons/filetype/code/JsFile.tsx
@@ -1,0 +1,8 @@
+// JavaScript source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function JsFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="JS" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/JsonFile.tsx
+++ b/packages/ui/src/icons/filetype/code/JsonFile.tsx
@@ -1,0 +1,8 @@
+// JSON file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function JsonFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="JSON" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/PyFile.tsx
+++ b/packages/ui/src/icons/filetype/code/PyFile.tsx
@@ -1,0 +1,8 @@
+// Python source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function PyFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="PY" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/RbFile.tsx
+++ b/packages/ui/src/icons/filetype/code/RbFile.tsx
@@ -1,0 +1,8 @@
+// Ruby source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function RbFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="RB" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/RsFile.tsx
+++ b/packages/ui/src/icons/filetype/code/RsFile.tsx
@@ -1,0 +1,8 @@
+// Rust source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function RsFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="RS" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/TsFile.tsx
+++ b/packages/ui/src/icons/filetype/code/TsFile.tsx
@@ -1,0 +1,8 @@
+// TypeScript source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function TsFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="TS" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/XmlFile.tsx
+++ b/packages/ui/src/icons/filetype/code/XmlFile.tsx
@@ -1,0 +1,8 @@
+// XML file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function XmlFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="XML" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/YamlFile.tsx
+++ b/packages/ui/src/icons/filetype/code/YamlFile.tsx
@@ -1,0 +1,8 @@
+// YAML file glyph (covers .yaml + .yml). Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function YamlFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="YAML" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/image/GifFile.tsx
+++ b/packages/ui/src/icons/filetype/image/GifFile.tsx
@@ -1,0 +1,8 @@
+// GIF image file glyph. Image category — emerald band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function GifFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="GIF" bandColor={CATEGORY_BAND.image} />;
+}

--- a/packages/ui/src/icons/filetype/image/HeicFile.tsx
+++ b/packages/ui/src/icons/filetype/image/HeicFile.tsx
@@ -1,0 +1,8 @@
+// HEIC image file glyph. Image category — emerald band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function HeicFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="HEIC" bandColor={CATEGORY_BAND.image} />;
+}

--- a/packages/ui/src/icons/filetype/image/JpgFile.tsx
+++ b/packages/ui/src/icons/filetype/image/JpgFile.tsx
@@ -1,0 +1,8 @@
+// JPG image file glyph. Image category — emerald band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function JpgFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="JPG" bandColor={CATEGORY_BAND.image} />;
+}

--- a/packages/ui/src/icons/filetype/image/PngFile.tsx
+++ b/packages/ui/src/icons/filetype/image/PngFile.tsx
@@ -1,0 +1,8 @@
+// PNG image file glyph. Image category — emerald band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function PngFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="PNG" bandColor={CATEGORY_BAND.image} />;
+}

--- a/packages/ui/src/icons/filetype/image/RawFile.tsx
+++ b/packages/ui/src/icons/filetype/image/RawFile.tsx
@@ -1,0 +1,9 @@
+// RAW image file glyph (camera RAW container — covers .raw, .cr2, .nef,
+// .arw, .dng aliases). Image category — emerald band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function RawFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="RAW" bandColor={CATEGORY_BAND.image} />;
+}

--- a/packages/ui/src/icons/filetype/image/SvgFile.tsx
+++ b/packages/ui/src/icons/filetype/image/SvgFile.tsx
@@ -1,0 +1,8 @@
+// SVG image file glyph. Image category — emerald band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function SvgFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="SVG" bandColor={CATEGORY_BAND.image} />;
+}

--- a/packages/ui/src/icons/filetype/image/WebpFile.tsx
+++ b/packages/ui/src/icons/filetype/image/WebpFile.tsx
@@ -1,0 +1,8 @@
+// WEBP image file glyph. Image category — emerald band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function WebpFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="WEBP" bandColor={CATEGORY_BAND.image} />;
+}

--- a/packages/ui/src/icons/filetype/index.ts
+++ b/packages/ui/src/icons/filetype/index.ts
@@ -7,13 +7,13 @@
 // for per-extension artwork.
 //
 // Phase scope (from #370):
-//   - **D.4.a (this):** Document + Spreadsheet + Presentation —
+//   - D.4.a (shipped): Document + Spreadsheet + Presentation —
 //                       PDF, DOCX, DOC, PAGES, TXT, MD, RTF,
 //                       XLSX, XLS, NUMBERS, CSV, PPTX, KEY (13).
-//   - D.4.b (next)  :   Image + Audio + Video — PNG, JPG, GIF,
-//                       SVG, WEBP, HEIC, MP3, WAV, FLAC, AAC,
-//                       MP4, MOV, AVI, MKV, WEBM.
-//   - D.4.c         :   Archive + Code + Other — ZIP, RAR, TAR,
+//   - **D.4.b (this):** Image + Audio + Video — PNG, JPG, GIF,
+//                       SVG, WEBP, HEIC, RAW, MP3, WAV, FLAC, AAC,
+//                       MP4, MOV, AVI, MKV, WEBM (16).
+//   - D.4.c (next)  :   Archive + Code + Other — ZIP, RAR, TAR,
 //                       7z, JS, TS, JSON, YAML, XML, HTML, CSS,
 //                       PY, RB, GO, RS, DMG, EXE, APK.
 //
@@ -23,10 +23,14 @@
 // which renders a "file with corner fold" silhouette + a coloured
 // extension band — per-category palette keeps a directory listing
 // scannable at a glance (blue=document, green=spreadsheet,
-// orange=presentation, …).
+// orange=presentation, emerald=image, purple=audio, pink=video).
 
 import type { ComponentType } from 'react';
 
+import { AacFile } from './audio/AacFile';
+import { FlacFile } from './audio/FlacFile';
+import { Mp3File } from './audio/Mp3File';
+import { WavFile } from './audio/WavFile';
 import { DocFile } from './document/DocFile';
 import { DocxFile } from './document/DocxFile';
 import { MdFile } from './document/MdFile';
@@ -34,27 +38,55 @@ import { PagesFile } from './document/PagesFile';
 import { PdfFile } from './document/PdfFile';
 import { RtfFile } from './document/RtfFile';
 import { TxtFile } from './document/TxtFile';
+import { GifFile } from './image/GifFile';
+import { HeicFile } from './image/HeicFile';
+import { JpgFile } from './image/JpgFile';
+import { PngFile } from './image/PngFile';
+import { RawFile } from './image/RawFile';
+import { SvgFile } from './image/SvgFile';
+import { WebpFile } from './image/WebpFile';
 import { KeyFile } from './presentation/KeyFile';
 import { PptxFile } from './presentation/PptxFile';
 import { CsvFile } from './spreadsheet/CsvFile';
 import { NumbersFile } from './spreadsheet/NumbersFile';
 import { XlsFile } from './spreadsheet/XlsFile';
 import { XlsxFile } from './spreadsheet/XlsxFile';
+import { AviFile } from './video/AviFile';
+import { MkvFile } from './video/MkvFile';
+import { MovFile } from './video/MovFile';
+import { Mp4File } from './video/Mp4File';
+import { WebmFile } from './video/WebmFile';
 import type { FileTypeIconCatalogEntry, FileTypeIconProps } from './types';
 
 export type { FileTypeCategory, FileTypeIconCatalogEntry, FileTypeIconProps } from './types';
 export {
+  AacFile,
+  AviFile,
   CsvFile,
   DocFile,
   DocxFile,
+  FlacFile,
+  GifFile,
+  HeicFile,
+  JpgFile,
   KeyFile,
   MdFile,
+  MkvFile,
+  MovFile,
+  Mp3File,
+  Mp4File,
   NumbersFile,
   PagesFile,
   PdfFile,
+  PngFile,
   PptxFile,
+  RawFile,
   RtfFile,
+  SvgFile,
   TxtFile,
+  WavFile,
+  WebmFile,
+  WebpFile,
   XlsFile,
   XlsxFile,
 };
@@ -105,6 +137,49 @@ export function fileTypeIconForExtension(
     case 'key':
     case 'keynote':
       return KeyFile;
+    // Image
+    case 'png':
+      return PngFile;
+    case 'jpg':
+    case 'jpeg':
+      return JpgFile;
+    case 'gif':
+      return GifFile;
+    case 'svg':
+      return SvgFile;
+    case 'webp':
+      return WebpFile;
+    case 'heic':
+    case 'heif':
+      return HeicFile;
+    case 'raw':
+    case 'cr2':
+    case 'nef':
+    case 'arw':
+    case 'dng':
+      return RawFile;
+    // Audio
+    case 'mp3':
+      return Mp3File;
+    case 'wav':
+      return WavFile;
+    case 'flac':
+      return FlacFile;
+    case 'aac':
+    case 'm4a':
+      return AacFile;
+    // Video
+    case 'mp4':
+    case 'm4v':
+      return Mp4File;
+    case 'mov':
+      return MovFile;
+    case 'avi':
+      return AviFile;
+    case 'mkv':
+      return MkvFile;
+    case 'webm':
+      return WebmFile;
     default:
       return undefined;
   }
@@ -114,7 +189,7 @@ export function fileTypeIconForExtension(
  * Searchable catalog used by the `Foundations / File Type Icons`
  * Storybook docs page. Order is alphabetical within each category
  * so the rendered grid stays predictable for snapshot tests.
- * Future phases (D.4.b–c) append.
+ * Future phases (D.4.c) append.
  */
 export const fileTypeCatalog: readonly FileTypeIconCatalogEntry[] = [
   // --- D.4.a Document ---
@@ -133,4 +208,23 @@ export const fileTypeCatalog: readonly FileTypeIconCatalogEntry[] = [
   // --- D.4.a Presentation ---
   { id: 'key', label: 'Keynote', category: 'presentation', Icon: KeyFile },
   { id: 'pptx', label: 'PPTX', category: 'presentation', Icon: PptxFile },
+  // --- D.4.b Image ---
+  { id: 'gif', label: 'GIF', category: 'image', Icon: GifFile },
+  { id: 'heic', label: 'HEIC', category: 'image', Icon: HeicFile },
+  { id: 'jpg', label: 'JPG', category: 'image', Icon: JpgFile },
+  { id: 'png', label: 'PNG', category: 'image', Icon: PngFile },
+  { id: 'raw', label: 'RAW', category: 'image', Icon: RawFile },
+  { id: 'svg', label: 'SVG', category: 'image', Icon: SvgFile },
+  { id: 'webp', label: 'WEBP', category: 'image', Icon: WebpFile },
+  // --- D.4.b Audio ---
+  { id: 'aac', label: 'AAC', category: 'audio', Icon: AacFile },
+  { id: 'flac', label: 'FLAC', category: 'audio', Icon: FlacFile },
+  { id: 'mp3', label: 'MP3', category: 'audio', Icon: Mp3File },
+  { id: 'wav', label: 'WAV', category: 'audio', Icon: WavFile },
+  // --- D.4.b Video ---
+  { id: 'avi', label: 'AVI', category: 'video', Icon: AviFile },
+  { id: 'mkv', label: 'MKV', category: 'video', Icon: MkvFile },
+  { id: 'mov', label: 'MOV', category: 'video', Icon: MovFile },
+  { id: 'mp4', label: 'MP4', category: 'video', Icon: Mp4File },
+  { id: 'webm', label: 'WEBM', category: 'video', Icon: WebmFile },
 ];

--- a/packages/ui/src/icons/filetype/index.ts
+++ b/packages/ui/src/icons/filetype/index.ts
@@ -10,12 +10,12 @@
 //   - D.4.a (shipped): Document + Spreadsheet + Presentation —
 //                       PDF, DOCX, DOC, PAGES, TXT, MD, RTF,
 //                       XLSX, XLS, NUMBERS, CSV, PPTX, KEY (13).
-//   - **D.4.b (this):** Image + Audio + Video — PNG, JPG, GIF,
+//   - D.4.b (shipped): Image + Audio + Video — PNG, JPG, GIF,
 //                       SVG, WEBP, HEIC, RAW, MP3, WAV, FLAC, AAC,
 //                       MP4, MOV, AVI, MKV, WEBM (16).
-//   - D.4.c (next)  :   Archive + Code + Other — ZIP, RAR, TAR,
+//   - **D.4.c (this):** Archive + Code + Other — ZIP, RAR, TAR,
 //                       7z, JS, TS, JSON, YAML, XML, HTML, CSS,
-//                       PY, RB, GO, RS, DMG, EXE, APK.
+//                       PY, RB, GO, RS, DMG, EXE, APK (18).
 //
 // Each glyph component accepts the narrow `FileTypeIconProps`
 // (`className`, `aria-hidden` default true, `aria-label`). All
@@ -23,14 +23,30 @@
 // which renders a "file with corner fold" silhouette + a coloured
 // extension band — per-category palette keeps a directory listing
 // scannable at a glance (blue=document, green=spreadsheet,
-// orange=presentation, emerald=image, purple=audio, pink=video).
+// orange=presentation, emerald=image, purple=audio, pink=video,
+// red=archive, sky=code, gray=other).
 
 import type { ComponentType } from 'react';
 
+import { RarFile } from './archive/RarFile';
+import { SevenZipFile } from './archive/SevenZipFile';
+import { TarFile } from './archive/TarFile';
+import { ZipFile } from './archive/ZipFile';
 import { AacFile } from './audio/AacFile';
 import { FlacFile } from './audio/FlacFile';
 import { Mp3File } from './audio/Mp3File';
 import { WavFile } from './audio/WavFile';
+import { CssFile } from './code/CssFile';
+import { GoFile } from './code/GoFile';
+import { HtmlFile } from './code/HtmlFile';
+import { JsFile } from './code/JsFile';
+import { JsonFile } from './code/JsonFile';
+import { PyFile } from './code/PyFile';
+import { RbFile } from './code/RbFile';
+import { RsFile } from './code/RsFile';
+import { TsFile } from './code/TsFile';
+import { XmlFile } from './code/XmlFile';
+import { YamlFile } from './code/YamlFile';
 import { DocFile } from './document/DocFile';
 import { DocxFile } from './document/DocxFile';
 import { MdFile } from './document/MdFile';
@@ -45,6 +61,9 @@ import { PngFile } from './image/PngFile';
 import { RawFile } from './image/RawFile';
 import { SvgFile } from './image/SvgFile';
 import { WebpFile } from './image/WebpFile';
+import { ApkFile } from './other/ApkFile';
+import { DmgFile } from './other/DmgFile';
+import { ExeFile } from './other/ExeFile';
 import { KeyFile } from './presentation/KeyFile';
 import { PptxFile } from './presentation/PptxFile';
 import { CsvFile } from './spreadsheet/CsvFile';
@@ -61,14 +80,22 @@ import type { FileTypeIconCatalogEntry, FileTypeIconProps } from './types';
 export type { FileTypeCategory, FileTypeIconCatalogEntry, FileTypeIconProps } from './types';
 export {
   AacFile,
+  ApkFile,
   AviFile,
+  CssFile,
   CsvFile,
+  DmgFile,
   DocFile,
   DocxFile,
+  ExeFile,
   FlacFile,
   GifFile,
+  GoFile,
   HeicFile,
+  HtmlFile,
   JpgFile,
+  JsFile,
+  JsonFile,
   KeyFile,
   MdFile,
   MkvFile,
@@ -80,15 +107,25 @@ export {
   PdfFile,
   PngFile,
   PptxFile,
+  PyFile,
+  RarFile,
   RawFile,
+  RbFile,
+  RsFile,
   RtfFile,
+  SevenZipFile,
   SvgFile,
+  TarFile,
+  TsFile,
   TxtFile,
   WavFile,
   WebmFile,
   WebpFile,
   XlsFile,
   XlsxFile,
+  XmlFile,
+  YamlFile,
+  ZipFile,
 };
 
 /**
@@ -180,6 +217,54 @@ export function fileTypeIconForExtension(
       return MkvFile;
     case 'webm':
       return WebmFile;
+    // Archive
+    case 'zip':
+      return ZipFile;
+    case 'rar':
+      return RarFile;
+    case 'tar':
+    case 'tgz':
+    case 'gz':
+      return TarFile;
+    case '7z':
+      return SevenZipFile;
+    // Code
+    case 'js':
+    case 'mjs':
+    case 'cjs':
+    case 'jsx':
+      return JsFile;
+    case 'ts':
+    case 'tsx':
+      return TsFile;
+    case 'json':
+      return JsonFile;
+    case 'yaml':
+    case 'yml':
+      return YamlFile;
+    case 'xml':
+      return XmlFile;
+    case 'html':
+    case 'htm':
+      return HtmlFile;
+    case 'css':
+      return CssFile;
+    case 'py':
+      return PyFile;
+    case 'rb':
+      return RbFile;
+    case 'go':
+      return GoFile;
+    case 'rs':
+      return RsFile;
+    // Other
+    case 'dmg':
+      return DmgFile;
+    case 'exe':
+    case 'msi':
+      return ExeFile;
+    case 'apk':
+      return ApkFile;
     default:
       return undefined;
   }
@@ -189,7 +274,8 @@ export function fileTypeIconForExtension(
  * Searchable catalog used by the `Foundations / File Type Icons`
  * Storybook docs page. Order is alphabetical within each category
  * so the rendered grid stays predictable for snapshot tests.
- * Future phases (D.4.c) append.
+ * Phase D.4 ships all categories; new aliases land in the helper
+ * switch above without changing the catalog.
  */
 export const fileTypeCatalog: readonly FileTypeIconCatalogEntry[] = [
   // --- D.4.a Document ---
@@ -227,4 +313,25 @@ export const fileTypeCatalog: readonly FileTypeIconCatalogEntry[] = [
   { id: 'mov', label: 'MOV', category: 'video', Icon: MovFile },
   { id: 'mp4', label: 'MP4', category: 'video', Icon: Mp4File },
   { id: 'webm', label: 'WEBM', category: 'video', Icon: WebmFile },
+  // --- D.4.c Archive ---
+  { id: '7z', label: '7z', category: 'archive', Icon: SevenZipFile },
+  { id: 'rar', label: 'RAR', category: 'archive', Icon: RarFile },
+  { id: 'tar', label: 'TAR', category: 'archive', Icon: TarFile },
+  { id: 'zip', label: 'ZIP', category: 'archive', Icon: ZipFile },
+  // --- D.4.c Code ---
+  { id: 'css', label: 'CSS', category: 'code', Icon: CssFile },
+  { id: 'go', label: 'Go', category: 'code', Icon: GoFile },
+  { id: 'html', label: 'HTML', category: 'code', Icon: HtmlFile },
+  { id: 'js', label: 'JS', category: 'code', Icon: JsFile },
+  { id: 'json', label: 'JSON', category: 'code', Icon: JsonFile },
+  { id: 'py', label: 'Python', category: 'code', Icon: PyFile },
+  { id: 'rb', label: 'Ruby', category: 'code', Icon: RbFile },
+  { id: 'rs', label: 'Rust', category: 'code', Icon: RsFile },
+  { id: 'ts', label: 'TS', category: 'code', Icon: TsFile },
+  { id: 'xml', label: 'XML', category: 'code', Icon: XmlFile },
+  { id: 'yaml', label: 'YAML', category: 'code', Icon: YamlFile },
+  // --- D.4.c Other ---
+  { id: 'apk', label: 'APK', category: 'other', Icon: ApkFile },
+  { id: 'dmg', label: 'DMG', category: 'other', Icon: DmgFile },
+  { id: 'exe', label: 'EXE', category: 'other', Icon: ExeFile },
 ];

--- a/packages/ui/src/icons/filetype/other/ApkFile.tsx
+++ b/packages/ui/src/icons/filetype/other/ApkFile.tsx
@@ -1,0 +1,8 @@
+// Android APK package glyph. Other category — gray band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function ApkFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="APK" bandColor={CATEGORY_BAND.other} />;
+}

--- a/packages/ui/src/icons/filetype/other/DmgFile.tsx
+++ b/packages/ui/src/icons/filetype/other/DmgFile.tsx
@@ -1,0 +1,8 @@
+// macOS DMG disk image glyph. Other category — gray band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function DmgFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="DMG" bandColor={CATEGORY_BAND.other} />;
+}

--- a/packages/ui/src/icons/filetype/other/ExeFile.tsx
+++ b/packages/ui/src/icons/filetype/other/ExeFile.tsx
@@ -1,0 +1,8 @@
+// Windows EXE binary glyph. Other category — gray band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function ExeFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="EXE" bandColor={CATEGORY_BAND.other} />;
+}

--- a/packages/ui/src/icons/filetype/video/AviFile.tsx
+++ b/packages/ui/src/icons/filetype/video/AviFile.tsx
@@ -1,0 +1,8 @@
+// AVI video file glyph. Video category — pink band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function AviFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="AVI" bandColor={CATEGORY_BAND.video} />;
+}

--- a/packages/ui/src/icons/filetype/video/MkvFile.tsx
+++ b/packages/ui/src/icons/filetype/video/MkvFile.tsx
@@ -1,0 +1,8 @@
+// MKV (Matroska) video file glyph. Video category — pink band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function MkvFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="MKV" bandColor={CATEGORY_BAND.video} />;
+}

--- a/packages/ui/src/icons/filetype/video/MovFile.tsx
+++ b/packages/ui/src/icons/filetype/video/MovFile.tsx
@@ -1,0 +1,8 @@
+// MOV video file glyph. Video category — pink band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function MovFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="MOV" bandColor={CATEGORY_BAND.video} />;
+}

--- a/packages/ui/src/icons/filetype/video/Mp4File.tsx
+++ b/packages/ui/src/icons/filetype/video/Mp4File.tsx
@@ -1,0 +1,8 @@
+// MP4 video file glyph. Video category — pink band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function Mp4File(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="MP4" bandColor={CATEGORY_BAND.video} />;
+}

--- a/packages/ui/src/icons/filetype/video/WebmFile.tsx
+++ b/packages/ui/src/icons/filetype/video/WebmFile.tsx
@@ -1,0 +1,8 @@
+// WEBM video file glyph. Video category — pink band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function WebmFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="WEBM" bandColor={CATEGORY_BAND.video} />;
+}


### PR DESCRIPTION
Phase D.4.b of #309 / #370. Stacked on #388 (D.4.a). Adds 16 file-type glyphs covering image / audio / video.

Coverage:
- Image (7, emerald band): PNG, JPG, GIF, SVG, WEBP, HEIC, RAW
- Audio (4, purple band): MP3, WAV, FLAC, AAC
- Video (5, pink band): MP4, MOV, AVI, MKV, WEBM

## Scope (In)
- 16 new \`<Foo>File\` components, each a 5-line FileShape wrapper.
- \`fileTypeIconForExtension\` extended with primary keys + aliases (jpeg, heif, m4a, m4v, RAW family cr2/nef/arw/dng).
- \`fileTypeCatalog\` appends three alphabetical sections — Storybook Foundations / File Type Icons grid lights up the Image/Audio/Video chips.
- Barrel re-exports updated.

## Scope (Out)
- D.4.c (archive/code/other) — next PR.
- New behavior on \`<Table.Cell.FileTypeIcon>\` — already wired via D.4.a; new extensions just resolve through the existing helper.

## Test plan
- [x] type-check
- [x] lint
- [x] test (108/108)
- [x] build-storybook
- [ ] Storybook catalog manual smoke (chips for Image / Audio / Video render the new glyphs)
- [ ] Chromatic baseline review

Refs #309, #370