### PR TITLE
feat(ui): app icon registry D.1.e — fill catalog with brand cross-refs

### DIFF
--- a/packages/ui/src/icons/app/index.ts
+++ b/packages/ui/src/icons/app/index.ts
@@ -12,16 +12,20 @@
 //   - Phase D.1.c (#402 ✓): Design (Sketch, Adobe XD, Photoshop,
 //                            Illustrator) — four glyphs + Figma
 //                            cross-ref from the brand registry.
-//   - Phase D.1.d (this)  : Messengers (Signal) — one new glyph +
+//   - Phase D.1.d (#403 ✓): Messengers (Signal) — one new glyph +
 //                            Discord / Slack / Telegram / WhatsApp
 //                            cross-refs from the brand registry.
-//   - Phase D.1.e (todo)  : Music / Video / Productivity / OS / Other
+//   - Phase D.1.e (this)  : Music / Video / Productivity / OS /
+//                            Social-networks / Other — fills the
+//                            remaining catalog categories purely
+//                            with cross-refs from the brand registry
+//                            (no new SVGs). Closes the D.1 rollout.
 //
 // Each glyph component accepts the narrow `AppIconProps`
 // (`className`, `aria-hidden`, `aria-label`); brand-spec multi-colour
 // glyphs ship hard-coded fills, single-colour glyphs would inherit
-// `currentColor` (none yet — every browser / coding / design /
-// messenger logo is multi-colour by definition).
+// `currentColor`. Cross-referenced brand-registry glyphs use
+// `BrandIconProps` (structurally identical to `AppIconProps`).
 
 import { Brave } from './browsers/Brave';
 import { Chrome } from './browsers/Chrome';
@@ -46,11 +50,39 @@ import { Signal } from './messengers/Signal';
 // Cross-references from the brand / integration registries so
 // consumers reach the same canonical glyph from either entry — same
 // brand, one mark.
+import { AngelList } from '../brand/AngelList';
+import { Apple } from '../brand/Apple';
+import { Asana } from '../brand/Asana';
+import { Atlassian } from '../brand/Atlassian';
+import { Bitbucket } from '../brand/Bitbucket';
+import { Clubhouse } from '../brand/Clubhouse';
 import { Discord } from '../brand/Discord';
+import { Dribbble } from '../brand/Dribbble';
+import { Dropbox } from '../brand/Dropbox';
+import { Facebook } from '../brand/Facebook';
 import { Figma } from '../brand/Figma';
+import { Github } from '../brand/Github';
+import { Gitlab } from '../brand/Gitlab';
+import { Google } from '../brand/Google';
+import { Linkedin } from '../brand/Linkedin';
+import { Medium } from '../brand/Medium';
+import { Microsoft } from '../brand/Microsoft';
+import { Notion } from '../brand/Notion';
+import { Pinterest } from '../brand/Pinterest';
+import { Reddit } from '../brand/Reddit';
 import { Slack } from '../brand/Slack';
+import { Snapchat } from '../brand/Snapchat';
+import { Spotify } from '../brand/Spotify';
+import { StackOverflow } from '../brand/StackOverflow';
 import { Telegram } from '../brand/Telegram';
+import { TikTok } from '../brand/TikTok';
+import { Trello } from '../brand/Trello';
+import { Tumblr } from '../brand/Tumblr';
+import { Twitch } from '../brand/Twitch';
+import { Twitter } from '../brand/Twitter';
+import { Vimeo } from '../brand/Vimeo';
 import { WhatsApp } from '../brand/WhatsApp';
+import { YouTube } from '../brand/YouTube';
 import { Cursor } from '../integration/Cursor';
 
 import type { AppIconCatalogEntry } from './types';
