### PR TITLE
feat(ui): select item composition + indicator + state stories

### DIFF
--- a/packages/ui/src/components/Select/Select.mdx
+++ b/packages/ui/src/components/Select/Select.mdx
@@ -43,6 +43,32 @@ via the `children` render function consuming the `items` collection.
 </Select>
 ```
 
+## Item composition
+
+`SelectItem` accepts a small set of presentation props that cover the
+common Figma patterns without custom rendering:
+
+- `icon` — leading icon (React component or element). See
+  `WithLeadingIcon` story.
+- `avatarUrl` — leading avatar (replaces `icon` when both are set).
+  See `WithAvatar` story.
+- `supportingText` — secondary text rendered next to the label
+  (truncates with the label when space is tight). See
+  `WithSupportingText` story.
+- `selectionIndicator` — `'checkmark'` (default), `'checkbox'`, or
+  `'none'`. Controls the visual marker for the selected item.
+- `selectionIndicatorAlign` — `'right'` (default) or `'left'`. Mirror
+  the indicator side so it reads with the label. See `CheckmarkLeft`,
+  `CheckboxIndicator`, `NoIndicator` stories.
+- `isDisabled` — single-item disable; the trigger keeps the option in
+  the list (focusable, screen-reader announces) but blocks selection.
+  See `DisabledItem` story.
+
+For per-item layout beyond these props (trailing badges, color
+swatches, custom flag art) drop the `SelectItem` helper and render an
+`AriaListBoxItem` directly with your own children — this is rare and
+should be confined to one place per app.
+
 ## Variants
 
 <Stories includePrimary={false} />

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
 
 import { defineControls } from '../_internal/controls';
+import { storybookIcons } from '../../icons/storybook';
 import {
   ComboBox,
   MultiSelect,
@@ -177,4 +178,194 @@ export const Native: Story = {
       />
     </div>
   ),
+};
+
+// Item content composition stories — kit `SelectItem` already supports
+// `icon`, `avatarUrl`, `supportingText`, `selectionIndicator` and
+// `selectionIndicatorAlign`; these stories surface that matrix in
+// Storybook so designers can review the variants against the Figma
+// frame (Design System / Select node 10673-194380).
+
+const APPS: SelectItemType[] = [
+  { id: 'mail', label: 'Mail', icon: storybookIcons.mail },
+  { id: 'settings', label: 'Settings', icon: storybookIcons.settings },
+  { id: 'inbox', label: 'Inbox', icon: storybookIcons.bell },
+  { id: 'profile', label: 'Profile', icon: storybookIcons.user },
+];
+
+const renderItemWithIcon = (item: SelectItemType) => (
+  <SelectItem key={item.id} id={item.id} label={item.label ?? ''} icon={item.icon} />
+);
+
+export const WithLeadingIcon: Story = {
+  args: {
+    items: APPS,
+    children: renderItemWithIcon,
+    label: 'Section',
+    placeholder: 'Pick a section',
+  },
+};
+
+const TEAM: SelectItemType[] = [
+  {
+    id: 'olivia',
+    label: 'Olivia Rhye',
+    avatarUrl: 'https://www.untitledui.com/images/avatars/olivia-rhye?bg=%23E0E0E0',
+    supportingText: 'olivia@untitledui.com',
+  },
+  {
+    id: 'phoenix',
+    label: 'Phoenix Baker',
+    avatarUrl: 'https://www.untitledui.com/images/avatars/phoenix-baker?bg=%23E0E0E0',
+    supportingText: 'phoenix@untitledui.com',
+  },
+  {
+    id: 'lana',
+    label: 'Lana Steiner',
+    avatarUrl: 'https://www.untitledui.com/images/avatars/lana-steiner?bg=%23E0E0E0',
+    supportingText: 'lana@untitledui.com',
+  },
+];
+
+// `exactOptionalPropertyTypes: true` rejects passing an explicit
+// `undefined` to optional string props; spread guards keep us
+// schema-compatible whether or not the fixture supplies the field.
+const renderTeamItem = (item: SelectItemType) => (
+  <SelectItem
+    key={item.id}
+    id={item.id}
+    label={item.label ?? ''}
+    {...(item.avatarUrl !== undefined ? { avatarUrl: item.avatarUrl } : {})}
+    {...(item.supportingText !== undefined ? { supportingText: item.supportingText } : {})}
+  />
+);
+
+export const WithAvatar: Story = {
+  args: {
+    items: TEAM,
+    children: renderTeamItem,
+    label: 'Assign to',
+    placeholder: 'Pick a teammate',
+  },
+};
+
+const PLANS: SelectItemType[] = [
+  { id: 'free', label: 'Free', supportingText: '$0 / month' },
+  { id: 'starter', label: 'Starter', supportingText: '$10 / month' },
+  { id: 'pro', label: 'Pro', supportingText: '$30 / month' },
+  { id: 'enterprise', label: 'Enterprise', supportingText: 'Contact sales' },
+];
+
+const renderPlanItem = (item: SelectItemType) => (
+  <SelectItem
+    key={item.id}
+    id={item.id}
+    label={item.label ?? ''}
+    {...(item.supportingText !== undefined ? { supportingText: item.supportingText } : {})}
+  />
+);
+
+export const WithSupportingText: Story = {
+  args: {
+    items: PLANS,
+    children: renderPlanItem,
+    label: 'Plan',
+    placeholder: 'Choose a plan',
+  },
+};
+
+// `selectionIndicator` matrix — checkmark right (default), checkmark
+// left, checkbox right, checkbox left, none. Custom `children`
+// renderer so each story can wire the prop without re-declaring the
+// item list.
+
+const renderItemWithIndicator = (
+  indicator: 'checkmark' | 'checkbox' | 'none',
+  align: 'left' | 'right',
+) =>
+  function ItemWithIndicator(item: SelectItemType) {
+    return (
+      <SelectItem
+        key={item.id}
+        id={item.id}
+        label={item.label ?? ''}
+        selectionIndicator={indicator}
+        selectionIndicatorAlign={align}
+      />
+    );
+  };
+
+export const CheckmarkLeft: Story = {
+  args: {
+    items: COUNTRIES,
+    children: renderItemWithIndicator('checkmark', 'left'),
+    defaultSelectedKey: 'tr',
+    label: 'Country',
+  },
+};
+
+export const CheckboxIndicator: Story = {
+  args: {
+    items: COUNTRIES,
+    children: renderItemWithIndicator('checkbox', 'right'),
+    defaultSelectedKey: 'tr',
+    label: 'Country',
+  },
+};
+
+export const NoIndicator: Story = {
+  args: {
+    items: COUNTRIES,
+    children: renderItemWithIndicator('none', 'right'),
+    defaultSelectedKey: 'tr',
+    label: 'Country',
+  },
+};
+
+const ITEMS_WITH_DISABLED: SelectItemType[] = [
+  { id: 'free', label: 'Free' },
+  { id: 'starter', label: 'Starter' },
+  { id: 'pro', label: 'Pro', isDisabled: true },
+  { id: 'enterprise', label: 'Enterprise' },
+];
+
+const renderItemHonouringDisabled = (item: SelectItemType) => (
+  <SelectItem
+    key={item.id}
+    id={item.id}
+    label={item.label ?? ''}
+    {...(item.isDisabled !== undefined ? { isDisabled: item.isDisabled } : {})}
+  />
+);
+
+export const DisabledItem: Story = {
+  args: {
+    items: ITEMS_WITH_DISABLED,
+    children: renderItemHonouringDisabled,
+    label: 'Plan',
+    placeholder: 'Choose a plan',
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    items: [],
+    children: renderItem,
+    label: 'Empty list',
+    placeholder: 'No options available',
+  },
+};
+
+// `OpenState` — popover-open baseline for Chromatic. `isOpen` keeps
+// the listbox visible without user interaction; `docs.disable` hides
+// it from MDX so the regular variant catalogue stays clean.
+export const OpenState: Story = {
+  parameters: { docs: { disable: true } },
+  args: {
+    items: COUNTRIES,
+    children: renderItem,
+    label: 'Country',
+    placeholder: 'Select your billing country.',
+    isOpen: true,
+  },
 };


### PR DESCRIPTION
## Summary

- Kit `SelectItem`'in zaten desteklediği prop matrisi Storybook'ta görünür hale getirildi: leading icon, avatar, supporting text, selection indicator (checkmark/checkbox/none × left/right), single-item disabled, empty state, popover-open baseline.
- 9 yeni story eklendi: `WithLeadingIcon`, `WithAvatar`, `WithSupportingText`, `CheckmarkLeft`, `CheckboxIndicator`, `NoIndicator`, `DisabledItem`, `EmptyState`, `OpenState`.
- `Select.mdx` "Item composition" bölümü kazandı — SelectItem props referans tablosu.
- Wrap (`Select.tsx`) ve kit kaynağına dokunulmadı; UUI source rule + sade re-export pattern korundu.

## Scope

**In**
- `packages/ui/src/components/Select/Select.stories.tsx` — 9 yeni story + fixture'lar (APPS, TEAM, PLANS, ITEMS_WITH_DISABLED) + 4 yeni renderer
- `packages/ui/src/components/Select/Select.mdx` — Item composition bölümü

**Out (issue #385'te follow-up için kayıtlı)**
- Sections / dividers / popover footer — kit `Section`/`Header` desteği yok, wrap genişletmesi gerekir
- ComboBox: `allowsCustomValue`, async filter, no-results CTA, "Create new" item — ayrı PR
- MultiSelect: select-all, count display, chip rendering, max items — ayrı PR
- TagSelect: overflow ("+3 more"), removable chips, max chips, paste→tag — ayrı PR
- Trigger state matrisi (loading spinner, success, warning) — wrap genişletmesi gerekir
- ComboBox/MultiSelect/TagSelect ayrı story dosyalarına bölünmesi — yapısal karar follow-up'ta
- `apps/web` veya `apps/mobile` tüketimi
- Mobile RN Select — phase-2

## Test plan

- [ ] `pnpm --filter @glaon/ui type-check` ✅ (yerel)
- [ ] `pnpm --filter @glaon/ui lint` ✅ (yerel)
- [ ] `pnpm --filter @glaon/ui test` ✅ (108 unit test, yerel)
- [ ] CI yeşil (story-tests, Chromatic publish, type-check · lint · audit, conventional-commits)
- [ ] Chromatic'te 9 yeni baseline kabul edilir
- [ ] Storybook'ta manuel doğrulama (`pnpm --filter @glaon/ui storybook`):
  - WithLeadingIcon: 4 item, her biri farklı UntitledUI ikonuyla
  - WithAvatar: 3 ekip üyesi, her birinin avatar URL'si + email supporting text
  - WithSupportingText: 4 plan kartı (Free/Starter/Pro/Enterprise) fiyatlarıyla
  - CheckmarkLeft: tr seçili, checkmark sol tarafta görünür
  - CheckboxIndicator: tr seçili, sağ tarafta checkbox ikonu (selected ✓)
  - NoIndicator: tr seçili ama hiçbir görsel marker yok (sadece bg-primary_hover)
  - DisabledItem: Pro plan dimmed, focusable ama seçilemez
  - EmptyState: items=[] placeholder, "No options available" listesi boş
  - OpenState: popover açık, Chromatic baseline için
- [ ] `addon-a11y` her yeni story'de yeşil; `aria-selected`, `aria-disabled` doğru

## Notes

- `exactOptionalPropertyTypes: true` `undefined` prop atamasına izin vermediği için renderer'lar conditional spread (`...(item.x !== undefined ? { x: item.x } : {})`) kullanıyor — fixture'larda alan tanımlı olsa bile tip kontratını koruyor.
- Avatar URL'leri `https://www.untitledui.com/images/avatars/{name}` üstünden — UUI'nin demo CDN'i, Chromatic capture'da stable.
- `OpenState` story `parameters.docs.disable: true` ile MDX'ten gizli; sadece visual-regression için var.

Closes #385