### PR TITLE
feat(ui): breadcrumb react native counterpart

### DIFF
--- a/packages/ui/src/components/Breadcrumb/Breadcrumb.native.controls.ts
+++ b/packages/ui/src/components/Breadcrumb/Breadcrumb.native.controls.ts
@@ -1,0 +1,37 @@
+// `Breadcrumb.native.controls.ts` — RN-side variant matrix. Native pattern is "back +
+// title", so the prop surface is intentionally narrow vs. the web Breadcrumb wrap (which
+// owns kit-driven `type` / `divider` / `maxVisibleItems`). Story
+// (`Breadcrumb.native.stories.tsx`) imports this spec and spreads it into
+// `meta.args` / `meta.argTypes`.
+
+import type { ControlSpec } from '../_internal/controls';
+
+export const breadcrumbNativeControls = {
+  title: {
+    type: 'text',
+    default: 'Living room',
+    description:
+      'Current screen title. Equivalent to the last `<Breadcrumb.Item>` on the web wrap.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  subtitle: {
+    type: 'text',
+    default: '',
+    description:
+      'Optional second line, typically the parent screen name on iOS-style large headers.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  backLabel: {
+    type: 'text',
+    default: 'Back',
+    description:
+      'Accessibility label for the back button. Localize per locale catalog (i18n-B / #424).',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  onBack: {
+    type: false,
+    description:
+      'Tap callback for the back affordance. Omit on root screens — the button hides and only the title renders.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+} as const;

--- a/packages/ui/src/components/Breadcrumb/Breadcrumb.native.stories.tsx
+++ b/packages/ui/src/components/Breadcrumb/Breadcrumb.native.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { View } from 'react-native';
+
+import { defineControls } from '../_internal/controls';
+import { BreadcrumbNative } from './Breadcrumb.native';
+import { breadcrumbNativeControls } from './Breadcrumb.native.controls';
+
+const { args, argTypes } = defineControls(breadcrumbNativeControls);
+
+const noop = (): void => undefined;
+
+const meta: Meta<typeof BreadcrumbNative> = {
+  title: 'Mobile Primitives/Breadcrumb',
+  component: BreadcrumbNative,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=mobile-primitives-breadcrumb',
+    },
+  },
+  args,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <View style={{ width: 360, paddingHorizontal: 16, paddingTop: 12 }}>
+        <Story />
+      </View>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BreadcrumbNative>;
+
+export const Default: Story = {
+  args: {
+    title: 'Living room',
+    onBack: noop,
+  },
+};
+
+export const WithSubtitle: Story = {
+  args: {
+    title: 'Living room',
+    subtitle: 'Home',
+    onBack: noop,
+  },
+};
+
+export const RootScreen: Story = {
+  args: {
+    title: 'Home',
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    title: 'Master bedroom — south-facing window with curtains',
+    subtitle: 'Upstairs',
+    onBack: noop,
+  },
+};

--- a/packages/ui/src/components/Breadcrumb/Breadcrumb.native.tsx
+++ b/packages/ui/src/components/Breadcrumb/Breadcrumb.native.tsx
@@ -1,0 +1,128 @@
+// React Native counterpart of the web Breadcrumb wrap. Per CLAUDE.md's UUI Source Rule,
+// the RN-side hand-roll carve-out applies because no Untitled UI source ships for React
+// Native — the kit only generates DOM / RAC. Issue #240 picked the "native back button +
+// screen header" pattern over a horizontal trail; iOS / Android stack navigators surface
+// the parent route via this exact shape (UINavigationBar / Material Toolbar).
+//
+// The web Breadcrumb expresses a hierarchy by stringing item segments together; the RN
+// counterpart expresses the same notion by pointing at the previous level (back) and
+// naming the current one (title). Props that don't translate one-to-one (`type`,
+// `divider`, `maxVisibleItems`) live only on the web wrap. The intersection — `title` /
+// `subtitle` / `onBack` / `backLabel` — is what RN consumers actually need.
+
+import type { ReactNode } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { useTheme } from '../../theme';
+
+interface BreadcrumbNativeProps {
+  /** Current screen title — the equivalent of the last `<Breadcrumb.Item>` on web. */
+  readonly title: string;
+  /** Optional second line, often used for the parent screen name on iOS-style headers. */
+  readonly subtitle?: string;
+  /**
+   * Tapping the back affordance fires this callback. Omit it on root screens; the back
+   * button hides automatically and only the title renders.
+   */
+  readonly onBack?: () => void;
+  /** Accessibility label for the back button. Defaults to "Back". */
+  readonly backLabel?: string;
+}
+
+interface BreadcrumbNativeTokens {
+  readonly textStrong: string;
+  readonly textMuted: string;
+  readonly backTint: string;
+  readonly pressedBg: string;
+}
+
+const DEFAULT_TOKENS: BreadcrumbNativeTokens = {
+  textStrong: '#0a0d12',
+  textMuted: '#475467',
+  backTint: '#0a0d12',
+  pressedBg: '#0a0d121a',
+};
+
+export function BreadcrumbNative({
+  title,
+  subtitle,
+  onBack,
+  backLabel = 'Back',
+}: BreadcrumbNativeProps): ReactNode {
+  const theme = useTheme<{ breadcrumbNative?: Partial<BreadcrumbNativeTokens> }>();
+  const tokens: BreadcrumbNativeTokens = {
+    ...DEFAULT_TOKENS,
+    ...theme.tokens.breadcrumbNative,
+  };
+
+  return (
+    <View accessibilityRole="header" style={styles.row} testID="breadcrumb-native">
+      {onBack !== undefined && (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={backLabel}
+          onPress={onBack}
+          testID="breadcrumb-native-back"
+          hitSlop={8}
+          style={({ pressed }) => [
+            styles.backButton,
+            pressed && { backgroundColor: tokens.pressedBg },
+          ]}
+        >
+          <Text style={[styles.backGlyph, { color: tokens.backTint }]}>‹</Text>
+        </Pressable>
+      )}
+      <View style={styles.titleColumn}>
+        <Text
+          accessibilityRole="text"
+          numberOfLines={1}
+          style={[styles.title, { color: tokens.textStrong }]}
+        >
+          {title}
+        </Text>
+        {subtitle !== undefined && (
+          <Text
+            accessibilityRole="text"
+            numberOfLines={1}
+            style={[styles.subtitle, { color: tokens.textMuted }]}
+          >
+            {subtitle}
+          </Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  backButton: {
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 16,
+    marginRight: 4,
+  },
+  backGlyph: {
+    fontSize: 28,
+    lineHeight: 28,
+    fontWeight: '300',
+  },
+  titleColumn: {
+    flexShrink: 1,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  subtitle: {
+    fontSize: 13,
+    fontWeight: '400',
+    marginTop: 2,
+  },
+});


### PR DESCRIPTION
## Summary

Adds the RN-side counterpart of the web Breadcrumb wrap (P9-RN follow-up, issue #240). Native back-button + screen-header pattern — the iOS / Android stack-navigator equivalent of the web horizontal trail.

## Scope (In)

- **\`packages/ui/src/components/Breadcrumb/Breadcrumb.native.tsx\`** — Pressable back affordance + title / subtitle column. Tokens via \`useTheme()\` with safe defaults; native \`testID\`s (\`breadcrumb-native\`, \`breadcrumb-native-back\`).
- **\`packages/ui/src/components/Breadcrumb/Breadcrumb.native.controls.ts\`** — narrow control matrix (\`title\`, \`subtitle\`, \`backLabel\`, \`onBack\`). Web-only props (\`type\`, \`divider\`, \`maxVisibleItems\`) stay on the web wrap because the patterns differ at the conceptual level.
- **\`packages/ui/src/components/Breadcrumb/Breadcrumb.native.stories.tsx\`** — \`Default\`, \`WithSubtitle\`, \`RootScreen\` (no back affordance), \`LongTitle\` (\`numberOfLines\` truncation). Lives under "Mobile Primitives/Breadcrumb".

## Pattern decision

Issue #240 listed two options. Picked native back-button + screen-header over the horizontal trail because:
- Stack navigators (UINavigationBar / Material Toolbar) already surface the parent route via this exact shape.
- Small screens make multi-segment trails noisy.
- The web wrap stays the canonical place for the segment-list semantic.

The web Breadcrumb expresses hierarchy by stringing items together; the RN counterpart expresses the same notion by pointing at the previous level (back) and naming the current one (title).

## Scope (Out)

- Routed breadcrumb / URL sync — separate Phase 2 issue.
- Cross-platform sharing of breadcrumb segments — feature-layer concern.
- MDX docs page update — current \`Breadcrumb.mdx\` documents the web wrap; the RN counterpart doc-block can land in a follow-up MDX section without blocking this PR.
- UUI source pull — no UUI source ships for React Native; the RN-side hand-roll carve-out in CLAUDE.md UUI Source Rule applies.

## Test plan

- [x] \`pnpm --filter @glaon/ui type-check\` — clean.
- [x] \`pnpm --filter @glaon/ui lint\` — clean.
- [x] \`pnpm --filter @glaon/ui test\` — 123 passed.
- [ ] CI green: typecheck, lint, audit, package-contract, conventional-commits, gitleaks, visual regression, Storybook publish.
- [ ] Chromatic baseline accepted for the four new stories.

## Acceptance (issue #240)

- [x] RN component shipped with at least one story (4 stories: Default, WithSubtitle, RootScreen, LongTitle).
- [x] No web imports leak into the RN file — no \`react-aria-components\`, no DOM types.
- [x] \`addon-a11y\` covered by Pressable \`accessibilityRole="button"\` + \`accessibilityLabel\` for the back affordance.
- [x] Light + dark via \`ThemeProvider\` — \`useTheme()\` reads a \`breadcrumbNative\` slot and falls back to safe defaults when the override is absent.

Refs #184
Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)