### PR TITLE
feat(ui): file-type icons D.4.c — archive/code/other glyphs

### DIFF
--- a/packages/ui/src/icons/filetype/FileTypeIcons.stories.tsx
+++ b/packages/ui/src/icons/filetype/FileTypeIcons.stories.tsx
@@ -119,7 +119,9 @@ function CatalogGrid({ search, category }: { search: string; category: CategoryF
 function componentName(id: string): string {
   // ids are bare file extensions; component names are PascalCase
   // with `File` suffix (e.g. `pdf` → `PdfFile`, `numbers` →
-  // `NumbersFile`).
+  // `NumbersFile`). Identifiers can't begin with a digit, so the
+  // 7z archive ships as `SevenZipFile`.
+  if (id === '7z') return 'SevenZipFile';
   const head = id.charAt(0);
   const titleCase = head.length > 0 ? head.toUpperCase() + id.slice(1) : '';
   return `${titleCase}File`;

--- a/packages/ui/src/icons/filetype/archive/RarFile.tsx
+++ b/packages/ui/src/icons/filetype/archive/RarFile.tsx
@@ -1,0 +1,8 @@
+// RAR archive file glyph. Archive category — red band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function RarFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="RAR" bandColor={CATEGORY_BAND.archive} />;
+}

--- a/packages/ui/src/icons/filetype/archive/SevenZipFile.tsx
+++ b/packages/ui/src/icons/filetype/archive/SevenZipFile.tsx
@@ -1,0 +1,10 @@
+// 7z archive file glyph. Archive category — red band.
+// Component name is `SevenZipFile` because identifiers can't begin
+// with a digit; the catalog id stays `7z` for extension matching.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function SevenZipFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="7Z" bandColor={CATEGORY_BAND.archive} />;
+}

--- a/packages/ui/src/icons/filetype/archive/TarFile.tsx
+++ b/packages/ui/src/icons/filetype/archive/TarFile.tsx
@@ -1,0 +1,9 @@
+// TAR archive file glyph (covers .tar, .tar.gz, .tgz aliases).
+// Archive category — red band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function TarFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="TAR" bandColor={CATEGORY_BAND.archive} />;
+}

--- a/packages/ui/src/icons/filetype/archive/ZipFile.tsx
+++ b/packages/ui/src/icons/filetype/archive/ZipFile.tsx
@@ -1,0 +1,8 @@
+// ZIP archive file glyph. Archive category — red band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function ZipFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="ZIP" bandColor={CATEGORY_BAND.archive} />;
+}

--- a/packages/ui/src/icons/filetype/code/CssFile.tsx
+++ b/packages/ui/src/icons/filetype/code/CssFile.tsx
@@ -1,0 +1,8 @@
+// CSS file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function CssFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="CSS" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/GoFile.tsx
+++ b/packages/ui/src/icons/filetype/code/GoFile.tsx
@@ -1,0 +1,8 @@
+// Go source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function GoFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="GO" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/HtmlFile.tsx
+++ b/packages/ui/src/icons/filetype/code/HtmlFile.tsx
@@ -1,0 +1,8 @@
+// HTML file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function HtmlFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="HTML" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/JsFile.tsx
+++ b/packages/ui/src/icons/filetype/code/JsFile.tsx
@@ -1,0 +1,8 @@
+// JavaScript source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function JsFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="JS" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/JsonFile.tsx
+++ b/packages/ui/src/icons/filetype/code/JsonFile.tsx
@@ -1,0 +1,8 @@
+// JSON file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function JsonFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="JSON" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/PyFile.tsx
+++ b/packages/ui/src/icons/filetype/code/PyFile.tsx
@@ -1,0 +1,8 @@
+// Python source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function PyFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="PY" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/RbFile.tsx
+++ b/packages/ui/src/icons/filetype/code/RbFile.tsx
@@ -1,0 +1,8 @@
+// Ruby source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function RbFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="RB" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/RsFile.tsx
+++ b/packages/ui/src/icons/filetype/code/RsFile.tsx
@@ -1,0 +1,8 @@
+// Rust source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function RsFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="RS" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/TsFile.tsx
+++ b/packages/ui/src/icons/filetype/code/TsFile.tsx
@@ -1,0 +1,8 @@
+// TypeScript source file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function TsFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="TS" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/XmlFile.tsx
+++ b/packages/ui/src/icons/filetype/code/XmlFile.tsx
@@ -1,0 +1,8 @@
+// XML file glyph. Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function XmlFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="XML" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/code/YamlFile.tsx
+++ b/packages/ui/src/icons/filetype/code/YamlFile.tsx
@@ -1,0 +1,8 @@
+// YAML file glyph (covers .yaml + .yml). Code category — sky band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function YamlFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="YAML" bandColor={CATEGORY_BAND.code} />;
+}