@@ -75,8 +107,12 @@ export const appCatalog: AppIconCatalogEntry[] = [
   { id: 'opera', label: 'Opera', category: 'browsers', Icon: Opera },
   { id: 'safari', label: 'Safari', category: 'browsers', Icon: Safari },
   // Coding
+  { id: 'bitbucket', label: 'Bitbucket', category: 'coding', Icon: Bitbucket },
   { id: 'cursor', label: 'Cursor', category: 'coding', Icon: Cursor },
+  { id: 'github', label: 'GitHub', category: 'coding', Icon: Github },
+  { id: 'gitlab', label: 'GitLab', category: 'coding', Icon: Gitlab },
   { id: 'intellij', label: 'IntelliJ IDEA', category: 'coding', Icon: IntelliJ },
+  { id: 'stackoverflow', label: 'Stack Overflow', category: 'coding', Icon: StackOverflow },
   { id: 'sublime', label: 'Sublime Text', category: 'coding', Icon: Sublime },
   { id: 'vim', label: 'Vim', category: 'coding', Icon: Vim },
   { id: 'vscode', label: 'Visual Studio Code', category: 'coding', Icon: VsCode },
@@ -93,4 +129,33 @@ export const appCatalog: AppIconCatalogEntry[] = [
   { id: 'slack', label: 'Slack', category: 'messengers', Icon: Slack },
   { id: 'telegram', label: 'Telegram', category: 'messengers', Icon: Telegram },
   { id: 'whatsapp', label: 'WhatsApp', category: 'messengers', Icon: WhatsApp },
+  // Music
+  { id: 'spotify', label: 'Spotify', category: 'music', Icon: Spotify },
+  // Video
+  { id: 'twitch', label: 'Twitch', category: 'video', Icon: Twitch },
+  { id: 'vimeo', label: 'Vimeo', category: 'video', Icon: Vimeo },
+  { id: 'youtube', label: 'YouTube', category: 'video', Icon: YouTube },
+  // OS
+  { id: 'apple', label: 'Apple', category: 'os', Icon: Apple },
+  { id: 'microsoft', label: 'Microsoft', category: 'os', Icon: Microsoft },
+  // Productivity
+  { id: 'asana', label: 'Asana', category: 'productivity', Icon: Asana },
+  { id: 'atlassian', label: 'Atlassian', category: 'productivity', Icon: Atlassian },
+  { id: 'dropbox', label: 'Dropbox', category: 'productivity', Icon: Dropbox },
+  { id: 'notion', label: 'Notion', category: 'productivity', Icon: Notion },
+  { id: 'trello', label: 'Trello', category: 'productivity', Icon: Trello },
+  // Social networks
+  { id: 'angellist', label: 'AngelList', category: 'social-networks', Icon: AngelList },
+  { id: 'clubhouse', label: 'Clubhouse', category: 'social-networks', Icon: Clubhouse },
+  { id: 'dribbble', label: 'Dribbble', category: 'social-networks', Icon: Dribbble },
+  { id: 'facebook', label: 'Facebook', category: 'social-networks', Icon: Facebook },
+  { id: 'google', label: 'Google', category: 'social-networks', Icon: Google },
+  { id: 'linkedin', label: 'LinkedIn', category: 'social-networks', Icon: Linkedin },
+  { id: 'medium', label: 'Medium', category: 'social-networks', Icon: Medium },
+  { id: 'pinterest', label: 'Pinterest', category: 'social-networks', Icon: Pinterest },
+  { id: 'reddit', label: 'Reddit', category: 'social-networks', Icon: Reddit },
+  { id: 'snapchat', label: 'Snapchat', category: 'social-networks', Icon: Snapchat },
+  { id: 'tiktok', label: 'TikTok', category: 'social-networks', Icon: TikTok },
+  { id: 'tumblr', label: 'Tumblr', category: 'social-networks', Icon: Tumblr },
+  { id: 'twitter', label: 'Twitter', category: 'social-networks', Icon: Twitter },
 ];


### PR DESCRIPTION
## Summary

- **Final D.1 sub-PR**. Stacked on #403. Fills the remaining \`appCatalog\` categories purely with cross-references to the existing brand registry — no new hand-rolled SVGs.
- Closes #367 once the stack lands. Augments the existing \`coding\` rows from D.1.b with GitHub / GitLab / Bitbucket / Stack Overflow, and seeds the \`music\` / \`video\` / \`os\` / \`productivity\` / \`social-networks\` taxonomies with the brand glyphs already shipping.

## Cross-refs added (28 entries)

- **Coding** (augment): Bitbucket, GitHub, GitLab, Stack Overflow
- **Music**: Spotify
- **Video**: Twitch, Vimeo, YouTube
- **OS**: Apple, Microsoft
- **Productivity**: Asana, Atlassian, Dropbox, Notion, Trello
- **Social networks**: AngelList, Clubhouse, Dribbble, Facebook, Google, LinkedIn, Medium, Pinterest, Reddit, Snapchat, TikTok, Tumblr, Twitter

\`appCatalog\` now spans every taxonomy entry from \`AppIconCategory\` (browsers / coding / design / messengers / music / video / os / productivity / social-networks). The \`finance\` and \`other\` categories stay empty until a consumer surfaces a real need.

## Scope

**In**
- \`packages/ui/src/icons/app/index.ts\` — 28 new cross-ref imports + catalog rows + comment block updated to mark D.1 closed

**Out (deferred follow-ups)**
- Apple Music / YouTube Music / Tidal — Music category has only Spotify; specific marks need hand-roll
- Netflix / Disney+ / HBO / Amazon Prime — Video category leans on existing brand glyphs only
- Linux / Android / iOS / ChromeOS — OS category covers only Apple + Microsoft
- Microsoft Office family (Word / Excel / PowerPoint / Outlook), Google Workspace (Docs / Sheets / Slides / Drive / Gmail / Meet / Calendar) — productivity long tail
- iMessage / Microsoft Teams / Zoom / Wire / Threema — messenger long tail
- All deferred glyphs become individual follow-up PRs only when a real consumer requires them; every cross-ref currently shipping has zero implementation cost.

## Test plan

- [ ] \`pnpm --filter @glaon/ui type-check\` ✅ (yerel)
- [ ] \`pnpm --filter @glaon/ui lint\` ✅ (yerel)
- [ ] \`pnpm --filter @glaon/ui test\` ✅ (120 unit test, yerel)
- [ ] CI yeşil (story-tests, Chromatic publish, type-check · lint · audit, conventional-commits)
- [ ] Storybook'ta manuel doğrulama:
  - \`Foundations / App Icons\`: category dropdown her kategori için cross-ref'leri gösteriyor
  - Search \"spotify\" / \"github\" / \"facebook\" tetikliyor
  - Coding kategorisinde D.1.b hand-roll'ları + 4 yeni cross-ref toplam 10 entry
  - Social networks kategorisinde 13 entry

## Notes

- **Stacked PR**: base is \`367-app-icons-d-1-d-messengers\` (PR #403). Bottom-up rebases as ancestors merge.
- This PR is the catalog-fill pass: kit-ui consumers can already \`import\` every brand glyph today via the \`./icons/brand\` barrel; D.1.e just makes them visible in the App Icons category browser too. No new dependencies, no new SVGs.
- Comment block in \`index.ts\` marks the D.1 sub-phase rollout as complete.

Refs #309
Closes #367