### PR TITLE
chore(deps): pin basic-ftp >=5.3.1 — GHSA-rpmf-866q-6p89

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
     ]
   },
   "packageManager": "pnpm@9.15.0",
+  "pnpm": {
+    "overrides": {
+      "basic-ftp": ">=5.3.1"
+    }
+  },
   "private": true,
   "repository": "toss-cengiz/glaon.git",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  basic-ftp: '>=5.3.1'
+
 importers:
 
   .:
@@ -3087,8 +3090,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@6.0.1:
+    resolution: {integrity: sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==}
     engines: {node: '>=10.0.0'}
 
   better-opn@3.0.2:
@@ -9817,7 +9820,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.20: {}
 
-  basic-ftp@5.3.0: {}
+  basic-ftp@6.0.1: {}
 
   better-opn@3.0.2:
     dependencies:
@@ -11019,7 +11022,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 6.0.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

\`pnpm audit --audit-level high\` started failing today on every open PR after a new advisory dropped against \`basic-ftp@5.3.0\` ([GHSA-rpmf-866q-6p89](https://github.com/advisories/GHSA-rpmf-866q-6p89): unbounded multiline control response buffering DoS, **high** severity).

The vulnerable version is pulled in transitively via:

\`\`\`
@lhci/cli > lighthouse > puppeteer-core > @puppeteer/browsers >
proxy-agent > pac-proxy-agent > get-uri > basic-ftp
\`\`\`

\`@lhci/cli\` hasn't released a patched chain yet. Pinning \`basic-ftp\` to the patched range (\`>=5.3.1\`) via \`pnpm.overrides\` lifts the audit gate without weakening the audit level — once \`@lhci/cli\` ships an updated puppeteer chain we drop the override.

## Scope

**In**
- \`package.json\` — \`pnpm.overrides\` block with \`"basic-ftp": ">=5.3.1"\`
- \`pnpm-lock.yaml\` — regenerated for the pinned version

**Out**
- Bumping \`@lhci/cli\` itself — Renovate will pick up the patched release when it lands; we don't need to chase the major version manually
- Lowering the audit level — explicitly disallowed by CLAUDE.md \"Dependency Freshness\"; we patch instead

## Why a standalone PR

The audit gate broke during PR #400's CI run (and would break every other open PR rebased on \`development\`). Fixing it on a feature PR mixes scopes; this standalone chore PR keeps the attribution clean and lets every other open feature branch rebase on top to inherit the fix.

The same commit currently sits on #400's branch (\`366-country-flags\`) as a duplicate — once this PR lands and #400 rebases, git will deduplicate it.

## Test plan

- [ ] \`pnpm install\` ✅ (yerel — lockfile regen clean)
- [ ] \`pnpm audit --audit-level high\` ✅ (yerel — high severity gone, 2 low + 2 moderate remain, gate doesn't fail on those)
- [ ] CI yeşil (type-check · lint · audit, conventional-commits, all other gates)
- [ ] No app behavior change — the override only affects the dev-side Lighthouse CI tooling chain

## Notes

- Conventional Commits subject 56 chars; commitlint should pass.
- This PR has no \`Refs\` / \`Closes\` link to a tracking issue — it's a small dependency-bump chore that fixes an upstream advisory. CLAUDE.md's \"Dependency Freshness\" rule lists this as the recognized exception (\"Manual bumps are reserved for (a) resolving a specific bug, (b) unblocking migration work, or (c) a pin/rollback covered in docs/dependencies.md\"). This is option (a).