--- a/packages/ui/src/icons/filetype/index.ts
+++ b/packages/ui/src/icons/filetype/index.ts
@@ -10,12 +10,12 @@
 //   - D.4.a (shipped): Document + Spreadsheet + Presentation —
 //                       PDF, DOCX, DOC, PAGES, TXT, MD, RTF,
 //                       XLSX, XLS, NUMBERS, CSV, PPTX, KEY (13).
-//   - **D.4.b (this):** Image + Audio + Video — PNG, JPG, GIF,
+//   - D.4.b (shipped): Image + Audio + Video — PNG, JPG, GIF,
 //                       SVG, WEBP, HEIC, RAW, MP3, WAV, FLAC, AAC,
 //                       MP4, MOV, AVI, MKV, WEBM (16).
-//   - D.4.c (next)  :   Archive + Code + Other — ZIP, RAR, TAR,
+//   - **D.4.c (this):** Archive + Code + Other — ZIP, RAR, TAR,
 //                       7z, JS, TS, JSON, YAML, XML, HTML, CSS,
-//                       PY, RB, GO, RS, DMG, EXE, APK.
+//                       PY, RB, GO, RS, DMG, EXE, APK (18).
 //
 // Each glyph component accepts the narrow `FileTypeIconProps`
 // (`className`, `aria-hidden` default true, `aria-label`). All
@@ -23,14 +23,30 @@
 // which renders a "file with corner fold" silhouette + a coloured
 // extension band — per-category palette keeps a directory listing
 // scannable at a glance (blue=document, green=spreadsheet,
-// orange=presentation, emerald=image, purple=audio, pink=video).
+// orange=presentation, emerald=image, purple=audio, pink=video,
+// red=archive, sky=code, gray=other).
 
 import type { ComponentType } from 'react';
 
+import { RarFile } from './archive/RarFile';
+import { SevenZipFile } from './archive/SevenZipFile';
+import { TarFile } from './archive/TarFile';
+import { ZipFile } from './archive/ZipFile';
 import { AacFile } from './audio/AacFile';
 import { FlacFile } from './audio/FlacFile';
 import { Mp3File } from './audio/Mp3File';
 import { WavFile } from './audio/WavFile';
+import { CssFile } from './code/CssFile';
+import { GoFile } from './code/GoFile';
+import { HtmlFile } from './code/HtmlFile';
+import { JsFile } from './code/JsFile';
+import { JsonFile } from './code/JsonFile';
+import { PyFile } from './code/PyFile';
+import { RbFile } from './code/RbFile';
+import { RsFile } from './code/RsFile';
+import { TsFile } from './code/TsFile';
+import { XmlFile } from './code/XmlFile';
+import { YamlFile } from './code/YamlFile';
 import { DocFile } from './document/DocFile';
 import { DocxFile } from './document/DocxFile';
 import { MdFile } from './document/MdFile';
@@ -45,6 +61,9 @@ import { PngFile } from './image/PngFile';
 import { RawFile } from './image/RawFile';
 import { SvgFile } from './image/SvgFile';
 import { WebpFile } from './image/WebpFile';
