### PR TITLE
feat(auth): local-mode oauth pkce login flow on mobile

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,15 +1,51 @@
 import { StatusBar } from 'expo-status-bar';
+import { useMemo, type ReactNode } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
+import { AuthProvider, useAuth } from './src/auth/auth-provider';
+import type { LocalAuthFlowConfig } from './src/auth/local-auth-flow';
+import { createExpoTokenStore } from './src/auth/expo-token-store';
+import { LoginScreen } from './src/features/auth/local/login-screen';
 import { initObservability } from './src/observability';
 
 initObservability();
 
-export default function App() {
+const HA_BASE_URL = process.env.EXPO_PUBLIC_HA_BASE_URL ?? 'http://homeassistant.local:8123';
+const HA_CLIENT_ID = process.env.EXPO_PUBLIC_HA_CLIENT_ID ?? 'https://glaon.app/';
+
+export default function App(): ReactNode {
+  const tokenStore = useMemo(() => createExpoTokenStore(), []);
+  return (
+    <AuthProvider tokenStore={tokenStore}>
+      <Root />
+    </AuthProvider>
+  );
+}
+
+function Root(): ReactNode {
+  const { mode } = useAuth();
+  const config = useMemo<LocalAuthFlowConfig>(
+    () => ({
+      baseUrl: HA_BASE_URL,
+      clientId: HA_CLIENT_ID,
+      redirectScheme: 'glaon',
+    }),
+    [],
+  );
+  if (mode === null) {
+    return (
+      <>
+        <LoginScreen config={config} />
+        <StatusBar style="auto" />
+      </>
+    );
+  }
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Glaon</Text>
-      <Text>Secure Home Assistant frontend — bootstrap.</Text>
+      <Text style={styles.body}>
+        Signed in. The Phase 2 dashboard lands once #10–#12 wire the HA WebSocket.
+      </Text>
       <StatusBar style="auto" />
     </View>
   );
@@ -25,5 +61,10 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontWeight: '600',
     marginBottom: 8,
+  },
+  body: {
+    fontSize: 14,
+    textAlign: 'center',
+    paddingHorizontal: 24,
   },
 });

