### PR TITLE
feat(ui): modal title/description/closebutton/featuredicon + xl size

### DIFF
--- a/packages/ui/src/components/Modal/Modal.mdx
+++ b/packages/ui/src/components/Modal/Modal.mdx
@@ -42,15 +42,24 @@ Compose with these slots:
 
 - **`Modal.Trigger`** — focusable child that opens the dialog.
 - **`Modal.Content`** — the dialog surface itself. Owns `size`
-  (`sm` / `md` / `lg` / `full`) and the dismiss flags
+  (`sm` / `md` / `lg` / `xl` / `full`) and the dismiss flags
   (`isDismissable`, `isKeyboardDismissDisabled`).
-- **`Modal.Header`** — title + optional subtitle, with a bottom
-  border.
+- **`Modal.CloseButton`** — optional X affordance pinned to the
+  top-right corner. Closes the dialog through RAC's `slot="close"`
+  contract — no `onPress` wiring required.
+- **`Modal.Header`** — featured icon + title + description, with a
+  bottom border.
+- **`Modal.FeaturedIcon`** — colored chip rendered above the title
+  for intent-themed dialogs (success / warning / error / brand).
+- **`Modal.Title`** — RAC `<Heading slot="title">`. The kit reads
+  this slot for `aria-labelledby` automatically.
+- **`Modal.Description`** — RAC `<Text slot="description">`. Wired
+  to the dialog through `aria-describedby`.
 - **`Modal.Body`** — main content area. Scrollable
   (`overflow-y-auto`) so long forms / Terms of Service render an
   internal scrollbar instead of pushing footer buttons off-screen.
-- **`Modal.Footer`** — action buttons aligned to the end. Order:
-  dismiss / cancel on the left, primary action on the right.
+- **`Modal.Footer`** — action buttons. Owns the `align` prop:
+  `right` (default) / `between` / `center` / `stacked`.
 
 ```tsx
 <Modal>
@@ -58,8 +67,11 @@ Compose with these slots:
     <Button>Open</Button>
   </Modal.Trigger>
   <Modal.Content size="md">
+    <Modal.CloseButton />
     <Modal.Header>
-      <h2>Confirm</h2>
+      <Modal.FeaturedIcon icon={CheckCircle} color="success" theme="light" />
+      <Modal.Title>Confirm</Modal.Title>
+      <Modal.Description>This will permanently apply the change.</Modal.Description>
     </Modal.Header>
     <Modal.Body>…content…</Modal.Body>
     <Modal.Footer>
@@ -69,6 +81,28 @@ Compose with these slots:
   </Modal.Content>
 </Modal>
 ```
+
+## Featured icon themes
+
+`Modal.FeaturedIcon` forwards to the foundation `<FeaturedIcon>` —
+all of its `color` (`brand` / `gray` / `success` / `warning` /
+`error`) and `theme` (`light` / `gradient` / `dark` / `outline` /
+`modern` / `modern-neue`) options are reachable. The defaults
+(`color="brand"`, `theme="light"`, `size="lg"`) match the typical
+Modal Header proportions, so most stories only set the `icon` prop.
+
+## Footer alignment
+
+`Modal.Footer align="…"` covers the four common action layouts:
+
+- `right` (default) — secondary then primary, right-aligned. Best
+  for editorial / Save-Cancel patterns.
+- `between` — secondary on the left, primary on the right. Pair
+  with wizard-style "Back" + "Continue" flows.
+- `center` — actions centred, typically used with a featured icon
+  on top + a single CTA.
+- `stacked` — actions stretched to full width and stacked. Mobile
+  patterns; primary on top, secondary below.
 
 ## Variants
 

--- a/packages/ui/src/components/Modal/Modal.stories.tsx
+++ b/packages/ui/src/components/Modal/Modal.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { AlertTriangle, CheckCircle, InfoCircle, Trash01, Zap } from '@untitledui/icons';
 
 import { defineControls } from '../_internal/controls';
 import { Button } from '../Button';
@@ -51,8 +52,8 @@ export const excludeFromArgs = modalExcludeFromArgs;
 
 const SampleHeader = () => (
   <>
-    <h2 className="text-lg font-semibold text-primary">Confirm action</h2>
-    <p className="text-sm text-tertiary">This will permanently apply the change.</p>
+    <Modal.Title>Confirm action</Modal.Title>
+    <Modal.Description>This will permanently apply the change.</Modal.Description>
   </>
 );
 