+import { ApkFile } from './other/ApkFile';
+import { DmgFile } from './other/DmgFile';
+import { ExeFile } from './other/ExeFile';
 import { KeyFile } from './presentation/KeyFile';
 import { PptxFile } from './presentation/PptxFile';
 import { CsvFile } from './spreadsheet/CsvFile';
@@ -61,14 +80,22 @@ import type { FileTypeIconCatalogEntry, FileTypeIconProps } from './types';
 export type { FileTypeCategory, FileTypeIconCatalogEntry, FileTypeIconProps } from './types';
 export {
   AacFile,
+  ApkFile,
   AviFile,
+  CssFile,
   CsvFile,
+  DmgFile,
   DocFile,
   DocxFile,
+  ExeFile,
   FlacFile,
   GifFile,
+  GoFile,
   HeicFile,
+  HtmlFile,
   JpgFile,
+  JsFile,
+  JsonFile,
   KeyFile,
   MdFile,
   MkvFile,
@@ -80,15 +107,25 @@ export {
   PdfFile,
   PngFile,
   PptxFile,
+  PyFile,
+  RarFile,
   RawFile,
+  RbFile,
+  RsFile,
   RtfFile,
+  SevenZipFile,
   SvgFile,
+  TarFile,
+  TsFile,
   TxtFile,
   WavFile,
   WebmFile,
   WebpFile,
   XlsFile,
   XlsxFile,
+  XmlFile,
+  YamlFile,
+  ZipFile,
 };
 
 /**
@@ -180,6 +217,54 @@ export function fileTypeIconForExtension(
       return MkvFile;
     case 'webm':
       return WebmFile;
+    // Archive
+    case 'zip':
+      return ZipFile;
+    case 'rar':
+      return RarFile;
+    case 'tar':
+    case 'tgz':
+    case 'gz':
+      return TarFile;
+    case '7z':
+      return SevenZipFile;
+    // Code
+    case 'js':
+    case 'mjs':
+    case 'cjs':
+    case 'jsx':
+      return JsFile;
+    case 'ts':
+    case 'tsx':
+      return TsFile;
+    case 'json':
+      return JsonFile;
+    case 'yaml':
+    case 'yml':
+      return YamlFile;
+    case 'xml':
+      return XmlFile;
+    case 'html':
+    case 'htm':
+      return HtmlFile;
+    case 'css':
+      return CssFile;
+    case 'py':
+      return PyFile;
+    case 'rb':
+      return RbFile;
+    case 'go':
+      return GoFile;
+    case 'rs':
+      return RsFile;
+    // Other
+    case 'dmg':
+      return DmgFile;
+    case 'exe':
+    case 'msi':
+      return ExeFile;
+    case 'apk':
+      return ApkFile;
     default:
       return undefined;
   }
@@ -189,7 +274,8 @@ export function fileTypeIconForExtension(
  * Searchable catalog used by the `Foundations / File Type Icons`
  * Storybook docs page. Order is alphabetical within each category
  * so the rendered grid stays predictable for snapshot tests.
- * Future phases (D.4.c) append.
+ * Phase D.4 ships all categories; new aliases land in the helper
+ * switch above without changing the catalog.
  */
 export const fileTypeCatalog: readonly FileTypeIconCatalogEntry[] = [
   // --- D.4.a Document ---
@@ -227,4 +313,25 @@ export const fileTypeCatalog: readonly FileTypeIconCatalogEntry[] = [
   { id: 'mov', label: 'MOV', category: 'video', Icon: MovFile },
   { id: 'mp4', label: 'MP4', category: 'video', Icon: Mp4File },
   { id: 'webm', label: 'WEBM', category: 'video', Icon: WebmFile },
+  // --- D.4.c Archive ---
+  { id: '7z', label: '7z', category: 'archive', Icon: SevenZipFile },
+  { id: 'rar', label: 'RAR', category: 'archive', Icon: RarFile },
+  { id: 'tar', label: 'TAR', category: 'archive', Icon: TarFile },
+  { id: 'zip', label: 'ZIP', category: 'archive', Icon: ZipFile },
+  // --- D.4.c Code ---
+  { id: 'css', label: 'CSS', category: 'code', Icon: CssFile },
+  { id: 'go', label: 'Go', category: 'code', Icon: GoFile },
+  { id: 'html', label: 'HTML', category: 'code', Icon: HtmlFile },
+  { id: 'js', label: 'JS', category: 'code', Icon: JsFile },
+  { id: 'json', label: 'JSON', category: 'code', Icon: JsonFile },
+  { id: 'py', label: 'Python', category: 'code', Icon: PyFile },
+  { id: 'rb', label: 'Ruby', category: 'code', Icon: RbFile },
+  { id: 'rs', label: 'Rust', category: 'code', Icon: RsFile },
+  { id: 'ts', label: 'TS', category: 'code', Icon: TsFile },
+  { id: 'xml', label: 'XML', category: 'code', Icon: XmlFile },
+  { id: 'yaml', label: 'YAML', category: 'code', Icon: YamlFile },
+  // --- D.4.c Other ---
+  { id: 'apk', label: 'APK', category: 'other', Icon: ApkFile },
+  { id: 'dmg', label: 'DMG', category: 'other', Icon: DmgFile },
+  { id: 'exe', label: 'EXE', category: 'other', Icon: ExeFile },
 ];

--- a/packages/ui/src/icons/filetype/other/ApkFile.tsx
+++ b/packages/ui/src/icons/filetype/other/ApkFile.tsx
@@ -1,0 +1,8 @@
+// Android APK package glyph. Other category — gray band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function ApkFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="APK" bandColor={CATEGORY_BAND.other} />;
+}

--- a/packages/ui/src/icons/filetype/other/DmgFile.tsx
+++ b/packages/ui/src/icons/filetype/other/DmgFile.tsx
@@ -1,0 +1,8 @@
+// macOS DMG disk image glyph. Other category — gray band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function DmgFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="DMG" bandColor={CATEGORY_BAND.other} />;
+}

