### PR TITLE
docs(adr): 0015 + 0016 — lock state mgmt + HA WS transport

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,6 +62,14 @@ Sürümler anlamlı teslimatlarla işaretlenir; tarihler yaklaşıktır. Güvenl
 
 ## Kararlar ve Açık Sorular
 
-- **State yönetimi**: zustand mı, redux-toolkit mi? Faz 1 başında karar.
-- **i18n kütüphanesi**: `react-i18next` vs `lingui` — Faz 5 kararı.
+Kararlaştırılmış konular ADR olarak [docs/adr/](adr/README.md) altında dondurulur. Açık sorular bu listede tutulur.
+
+Kapatılan sorular:
+
+- ✅ **State yönetimi** → [ADR 0015 — Zustand + Immer (client state) + TanStack Query (server state)](adr/0015-state-management.md).
+- ✅ **HA WebSocket transport mimarisi** → [ADR 0016 — Tek `HaClient`, transport interface arkasında multiplexing + reconnect](adr/0016-ha-ws-transport.md).
+
+Açık sorular:
+
+- **i18n kütüphanesi**: `react-i18next` vs `lingui` vs FormatJS — epic [#406](https://github.com/toss-cengiz/glaon/issues/406), kararı i18n-A ([#407](https://github.com/toss-cengiz/glaon/issues/407)) ADR'si verecek (planlanan numara 0023).
 - **Grafik**: Recharts mı, Victory Native XL mi? Tek kütüphane web + mobilde çalışmalı.

--- a/docs/adr/0015-state-management.md
+++ b/docs/adr/0015-state-management.md
@@ -1,0 +1,90 @@
+# ADR 0015 — State yönetimi: Zustand + Immer (client state) + TanStack Query (server state)
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-05-07
+- **Karar verenler:** @cengizdoyran
+- **İlgili konular:** issue #332, #10 (HaClient), #11 (entity state store), #12 (service call API), [ADR 0004 — `@glaon/core` platform-agnostic](0004-glaon-core-platform-agnostic.md), [CLAUDE.md — Component Data-Fetching Boundary](../../CLAUDE.md#component-data-fetching-boundary-mandatory)
+
+## Bağlam
+
+Phase 2 ile birlikte Glaon'un state surface'i somutlaşıyor:
+
+- **Server state (HA-canlı):** Home Assistant WebSocket'i `state_changed` event'lerini saniyede 10–100+ adet basabilir (yoğun bir evde). Bu state Glaon'a "ait" değil — HA'nın sahip olduğu canlı veriyi ekrana yansıtan, push-stream tabanlı bir mirror.
+- **Server state (HA-dışı):** `apps/api`'den (epic #392) gelen kullanıcı tercihleri, dashboard layout'ları gibi REST üzerinden çekilen, cache + invalidation gerektiren conventional REST veri.
+- **Client state:** UI navigation durumu, optimistic update'lerin local kopyası, pairing wizard'ı gibi multi-step akışların geçici state'i.
+
+Phase 0'da [ROADMAP](../ROADMAP.md#kararlar-ve-açık-sorular) bölümünde "zustand mı, redux-toolkit mi?" sorusu açık bırakılmıştı. Phase 2'nin başında bu kararı kilitlemek gerekli; çünkü #11 (entity state store) ve #12 (service call API) implementasyonu seçilen kütüphanenin store + selector idiomlarına göre yazılacak.
+
+[CLAUDE.md — Component Data-Fetching Boundary](../../CLAUDE.md#component-data-fetching-boundary-mandatory) zaten **server state'in TanStack Query üzerinden feature layer'da yönetilmesini** zorunlu kılıyor; UI component'leri data fetch etmiyor. Bu kural verili. Bu ADR client state ve push-stream tabanlı server state için bir kütüphane seçimi yapıyor; TanStack Query kararı re-litige edilmiyor, yalnızca kapsamı netleştiriliyor.
+
+`@glaon/core` paketi [ADR 0004](0004-glaon-core-platform-agnostic.md) gereği DOM'a ve React Native runtime'ına bağımsız olmak zorunda; entity state store burada yaşıyor → seçilen kütüphane vanilla (React-bağımsız) bir API sunmalı.
+
+Göz önünde bulundurulan alternatifler:
+
+- **Seçenek A — Redux Toolkit (RTK Query olmadan):** Reddedildi. RTK'nın değer önerisinin büyük kısmı RTK Query'dir; biz server state için TanStack Query'yi kilitlemiş durumdayız (CLAUDE.md). RTK Query olmadan, kalan slice/thunk ergonomisi Zustand'ın `set` çağrılarıyla zaten ifade edilebiliyor — net dezavantaj olarak ekstra bundle (~12 KB minified+gzipped, vs Zustand'ın ~1 KB'i) ve action/reducer/middleware ceremony'si kalıyor.
+- **Seçenek B — Redux Toolkit + RTK Query (TanStack Query yerine):** Reddedildi. Bu seçim CLAUDE.md'in data-fetching boundary kuralını yeniden yazmayı, mobile'da (RN) TanStack Query yerine RTK Query kullanmayı, ve `apps/api` client'ını da RTK Query baseQuery'sine yeniden yazmayı gerektirirdi. TanStack Query halihazırda hem web hem RN'de iyi çalışıyor; cache, retry, refetch, optimistic update story'si zaten oturmuş. Migrasyon maliyeti yüksek, kazanç yok.
+- **Seçenek C — Jotai / Valtio / signal-tabanlı (signia, @preact/signals-react):** Reddedildi. Atom-based veya signal-based modeller HA WS push stream'i için gayet uygun ama (a) ekosistem küçük, (b) RN entegrasyonu Zustand kadar olgun değil, (c) `@glaon/core`'da React-bağımsız vanilla store kullanmak için ek wrapper yazılması gerekiyor. Zustand "boring-but-proven" pick.
+- **Seçenek D — Vanilla `useSyncExternalStore` + el ile WS subscriber:** Reddedildi. Zustand'ın sunduğunu daha kötü yeniden yazmak olur. `useSyncExternalStore` zaten Zustand'ın React adapter'ının altında; biz onu kendi elimizle wrap etmek yerine kütüphaneyi getiriyoruz.
+- **Seçenek E — Zustand + Immer (client state) + TanStack Query (server state) (seçilen):** Karar bölümünde detay.
+
+## Karar
+
+**Glaon'un state mimarisi üç katman olarak donduruluyor:**
+
+1. **Server state — push stream (HA WebSocket):** `@glaon/core` içinde **Zustand vanilla store** + **Immer middleware** ile yönetilir. Entity store (#11) bu kategoride; HA `state_changed` event'leri Immer üzerinden in-place mutate ediliyor gibi görünen, altında immutable update üreten kod ile uygulanır.
+2. **Server state — REST (HA-dışı, `apps/api`):** Feature layer'da **TanStack Query** ile yönetilir. CLAUDE.md Component Data-Fetching Boundary kuralı geçerli; component'ler `useQuery` çağırmaz, hook feature klasöründe yaşar, sonuç prop olarak akar.
+3. **Client state:** UI'a yakın geçici state'ler (modal açık/kapalı, multi-step wizard adımı, optimistic patch'in local snapshot'ı) yine **Zustand** ile, ama feature klasöründe — `@glaon/core`'da değil. Trivial state için `useState` kalmaya devam eder; Zustand sadece birden fazla component'in paylaştığı veya cross-tree erişim gereken state için.
+
+Kararın teknik detayları:
+
+- **Zustand sürümü:** `zustand` package'ı, `zustand/middleware/immer` ile birlikte. Pinning Renovate'in normal bump akışına bırakılır.
+- **Slice-per-file konvansiyonu:** Her domain bir dosyada — `packages/core/src/state/entities.ts`, `packages/core/src/state/connection.ts`, vs. Tek bir devasa store yok; her slice kendi `create()` çağrısını yapar.
+- **Selector-only subscription kuralı:** Component'ler `useStore(state => state.someSlice)` veya `useStore()` (tüm tree'yi return) yazmaz. Her erişim bir **selector** üzerinden gider: `useEntity(id)`, `useEntitiesByDomain(domain)` gibi typed helper'lar slice dosyasında export edilir; component yalnızca bu helper'ı çağırır. Amaç: re-render granülerliği + API kontratı.
+- **ESLint kuralı:** Selector-only kuralı ESLint custom rule ile zorlanır. **Bu ADR sadece kuralı kararlaştırır;** rule'un implementasyonu (paket adı, custom rule mu yoksa `no-restricted-imports` ile kombinasyon mu) #11 ile birlikte iner — ADR ile aynı PR'da değil, çünkü kural ancak store dosyaları varken anlamlı.
+- **Vanilla store / React store ayrımı:** `@glaon/core` slice'ları **vanilla** Zustand store olarak (createStore, React-free) yazılır; React adapter (`useStore` hook'u) `apps/web` ve `apps/mobile` tarafında bu vanilla store'u sarmalar. Bu sayede `@glaon/core` unit testleri React render gerektirmez, hot Vitest çalışır; aynı core hem web hem RN'den import edilebilir ([ADR 0004](0004-glaon-core-platform-agnostic.md)).
+- **Immer kullanım skobu:** Yalnız entity store gibi nested update gerektiren slice'lar Immer middleware ile sarılır. Trivial slice'lar (örn. connection durumu enum) Immer overhead'ine girmez.
+- **TanStack Query versiyon devamlılığı:** TanStack Query zaten `apps/web` ve `apps/mobile` planında; kullanım kuralları (queryKey naming, stale time defaults) #392 epic'inin ileri sub-issue'larında kararlaştırılır, bu ADR'in dışında.
+
+## Sonuçlar
+
+### Olumlu
+
+- **Push-stream uyumu:** Zustand'ın selector-tabanlı subscription'ı saniyede 100+ event'lik HA stream'inde yalnızca o entity'yi izleyen component'leri re-render eder. RTK + memoized selector ile aynı seviye granülerliği elde etmek için her event normalize → reducer → memoization katmanını geçer; Zustand'da bu katmanlar yok.
+- **Bundle bütçesi:** `apps/web` HA Add-on Ingress üzerinden statik bundle olarak teslim edildiği ([ADR 0009](0009-ha-addon-ingress-delivery.md)) için bundle KB başına önemli — ~11 KB tasarruf (RTK karşısında) küçük ama kümülatif.
+- **`@glaon/core` saflığı:** Vanilla Zustand store React-free; [ADR 0004](0004-glaon-core-platform-agnostic.md)'ın platform-agnostic kuralını koruyor. Mobile (Expo, RN 0.81) aynı slice dosyasını import ediyor.
+- **Test ergonomisi:** Vitest unit testlerinde fake transport + scripted frame'lerle store'a doğrudan event akıtılıp selector çıktısı assert edilebilir; React test utility gerektirmez.
+- **Üç ayrı runtime için tek mental model:** "Push-stream ise Zustand, REST ise TanStack Query" basit bir kural — yeni geliştirici cheatsheet'i bir cümle.
+
+### Olumsuz / ödenecek bedel
+
+- **Konvansiyon yükü:** Zustand "building blocks, not conventions" sunar; store sprawl (her component'in kendi store'unu yazması, selector helper'ları olmadan raw subscribe etmesi) ekiple birlikte ortaya çıkabilen risk. Mitigasyon: slice-per-file kuralı + selector-only ESLint rule + code review'da raw `useStore()` reddi.
+- **DevTools kapsamı:** Redux DevTools ekosistemi RTK'da çok zengin; Zustand DevTools middleware'i var ama time-travel debugging ve action replay deneyimi RTK kadar olgun değil. Phase 2'de yaşanmadıkça bu eksiklik küçük; gerekirse Zustand'ın kendi DevTools middleware'ı entegre edilir.
+- **Server state'i Zustand'a kaçırma cazibesi:** TanStack Query yerine "bir slice yazıp REST cevabını oraya basayım" eğilimi olabilir. CLAUDE.md kuralı + code review bu sapmayı yakalar; tekrarlanan ihlaller görülürse ek bir ESLint rule (örn. `no-fetch-in-store-slice`) eklenir.
+- **Optimistic update ergonomi:** TanStack Query'nin `useMutation` + `onMutate` rollback story'si oturuyor ama push-stream tarafında entity store ile mutation arasındaki sync (örn. `light.toggle` → optimistic Zustand update → HA WS confirms via `state_changed` → optimistic patch'in temizlenmesi) #12'nin tasarım yüküne giriyor. Bu ADR'in çözmediği, #12'nin çözeceği bir konu.
+
+### Etkileri
+
+- **Kod organizasyonu:** `packages/core/src/state/` yeni dizin; `entities.ts`, `connection.ts`, vb. slice dosyaları. `packages/core/src/index.ts` selector'ları re-export eder; raw `useStore` export edilmez (kapı kapalı).
+- **Bağımlılık:** `packages/core/package.json`'a `zustand` ve `immer` runtime dep olarak eklenir. TanStack Query zaten `apps/web` ve `apps/mobile`'da kullanılıyor / kullanılacak; `@glaon/core` bu kütüphaneye bağımlı **değil** (server state core'da değil).
+- **Test setup:** `vitest.config.ts` ek bir setup gerektirmiyor; Zustand vanilla store Node ortamında zaten çalışıyor.
+- **Mobile (`apps/mobile`):** Aynı core slice'larını import ediyor; React adapter `apps/mobile/src/hooks/use-store.ts` gibi bir wrapper olarak yazılıyor (web'de aynı pattern). RN'de side effect yok.
+- **Storybook:** `@glaon/ui` story'leri component-level state için ayrı bir Zustand store yaratmıyor; mock'lar prop olarak (CLAUDE.md Component Data-Fetching Boundary) geliyor. State decorator gerekirse story-level oluşturulur, global store'a değdirilmez.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Zustand'ın React 19+ veya RN new architecture ile uyumsuzluğu ortaya çıkarsa (örn. Concurrent Mode ile selector subscription'ında race) — alternatif aday Jotai veya `@preact/signals-react`.
+- TanStack Query kararı CLAUDE.md'den çıkarılır veya `apps/api` farklı bir client (tRPC, gRPC-web) kullanmaya zorlanırsa — server state stratejisi yeniden açılır; bu ADR'in client state kararı (Zustand) etkilenmez.
+- Store sprawl problemi 2 quarter'dan uzun süre code review'da yakalanmaya devam ederse — daha opinionated bir framework (Redux Toolkit, Effector) yeniden masaya gelir.
+- HA WS event volume'u öyle bir noktaya gelir ki Zustand selector overhead'i ölçülebilir performance sorunu yaratır — entity store'un altında düşük seviye bir push-stream primitive'i (RxJS, signals) ile decouple edilmesi araştırılır.
+
+## Referanslar
+
+- Issue [#332 — state management + HA transport architecture decision](https://github.com/toss-cengiz/glaon/issues/332).
+- Issue [#11 — entity state store](https://github.com/toss-cengiz/glaon/issues/11) — bu ADR'in ilk implementasyon noktası.
+- Issue [#12 — service call API](https://github.com/toss-cengiz/glaon/issues/12) — optimistic update story store ile birlikte tasarlanır.
+- [ADR 0004 — `@glaon/core` platform-agnostic](0004-glaon-core-platform-agnostic.md) — vanilla store kararının arkasındaki ana kısıt.
+- [CLAUDE.md — Component Data-Fetching Boundary](../../CLAUDE.md#component-data-fetching-boundary-mandatory) — TanStack Query kuralının tek kaynağı.
+- [docs/ROADMAP.md](../ROADMAP.md) — Phase 2 başlangıcında bu açık soru kapatılıyor.
+- Zustand: <https://github.com/pmndrs/zustand>
+- Immer: <https://immerjs.github.io/immer/>
+- TanStack Query: <https://tanstack.com/query>

--- a/docs/adr/0016-ha-ws-transport.md
+++ b/docs/adr/0016-ha-ws-transport.md
@@ -1,0 +1,165 @@
+# ADR 0016 — HA WebSocket transport mimarisi
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-05-07
+- **Karar verenler:** @cengizdoyran
+- **İlgili konular:** issue #332, #10 (HaClient implementation), #11 (entity state store), #12 (service call API), [ADR 0015 — state management](0015-state-management.md), [ADR 0017 — dual-mode auth (planlanmış)](https://github.com/toss-cengiz/glaon/issues/337), [ADR 0018 — cloud relay topology (planlanmış)](https://github.com/toss-cengiz/glaon/issues/338)
+
+## Bağlam
+
+Home Assistant'ın WebSocket API'si Glaon'un canlı veri yolu. Phase 1'de `packages/core/src/ha/client.ts` yalnızca bir iskelet — handshake yarım, multiplexing yok, reconnect yok. Phase 2'de bu transport iki farklı modda çalışacak ([dual-mode auth ADR'sı, #337](https://github.com/toss-cengiz/glaon/issues/337)):
+
+- **Local mod:** Tarayıcı / Expo doğrudan ev içindeki HA örneğine WebSocket açar.
+- **Cloud mod:** Glaon cloud relay'ine WebSocket açar; relay HA add-on agent'ına forward eder ([cloud relay topology, #338](https://github.com/toss-cengiz/glaon/issues/338)).
+
+Her iki yolda **aynı mesaj kontratını** taşımak gerekiyor — `subscribe_entities`, `call_service`, `get_states` gibi HA-yerli komutlar her iki transportta aynı şekilde gönderilebilmeli ki entity store (#11) ve service API (#12) transport-agnostic kalsın.
+
+Phase 0'daki [ROADMAP](../ROADMAP.md#kararlar-ve-açık-sorular) açık soru olarak "WS transport mimarisi" bırakmıştı. Phase 2'nin başında bu mimariyi kilitlemek gerek; çünkü:
+
+- #10 (dual-transport HaClient) iki farklı transport implementasyonunu paralel yazacak; ortak interface'i ADR'in hangi seam'lerini sabitleyeceğine bağlı.
+- #11 ve #12 store + service API kontratını HaClient'ın yüzeyine bağımlı tasarlayacak.
+- Cloud track ADR'leri (0018 — relay topology, 0021 — pairing) bu transport yüzeyine referans verecek.
+
+Tartışma çerçevesi:
+
+1. **Tek client mı, feature-bazlı çoklu client mı?** Bir oturumda 5 farklı feature `subscribe_entities` çağırırsa 5 ayrı WS mu açılır, yoksa tek bir WS üzerinden subscription multiplexing mi?
+2. **Subscription modeli:** HA WS protokolü her message için artan bir `id` kullanıyor; subscription'lar bu id ile keyleniyor. Glaon kendi observer'larını HA `id`'sine mi yoksa Glaon-tarafı bir subscription handle'ına mı bağlamalı?
+3. **Reconnect davranışı:** Bağlantı koparsa ne olur? In-flight request'lerin promise'lerine ne olur? Subscription'lar otomatik mi yenilenir? Snapshot reconciliation nerede?
+4. **Auth lifecycle:** WS client `auth_invalid` aldığında ne yapar? Token refresh kim tetikler? Cloud transport'ta JWT rotation WS'i kapatmadan nasıl olur?
+5. **Test surface:** Bu transport unit, integration ve E2E katmanlarında nasıl mock'lanacak?
+
+Göz önünde bulundurulan alternatifler:
+
+- **Seçenek A — Feature-bazlı çoklu HaClient:** Her feature kendi HA WS'ini açar. Reddedildi: HA'nın tek bağlantı başına resource overhead'i + auth handshake'in her bağlantıda tekrarlanması + pratik bir kazancı yok. Subscription multiplexing zaten HA protokolünün doğal davranışı (her message id farklı, server bunları ayırıyor).
+- **Seçenek B — `home-assistant-js-websocket` kütüphanesini kullan:** Reddedildi (yeniden değerlendirme tetikleyicisi olarak açık bırakıldı). Resmi HA frontend bu kütüphaneyi kullanıyor; battle-tested. Ama (a) `@glaon/core` platform-agnostic olmak zorunda ([ADR 0004](0004-glaon-core-platform-agnostic.md)), kütüphane RN uyumluluğu net değil ve hâlâ test edilmedi, (b) cloud relay transport'unu (ADR 0018) bu kütüphane içine sokmak zorlaşıyor — kütüphane "raw HA WS" varsayımıyla yazılmış, relay envelope'unu wrap eden kendi transport adapter'ımıza ihtiyaç var, (c) bağımlılığı tek bir runtime client'a kilitler (kütüphane ekibi cloud relay senaryosunu desteklemez). Hand-rolled implementation'ın komplikasyon bütçesi büyük değil; HA WS protokolü stabil ve dar kapsamlı.
+- **Seçenek C — Tek `HaClient` instance + transport interface + multiplexing (seçilen):** Karar bölümünde detay.
+- **Seçenek D — Server-Sent Events / polling fallback:** Reddedildi. Sadece WebSocket özelliklerini kullanmak için polling emek-yoğun + HA tarafı SSE sunmuyor. Cloud relay zaten WebSocket; tek transport tipi yeterli.
+
+## Karar
+
+**Glaon'un HA bağlantısı tek bir `HaClient` instance üzerinden, transport interface arkasında multiplex edilir. İki transport implementasyonu (DirectWsTransport, CloudRelayTransport) aynı `HaClient`'a takılır; client transport-agnostic davranır.**
+
+Kararın teknik detayları:
+
+### Sınıf yapısı
+
+```
+packages/core/src/ha/
+  client.ts        # HaClient — multiplexing, subscription registry, reconnect orchestration
+  transport.ts     # HaTransport interface
+  transports/
+    direct-ws.ts   # DirectWsTransport — raw WS to HA
+    cloud-relay.ts # CloudRelayTransport — Glaon envelope to relay (#10 + ADR 0018'de iniyor)
+  protocol/
+    messages.ts    # HA WS message types (auth, subscribe_entities, call_service, ...)
+    relay.ts       # Glaon relay envelope (ADR 0018'de iniyor)
+```
+
+`HaClient` constructor'ı bir transport alır; transport'u soyut bilir, üstüne kendi subscription registry'sini, message id correlation'ını ve reconnect logic'ini ekler.
+
+### Transport interface
+
+```ts
+interface HaTransport {
+  connect(): Promise<void>;
+  send(frame: HaOutboundFrame): void; // fire-and-forget; HaClient id correlation yapar
+  on(event: 'message', handler: (frame: HaInboundFrame) => void): () => void;
+  on(event: 'close', handler: (info: CloseInfo) => void): () => void;
+  on(event: 'error', handler: (err: Error) => void): () => void;
+  close(): Promise<void>;
+}
+```
+
+Transport seviyesinde HA `id` correlation **yok** — her transport sadece raw frame ileti taşıyıcısı. Id atama, request/response Promise resolution, subscription routing tamamen `HaClient`'ta.
+
+### Subscription multiplexing
+
+- HA WS protokolü artan integer `id` kullanır; her message bir `id` taşır, response/event aynı `id` ile döner.
+- `HaClient` her outbound message'a yeni bir id verir, in-flight request map'inde tutar:
+
+  ```ts
+  type PendingRequest = { resolve: (data: unknown) => void; reject: (err: Error) => void };
+  const pending = new Map<number, PendingRequest>();
+  ```
+
+- Subscription'lar (`subscribe_entities`, `subscribe_events`) için ayrı bir registry:
+
+  ```ts
+  type SubscriptionHandle = { id: number; unsubscribe: () => Promise<void> };
+  const subscriptions = new Map<number, (event: HaEvent) => void>();
+  ```
+
+- Glaon-yüzü API: `client.subscribe(entityIdsOrEvents, callback): SubscriptionHandle` döner. Caller `unsubscribe()` çağırır → client `unsubscribe_events` mesajını HA'ya gönderir, registry'den temizler.
+
+- Yüzlerce concurrent observer için: tek subscription, çoklu callback yerine her caller kendi subscription'ını alır. HA tarafı bu maliyeti taşıyabilir; Glaon tarafında Map<number, ...> O(1) lookup. Optimizasyon (örn. aynı target için subscription paylaşımı) ölçüm sonrası, ihtiyaç doğmadan yapılmaz.
+
+### Reconnect davranışı
+
+- **Backoff:** Exponential + jitter — `min(baseDelay * 2 ** attempt, maxDelay)` ± random %25. `baseDelay = 500ms`, `maxDelay = 30s`.
+- **Max attempts:** Yok (sürekli dener). Kullanıcı manuel olarak "Sign out" derse client `close()` çağrılır ve döngü iptal edilir.
+- **In-flight requests:** Bağlantı koptuğu anda pending Map'teki tüm Promise'lar `HaConnectionLostError` ile reject edilir. Caller (genelde TanStack Query veya `callService`) bu hatayı görüp retry stratejisine girer.
+- **Subscription replay:** Yeniden bağlandıktan sonra `HaClient` tüm aktif subscription'ları otomatik resubscribe eder; yeni HA `id`'leri eski Glaon-tarafı handle'lara remap edilir → caller'lar aynı `unsubscribe` referansını kullanmaya devam eder.
+- **Snapshot reconciliation:** Reconnect başarılı olduktan sonra client otomatik bir `get_states` çağırır → snapshot entity store'a `applySnapshot()` ile yazılır → store eski `state_changed` event'leriyle delta birikmiş olabilir, snapshot otorite olur (uçtan uca durum). Snapshot reconciliation'ın store-side detayı [ADR 0015](0015-state-management.md) ile #11'de bağlanır.
+- **Online/offline UX hook:** Client `connectionState: 'connecting' | 'open' | 'closed' | 'reconnecting'` değerini yayınlar; UI banner'ları bu state'e bağlanır. Implementation #11/#12 ile birlikte iner.
+
+### Auth lifecycle
+
+- **Local mod (DirectWsTransport):** HA `auth_required` mesajı geldiğinde, HaClient `getAccessToken()` callback'ini çağırır → token'ı `auth` mesajıyla gönderir. `auth_ok` → ready. `auth_invalid` → TokenStore'dan refresh isteği yapılır (mutex'li, [#9](https://github.com/toss-cengiz/glaon/issues/9) gereği), yeni access token ile aynı WS üzerinde bir kez daha `auth` denenir; tekrar başarısızsa client `closed` state'e girer ve mode selector'a (E2 / G2) yönlendirme sinyali yayınlar.
+- **Cloud mod (CloudRelayTransport):** Cloud relay Clerk JWT ile WS upgrade'i authenticate eder ([ADR 0018, planlanmış](https://github.com/toss-cengiz/glaon/issues/338)). Mid-session JWT rotation control frame (`session_refresh`) ile yapılır — WS kopmaz. HA-tarafı auth tokenları cloud'a hiç ulaşmaz; addon agent kendi HA Supervisor token'ı ile local HA'ya konuşur.
+- **Token refresh çakışması:** Birden çok concurrent request token expire olduğunu görürse `auth_invalid` mesajı bir tane gelir; HaClient bunu tek bir refresh task'a kanalize eder ([#9](https://github.com/toss-cengiz/glaon/issues/9) TokenStore mutex). Refresh sırasında gelen yeni request'ler refresh tamamlanana kadar bekler.
+
+### Message id correlation stratejisi
+
+- Client startup'ta `nextId = 1`. Her outbound request öncesinde `nextId++`.
+- Reconnect sonrası id sayacı **reset edilir** çünkü HA tarafı yeni bağlantı için id space'ini sıfırlar. Eski subscription'ların Glaon-tarafı handle'ları aynı kalır; sadece HA-tarafı id'leri yeni `subscribe_*` cevaplarından okunup map'e yazılır.
+- Outbound mesaj log formatında her zaman `id` görülür → debugging'de event ↔ request eşleştirmesi mümkün.
+
+### Test surface
+
+- **Unit (`packages/core`):** Fake `HaTransport` implementasyonu — scripted frame stream. HaClient'a frame inject edip pending Promise resolve'unu, subscription routing'ini, reconnect snapshot replay'ini assert ederiz.
+- **Integration (`apps/web-e2e` / mobile):** Gerçek HA fixture (Docker, [#331](https://github.com/toss-cengiz/glaon/issues/331)) ile E2E [#13](https://github.com/toss-cengiz/glaon/issues/13). Test reconnect behavior'unu HA container'ı kapatıp açarak kontrol eder.
+- **Storybook decorator:** Story-level fake HaClient (vanilla store ile beslenmiş) sayesinde component'ler storybook'ta WS gerektirmez. CLAUDE.md Component Data-Fetching Boundary kuralı zaten component'ten fetch'i yasaklıyor — story decorator yalnız store'u dolduruyor.
+
+## Sonuçlar
+
+### Olumlu
+
+- **Tek bağlantı, paylaşılan handshake:** Auth handshake oturum başına bir kez. Mobile data plan için tasarruf, server-side resource için saygı.
+- **Transport-agnostic core:** `HaClient` kodu DirectWsTransport ile CloudRelayTransport arasında değişmiyor → store ve service API tek codebase, iki mod.
+- **Test ergonomi:** Fake transport ile birim testler hızlı ve deterministik. Reconnect senaryolarını gerçek WS açmadan tetiklemek mümkün.
+- **HA protokolüyle uyum:** id correlation HA'nın doğal modeliyle eşleşiyor; ekstra çeviri katmanı yok. HA frontend ile aynı mental model — debugging için ekibe avantaj.
+- **Cloud relay paralel implementasyonu:** Transport interface stabil olduğu için B3 (#345 — cloud WS endpoint) ve D1 (#348 — addon relay agent) implementasyonu HaClient'ın iç değişikliklerine bağlı değil; ayrı PR'larda paralel ilerleyebilir.
+
+### Olumsuz / ödenecek bedel
+
+- **Hand-rolled WS client:** `home-assistant-js-websocket`'i kullanmadığımız için handshake, reconnect ve subscription registry'sini biz yazıyoruz. Edge case'ler (auth race, half-open WS, rapid disconnect) test surface'inin kapsamına bağlı olarak sürünebilir; ilk turda bilinen tüm senaryolar unit testle korunur, gerisi production'da gözlemlenir.
+- **Subscription registry sprawl:** Yüzlerce caller'ın aynı entity'ye subscribe olduğu bir UI varsa, HA tarafına yüzlerce subscription gönderiyoruz. Sharing optimizasyonu yapmadık — ihtiyaç ölçülürse bir overlay registry eklenir, bu ADR re-değerlendirilmez.
+- **Snapshot reconciliation maliyeti:** Her reconnect bir `get_states` round-trip + büyük bir state replace. Yoğun evlerde bu birkaç yüz KB transfer + entity store re-render dalgası. Daha akıllı bir delta diff yapısı (sadece değişen entity'leri reconcile etmek) ileriki bir optimizasyon konusu — şimdi gereksiz karmaşıklık.
+- **Cloud relay control frame'lerinin ham WS üzerinde geçmemesi:** CloudRelayTransport `ha_ws_frame` ve `control` envelope'larını ayırt etmek zorunda. Bu envelope tasarımı [ADR 0018'de](https://github.com/toss-cengiz/glaon/issues/338) iniyor; bu ADR yalnız transport interface'inin ikinci implementasyonu olduğunu söyler, envelope detayı oraya bırakılır.
+
+### Etkileri
+
+- **Kod organizasyonu:** `packages/core/src/ha/` mevcut iskeleti yeni dosyalara genişler; mevcut `client.ts` placeholder #10'da yeniden yazılır.
+- **CI / build:** Yeni runtime bağımlılığı yok (WebSocket browser ve RN'de native; Node ortamında `ws` peer Phase 2'nin entegrasyon test ortamı için eklenebilir, vitest kapsamında değerlendirilir).
+- **`@glaon/core` exports:** `./ha` zaten export ediliyor; transport interface ve fake helper test utility'leri olarak ayrı path (`./ha/testing` gibi) export edilir — production bundle'a girmesin.
+- **Mobile (`apps/mobile`):** RN runtime'ı hem WebSocket hem `Map`/`Promise` API'lerini destekliyor; ek polyfill yok. New architecture (RN 0.81 + Hermes) bu kodla uyumlu.
+- **Cloud relay decisions:** [ADR 0018, 0019, 0020, 0021, 0022](https://github.com/toss-cengiz/glaon/issues/338) bu transport interface'ini "stabil" varsayar; kontrat değişimi onları etkilerse breaking change olarak ele alınır (ADR superseded edilir, eski 0016 kalır).
+
+## Tekrar değerlendirme tetikleyicileri
+
+- HA topluluğu `home-assistant-js-websocket`'in modern bir RN-uyumlu sürümünü yayınlar veya HA bir resmi typed client publish ederse — hand-rolled client'tan kütüphaneye geçiş değerlendirilir; bu ADR superseded edilir.
+- HA WS protokolünde breaking değişiklik olursa (örn. id correlation modeli değişirse) — yeni ADR; bu kalır arşiv olarak.
+- Reconnect snapshot reconciliation'ın production'da unacceptable performance dalgası yarattığı ölçülürse (saniyelerce frozen UI) — delta-only reconciliation tasarımı ayrı bir ADR olarak girer.
+- Cloud relay endpoint'i transport interface'ini (örn. unidirectional event stream + ayrı request channel) zorunlu kılarsa — interface re-tasarımı yeni bir ADR.
+
+## Referanslar
+
+- Issue [#332 — state management + HA transport architecture decision](https://github.com/toss-cengiz/glaon/issues/332).
+- Issue [#10 — feat(core): dual-transport HaClient — direct + cloud relay](https://github.com/toss-cengiz/glaon/issues/10) — bu ADR'in implementasyonu.
+- Issue [#11 — entity state store](https://github.com/toss-cengiz/glaon/issues/11) — store ↔ transport sınırı bu ADR'in 4. ve 5. seam'lerinde.
+- Issue [#12 — service call API](https://github.com/toss-cengiz/glaon/issues/12) — service helper'lar HaClient yüzeyini consume eder.
+- Issue [#9 — secure token storage](https://github.com/toss-cengiz/glaon/issues/9) — auth lifecycle TokenStore mutex'iyle çalışır.
+- [ADR 0004 — `@glaon/core` platform-agnostic](0004-glaon-core-platform-agnostic.md) — vanilla / no-DOM kuralı.
+- [ADR 0015 — state management](0015-state-management.md) — entity store'un Zustand vanilla store olması bu transport'la birlikte sürdürülebilir.
+- HA WebSocket API: <https://developers.home-assistant.io/docs/api/websocket>.
+- `home-assistant-js-websocket` (alternatif olarak değerlendirildi): <https://github.com/home-assistant/home-assistant-js-websocket>.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,7 +24,7 @@ ADR yazılmayacak olanlar: kütüphane version bump'ları, rutin refactor, bug f
 
 ### Yeni ADR açmak
 
-1. Bu klasörde `NNNN-kisa-baslik.md` dosyası oluştur. Numara sıradaki boş numara (şu an `0015`'ten başlıyor).
+1. Bu klasörde `NNNN-kisa-baslik.md` dosyası oluştur. Numara sıradaki boş numara (şu an `0017`'den başlıyor; 0017–0023 aralığı Phase 2 ADR'leri için rezerve — bkz. issue #337, #338, #339, #340, #341, #342, #407).
 2. [`template.md`](template.md)'i şablon olarak kullan.
 3. İlk hali **Status: Proposed** olarak açılır. Tartışma açıksa bu aşamada PR review üzerinden yürütülür.
 4. Karar kesinleştiğinde status'ü **Accepted**'e geçir ve karar tarihini yaz.
@@ -61,6 +61,8 @@ Deprecated durumu, kararı yapılacak işin dışına çıkarttığımızda kull
 | 0012 | [Tailwind CSS for `@glaon/ui`](0012-tailwind-css-for-glaon-ui.md)                       | Superseded by 0013 | 2026-04-27 |
 | 0013 | [Tailwind v4 + Untitled UI theme.css](0013-tailwind-v4-uui-theme.md)                    | Accepted           | 2026-04-27 |
 | 0014 | [`apps/api` ayrı backend service (Next.js geçişi yerine)](0014-apps-api-over-nextjs.md) | Accepted           | 2026-05-06 |
+| 0015 | [State yönetimi — Zustand + Immer + TanStack Query](0015-state-management.md)           | Accepted           | 2026-05-07 |
+| 0016 | [HA WebSocket transport mimarisi](0016-ha-ws-transport.md)                              | Accepted           | 2026-05-07 |
 
 ## Konvansiyonlar
 


### PR DESCRIPTION
## Summary

- ADR 0015 — `Zustand + Immer (client state) + TanStack Query (server state)`. Locks the state management direction for `@glaon/core` + feature layer; documents alternatives (RTK ±RTK Query, Jotai/Valtio/signals, hand-rolled `useSyncExternalStore`) and the slice-per-file + selector-only ESLint convention.
- ADR 0016 — `HA WebSocket transport mimarisi`. Single `HaClient` instance + `HaTransport` interface with `DirectWsTransport` / `CloudRelayTransport` implementations; subscription multiplexing on HA message ids; exponential backoff (500ms → 30s, ±25% jitter) reconnect with auto `get_states` snapshot reconciliation; dual-mode auth lifecycle (`auth_invalid` refresh on local, `session_refresh` control frame on cloud); fake-transport test surface.
- `docs/ROADMAP.md` "Kararlar ve Açık Sorular" updated — state mgmt + WS transport entries replaced with ADR references; i18n + grafik kalır açık.
- `docs/adr/README.md` index gets rows for 0015 + 0016; "next available" hint bumped.
- Issue bodies #10 and #11 updated (out of band) to reference 0015 / 0016 so implementation starts from the locked decisions, not the debate.

## Scope

### In

- `docs/adr/0015-state-management.md`
- `docs/adr/0016-ha-ws-transport.md`
- `docs/adr/README.md` index
- `docs/ROADMAP.md` open-questions list
- Issue body updates: #10, #11 (already pushed via `gh issue edit`)

### Out

- Implementation of either decision — that lives in #10 (HaClient), #11 (entity store), #12 (service call API).
- ESLint custom rule for selector-only subscriptions — lands with #11 where the store actually exists (per ADR 0015 explicit deferral).
- Token storage mechanism — already #9.
- Cloud relay wire envelope details — ADR 0018 (#338).
- ADR re-numbering housekeeping for #337/#338/#339/#340/#341/#342/#407 — already pushed via `gh issue edit` before this PR (cloud track shifted to 0017–0022, i18n-A to 0023, since 0014 was taken by `apps/api` ADR).

## Test plan

- [ ] Pure-docs PR — no code touched, no dependency added; confirm via `git diff --stat`.
- [ ] `prettier --check` passes (already enforced by pre-commit + CI).
- [ ] CI (typecheck, lint, audit, commitlint) green.
- [ ] Chromatic: no story changes, baseline unaffected.
- [ ] ADR file paths reachable from the README index.
- [ ] `docs/ROADMAP.md` no longer mentions state mgmt or WS transport as open questions.
- [ ] Issue #10 body references ADR 0016; issue #11 body references ADR 0015 + 0016.

Closes #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)