### PR TITLE
feat(auth): secure token storage (TokenStore three-slot model)

### DIFF
--- a/apps/mobile/src/auth/expo-token-store.ts
+++ b/apps/mobile/src/auth/expo-token-store.ts
@@ -1,0 +1,39 @@
+// Mobile TokenStore implementation — see ADR 0006 (Phase 2 revision via ADR 0017) and issue #9.
+//
+// All three slots (ha-access, ha-refresh, cloud-session) live in expo-secure-store, which is
+// backed by iOS Keychain and Android Keystore. Hardware-backed encryption + per-device-only
+// access (`WHEN_UNLOCKED_THIS_DEVICE_ONLY`) makes off-device exfiltration impractical without
+// physical compromise.
+//
+// AsyncStorage and any other plain-file storage are forbidden in this file. An ESLint guard
+// blocks the import of `@react-native-async-storage/async-storage` from `apps/mobile/src/auth/**`.
+
+import * as SecureStore from 'expo-secure-store';
+
+import { KeyValueTokenStore, type KeyValueBackend, type TokenStore } from '@glaon/core/auth';
+
+const SECURE_STORE_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+};
+
+const expoSecureStoreBackend: KeyValueBackend = {
+  async get(key: string): Promise<string | null> {
+    return SecureStore.getItemAsync(key, SECURE_STORE_OPTIONS);
+  },
+  async set(key: string, value: string): Promise<void> {
+    await SecureStore.setItemAsync(key, value, SECURE_STORE_OPTIONS);
+  },
+  async delete(key: string): Promise<void> {
+    await SecureStore.deleteItemAsync(key, SECURE_STORE_OPTIONS);
+  },
+};
+
+/**
+ * Factory for the mobile TokenStore. Returns a `KeyValueTokenStore` bound to expo-secure-store
+ * — the real `TokenStore` interface implementation.
+ *
+ * Single backend instance is reused across calls (SecureStore itself is process-global).
+ */
+export function createExpoTokenStore(): TokenStore {
+  return new KeyValueTokenStore(expoSecureStoreBackend);
+}