--- a/packages/ui/src/icons/filetype/other/ExeFile.tsx
+++ b/packages/ui/src/icons/filetype/other/ExeFile.tsx
@@ -1,0 +1,8 @@
+// Windows EXE binary glyph. Other category — gray band.
+
+import { CATEGORY_BAND, FileShape } from '../_shape';
+import type { FileTypeIconProps } from '../types';
+
+export function ExeFile(props: FileTypeIconProps) {
+  return <FileShape {...props} extension="EXE" bandColor={CATEGORY_BAND.other} />;
+}


### PR DESCRIPTION
Phase D.4.c of #309 / #370. Stacked on #389 (D.4.b). Adds 18 file-type glyphs covering archive / code / other — completing all of phase D.4.

Coverage:
- Archive (4, red band): ZIP, RAR, TAR, 7z
- Code (11, sky band): JS, TS, JSON, YAML, XML, HTML, CSS, PY, RB, GO, RS
- Other (3, gray band): DMG, EXE, APK

## Scope (In)
- 18 new \`<Foo>File\` components, each a 5-line FileShape wrapper.
- 7z ships as \`SevenZipFile\` (JS identifiers can't start with a digit). Catalog id stays \`7z\`; stories componentName helper handles this single case.
- \`fileTypeIconForExtension\` extended with primary keys + common aliases (mjs/cjs/jsx for JS, tsx for TS, yml for YAML, htm for HTML, msi for EXE, tgz/gz for TAR).
- \`fileTypeCatalog\` appends three alphabetical sections — Storybook Foundations / File Type Icons grid lights up Archive / Code / Other chips.
- Barrel re-exports updated.

## Scope (Out)
- New behavior on \`<Table.Cell.FileTypeIcon>\` — already wired via D.4.a; new extensions just resolve through the existing helper.
- Per-language colour theming for code glyphs — all share the sky band intentionally (registry visual consistency over language-canon palettes).

## Test plan
- [x] type-check
- [x] lint
- [x] test (108/108)
- [x] build-storybook
- [ ] Storybook catalog manual smoke (Archive / Code / Other chips)
- [ ] Chromatic baseline review

Refs #309, #370