@@ -303,8 +304,8 @@ export const Confirmation: Story = {
       </Modal.Trigger>
       <Modal.Content size="sm">
         <Modal.Header>
-          <h2 className="text-lg font-semibold text-primary">Delete project?</h2>
-          <p className="text-sm text-tertiary">This action cannot be undone.</p>
+          <Modal.Title>Delete project?</Modal.Title>
+          <Modal.Description>This action cannot be undone.</Modal.Description>
         </Modal.Header>
         <Modal.Footer>
           <Button color="secondary" size="sm">
@@ -312,6 +313,307 @@ export const Confirmation: Story = {
           </Button>
           <Button color="primary-destructive" size="sm">
             Delete
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const SizeXl: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Extra large
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="xl">
+        <Modal.Header>
+          <Modal.Title>Extra-large modal</Modal.Title>
+          <Modal.Description>
+            Wider than `lg`; useful for split panes or rich previews.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">
+            Use sparingly — desktop only flows where the content genuinely benefits from extra
+            horizontal real estate.
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="primary" size="sm">
+            OK
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+// ─── New sub-component stories ───────────────────────────────────────────
+//
+// Modal.CloseButton renders an X affordance in the top-right corner
+// using RAC `slot="close"` so the dialog closes via the click-target
+// without consumer wiring. Modal.FeaturedIcon renders a colored chip
+// above the title for intent-themed dialogs (success / warning /
+// error / info / brand). Pair them with Modal.Title +
+// Modal.Description so RAC's `aria-labelledby` /
+// `aria-describedby` slots wire up automatically.
+
+export const WithCloseButton: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Open with X
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.CloseButton />
+        <Modal.Header>
+          <Modal.Title>Settings updated</Modal.Title>
+          <Modal.Description>
+            Your preferences were saved. Close the dialog when you&apos;re done reviewing.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">
+            The X in the top-right closes via RAC&apos;s &ldquo;slot=close&rdquo; contract — no
+            onPress wiring required.
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button color="primary" size="sm">
+            Got it
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const WithFeaturedIconBrand: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="primary" size="sm">
+          Upgrade plan
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.CloseButton />
+        <Modal.Header>
+          <Modal.FeaturedIcon icon={Zap} color="brand" theme="light" />
+          <Modal.Title>Upgrade to Pro</Modal.Title>
+          <Modal.Description>
+            Unlock priority support, advanced analytics, and unlimited integrations.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Footer>
+          <Button color="secondary" size="sm">
+            Maybe later
+          </Button>
+          <Button color="primary" size="sm">
+            Upgrade
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const IntentSuccess: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Show success
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.FeaturedIcon icon={CheckCircle} color="success" theme="light" />
+          <Modal.Title>Payment received</Modal.Title>
+          <Modal.Description>
+            Your invoice has been settled and a receipt was sent to your email.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Footer align="center">
+          <Button color="primary" size="sm">
+            Done
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const IntentWarning: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Show warning
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.FeaturedIcon icon={AlertTriangle} color="warning" theme="light" />
+          <Modal.Title>Unsaved changes</Modal.Title>
+          <Modal.Description>
+            Leaving now will discard the changes you made to this device profile.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Footer>
+          <Button color="secondary" size="sm">
+            Stay
+          </Button>
+          <Button color="primary" size="sm">
+            Discard
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const IntentError: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="primary-destructive" size="sm">
+          Delete project
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.FeaturedIcon icon={Trash01} color="error" theme="light" />
+          <Modal.Title>Delete project?</Modal.Title>
+          <Modal.Description>
+            This action cannot be undone. All devices and automations under this project will be
+            removed.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Footer>
+          <Button color="secondary" size="sm">
+            Cancel
+          </Button>
+          <Button color="primary-destructive" size="sm">
+            Delete
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const IntentInfo: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Show info
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.FeaturedIcon icon={InfoCircle} color="brand" theme="modern" />
+          <Modal.Title>What&apos;s new in Glaon 1.4</Modal.Title>
+          <Modal.Description>
+            We&apos;ve added device groups, scene previews, and faster pairing for Matter devices.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Footer align="center">
+          <Button color="primary" size="sm">
+            Got it
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+// ─── Footer alignment variants ───────────────────────────────────────────
+
+export const FooterCenter: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Centered actions
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.FeaturedIcon icon={CheckCircle} color="success" theme="light" />
+          <Modal.Title>All synced</Modal.Title>
+          <Modal.Description>Single CTA, centred under a featured icon.</Modal.Description>
+        </Modal.Header>
+        <Modal.Footer align="center">
+          <Button color="primary" size="sm">
+            Done
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const FooterBetween: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Step navigation
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.Header>
+          <Modal.Title>Step 2 of 3</Modal.Title>
+          <Modal.Description>Configure the device&apos;s network settings.</Modal.Description>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="text-sm text-secondary">
+            Use align=&ldquo;between&rdquo; for wizard-style flows where the back action lives on
+            the left and the forward action on the right.
+          </p>
+        </Modal.Body>
+        <Modal.Footer align="between">
+          <Button color="secondary" size="sm">
+            Back
+          </Button>
+          <Button color="primary" size="sm">
+            Continue
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  ),
+};
+
+export const FooterStacked: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <Modal.Trigger>
+        <Button color="secondary" size="sm">
+          Mobile-style stack
+        </Button>
+      </Modal.Trigger>
+      <Modal.Content size="sm">
+        <Modal.Header>
+          <Modal.FeaturedIcon icon={AlertTriangle} color="warning" theme="light" />
+          <Modal.Title>Replace existing scene?</Modal.Title>
+          <Modal.Description>
+            A scene with this name already exists. The new one will overwrite it.
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Footer align="stacked">
+          <Button color="primary" size="sm">
+            Replace
+          </Button>
+          <Button color="secondary" size="sm">
+            Cancel
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -54,7 +54,7 @@ import {
 import { cx } from '../../utils/cx';
 
 export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'full';
-export type ModalFooterAlign = 'right' | 'between' | 'center' | 'stacked';
+type ModalFooterAlign = 'right' | 'between' | 'center' | 'stacked';
 
 export interface ModalProps extends AriaDialogTriggerProps {
   /** Trigger + content slots. Use `Modal.Trigger` and `Modal.Content`. */
@@ -102,24 +102,24 @@ export interface ModalFooterProps {
   children: ReactNode;
 }
 
-export interface ModalTitleProps {
+interface ModalTitleProps {
   /** Optional Tailwind override; replaces nothing of the default styling. */
   className?: string;
   children: ReactNode;
 }
 
-export interface ModalDescriptionProps {
+interface ModalDescriptionProps {
   className?: string;
   children: ReactNode;
 }
 
-export interface ModalCloseButtonProps {
+interface ModalCloseButtonProps {
   /** Override the default `Close` aria-label (e.g. for translation). */
   'aria-label'?: string;
   className?: string;
 }
 
-export interface ModalFeaturedIconProps {
+interface ModalFeaturedIconProps {
   /** Icon component or element rendered inside the chip. */
   icon: FC<{ className?: string }> | ReactNode;
   /** @default 'lg' (matches the typical Modal Header proportions) */

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -3,16 +3,20 @@
 // react-aria-components' `<ModalOverlay>` + `<Modal>` + `<Dialog>` +
 // `<DialogTrigger>` chain (backdrop + zoom-in animations + responsive
 // sizing). Glaon composes those kit primitives into a Trigger /
-// Content / Header / Body / Footer slot pattern so consumers can
-// drop a complete modal in inline:
+// Content / Header / Body / Footer slot pattern with optional
+// FeaturedIcon / Title / Description / CloseButton slots so consumers
+// can drop a complete modal in inline:
 //
 //   <Modal>
 //     <Modal.Trigger>
 //       <Button>Open</Button>
 //     </Modal.Trigger>
 //     <Modal.Content size="md">
+//       <Modal.CloseButton />
 //       <Modal.Header>
-//         <h2>Confirm</h2>
+//         <Modal.FeaturedIcon color="success" theme="light" icon={CheckIcon} />
+//         <Modal.Title>Confirm</Modal.Title>
+//         <Modal.Description>Apply the change permanently?</Modal.Description>
 //       </Modal.Header>
 //       <Modal.Body>…content…</Modal.Body>
 //       <Modal.Footer>
@@ -25,23 +29,32 @@
 // The RAC foundation handles the full a11y contract: focus-trap +
 // return on close, scroll lock on the backdrop, escape close,
 // click-outside dismiss (when `isDismissable`), `aria-labelledby` /
-// `aria-describedby` wiring on the dialog.
+// `aria-describedby` wiring on the dialog (driven by the
+// `slot="title"` / `slot="description"` on Modal.Title /
+// Modal.Description).
 
-import type { ReactNode } from 'react';
+import { type ComponentProps, type FC, type ReactNode } from 'react';
+import { X } from '@untitledui/icons';
 
 import {
+  Button as AriaButton,
   type DialogTriggerProps as AriaDialogTriggerProps,
+  Heading as AriaHeading,
   type ModalOverlayProps as AriaModalOverlayProps,
+  Text as AriaText,
 } from 'react-aria-components';
 
+import { FeaturedIcon as KitFeaturedIcon } from '../foundations/featured-icon/featured-icon';
 import {
   Dialog as KitDialog,
   DialogTrigger as KitDialogTrigger,
   Modal as KitModal,
   ModalOverlay as KitModalOverlay,
 } from '../application/modals/modal';
+import { cx } from '../../utils/cx';
 
-export type ModalSize = 'sm' | 'md' | 'lg' | 'full';
+export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'full';
+export type ModalFooterAlign = 'right' | 'between' | 'center' | 'stacked';
 
 export interface ModalProps extends AriaDialogTriggerProps {
   /** Trigger + content slots. Use `Modal.Trigger` and `Modal.Content`. */
@@ -75,14 +88,64 @@ export interface ModalBodyProps {
 
 export interface ModalFooterProps {
   className?: string;
+  /**
+   * Action layout.
+   * - `right` (default) — secondary then primary, right-aligned.
+   * - `between` — secondary on the left, primary on the right
+   *   (typical for "Back" + "Continue" pairs).
+   * - `center` — actions centred (used with featured-icon-top
+   *   patterns).
+   * - `stacked` — actions stretched to full width and stacked
+   *   vertically (mobile-first).
+   */
+  align?: ModalFooterAlign;
   children: ReactNode;
+}
+
+export interface ModalTitleProps {
+  /** Optional Tailwind override; replaces nothing of the default styling. */
+  className?: string;
+  children: ReactNode;
+}
+
+export interface ModalDescriptionProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export interface ModalCloseButtonProps {
+  /** Override the default `Close` aria-label (e.g. for translation). */
+  'aria-label'?: string;
+  className?: string;
+}
+
+export interface ModalFeaturedIconProps {
+  /** Icon component or element rendered inside the chip. */
+  icon: FC<{ className?: string }> | ReactNode;
+  /** @default 'lg' (matches the typical Modal Header proportions) */
+  size?: ComponentProps<typeof KitFeaturedIcon>['size'];
+  /** @default 'brand' */
+  color?: ComponentProps<typeof KitFeaturedIcon>['color'];
+  /** @default 'light' */
+  theme?: ComponentProps<typeof KitFeaturedIcon>['theme'];
+  className?: string;
 }
 
 const sizeStyles: Record<ModalSize, string> = {
   sm: 'sm:max-w-sm',
   md: 'sm:max-w-md',
   lg: 'sm:max-w-2xl',
+  xl: 'sm:max-w-3xl',
   full: 'sm:max-w-[min(100vw-4rem,80rem)]',
+};
+
+const footerAlignStyles: Record<ModalFooterAlign, string> = {
+  right: 'flex justify-end gap-3',
+  between: 'flex justify-between gap-3',
+  center: 'flex justify-center gap-3',
+  // `[&>*]:flex-1` stretches direct button children to equal columns
+  // for the stacked layout's mobile-first equal-width pair.
+  stacked: 'flex flex-col gap-2 [&>*]:w-full',
 };
 
 function joinClasses(...parts: (string | undefined | false)[]): string {
@@ -104,8 +167,7 @@ function ModalContent({ size = 'md', className, children, ...rest }: ModalConten
         className={(state) =>
           joinClasses(
             sizeStyles[size],
-            'rounded-xl bg-primary shadow-2xl ring-1 ring-secondary_alt',
-            // Reuse the kit's animations on the inner Modal node.
+            'relative rounded-xl bg-primary shadow-2xl ring-1 ring-secondary_alt',
             state.isEntering && 'duration-300 ease-out animate-in zoom-in-95',
             state.isExiting && 'duration-200 ease-in animate-out zoom-out-95',
             typeof className === 'function' ? className(state) : className,
@@ -122,7 +184,7 @@ function ModalHeader({ className, children }: ModalHeaderProps) {
   return (
     <div
       className={joinClasses(
-        'flex flex-col gap-1 border-b border-secondary_alt px-6 pt-6 pb-4',
+        'flex flex-col gap-2 border-b border-secondary_alt px-6 pt-6 pb-4',
         className,
       )}
     >
@@ -144,16 +206,76 @@ function ModalBody({ className, children }: ModalBodyProps) {
   );
 }
 
-function ModalFooter({ className, children }: ModalFooterProps) {
+function ModalFooter({ className, align = 'right', children }: ModalFooterProps) {
   return (
     <div
       className={joinClasses(
-        'flex justify-end gap-3 border-t border-secondary_alt px-6 pt-4 pb-6',
+        footerAlignStyles[align],
+        'border-t border-secondary_alt px-6 pt-4 pb-6',
         className,
       )}
     >
       {children}
     </div>
+  );
+}
+
+// `Modal.Title` and `Modal.Description` map to RAC `<Heading slot="title">`
+// and `<Text slot="description">`. RAC's `<Dialog>` reads those slots and
+// forwards `aria-labelledby` + `aria-describedby` to the dialog
+// container automatically — consumers don't need to wire them manually.
+function ModalTitle({ className, children }: ModalTitleProps) {
+  return (
+    <AriaHeading slot="title" className={cx('text-lg font-semibold text-primary', className)}>
+      {children}
+    </AriaHeading>
+  );
+}
+
+function ModalDescription({ className, children }: ModalDescriptionProps) {
+  return (
+    <AriaText slot="description" className={cx('text-sm text-tertiary', className)}>
+      {children}
+    </AriaText>
+  );
+}
+
+// `Modal.CloseButton` renders a top-right X affordance that closes
+// the dialog via RAC's `slot="close"` contract. Stays absolutely
+// positioned inside `Modal.Content`'s `relative` container so it
+// floats over the header without consuming layout space.
+function ModalCloseButton({ 'aria-label': ariaLabel, className }: ModalCloseButtonProps) {
+  return (
+    <AriaButton
+      slot="close"
+      aria-label={ariaLabel ?? 'Close'}
+      className={cx(
+        'absolute top-4 right-4 z-10 inline-flex size-8 items-center justify-center rounded-md text-tertiary outline-none transition-colors',
+        'hover:bg-primary_hover hover:text-secondary',
+        'data-[focus-visible]:ring-2 data-[focus-visible]:ring-focus-ring',
+        className,
+      )}
+    >
+      <X aria-hidden="true" className="size-5" />
+    </AriaButton>
+  );
+}
+
+function ModalFeaturedIcon({
+  icon,
+  size = 'lg',
+  color = 'brand',
+  theme = 'light',
+  className,
+}: ModalFeaturedIconProps) {
+  return (
+    <KitFeaturedIcon
+      icon={icon}
+      size={size}
+      color={color}
+      theme={theme}
+      className={cx('mb-1', className)}
+    />
   );
 }
 
@@ -163,6 +285,10 @@ type ModalNamespace = typeof ModalRoot & {
   Header: typeof ModalHeader;
   Body: typeof ModalBody;
   Footer: typeof ModalFooter;
+  Title: typeof ModalTitle;
+  Description: typeof ModalDescription;
+  CloseButton: typeof ModalCloseButton;
+  FeaturedIcon: typeof ModalFeaturedIcon;
 };
 
 export const Modal: ModalNamespace = Object.assign(ModalRoot, {
@@ -171,4 +297,8 @@ export const Modal: ModalNamespace = Object.assign(ModalRoot, {
   Header: ModalHeader,
   Body: ModalBody,
   Footer: ModalFooter,
+  Title: ModalTitle,
+  Description: ModalDescription,
+  CloseButton: ModalCloseButton,
+  FeaturedIcon: ModalFeaturedIcon,
 });


### PR DESCRIPTION
## Summary

- New sub-components: `Modal.Title`, `Modal.Description`, `Modal.CloseButton`, `Modal.FeaturedIcon`. Title/Description map to RAC `slot="title"` / `slot="description"` so RAC's dialog auto-wires `aria-labelledby` / `aria-describedby` without consumer plumbing. CloseButton uses RAC `slot="close"` (no `onPress` wiring needed). FeaturedIcon forwards to the foundation `<FeaturedIcon>` (`color`: brand/gray/success/warning/error × `theme`: light/gradient/dark/outline/modern/modern-neue).
- `Modal.Footer align` prop with 4 layouts: `right` (default), `between`, `center`, `stacked`.
- `Modal.Content` gains `xl` size between `lg` and `full`.
- 10 new stories: SizeXl, WithCloseButton, WithFeaturedIconBrand, IntentSuccess/Warning/Error/Info, FooterCenter/Between/Stacked.
- Existing stories unchanged behaviorally; `Default` / `Confirmation` / `SampleHeader` migrated to `Modal.Title` + `Modal.Description` to demonstrate the new pattern.
- `Modal.mdx` updated with "Featured icon themes" and "Footer alignment" sections.

## Scope

**In**
- `packages/ui/src/components/Modal/Modal.tsx` — adds Title/Description/CloseButton/FeaturedIcon sub-components, `xl` size, `align` prop on Footer
- `packages/ui/src/components/Modal/Modal.stories.tsx` — 10 new stories + import of `@untitledui/icons` (AlertTriangle/CheckCircle/InfoCircle/Trash01/Zap)
- `packages/ui/src/components/Modal/Modal.mdx` — documentation refresh

**Out (issue #382'de follow-up için kayıtlı)**
- `packages/ui/src/components/application/modals/modal.tsx` — UUI source rule, hand-edit yasak
- Mobile bottom-sheet davranışı — Drawer ile rol ayrımı kararı follow-up issue
- Featured icon helper'ının ortak `_internal/featured-icon` location'a çıkarılması — şu an Modal-içi yeterli, refactor başka bir issue'da
- `apps/web` veya `apps/mobile` tüketimi
- Mobile RN Modal — phase-2

## Test plan

- [ ] \`pnpm --filter @glaon/ui type-check\` ✅ (yerel)
- [ ] \`pnpm --filter @glaon/ui lint\` ✅ (yerel)
- [ ] \`pnpm --filter @glaon/ui test\` ✅ (108 unit test, yerel)
- [ ] CI yeşil (story-tests, Chromatic publish, type-check · lint · audit, conventional-commits)
- [ ] Chromatic'te 10 yeni baseline kabul edilir
- [ ] Storybook'ta manuel doğrulama (\`pnpm --filter @glaon/ui storybook\`):
  - Default + Confirmation: yeni Title/Description sub-component'leri ile doğru render
  - SizeXl: yeni boyut presetinde max-width 3xl uygulanmış
  - WithCloseButton: X butonu sağ üst köşede, hover/focus state'leri çalışıyor, tıklayınca kapatıyor
  - WithFeaturedIconBrand / IntentSuccess / IntentWarning / IntentError / IntentInfo: doğru renk + theme kombinasyonu, ikon header üstünde
  - FooterCenter/Between/Stacked: action layout'u beklenen şekilde
- [ ] \`addon-a11y\` her yeni story'de yeşil; CloseButton \`aria-label="Close"\` set, FeaturedIcon \`aria-hidden="true"\`, Title/Description RAC slot'ları üzerinden ARIA wire'lı

## Notes

- F1.5 MDX/controls kontratı korundu — sub-component prop'ları (\`align\`, \`color\`, \`theme\`, \`icon\`) docgen üzerinden static-property pattern ile akıyor; \`modalControls\` ve \`modalExcludeFromArgs\` zaten bu durumu yönetiyor (test geçti).
- \`Modal.CloseButton\` \`absolute\`-positioned, \`Modal.Content\`'in \`relative\` container'ına yapıştığı için header'ın üstünde float ediyor.
- \`Modal.Footer align="stacked"\` mobile-first equal-width pair için \`[&>*]:w-full\` selector kullanıyor.
- Intent template story'leri yeni sub-component compose ediyor; ayrı kod yok — Figma'daki "use case templates" tam olarak bu pattern.

Closes #382