--- a/apps/web/src/auth/web-token-store.test.ts
+++ b/apps/web/src/auth/web-token-store.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  CloudSessionCredential,
+  HaAccessCredential,
+  HaRefreshCredential,
+} from '@glaon/core/auth';
+
+import { WebTokenStore } from './web-token-store';
+
+const haAccess: HaAccessCredential = {
+  kind: 'ha-access',
+  token: 'access-1',
+  expiresAt: 1_000,
+};
+
+const haRefresh: HaRefreshCredential = {
+  kind: 'ha-refresh',
+  token: 'refresh-1',
+};
+
+const cloudSession: CloudSessionCredential = {
+  kind: 'cloud-session',
+  token: 'session-1',
+  expiresAt: 2_000,
+};
+
+describe('WebTokenStore — in-memory slots (ha-access, cloud-session)', () => {
+  it('round-trips ha-access in memory', async () => {
+    const store = new WebTokenStore();
+    await store.set(haAccess);
+    expect(await store.get('ha-access')).toEqual(haAccess);
+  });
+
+  it('round-trips cloud-session in memory', async () => {
+    const store = new WebTokenStore();
+    await store.set(cloudSession);
+    expect(await store.get('cloud-session')).toEqual(cloudSession);
+  });
+
+  it('clear(ha-access) removes only ha-access', async () => {
+    const store = new WebTokenStore();
+    await store.set(haAccess);
+    await store.set(cloudSession);
+    await store.clear('ha-access');
+    expect(await store.get('ha-access')).toBeNull();
+    expect(await store.get('cloud-session')).toEqual(cloudSession);
+  });
+});
+
+describe('WebTokenStore — ha-refresh slot (httpOnly cookie boundary)', () => {
+  it('get(ha-refresh) always resolves null even after set()', async () => {
+    const store = new WebTokenStore();
+    await store.set(haRefresh);
+    expect(await store.get('ha-refresh')).toBeNull();
+  });
+
+  it('set(ha-refresh) is a no-op (nginx proxy already set the cookie)', async () => {
+    const fetchImpl = vi.fn();
+    const store = new WebTokenStore({ logoutEndpoint: '/auth/logout', fetchImpl });
+    await store.set(haRefresh);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('clear(ha-refresh) POSTs to logoutEndpoint with credentials: include', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response());
+    const store = new WebTokenStore({ logoutEndpoint: '/auth/logout', fetchImpl });
+
+    await store.clear('ha-refresh');
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith('/auth/logout', {
+      method: 'POST',
+      credentials: 'include',
+    });
+  });
+
+  it('clear(ha-refresh) without logoutEndpoint is a documented no-op', async () => {
+    const fetchImpl = vi.fn();
+    const store = new WebTokenStore({ fetchImpl });
+    await store.clear('ha-refresh');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('clear() with no argument empties memory + requests cookie clear', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response());
+    const store = new WebTokenStore({ logoutEndpoint: '/auth/logout', fetchImpl });
+    await store.set(haAccess);
+    await store.set(cloudSession);
+
+    await store.clear();
+
+    expect(await store.get('ha-access')).toBeNull();
+    expect(await store.get('cloud-session')).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WebTokenStore — storage-leak invariants', () => {
+  it('does not touch localStorage during set/get/clear', async () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    const getItem = vi.spyOn(Storage.prototype, 'getItem');
+    const removeItem = vi.spyOn(Storage.prototype, 'removeItem');
+
+    const store = new WebTokenStore({
+      logoutEndpoint: '/auth/logout',
+      fetchImpl: vi.fn().mockResolvedValue(new Response()),
+    });
+    await store.set(haAccess);
+    await store.set(haRefresh);
+    await store.set(cloudSession);
+    await store.get('ha-access');
+    await store.get('ha-refresh');
+    await store.get('cloud-session');
+    await store.clear();
+
+    expect(setItem).not.toHaveBeenCalled();
+    expect(getItem).not.toHaveBeenCalled();
+    expect(removeItem).not.toHaveBeenCalled();
+
+    setItem.mockRestore();
+    getItem.mockRestore();
+    removeItem.mockRestore();
+  });
+});

--- a/apps/web/src/auth/web-token-store.ts
+++ b/apps/web/src/auth/web-token-store.ts
@@ -1,0 +1,87 @@
+// Web TokenStore implementation — see ADR 0006 (Phase 2 revision via ADR 0017) and issue #9.
+//
+// Slot semantics on web:
+//   - ha-access      : in-memory only. Lives for the current page lifetime; on hard reload the
+//                      OAuth refresh flow re-mints it.
+//   - ha-refresh     : httpOnly + SameSite=Strict + Secure cookie set by the addon nginx proxy
+//                      on /auth/token. JS can never read this cookie. Therefore:
+//                        - get('ha-refresh')   → null  (the cookie exists but is invisible)
+//                        - set('ha-refresh')   → no-op (the proxy already set Set-Cookie)
+//                        - clear('ha-refresh') → POST  to the configured logout endpoint so the
+//                                                server clears the cookie via Set-Cookie.
+//   - cloud-session  : in-memory only.
+//
+// localStorage / sessionStorage are forbidden in this file (and across `apps/web/src/auth/**`).
+// An ESLint guard blocks them; CI greps for the names as a belt-and-braces check.
+
+import {
+  InMemoryTokenStore,
+  type CredentialKind,
+  type CredentialOf,
+  type StoredCredential,
+  type TokenStore,
+} from '@glaon/core/auth';
+
+interface WebTokenStoreOptions {
+  /**
+   * URL that, when POSTed to with `credentials: 'include'`, instructs the server to clear the
+   * ha-refresh httpOnly cookie. Typically `/auth/logout` proxied by the addon nginx config.
+   *
+   * If omitted, `clear('ha-refresh')` becomes a documented no-op — useful for tests, never for
+   * production.
+   */
+  readonly logoutEndpoint?: string;
+
+  /**
+   * Optional fetch implementation injection point. Tests use this to assert behavior without
+   * touching the global; production code passes `globalThis.fetch`.
+   */
+  readonly fetchImpl?: typeof fetch;
+}
+
+export class WebTokenStore implements TokenStore {
+  private readonly memory = new InMemoryTokenStore();
+
+  constructor(private readonly options: WebTokenStoreOptions = {}) {}
+
+  async get<K extends CredentialKind>(kind: K): Promise<CredentialOf<K> | null> {
+    if (kind === 'ha-refresh') {
+      // The refresh token lives in an httpOnly cookie; JS cannot read it. By design.
+      return null;
+    }
+    return this.memory.get(kind);
+  }
+
+  async set(credential: StoredCredential): Promise<void> {
+    if (credential.kind === 'ha-refresh') {
+      // No-op: the addon nginx proxy sets the httpOnly cookie on /auth/token's Set-Cookie
+      // response. Calling set('ha-refresh', ...) from OAuth handler code is allowed (and
+      // silently ignored) so that the same exchange flow works for both web and mobile.
+      return;
+    }
+    await this.memory.set(credential);
+  }
+
+  async clear(kind?: CredentialKind): Promise<void> {
+    if (kind === undefined) {
+      await this.memory.clear();
+      await this.requestServerCookieClear();
+      return;
+    }
+    if (kind === 'ha-refresh') {
+      await this.requestServerCookieClear();
+      return;
+    }
+    await this.memory.clear(kind);
+  }
+
+  private async requestServerCookieClear(): Promise<void> {
+    const endpoint = this.options.logoutEndpoint;
+    if (endpoint === undefined) return;
+    const fetchImpl = this.options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+    await fetchImpl(endpoint, {
+      method: 'POST',
+      credentials: 'include',
+    });
+  }
+}

--- a/docs/adr/0006-token-storage.md
+++ b/docs/adr/0006-token-storage.md
@@ -5,6 +5,8 @@
 - **Karar verenler:** @toss-cengiz
 - **İlgili konular:** [docs/SECURITY.md](../SECURITY.md), [CLAUDE.md — Security-First Rules](../../CLAUDE.md#security-first-rules), ADR 0005
 
+> **Phase 2 revizyonu (2026-05-07):** Cloud mod (ADR 0017) `cloud-session` slot'unu eklediğinde `TokenStore` üç slot grubuna (`ha-access`, `ha-refresh`, `cloud-session`) genişledi. Saklama modeli ve güvenlik modeli aynen geçerli — yeni slot Clerk session JWT'sini taşır; web'de in-memory, mobile'da SecureStore'da yaşar. Implementation issue [#9](https://github.com/toss-cengiz/glaon/issues/9). Detaylar için bkz. [ADR 0017 — dual-mode auth](0017-dual-mode-auth.md).
+
 ## Bağlam
 
 ADR 0005 ile OAuth2 PKCE seçildi. Geriye access + refresh token'ları her istemcide güvenli saklama kararı kaldı. Saldırı modelleri:

--- a/knip.json
+++ b/knip.json
@@ -30,7 +30,7 @@
       "ignoreDependencies": ["@glaon/config"]
     },
     "apps/mobile": {
-      "entry": ["App.tsx"],
+      "entry": ["App.tsx", "src/auth/expo-token-store.ts"],
       "project": ["**/*.{ts,tsx}"],
       "ignoreDependencies": [
         "@glaon/ui",

--- a/packages/config/eslint.config.js
+++ b/packages/config/eslint.config.js
@@ -59,4 +59,35 @@ export default tseslint.config(
       'no-console': ['warn', { allow: ['warn', 'error'] }],
     },
   },
+  // Token storage boundary — see ADR 0006 (Phase 2 revision via ADR 0017) and issue #9.
+  // localStorage / sessionStorage are forbidden on web; AsyncStorage is forbidden on mobile.
+  // Refresh tokens must live in httpOnly cookies (web) or hardware-backed SecureStore (mobile).
+  {
+    files: ['**/auth/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'localStorage',
+          message: 'Token paths must not use localStorage — see ADR 0006 (issue #9).',
+        },
+        {
+          name: 'sessionStorage',
+          message: 'Token paths must not use sessionStorage — see ADR 0006 (issue #9).',
+        },
+      ],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@react-native-async-storage/async-storage',
+              message:
+                'Token paths must not use AsyncStorage — use expo-secure-store via @glaon/core/auth KeyValueTokenStore (ADR 0006).',
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,3 +1,5 @@
 export * from './pkce';
 export * from './oauth2';
 export * from './types';
+export * from './token-store';
+export * from './refresh-mutex';

--- a/packages/core/src/auth/refresh-mutex.ts
+++ b/packages/core/src/auth/refresh-mutex.ts
@@ -1,0 +1,31 @@
+// Per-slot refresh serialization. When several callers detect an expired token at once and
+// kick off refreshes concurrently, only one network round-trip should hit HA / cloud — the rest
+// await the same promise. Without this, HA frequently returns 429 / refresh-token-rotation can
+// invalidate an in-flight refresh.
+
+import type { CredentialKind } from './token-store';
+
+export class RefreshMutex {
+  private readonly inFlight = new Map<CredentialKind, Promise<unknown>>();
+
+  /**
+   * Run `refresh` for the given slot. Concurrent calls for the same slot share the same
+   * promise; the underlying refresh function executes exactly once until it settles.
+   */
+  async run<T>(slot: CredentialKind, refresh: () => Promise<T>): Promise<T> {
+    const existing = this.inFlight.get(slot);
+    if (existing) {
+      return existing as Promise<T>;
+    }
+    const promise = refresh().finally(() => {
+      this.inFlight.delete(slot);
+    });
+    this.inFlight.set(slot, promise);
+    return promise;
+  }
+
+  /** Test helper: number of refreshes currently in flight (across all slots). */
+  get inFlightCount(): number {
+    return this.inFlight.size;
+  }
+}

--- a/packages/core/src/auth/token-store.test.ts
+++ b/packages/core/src/auth/token-store.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RefreshMutex } from './refresh-mutex';
+import {
+  InMemoryTokenStore,
+  KeyValueTokenStore,
+  assertSlotTag,
+  type CloudSessionCredential,
+  type HaAccessCredential,
+  type HaRefreshCredential,
+  type KeyValueBackend,
+  type StoredCredential,
+} from './token-store';
+
+const haAccess: HaAccessCredential = {
+  kind: 'ha-access',
+  token: 'access-1',
+  expiresAt: 1_000_000,
+};
+
+const haRefresh: HaRefreshCredential = {
+  kind: 'ha-refresh',
+  token: 'refresh-1',
+};
+
+const cloudSession: CloudSessionCredential = {
+  kind: 'cloud-session',
+  token: 'session-1',
+  expiresAt: 2_000_000,
+};
+
+describe('InMemoryTokenStore', () => {
+  it('round-trips each slot independently', async () => {
+    const store = new InMemoryTokenStore();
+    await store.set(haAccess);
+    await store.set(haRefresh);
+    await store.set(cloudSession);
+
+    expect(await store.get('ha-access')).toEqual(haAccess);
+    expect(await store.get('ha-refresh')).toEqual(haRefresh);
+    expect(await store.get('cloud-session')).toEqual(cloudSession);
+  });
+
+  it('returns null for empty slots', async () => {
+    const store = new InMemoryTokenStore();
+    expect(await store.get('ha-access')).toBeNull();
+    expect(await store.get('ha-refresh')).toBeNull();
+    expect(await store.get('cloud-session')).toBeNull();
+  });
+
+  it('clear(kind) removes only the named slot', async () => {
+    const store = new InMemoryTokenStore();
+    await store.set(haAccess);
+    await store.set(haRefresh);
+
+    await store.clear('ha-access');
+
+    expect(await store.get('ha-access')).toBeNull();
+    expect(await store.get('ha-refresh')).toEqual(haRefresh);
+  });
+
+  it('clear() with no argument empties every slot', async () => {
+    const store = new InMemoryTokenStore();
+    await store.set(haAccess);
+    await store.set(haRefresh);
+    await store.set(cloudSession);
+
+    await store.clear();
+
+    expect(await store.get('ha-access')).toBeNull();
+    expect(await store.get('ha-refresh')).toBeNull();
+    expect(await store.get('cloud-session')).toBeNull();
+  });
+
+  it('overwrites existing credentials in the same slot', async () => {
+    const store = new InMemoryTokenStore();
+    await store.set(haAccess);
+    const newer: HaAccessCredential = { kind: 'ha-access', token: 'access-2', expiresAt: 9 };
+    await store.set(newer);
+
+    expect(await store.get('ha-access')).toEqual(newer);
+  });
+});
+
+describe('cross-slot leak guard', () => {
+  it('assertSlotTag throws when stored credential disagrees with requested slot', () => {
+    const tampered = { kind: 'cloud-session', token: 'x', expiresAt: 0 } as StoredCredential;
+    expect(() => {
+      assertSlotTag(tampered, 'ha-access');
+    }).toThrow(/cross-slot leak/i);
+  });
+
+  it('InMemoryTokenStore surfaces tampering through assertSlotTag', async () => {
+    const store = new InMemoryTokenStore();
+    // Bypass set() so the internal map carries the wrong tag for the slot — simulates a
+    // tampered SecureStore entry on mobile.
+    const internal = store as unknown as { slots: Map<string, StoredCredential> };
+    internal.slots.set('ha-access', cloudSession);
+
+    await expect(store.get('ha-access')).rejects.toThrow(/cross-slot leak/i);
+  });
+});
+
+describe('KeyValueTokenStore', () => {
+  function makeMockBackend(): KeyValueBackend & { state: Map<string, string> } {
+    const state = new Map<string, string>();
+    return {
+      state,
+      get(key) {
+        return Promise.resolve(state.get(key) ?? null);
+      },
+      set(key, value) {
+        state.set(key, value);
+        return Promise.resolve();
+      },
+      delete(key) {
+        state.delete(key);
+        return Promise.resolve();
+      },
+    };
+  }
+
+  it('serializes credentials per slot under stable keys', async () => {
+    const backend = makeMockBackend();
+    const store = new KeyValueTokenStore(backend);
+
+    await store.set(haAccess);
+    await store.set(haRefresh);
+    await store.set(cloudSession);
+
+    expect([...backend.state.keys()].sort()).toEqual([
+      'glaon.token.cloud-session',
+      'glaon.token.ha-access',
+      'glaon.token.ha-refresh',
+    ]);
+    const stored = backend.state.get('glaon.token.ha-access');
+    expect(stored).toBeDefined();
+    expect(JSON.parse(stored ?? '{}')).toEqual(haAccess);
+  });
+
+  it('round-trips each slot through the backend', async () => {
+    const store = new KeyValueTokenStore(makeMockBackend());
+    await store.set(haAccess);
+    await store.set(haRefresh);
+    await store.set(cloudSession);
+
+    expect(await store.get('ha-access')).toEqual(haAccess);
+    expect(await store.get('ha-refresh')).toEqual(haRefresh);
+    expect(await store.get('cloud-session')).toEqual(cloudSession);
+  });
+
+  it('returns null for missing slots', async () => {
+    const store = new KeyValueTokenStore(makeMockBackend());
+    expect(await store.get('ha-access')).toBeNull();
+  });
+
+  it('throws on tampered backend value (cross-slot leak)', async () => {
+    const backend = makeMockBackend();
+    const store = new KeyValueTokenStore(backend);
+    backend.state.set('glaon.token.ha-access', JSON.stringify(cloudSession));
+
+    await expect(store.get('ha-access')).rejects.toThrow(/cross-slot leak/i);
+  });
+
+  it('clear(kind) deletes only the named backend key', async () => {
+    const backend = makeMockBackend();
+    const store = new KeyValueTokenStore(backend);
+    await store.set(haAccess);
+    await store.set(haRefresh);
+
+    await store.clear('ha-access');
+
+    expect(backend.state.has('glaon.token.ha-access')).toBe(false);
+    expect(backend.state.has('glaon.token.ha-refresh')).toBe(true);
+  });
+
+  it('clear() with no argument deletes every slot key', async () => {
+    const backend = makeMockBackend();
+    const store = new KeyValueTokenStore(backend);
+    await store.set(haAccess);
+    await store.set(haRefresh);
+    await store.set(cloudSession);
+
+    await store.clear();
+
+    expect(backend.state.size).toBe(0);
+  });
+});
+
+describe('RefreshMutex', () => {
+  it('coalesces concurrent refreshes for the same slot to one round-trip', async () => {
+    const mutex = new RefreshMutex();
+    const refresh = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve('fresh');
+          }, 10);
+        }),
+    );
+
+    const [a, b, c] = await Promise.all([
+      mutex.run('ha-access', refresh),
+      mutex.run('ha-access', refresh),
+      mutex.run('ha-access', refresh),
+    ]);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect([a, b, c]).toEqual(['fresh', 'fresh', 'fresh']);
+  });
+
+  it('runs refreshes for different slots in parallel', async () => {
+    const mutex = new RefreshMutex();
+    const haRefreshFn = vi.fn().mockResolvedValue('ha');
+    const cloudRefreshFn = vi.fn().mockResolvedValue('cloud');
+
+    await Promise.all([
+      mutex.run('ha-access', haRefreshFn),
+      mutex.run('cloud-session', cloudRefreshFn),
+    ]);
+
+    expect(haRefreshFn).toHaveBeenCalledTimes(1);
+    expect(cloudRefreshFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the in-flight slot after the refresh settles, so a later refresh runs', async () => {
+    const mutex = new RefreshMutex();
+    const refresh = vi.fn().mockResolvedValueOnce('first').mockResolvedValueOnce('second');
+
+    const first = await mutex.run('ha-access', refresh);
+    const second = await mutex.run('ha-access', refresh);
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(first).toBe('first');
+    expect(second).toBe('second');
+    expect(mutex.inFlightCount).toBe(0);
+  });
+
+  it('clears the in-flight slot after a refresh rejects', async () => {
+    const mutex = new RefreshMutex();
+    const refresh = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('recovered');
+
+    await expect(mutex.run('ha-access', refresh)).rejects.toThrow('boom');
+    const recovered = await mutex.run('ha-access', refresh);
+
+    expect(recovered).toBe('recovered');
+    expect(mutex.inFlightCount).toBe(0);
+  });
+});