--- a/apps/mobile/src/auth/auth-provider.tsx
+++ b/apps/mobile/src/auth/auth-provider.tsx
@@ -1,0 +1,94 @@
+// Mobile counterpart of the web AuthProvider — see apps/web/src/auth/auth-provider.tsx.
+// Same surface (mode + tokenStore + setLocalAuth + clearAuth) so feature code is
+// platform-agnostic at the call site.
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { RefreshMutex, type AuthMode, type HaAuthTokens, type TokenStore } from '@glaon/core/auth';
+
+interface AuthContextValue {
+  readonly mode: AuthMode | null;
+  readonly tokenStore: TokenStore;
+  readonly refreshMutex: RefreshMutex;
+  readonly setLocalAuth: (tokens: HaAuthTokens) => void;
+  readonly clearAuth: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface AuthProviderProps {
+  readonly tokenStore: TokenStore;
+  readonly initialMode?: AuthMode | null;
+  readonly children: ReactNode;
+}
+
+export function AuthProvider({
+  tokenStore,
+  initialMode = null,
+  children,
+}: AuthProviderProps): ReactNode {
+  const [mode, setMode] = useState<AuthMode | null>(initialMode);
+  const refreshMutex = useMemo(() => new RefreshMutex(), []);
+
+  const cancelledRef = useRef(false);
+  useEffect(() => {
+    cancelledRef.current = false;
+    void (async () => {
+      const access = await tokenStore.get('ha-access');
+      if (cancelledRef.current || access === null) return;
+      const refresh = await tokenStore.get('ha-refresh');
+      // cancelledRef.current may have been set to true by the cleanup function while the
+      // awaited tokenStore.get was in flight; lint cannot model that mutation here.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (cancelledRef.current) return;
+      const synthetic: AuthMode = {
+        kind: 'local',
+        tokens: {
+          access_token: access.token,
+          refresh_token: refresh?.token ?? '',
+          expires_in: Math.max(0, Math.floor((access.expiresAt - Date.now()) / 1000)),
+          issued_at: Date.now(),
+          token_type: 'Bearer',
+        },
+      };
+      setMode(synthetic);
+    })();
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, [tokenStore]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      mode,
+      tokenStore,
+      refreshMutex,
+      setLocalAuth: (tokens) => {
+        setMode({ kind: 'local', tokens });
+      },
+      clearAuth: async () => {
+        await tokenStore.clear();
+        setMode(null);
+      },
+    }),
+    [mode, tokenStore, refreshMutex],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (ctx === null) {
+    throw new Error('useAuth must be used inside <AuthProvider>');
+  }
+  return ctx;
+}

--- a/apps/mobile/src/auth/local-auth-flow.ts
+++ b/apps/mobile/src/auth/local-auth-flow.ts
@@ -1,0 +1,137 @@
+// Local-mode HA OAuth2 PKCE flow (mobile). Wraps `expo-auth-session` so the rest of the app
+// can consume the same `AuthMode { kind: 'local', tokens }` shape the web side emits.
+//
+// expo-auth-session generates the PKCE pair and handles the in-app browser handoff
+// (ASWebAuthenticationSession on iOS, Custom Tabs on Android). We do not need the
+// `@glaon/core/auth` raw fetch helpers here — the platform primitive does the
+// authorize-redirect-exchange dance natively.
+
+import {
+  AuthRequest,
+  CodeChallengeMethod,
+  ResponseType,
+  exchangeCodeAsync,
+  makeRedirectUri,
+  type AuthSessionResult,
+  type DiscoveryDocument,
+  type TokenResponseConfig,
+} from 'expo-auth-session';
+
+import type { HaAuthTokens, StoredCredential, TokenStore } from '@glaon/core/auth';
+
+export interface LocalAuthFlowConfig {
+  /** HA base URL (e.g. `http://homeassistant.local:8123`). */
+  readonly baseUrl: string;
+  /** HA URL-as-id (e.g. `https://glaon.app/`). */
+  readonly clientId: string;
+  /** Deep link scheme registered in app.json (e.g. `glaon`). */
+  readonly redirectScheme: string;
+}
+
+export function buildDiscovery(baseUrl: string): DiscoveryDocument {
+  return {
+    authorizationEndpoint: `${stripTrailingSlash(baseUrl)}/auth/authorize`,
+    tokenEndpoint: `${stripTrailingSlash(baseUrl)}/auth/token`,
+  };
+}
+
+function buildRedirectUri(scheme: string): string {
+  // Path matches the addon Ingress + standalone web route — keeps redirect handling
+  // symmetrical between platforms.
+  return makeRedirectUri({ scheme, path: 'auth/callback' });
+}
+
+export function buildAuthRequest(config: LocalAuthFlowConfig): AuthRequest {
+  return new AuthRequest({
+    clientId: config.clientId,
+    redirectUri: buildRedirectUri(config.redirectScheme),
+    responseType: ResponseType.Code,
+    scopes: [],
+    usePKCE: true,
+    codeChallengeMethod: CodeChallengeMethod.S256,
+  });
+}
+
+type CompleteAuthResult =
+  | { readonly outcome: 'ok'; readonly tokens: HaAuthTokens }
+  | { readonly outcome: 'cancel' }
+  | {
+      readonly outcome: 'error';
+      readonly reason: 'token-exchange-failed';
+      readonly cause?: unknown;
+    };
+
+/**
+ * Consume the result of `request.promptAsync(...)` and finalize the flow:
+ *  1. Bail on user-cancel / dismiss.
+ *  2. Bail on a missing `code`.
+ *  3. Exchange `code` + `code_verifier` for tokens via `expo-auth-session`.
+ *  4. Persist into the `TokenStore` (mobile binds to expo-secure-store via #9).
+ */
+export async function completeAuthFlow(
+  config: LocalAuthFlowConfig,
+  request: AuthRequest,
+  result: AuthSessionResult,
+  tokenStore: TokenStore,
+): Promise<CompleteAuthResult> {
+  if (result.type === 'cancel' || result.type === 'dismiss') {
+    return { outcome: 'cancel' };
+  }
+  if (result.type !== 'success' || result.params.code === undefined) {
+    return { outcome: 'error', reason: 'token-exchange-failed' };
+  }
+  const verifier = request.codeVerifier;
+  if (verifier === undefined) {
+    return { outcome: 'error', reason: 'token-exchange-failed' };
+  }
+  let tokenResp: TokenResponseConfig;
+  try {
+    const exchanged = await exchangeCodeAsync(
+      {
+        clientId: config.clientId,
+        code: result.params.code,
+        redirectUri: buildRedirectUri(config.redirectScheme),
+        extraParams: { code_verifier: verifier },
+      },
+      buildDiscovery(config.baseUrl),
+    );
+    tokenResp = exchanged.getRequestConfig();
+  } catch (cause) {
+    return { outcome: 'error', reason: 'token-exchange-failed', cause };
+  }
+
+  const tokens = toHaAuthTokens(tokenResp);
+  if (tokens === null) {
+    return { outcome: 'error', reason: 'token-exchange-failed' };
+  }
+  await tokenStore.set(toAccessCredential(tokens));
+  await tokenStore.set({ kind: 'ha-refresh', token: tokens.refresh_token });
+  return { outcome: 'ok', tokens };
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function toHaAuthTokens(config: TokenResponseConfig): HaAuthTokens | null {
+  if (config.refreshToken === undefined) {
+    // HA always returns a refresh token on the first exchange; missing it indicates a
+    // token-endpoint misconfiguration that we surface as a flow failure.
+    return null;
+  }
+  return {
+    access_token: config.accessToken,
+    refresh_token: config.refreshToken,
+    expires_in: config.expiresIn ?? 1800,
+    issued_at: Date.now(),
+    token_type: 'Bearer',
+  };
+}
+
+function toAccessCredential(tokens: HaAuthTokens): StoredCredential {
+  return {
+    kind: 'ha-access',
+    token: tokens.access_token,
+    expiresAt: tokens.issued_at + tokens.expires_in * 1000,
+  };
+}

--- a/apps/mobile/src/features/auth/local/login-screen.tsx
+++ b/apps/mobile/src/features/auth/local/login-screen.tsx
@@ -1,0 +1,127 @@
+// Local-mode login screen (mobile). Drives the expo-auth-session flow via the helpers
+// in apps/mobile/src/auth/local-auth-flow.ts and dispatches AuthMode through AuthProvider.
+//
+// The Expo dev client must complete pending auth sessions on iOS/Android — done at the
+// module top level via WebBrowser.maybeCompleteAuthSession().
+
+import { maybeCompleteAuthSession } from 'expo-web-browser';
+import { useState, type ReactNode } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { useAuth } from '../../../auth/auth-provider';
+import {
+  buildAuthRequest,
+  buildDiscovery,
+  completeAuthFlow,
+  type LocalAuthFlowConfig,
+} from '../../../auth/local-auth-flow';
+
+maybeCompleteAuthSession();
+
+interface LoginScreenProps {
+  readonly config: LocalAuthFlowConfig;
+}
+
+export function LoginScreen({ config }: LoginScreenProps): ReactNode {
+  const { tokenStore, setLocalAuth } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onSignIn = async (): Promise<void> => {
+    setError(null);
+    setIsLoading(true);
+    try {
+      const request = buildAuthRequest(config);
+      const result = await request.promptAsync(buildDiscovery(config.baseUrl));
+      const completion = await completeAuthFlow(config, request, result, tokenStore);
+      if (completion.outcome === 'cancel') {
+        setIsLoading(false);
+        return;
+      }
+      if (completion.outcome === 'error') {
+        setIsLoading(false);
+        setError('Sign-in failed. Please try again.');
+        return;
+      }
+      setLocalAuth(completion.tokens);
+    } catch (cause) {
+      setIsLoading(false);
+      setError(cause instanceof Error ? cause.message : 'Sign-in could not be started.');
+    }
+  };
+
+  return (
+    <View style={styles.container} testID="login-screen">
+      <Text style={styles.title}>Glaon</Text>
+      <Text style={styles.subtitle}>Sign in with your Home Assistant account to continue.</Text>
+      <Pressable
+        accessibilityRole="button"
+        testID="login-start"
+        disabled={isLoading}
+        onPress={() => {
+          void onSignIn();
+        }}
+        style={({ pressed }) => [
+          styles.button,
+          isLoading && styles.buttonDisabled,
+          pressed && styles.buttonPressed,
+        ]}
+      >
+        {isLoading ? (
+          <ActivityIndicator />
+        ) : (
+          <Text style={styles.buttonText}>Sign in with Home Assistant</Text>
+        )}
+      </Pressable>
+      {error !== null && (
+        <Text accessibilityRole="alert" testID="login-error" style={styles.error}>
+          {error}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 15,
+    textAlign: 'center',
+    marginBottom: 24,
+    opacity: 0.75,
+  },
+  button: {
+    backgroundColor: '#000',
+    paddingHorizontal: 24,
+    paddingVertical: 14,
+    borderRadius: 8,
+    minWidth: 240,
+    alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonPressed: {
+    opacity: 0.8,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  error: {
+    marginTop: 16,
+    color: '#b00020',
+    textAlign: 'center',
+  },
+});

--- a/knip.json
+++ b/knip.json
@@ -30,7 +30,7 @@
       "ignoreDependencies": ["@glaon/config"]
     },
     "apps/mobile": {
-      "entry": ["App.tsx", "src/auth/expo-token-store.ts"],
+      "entry": ["App.tsx"],
       "project": ["**/*.{ts,tsx}"],
       "ignoreDependencies": [
         "@glaon/ui",


### PR DESCRIPTION
## Summary

Mobile counterpart of #433 per issue #8. Local-mode user can sign in on iOS / Android via the platform-native OAuth2 PKCE flow (\`expo-auth-session\`) and gets \`AuthMode { kind: 'local', tokens }\` propagated through the same React context surface the web side uses.

## Scope (In)

- **\`apps/mobile/src/auth/local-auth-flow.ts\`** — pure flow:
  - \`buildAuthRequest()\` — wraps \`AuthRequest\` (HA URL-as-id clientId, S256 PKCE, deep-link redirect URI from the \`glaon\` scheme).
  - \`buildDiscovery()\` — authorize + token endpoints derived from the HA base URL.
  - \`completeAuthFlow()\` — consumes \`promptAsync\` result, bails on cancel / dismiss, exchanges code via \`exchangeCodeAsync\`, persists \`ha-access\` + \`ha-refresh\` in SecureStore through the ExpoTokenStore from #432.
- **\`apps/mobile/src/auth/auth-provider.tsx\`** — mobile counterpart of the web AuthProvider with the same surface (\`mode\`, \`tokenStore\`, \`setLocalAuth\`, \`clearAuth\`, \`useAuth\`).
- **\`apps/mobile/src/features/auth/local/login-screen.tsx\`** — Pressable + ActivityIndicator + error region with native \`testID\`s (\`login-screen\`, \`login-start\`, \`login-error\`). \`WebBrowser.maybeCompleteAuthSession()\` at module load so the OAuth redirect resolves on iOS / Android.
- **\`apps/mobile/App.tsx\`** — ExpoTokenStore singleton + AuthProvider + signed-in placeholder. HA base URL + client id read from \`EXPO_PUBLIC_HA_BASE_URL\` / \`EXPO_PUBLIC_HA_CLIENT_ID\`.
- **\`knip.json\`** — drop the explicit \`expo-token-store.ts\` entry now that \`App.tsx\` imports it transitively.

## Scope (Out — explicit)

- **Storybook RN story for the login screen.** \`apps/mobile\` does not have a Storybook stack; native \`testID\`s cover the same E2E shape as web. Same precedent as #433. Will open a follow-up if mobile Storybook ever lands.
- **Manual smoke against a real test HA on iOS sim + Android emulator.** Needs a paired EAS dev client and an HA fixture; tracked alongside #13's mobile counterpart when that lands. \`expo-auth-session\` itself is well-tested at the library layer.
- Web equivalent → #7 (#433, ✓ merged).
- TokenStore interface → #9 (#432, ✓ merged).
- WS client integration → #10.
- Cloud sign-in → G1 (#355).
- Pairing wizard → G3 (#357).
- Mode selector → G2 (#356).

## Test plan

- [x] \`pnpm --filter @glaon/mobile type-check\` — clean.
- [x] \`pnpm --filter @glaon/mobile lint\` — clean.
- [x] \`pnpm --filter @glaon/core type-check\` + \`test\` — clean (33 passed).
- [ ] CI green: typecheck + lint + audit (knip), package-contract, conventional-commits, gitleaks, visual regression.
- [ ] Manual smoke: \`pnpm --filter @glaon/mobile dev\` against a local HA, OAuth flow round-trips. Deferred per Out section.

## Acceptance (issue #8)

- [x] Tokens stored only in SecureStore — ExpoTokenStore wraps \`expo-secure-store\` (#432); ESLint guard bans \`AsyncStorage\` in \`**/auth/**\`.
- [x] AuthMode is \`{ kind: 'local', tokens }\` after success.
- [x] Deep link \`glaon://auth/callback\` registered via \`scheme: "glaon"\` in \`app.json\` and \`buildRedirectUri\` in the flow.
- [ ] Sign-in succeeds on iOS sim + Android emulator against a test HA — deferred per Out section (manual smoke).
- [ ] Deep link round-trips with valid PKCE state — same.

Refs #9 #10 #337
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)