--- a/packages/core/src/auth/token-store.ts
+++ b/packages/core/src/auth/token-store.ts
@@ -1,0 +1,174 @@
+// Cross-platform secure token storage contract — see ADR 0006 (Phase 2 revision via ADR 0017).
+//
+// Three slot kinds, each with its own lifecycle and platform-specific backing:
+//   - ha-access      : HA OAuth2 access token (short-lived, 30 min by default).
+//                      Web: in-memory only (React context). Mobile: expo-secure-store.
+//   - ha-refresh     : HA OAuth2 refresh token (long-lived).
+//                      Web: httpOnly + SameSite=Strict cookie set by the addon nginx proxy on
+//                      /auth/token. JS never reads this slot — get('ha-refresh') resolves null on
+//                      web because the cookie is server-side only. Mobile: expo-secure-store.
+//   - cloud-session  : Cloud-mode IdP session JWT (Clerk per ADR 0019).
+//                      Web: in-memory only. Mobile: expo-secure-store.
+//
+// Cross-slot leak invariant: a credential written under one kind must NEVER come back from get()
+// under a different kind. Enforced at the type layer (typed get<K>) and at runtime (slot tag
+// assertion in implementations).
+//
+// localStorage / sessionStorage / AsyncStorage are forbidden in token paths — see ESLint guard.
+
+export interface HaAccessCredential {
+  readonly kind: 'ha-access';
+  readonly token: string;
+  /** ms since epoch when the access token expires. */
+  readonly expiresAt: number;
+}
+
+export interface HaRefreshCredential {
+  readonly kind: 'ha-refresh';
+  readonly token: string;
+}
+
+export interface CloudSessionCredential {
+  readonly kind: 'cloud-session';
+  readonly token: string;
+  /** ms since epoch when the session JWT expires. */
+  readonly expiresAt: number;
+}
+
+export type StoredCredential = HaAccessCredential | HaRefreshCredential | CloudSessionCredential;
+
+export type CredentialKind = StoredCredential['kind'];
+
+export type CredentialOf<K extends CredentialKind> = Extract<StoredCredential, { kind: K }>;
+
+export interface TokenStore {
+  /**
+   * Fetch the credential currently held in the given slot.
+   *
+   * Returns null when the slot is empty, or when the platform implementation cannot read this
+   * slot (e.g. ha-refresh on web — the httpOnly cookie is server-side only).
+   *
+   * Implementations MUST verify the stored credential's `kind` matches the requested slot before
+   * returning it (cross-slot leak guard); on mismatch they throw.
+   */
+  get<K extends CredentialKind>(kind: K): Promise<CredentialOf<K> | null>;
+
+  /**
+   * Persist the credential into the slot identified by `credential.kind`.
+   *
+   * On platforms where a slot is not directly writable from JS (e.g. ha-refresh on web — the
+   * cookie is set by the nginx proxy via Set-Cookie on /auth/token), this method is a no-op.
+   * The caller is expected to perform a network round-trip that produces the side effect.
+   */
+  set(credential: StoredCredential): Promise<void>;
+
+  /**
+   * Clear the given slot, or all slots when `kind` is omitted.
+   *
+   * On web, clearing `ha-refresh` MUST trigger a server-side action (e.g. POST /auth/logout) so
+   * the httpOnly cookie is unset; the in-process call alone cannot drop a cookie the browser
+   * stores under the server's authority.
+   */
+  clear(kind?: CredentialKind): Promise<void>;
+}
+
+/**
+ * Reference implementation that holds every slot in a Map. Used as a test fixture in
+ * @glaon/core and as the in-memory base for the web `ha-access` + `cloud-session` slots.
+ *
+ * MUST NOT be used as the storage for `ha-refresh` on web (refresh tokens require an httpOnly
+ * cookie boundary; in-memory exposes them to XSS by definition).
+ */
+// All methods are `async` (despite some bodies being synchronous) so that an `assertSlotTag`
+// throw surfaces as a Promise rejection rather than a synchronous exception. This keeps the
+// TokenStore contract uniform — callers always `await store.get(...)` and `try/catch` once.
+/* eslint-disable @typescript-eslint/require-await */
+export class InMemoryTokenStore implements TokenStore {
+  private readonly slots = new Map<CredentialKind, StoredCredential>();
+
+  async get<K extends CredentialKind>(kind: K): Promise<CredentialOf<K> | null> {
+    const stored = this.slots.get(kind);
+    if (!stored) return null;
+    assertSlotTag(stored, kind);
+    return stored;
+  }
+
+  async set(credential: StoredCredential): Promise<void> {
+    this.slots.set(credential.kind, credential);
+  }
+
+  async clear(kind?: CredentialKind): Promise<void> {
+    if (kind === undefined) {
+      this.slots.clear();
+    } else {
+      this.slots.delete(kind);
+    }
+  }
+}
+/* eslint-enable @typescript-eslint/require-await */
+
+/**
+ * Throws if the stored credential's tag does not match the requested slot.
+ * Cross-slot leak guard — typed get<K> already prevents the call shape, this catches storage
+ * corruption (e.g. a malicious tampered SecureStore entry).
+ */
+export function assertSlotTag<K extends CredentialKind>(
+  credential: StoredCredential,
+  expected: K,
+): asserts credential is CredentialOf<K> {
+  if (credential.kind !== expected) {
+    throw new Error(
+      `TokenStore cross-slot leak: requested ${expected} but stored credential has kind ${credential.kind}`,
+    );
+  }
+}
+
+/**
+ * Persistence boundary for `KeyValueTokenStore`. Implementations live in `apps/*` and bind
+ * to the platform's secure key-value primitive (e.g. expo-secure-store on mobile).
+ */
+export interface KeyValueBackend {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+const SLOT_KEYS: Record<CredentialKind, string> = {
+  'ha-access': 'glaon.token.ha-access',
+  'ha-refresh': 'glaon.token.ha-refresh',
+  'cloud-session': 'glaon.token.cloud-session',
+};
+
+/**
+ * TokenStore backed by a key-value store that serializes credentials as JSON.
+ *
+ * Designed for platforms where every slot has the same backing primitive — primarily
+ * `apps/mobile` paired with `expo-secure-store`. Web does NOT use this directly because
+ * `ha-refresh` requires a different boundary (httpOnly cookie); `WebTokenStore` composes
+ * around an in-memory map and a server-side endpoint instead.
+ */
+export class KeyValueTokenStore implements TokenStore {
+  constructor(private readonly backend: KeyValueBackend) {}
+
+  async get<K extends CredentialKind>(kind: K): Promise<CredentialOf<K> | null> {
+    const raw = await this.backend.get(SLOT_KEYS[kind]);
+    if (raw == null) return null;
+    const parsed = JSON.parse(raw) as StoredCredential;
+    assertSlotTag(parsed, kind);
+    return parsed;
+  }
+
+  async set(credential: StoredCredential): Promise<void> {
+    await this.backend.set(SLOT_KEYS[credential.kind], JSON.stringify(credential));
+  }
+
+  async clear(kind?: CredentialKind): Promise<void> {
+    if (kind !== undefined) {
+      await this.backend.delete(SLOT_KEYS[kind]);
+      return;
+    }
+    await Promise.all(
+      (Object.values(SLOT_KEYS) as readonly string[]).map((key) => this.backend.delete(key)),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2 \`TokenStore\` implementation per ADR 0006 (Phase 2 revision via ADR 0017) and issue #9. Three-slot discriminated union (\`ha-access\`, \`ha-refresh\`, \`cloud-session\`), platform-specific backends, refresh mutex, cross-slot leak guard, ESLint guard against \`localStorage\` / \`AsyncStorage\` in token paths.

## Scope (In)

**Core — \`@glaon/core/auth\`:**
- \`StoredCredential\` discriminated union: \`ha-access\` (HA OAuth access), \`ha-refresh\` (HA OAuth refresh), \`cloud-session\` (cloud IdP session JWT, Clerk per ADR 0019).
- \`TokenStore\` interface — typed \`get<K>(kind)\`, \`set(credential)\`, \`clear(kind?)\`.
- \`assertSlotTag()\` runtime cross-slot leak guard.
- \`InMemoryTokenStore\` (test fixture).
- \`KeyValueTokenStore\` + \`KeyValueBackend\` interface — generic JSON-serialized backend; mobile binds it to \`expo-secure-store\`.
- \`RefreshMutex\` — per-slot in-flight coalescing to prevent thundering-herd refreshes.
- 33 Vitest tests (cross-slot leak, mutex coalescing, slot isolation, recovery after rejection).

**Web — \`apps/web/src/auth/web-token-store.ts\`:**
- \`ha-access\` + \`cloud-session\` in-memory.
- \`ha-refresh\` slot honors the httpOnly cookie boundary:
  - \`get('ha-refresh')\` always resolves null (JS can't read the cookie).
  - \`set('ha-refresh')\` is a no-op (addon nginx proxy sets \`Set-Cookie\` on \`/auth/token\`).
  - \`clear('ha-refresh')\` POSTs to the configured logout endpoint with \`credentials: 'include'\`.
- 10 Vitest tests including a no-localStorage / no-sessionStorage invariant.

**Mobile — \`apps/mobile/src/auth/expo-token-store.ts\`:**
- \`createExpoTokenStore()\` factory returning \`KeyValueTokenStore\` + \`expo-secure-store\` backend with \`keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY\`.
- Type-checks clean; no Vitest unit suite for \`apps/mobile\` yet (mobile test runner is a separate scope).

**ESLint guard — \`packages/config/eslint.config.js\`:**
- \`no-restricted-globals\`: \`localStorage\` / \`sessionStorage\` banned in \`**/auth/**\`.
- \`no-restricted-imports\`: \`@react-native-async-storage/async-storage\` banned in \`**/auth/**\`.

**ADR 0006 header note:** Phase 2 revision pointer to ADR 0017 (header-only edit per immutability convention).

## Scope (Out)

- HA OAuth web flow consumer of \`TokenStore\` → #7 (E0/F0 web auth UI).
- HA OAuth mobile flow consumer of \`TokenStore\` → #8.
- \`HaClient\` integration with \`RefreshMutex\` on \`auth_invalid\` → #10.
- Clerk mobile + web SDK that writes \`cloud-session\` → #352 / #355.
- Mobile Vitest test runner setup → out of scope; tracked as a separate hygiene issue when mobile features actually need unit tests.

## Test plan

- [x] \`pnpm --filter @glaon/core test\` — 33 passed.
- [x] \`pnpm --filter @glaon/web test\` — 10 passed.
- [x] \`pnpm --filter @glaon/core --filter @glaon/web --filter @glaon/mobile type-check\` — clean.
- [x] \`pnpm --filter @glaon/core --filter @glaon/web --filter @glaon/mobile lint\` — clean (ESLint guard active).
- [ ] CI green: typecheck, lint, audit, unit-tests, package-contract, conventional-commits, gitleaks, visual regression.

## Acceptance (issue #9)

- [x] All three slots round-trip on web + mobile (in-memory + cookie + SecureStore via KeyValueTokenStore).
- [x] Cross-slot leak test passes (\`assertSlotTag\`).
- [x] Refresh mutex test passes (concurrent refreshes coalesce; settled mutex frees slot).
- [x] Lint guard prohibits \`localStorage\` / \`AsyncStorage\` references in token paths.
- [x] ADR 0006 revision header note merged with this PR.

Refs #7 #8 #10 #337
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)