### PR TITLE
feat(cloud): pairing endpoints for device-code flow (b4)

### DIFF
--- a/apps/cloud/migrations/0002_pair_codes.sql
+++ b/apps/cloud/migrations/0002_pair_codes.sql
@@ -1,0 +1,31 @@
+-- 0002_pair_codes.sql — pairing flow per ADR 0021. The 6-digit code is the OOB
+-- channel: the client mints it (POST /pair/initiate), the user reads it off
+-- their UI, types it into the addon's /pair page, the addon claims it (POST
+-- /pair/claim) and walks away with the relay_secret.
+--
+-- Codes are single-use (unique on `code`), bound to a Clerk user, expire after
+-- 10 min. `claimed_at` flips on the first successful claim — second claim of
+-- the same code returns 410.
+--
+-- `pair_failure_attempts` tracks per-IP bad-code attempts so the rate-limit
+-- middleware can lock out brute-force callers without persisting a separate
+-- store. Rows expire alongside their code window.
+
+CREATE TABLE IF NOT EXISTS pair_codes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  code TEXT NOT NULL UNIQUE,
+  clerk_user_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  claimed_at INTEGER,
+  claimed_home_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_pair_codes_clerk ON pair_codes(clerk_user_id);
+CREATE INDEX IF NOT EXISTS idx_pair_codes_expires ON pair_codes(expires_at);
+
+CREATE TABLE IF NOT EXISTS pair_failure_attempts (
+  ip TEXT PRIMARY KEY,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  locked_until INTEGER
+);

--- a/apps/cloud/src/db/fake.ts
+++ b/apps/cloud/src/db/fake.ts
@@ -36,6 +36,22 @@ interface EventRow {
   created_at: number;
 }
 
+interface PairCodeRow {
+  id: number;
+  code: string;
+  clerk_user_id: string;
+  created_at: number;
+  expires_at: number;
+  claimed_at: number | null;
+  claimed_home_id: string | null;
+}
+
+interface PairFailureRow {
+  ip: string;
+  attempts: number;
+  locked_until: number | null;
+}
+
 class Statement implements D1PreparedStatement {
   private boundArgs: unknown[] = [];
 
@@ -121,6 +137,91 @@ class Statement implements D1PreparedStatement {
       this.state.relaySecrets = this.state.relaySecrets.filter((r) => r.home_id !== homeId);
       return null;
     }
+    /* ---------- pair_codes ---------- */
+    if (q.startsWith('INSERT INTO pair_codes')) {
+      const [code, clerkUserId, createdAt, expiresAt] = this.boundArgs as [
+        string,
+        string,
+        number,
+        number,
+      ];
+      this.state.pairCodes.push({
+        id: this.state.pairCodes.length + 1,
+        code,
+        clerk_user_id: clerkUserId,
+        created_at: createdAt,
+        expires_at: expiresAt,
+        claimed_at: null,
+        claimed_home_id: null,
+      });
+      return null;
+    }
+    if (
+      q.startsWith(
+        'SELECT id, code, clerk_user_id, created_at, expires_at, claimed_at, claimed_home_id FROM pair_codes WHERE code = ? AND clerk_user_id = ?',
+      )
+    ) {
+      const [code, clerkUserId] = this.boundArgs as [string, string];
+      return (
+        this.state.pairCodes.find((p) => p.code === code && p.clerk_user_id === clerkUserId) ?? null
+      );
+    }
+    if (
+      q.startsWith(
+        'SELECT id, code, clerk_user_id, created_at, expires_at, claimed_at, claimed_home_id FROM pair_codes WHERE code = ?',
+      )
+    ) {
+      const [code] = this.boundArgs as [string];
+      return this.state.pairCodes.find((p) => p.code === code) ?? null;
+    }
+    if (q.startsWith('UPDATE pair_codes SET claimed_at')) {
+      const [claimedAt, homeId, code, now] = this.boundArgs as [number, string, string, number];
+      const row = this.state.pairCodes.find(
+        (p) => p.code === code && p.claimed_at === null && p.expires_at > now,
+      );
+      if (row) {
+        row.claimed_at = claimedAt;
+        row.claimed_home_id = homeId;
+      }
+      return null;
+    }
+
+    /* ---------- pair_failure_attempts ---------- */
+    if (q.startsWith('SELECT ip, attempts, locked_until FROM pair_failure_attempts')) {
+      const [ip] = this.boundArgs as [string];
+      return this.state.pairFailures.find((f) => f.ip === ip) ?? null;
+    }
+    if (q.startsWith('INSERT INTO pair_failure_attempts')) {
+      const [ip, attempts, lockedUntil] = this.boundArgs as [string, number, number | null];
+      this.state.pairFailures.push({ ip, attempts, locked_until: lockedUntil });
+      return null;
+    }
+    if (q.startsWith('UPDATE pair_failure_attempts')) {
+      const [attempts, lockedUntil, ip] = this.boundArgs as [number, number | null, string];
+      const row = this.state.pairFailures.find((f) => f.ip === ip);
+      if (row) {
+        row.attempts = attempts;
+        row.locked_until = lockedUntil;
+      }
+      return null;
+    }
+    if (q.startsWith('DELETE FROM pair_failure_attempts')) {
+      const [ip] = this.boundArgs as [string];
+      this.state.pairFailures = this.state.pairFailures.filter((f) => f.ip !== ip);
+      return null;
+    }
+
+    /* ---------- relay_secrets_hash insert ---------- */
+    if (q.startsWith('INSERT INTO relay_secrets_hash')) {
+      const [homeId, hashValue, createdAt] = this.boundArgs as [string, string, number];
+      this.state.relaySecrets.push({ home_id: homeId, hash: hashValue, created_at: createdAt });
+      return null;
+    }
+    if (q.startsWith('SELECT hash FROM relay_secrets_hash')) {
+      const [homeId] = this.boundArgs as [string];
+      return this.state.relaySecrets.find((r) => r.home_id === homeId) ?? null;
+    }
+
     if (q.startsWith('INSERT INTO home_events')) {
       const [eventType, userId, homeId, ip, userAgent, reason, createdAt] = this.boundArgs as [
         string,
@@ -152,10 +253,19 @@ interface FakeD1State {
   homes: HomeRow[];
   relaySecrets: RelaySecretRow[];
   events: EventRow[];
+  pairCodes: PairCodeRow[];
+  pairFailures: PairFailureRow[];
 }
 
 export class FakeD1 implements D1Database {
-  readonly state: FakeD1State = { users: [], homes: [], relaySecrets: [], events: [] };
+  readonly state: FakeD1State = {
+    users: [],
+    homes: [],
+    relaySecrets: [],
+    events: [],
+    pairCodes: [],
+    pairFailures: [],
+  };
 
   prepare(query: string): D1PreparedStatement {
     return new Statement(query, this.state);

--- a/apps/cloud/src/db/pair-repo.ts
+++ b/apps/cloud/src/db/pair-repo.ts
@@ -1,0 +1,101 @@
+// Pairing-flow repo per ADR 0021. Codes mint at /pair/initiate, get consumed by
+// /pair/claim. Single-use + 10min TTL enforced here; brute-force lockout sits
+// alongside on the same DB.
+
+import type { D1Database } from './types';
+
+interface PairCodeRow {
+  id: number;
+  code: string;
+  clerk_user_id: string;
+  created_at: number;
+  expires_at: number;
+  claimed_at: number | null;
+  claimed_home_id: string | null;
+}
+
+interface PairFailureRow {
+  ip: string;
+  attempts: number;
+  locked_until: number | null;
+}
+
+export class PairCodeRepo {
+  constructor(private readonly db: D1Database) {}
+
+  async insertCode(
+    code: string,
+    clerkUserId: string,
+    createdAt: number,
+    expiresAt: number,
+  ): Promise<void> {
+    await this.db
+      .prepare(
+        'INSERT INTO pair_codes (code, clerk_user_id, created_at, expires_at) VALUES (?, ?, ?, ?)',
+      )
+      .bind(code, clerkUserId, createdAt, expiresAt)
+      .run();
+  }
+
+  async findByCode(code: string): Promise<PairCodeRow | null> {
+    return (await this.db
+      .prepare(
+        'SELECT id, code, clerk_user_id, created_at, expires_at, claimed_at, claimed_home_id FROM pair_codes WHERE code = ?',
+      )
+      .bind(code)
+      .first()) as PairCodeRow | null;
+  }
+
+  async findByCodeAndUser(code: string, clerkUserId: string): Promise<PairCodeRow | null> {
+    return (await this.db
+      .prepare(
+        'SELECT id, code, clerk_user_id, created_at, expires_at, claimed_at, claimed_home_id FROM pair_codes WHERE code = ? AND clerk_user_id = ?',
+      )
+      .bind(code, clerkUserId)
+      .first()) as PairCodeRow | null;
+  }
+
+  /**
+   * Atomic-style claim: only flips claimed_at when the row is still pending and
+   * not expired. Caller checks the affected row count via a follow-up read.
+   * SQLite (D1) has no UPDATE...RETURNING here, so we update + re-read.
+   */
+  async claimCode(code: string, homeId: string, now: number): Promise<boolean> {
+    await this.db
+      .prepare(
+        'UPDATE pair_codes SET claimed_at = ?, claimed_home_id = ? WHERE code = ? AND claimed_at IS NULL AND expires_at > ?',
+      )
+      .bind(now, homeId, code, now)
+      .run();
+    const updated = await this.findByCode(code);
+    return updated !== null && updated.claimed_at === now && updated.claimed_home_id === homeId;
+  }
+
+  /* ---------------- failure / rate limit ---------------- */
+
+  async getFailure(ip: string): Promise<PairFailureRow | null> {
+    return (await this.db
+      .prepare('SELECT ip, attempts, locked_until FROM pair_failure_attempts WHERE ip = ?')
+      .bind(ip)
+      .first()) as PairFailureRow | null;
+  }
+
+  async recordFailure(ip: string, attempts: number, lockedUntil: number | null): Promise<void> {
+    const existing = await this.getFailure(ip);
+    if (existing === null) {
+      await this.db
+        .prepare('INSERT INTO pair_failure_attempts (ip, attempts, locked_until) VALUES (?, ?, ?)')
+        .bind(ip, attempts, lockedUntil)
+        .run();
+    } else {
+      await this.db
+        .prepare('UPDATE pair_failure_attempts SET attempts = ?, locked_until = ? WHERE ip = ?')
+        .bind(attempts, lockedUntil, ip)
+        .run();
+    }
+  }
+
+  async clearFailure(ip: string): Promise<void> {
+    await this.db.prepare('DELETE FROM pair_failure_attempts WHERE ip = ?').bind(ip).run();
+  }
+}

--- a/apps/cloud/src/index.ts
+++ b/apps/cloud/src/index.ts
@@ -14,6 +14,7 @@ import { requireClerkSession } from './auth/clerk';
 import type { D1Database } from './db/types';
 import { createLogger } from './logger';
 import { homesRouter } from './routes/homes';
+import { pairRouter } from './routes/pair';
 import { relayRouter } from './routes/relay';
 import { initSentry, type SentryClient } from './sentry';
 
@@ -100,5 +101,10 @@ app.route('/homes', homesRouter);
 
 // Relay WebSocket upgrade endpoints — agent + client. See routes/relay.ts.
 app.route('/relay', relayRouter);
+
+// Pairing flow per ADR 0021. /pair/initiate + /pair/status are Clerk-authed
+// (middleware applied inside pairRouter); /pair/claim is unauthenticated and
+// rate-limited per IP.
+app.route('/pair', pairRouter);
 
 export default app;

--- a/apps/cloud/src/pairing/code.ts
+++ b/apps/cloud/src/pairing/code.ts
@@ -1,0 +1,36 @@
+// 6-digit pair code minting. Per ADR 0021 we use a 30-character alphabet —
+// digits + uppercase A–Z minus the ambiguous-glyph set (O/0/1/I/L) — for a
+// total space of 30^6 ≈ 729M. crypto.getRandomValues() drives the picks.
+
+const ALPHABET = '23456789ABCDEFGHJKMNPQRSTUVWXYZ';
+const PAIR_CODE_LENGTH = 6;
+export const PAIR_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes per ADR 0021.
+
+export function generatePairCode(): string {
+  const buf = new Uint8Array(PAIR_CODE_LENGTH);
+  crypto.getRandomValues(buf);
+  let out = '';
+  for (let i = 0; i < PAIR_CODE_LENGTH; i++) {
+    const byte = buf[i] ?? 0;
+    const ch = ALPHABET.charAt(byte % ALPHABET.length);
+    out += ch;
+  }
+  return out;
+}
+
+/**
+ * 256-bit relay secret per ADR 0021 — base64url-encoded so the addon can store
+ * it in `/data/options.json` (JSON-safe).
+ */
+export function generateRelaySecret(): string {
+  const buf = new Uint8Array(32);
+  crypto.getRandomValues(buf);
+  return base64urlEncode(buf);
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const standard = btoa(binary);
+  return standard.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}

--- a/apps/cloud/src/routes/pair.test.ts
+++ b/apps/cloud/src/routes/pair.test.ts
@@ -1,0 +1,193 @@
+import { compare } from 'bcryptjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FakeD1 } from '../db/fake';
+import app, { type Bindings } from '../index';
+import * as clerk from '../auth/clerk';
+
+interface InitiateRes {
+  code: string;
+  expiresAt: number;
+}
+
+interface ClaimRes {
+  homeId: string;
+  relaySecret: string;
+  cloudUrl: string;
+}
+
+interface StatusRes {
+  status: 'pending' | 'claimed' | 'expired';
+  homeId?: string;
+}
+
+function envFor(db: FakeD1): Bindings {
+  return { LOG_LEVEL: 'error', DB: db, CLERK_ISSUER: 'https://test.clerk.dev' };
+}
+
+function authHeaders(token = 'tok'): Headers {
+  return new Headers({ Authorization: `Bearer ${token}` });
+}
+
+function stubClerk(claimSub: string): void {
+  vi.spyOn(clerk, 'requireClerkSession').mockReturnValue(async (c, next) => {
+    c.set('clerkUserId', claimSub);
+    await next();
+    return undefined;
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('pair flow happy path', () => {
+  it('initiate -> status pending -> claim -> status claimed', async () => {
+    const db = new FakeD1();
+    stubClerk('user_alice');
+
+    // 1. initiate
+    const initRes = await app.request(
+      '/pair/initiate',
+      { method: 'POST', headers: authHeaders() },
+      envFor(db),
+    );
+    expect(initRes.status).toBe(201);
+    const init: InitiateRes = await initRes.json();
+    expect(init.code).toMatch(/^[2-9A-HJ-NP-Z]{6}$/);
+    expect(init.expiresAt).toBeGreaterThan(Date.now());
+
+    // 2. status (pending)
+    const statusPending = await app.request(
+      `/pair/status?code=${init.code}`,
+      { headers: authHeaders() },
+      envFor(db),
+    );
+    expect(statusPending.status).toBe(200);
+    const pending: StatusRes = await statusPending.json();
+    expect(pending.status).toBe('pending');
+
+    // 3. claim
+    const claimRes = await app.request(
+      '/pair/claim',
+      { method: 'POST', body: JSON.stringify({ code: init.code }) },
+      envFor(db),
+    );
+    expect(claimRes.status).toBe(200);
+    const claim: ClaimRes = await claimRes.json();
+    expect(claim.homeId).toBeTruthy();
+    expect(claim.relaySecret.length).toBeGreaterThan(20);
+
+    // 4. relay_secret stored as bcrypt hash
+    const stored = db.state.relaySecrets[0];
+    expect(stored).toBeDefined();
+    expect(stored?.hash).not.toBe(claim.relaySecret);
+    if (stored !== undefined) {
+      expect(await compare(claim.relaySecret, stored.hash)).toBe(true);
+    }
+
+    // 5. status (claimed)
+    const statusClaimed = await app.request(
+      `/pair/status?code=${init.code}`,
+      { headers: authHeaders() },
+      envFor(db),
+    );
+    const claimed: StatusRes = await statusClaimed.json();
+    expect(claimed.status).toBe('claimed');
+    expect(claimed.homeId).toBe(claim.homeId);
+  });
+});
+
+describe('pair claim failure paths', () => {
+  it('returns 401 for an unknown code and writes a pair_failed_invalid_code audit row', async () => {
+    const db = new FakeD1();
+    const res = await app.request(
+      '/pair/claim',
+      { method: 'POST', body: JSON.stringify({ code: 'NOPE99' }) },
+      envFor(db),
+    );
+    expect(res.status).toBe(401);
+    const events = db.state.events.map((e) => e.event_type);
+    expect(events).toContain('pair_failed_invalid_code');
+  });
+
+  it('returns 410 when the same code is claimed twice', async () => {
+    const db = new FakeD1();
+    stubClerk('user_alice');
+    const init: InitiateRes = await (
+      await app.request('/pair/initiate', { method: 'POST', headers: authHeaders() }, envFor(db))
+    ).json();
+    const first = await app.request(
+      '/pair/claim',
+      { method: 'POST', body: JSON.stringify({ code: init.code }) },
+      envFor(db),
+    );
+    expect(first.status).toBe(200);
+
+    const second = await app.request(
+      '/pair/claim',
+      { method: 'POST', body: JSON.stringify({ code: init.code }) },
+      envFor(db),
+    );
+    expect(second.status).toBe(410);
+  });
+
+  it('returns 410 when the code is expired', async () => {
+    const db = new FakeD1();
+    stubClerk('user_alice');
+    const init: InitiateRes = await (
+      await app.request('/pair/initiate', { method: 'POST', headers: authHeaders() }, envFor(db))
+    ).json();
+
+    // Force expiry by mutating the FakeD1 state directly.
+    const stored = db.state.pairCodes.find((p) => p.code === init.code);
+    if (stored) stored.expires_at = Date.now() - 1;
+
+    const res = await app.request(
+      '/pair/claim',
+      { method: 'POST', body: JSON.stringify({ code: init.code }) },
+      envFor(db),
+    );
+    expect(res.status).toBe(410);
+  });
+
+  it('locks out the IP after 10 bad-code attempts', async () => {
+    const db = new FakeD1();
+    const headers = new Headers({ 'CF-Connecting-IP': '1.2.3.4' });
+    for (let i = 0; i < 10; i++) {
+      await app.request(
+        '/pair/claim',
+        { method: 'POST', headers, body: JSON.stringify({ code: `NOPE${String(i)}` }) },
+        envFor(db),
+      );
+    }
+    const lockedRes = await app.request(
+      '/pair/claim',
+      { method: 'POST', headers, body: JSON.stringify({ code: 'NOPE99' }) },
+      envFor(db),
+    );
+    expect(lockedRes.status).toBe(429);
+    const body: { code: string; retryAfterMs: number } = await lockedRes.json();
+    expect(body.code).toBe('claim-locked');
+    expect(body.retryAfterMs).toBeGreaterThan(0);
+  });
+});
+
+describe('pair status visibility', () => {
+  it('only the initiating user can see their pair code status', async () => {
+    const db = new FakeD1();
+    stubClerk('user_alice');
+    const init: InitiateRes = await (
+      await app.request('/pair/initiate', { method: 'POST', headers: authHeaders() }, envFor(db))
+    ).json();
+
+    // Bob looks up Alice's code via /status — must surface as 404.
+    stubClerk('user_bob');
+    const res = await app.request(
+      `/pair/status?code=${init.code}`,
+      { headers: authHeaders() },
+      envFor(db),
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/cloud/src/routes/pair.ts
+++ b/apps/cloud/src/routes/pair.ts
@@ -1,0 +1,252 @@
+// Pairing endpoints per ADR 0021 + issue #346.
+//
+// /pair/initiate (Clerk-authed): mint a 6-digit code, single-use, 10-min TTL,
+//   bound to the caller. Per-user rate limit: 5 initiations per 60s window.
+//
+// /pair/claim (unauthenticated): addon redeems the code, gets a fresh
+//   relay_secret. Per-IP rate limit: 10 attempts/min, exponential lockout on
+//   bad codes (1 min → 5 min → 30 min → 60 min).
+//
+// /pair/status?code=... (Clerk-authed): client polls for the claim.
+
+import { hash } from 'bcryptjs';
+import { Hono } from 'hono';
+
+import { requireClerkSession } from '../auth/clerk';
+import { HomeRegistryRepo } from '../db/repo';
+import { PairCodeRepo } from '../db/pair-repo';
+import { generatePairCode, generateRelaySecret, PAIR_CODE_TTL_MS } from '../pairing/code';
+import type { AppEnv } from '../index';
+
+const PER_USER_INITIATE_LIMIT = 5;
+const PER_USER_INITIATE_WINDOW_MS = 60_000;
+const PER_IP_BAD_CLAIM_THRESHOLD = 10;
+const LOCKOUT_TIERS_MS = [60_000, 5 * 60_000, 30 * 60_000, 60 * 60_000];
+
+export const pairRouter = new Hono<AppEnv>();
+
+interface ClaimBody {
+  readonly code?: unknown;
+}
+
+/* -------- middleware: Clerk for /initiate + /status -------- */
+
+pairRouter.use('/initiate', clerkOnly());
+pairRouter.use('/status', clerkOnly());
+
+function clerkOnly() {
+  return async (
+    c: Parameters<ReturnType<typeof requireClerkSession>>[0],
+    next: () => Promise<void>,
+  ) => {
+    const issuer = c.env.CLERK_ISSUER;
+    if (issuer === undefined || issuer.length === 0) {
+      return c.json({ error: 'misconfigured', code: 'no-clerk-issuer' }, 500);
+    }
+    return requireClerkSession({ issuer })(c, next);
+  };
+}
+
+/* -------- per-user initiate rate limiting (in-memory) --------
+ * 5 initiations per 60s window per Clerk user. Per-Worker isolate; a single
+ * Worker dyno handles each request, so this lives in-process. Clusters of
+ * isolates do not share state — that's acceptable at this scale; if a real
+ * abuse pattern shows up we move this to Durable Object or KV. */
+
+const initiateRateLimiter = new Map<string, number[]>();
+
+function trackInitiateAttempt(clerkUserId: string, now: number): boolean {
+  const recent = initiateRateLimiter.get(clerkUserId) ?? [];
+  const windowStart = now - PER_USER_INITIATE_WINDOW_MS;
+  const inWindow = recent.filter((ts) => ts > windowStart);
+  if (inWindow.length >= PER_USER_INITIATE_LIMIT) {
+    initiateRateLimiter.set(clerkUserId, inWindow);
+    return false;
+  }
+  inWindow.push(now);
+  initiateRateLimiter.set(clerkUserId, inWindow);
+  return true;
+}
+
+/* -------- routes -------- */
+
+pairRouter.post('/initiate', async (c) => {
+  const clerkUserId = c.get('clerkUserId');
+  const now = Date.now();
+  if (!trackInitiateAttempt(clerkUserId, now)) {
+    return c.json({ error: 'rate-limited', code: 'initiate-too-many' }, 429);
+  }
+  const code = generatePairCode();
+  const expiresAt = now + PAIR_CODE_TTL_MS;
+  const repo = new PairCodeRepo(c.env.DB);
+  await repo.insertCode(code, clerkUserId, now, expiresAt);
+  await new HomeRegistryRepo(c.env.DB).writeEvent(
+    {
+      type: 'pair_initiated',
+      userId: null,
+      homeId: null,
+      ip: clientIp(c),
+      userAgent: c.req.header('User-Agent'),
+    },
+    now,
+  );
+  return c.json({ code, expiresAt }, 201);
+});
+
+pairRouter.post('/claim', async (c) => {
+  const ip = clientIp(c) ?? 'unknown';
+  const now = Date.now();
+  const pairRepo = new PairCodeRepo(c.env.DB);
+  const homeRepo = new HomeRegistryRepo(c.env.DB);
+
+  // 1. Lockout check.
+  const failure = await pairRepo.getFailure(ip);
+  if (
+    failure?.locked_until !== undefined &&
+    failure.locked_until !== null &&
+    failure.locked_until > now
+  ) {
+    return c.json(
+      {
+        error: 'rate-limited',
+        code: 'claim-locked',
+        retryAfterMs: failure.locked_until - now,
+      },
+      429,
+    );
+  }
+
+  // 2. Body parse.
+  const body = (await c.req.json().catch(() => ({}))) as ClaimBody;
+  if (typeof body.code !== 'string' || body.code.trim().length === 0) {
+    return c.json({ error: 'invalid', code: 'code-required' }, 400);
+  }
+  const code = body.code.trim();
+
+  // 3. Lookup + validate.
+  const row = await pairRepo.findByCode(code);
+  if (row === null) {
+    await recordBadAttempt(pairRepo, homeRepo, ip, c.req.header('User-Agent'), failure, now);
+    return c.json({ error: 'invalid', code: 'unknown-code' }, 401);
+  }
+  if (row.expires_at <= now) {
+    await homeRepo.writeEvent(
+      {
+        type: 'pair_expired',
+        userId: null,
+        homeId: null,
+        ip,
+        userAgent: c.req.header('User-Agent'),
+        reason: 'code_expired',
+      },
+      now,
+    );
+    return c.json({ error: 'expired', code: 'code-expired' }, 410);
+  }
+  if (row.claimed_at !== null) {
+    await homeRepo.writeEvent(
+      {
+        type: 'pair_failed_invalid_code',
+        userId: null,
+        homeId: null,
+        ip,
+        userAgent: c.req.header('User-Agent'),
+        reason: 'already_claimed',
+      },
+      now,
+    );
+    return c.json({ error: 'expired', code: 'code-already-claimed' }, 410);
+  }
+
+  // 4. Mint home + relay_secret.
+  const user = await homeRepo.upsertUser(row.clerk_user_id, now);
+  const homeId = crypto.randomUUID();
+  await homeRepo.createHome(homeId, user.id, 'My home', now);
+  const relaySecret = generateRelaySecret();
+  const hashed = await hash(relaySecret, 10);
+  await c.env.DB.prepare(
+    'INSERT INTO relay_secrets_hash (home_id, hash, created_at) VALUES (?, ?, ?)',
+  )
+    .bind(homeId, hashed, now)
+    .run();
+
+  // 5. Atomic claim.
+  const claimed = await pairRepo.claimCode(code, homeId, now);
+  if (!claimed) {
+    return c.json({ error: 'expired', code: 'concurrent-claim' }, 410);
+  }
+  await pairRepo.clearFailure(ip);
+  await homeRepo.writeEvent(
+    {
+      type: 'pair_claimed',
+      userId: user.id,
+      homeId,
+      ip,
+      userAgent: c.req.header('User-Agent'),
+    },
+    now,
+  );
+  return c.json({
+    homeId,
+    relaySecret,
+    cloudUrl: c.req.url.replace(/\/pair\/claim$/, ''),
+  });
+});
+
+pairRouter.get('/status', async (c) => {
+  const code = c.req.query('code');
+  if (code === undefined || code.length === 0) {
+    return c.json({ error: 'invalid', code: 'code-required' }, 400);
+  }
+  const clerkUserId = c.get('clerkUserId');
+  const repo = new PairCodeRepo(c.env.DB);
+  const row = await repo.findByCodeAndUser(code, clerkUserId);
+  if (row === null) return c.json({ error: 'not-found' }, 404);
+  if (row.claimed_at !== null) {
+    return c.json({ status: 'claimed', homeId: row.claimed_home_id });
+  }
+  if (row.expires_at <= Date.now()) {
+    return c.json({ status: 'expired' });
+  }
+  return c.json({ status: 'pending', expiresAt: row.expires_at });
+});
+
+/* -------- helpers -------- */
+
+async function recordBadAttempt(
+  pairRepo: PairCodeRepo,
+  homeRepo: HomeRegistryRepo,
+  ip: string,
+  userAgent: string | undefined,
+  prior: { attempts: number; locked_until: number | null } | null,
+  now: number,
+): Promise<void> {
+  const attempts = (prior?.attempts ?? 0) + 1;
+  let lockedUntil: number | null = prior?.locked_until ?? null;
+  if (attempts >= PER_IP_BAD_CLAIM_THRESHOLD) {
+    const tierIndex = Math.min(
+      Math.floor((attempts - PER_IP_BAD_CLAIM_THRESHOLD) / PER_IP_BAD_CLAIM_THRESHOLD),
+      LOCKOUT_TIERS_MS.length - 1,
+    );
+    const tier = LOCKOUT_TIERS_MS[tierIndex] ?? LOCKOUT_TIERS_MS[0] ?? 60_000;
+    lockedUntil = now + tier;
+  }
+  await pairRepo.recordFailure(ip, attempts, lockedUntil);
+  await homeRepo.writeEvent(
+    {
+      type: 'pair_failed_invalid_code',
+      userId: null,
+      homeId: null,
+      ip,
+      userAgent,
+      reason: lockedUntil !== null && lockedUntil > now ? 'locked_out' : 'bad_code',
+    },
+    now,
+  );
+}
+
+function clientIp(c: {
+  req: { header: (name: string) => string | undefined };
+}): string | undefined {
+  return c.req.header('CF-Connecting-IP') ?? c.req.header('X-Forwarded-For');
+}


### PR DESCRIPTION
## Summary

Layers \`/pair/initiate\` + \`/pair/claim\` + \`/pair/status\` on the cloud relay per [ADR 0021](https://github.com/toss-cengiz/glaon/blob/development/docs/adr/0021-pairing-and-relay-credentials.md) + issue #346. Closes the loop between Clerk-authenticated clients and addon agents — both sides walk away with a matching \`homeId\` and a fresh \`relay_secret\`.

## Scope (In)

**Schema (\`migrations/0002_pair_codes.sql\`):**
- \`pair_codes\`: 6-digit code, single-use, 10-min TTL, bound to \`clerk_user_id\`.
- \`pair_failure_attempts\`: per-IP brute-force tracker for \`/pair/claim\` lockouts.

**Code minting (\`src/pairing/code.ts\`):**
- 30-character alphabet (digits + uppercase A–Z minus O/0/1/I/L) per ADR 0021. Total space 30^6 ≈ 729M.
- 256-bit relay secret, base64url-encoded.

**Repo (\`src/db/pair-repo.ts\`):** \`insertCode\` / \`findByCode\` / \`findByCodeAndUser\` / \`claimCode\` (atomic-ish: only flips \`claimed_at\` when row is still pending and not expired). \`getFailure\` / \`recordFailure\` / \`clearFailure\` for the lockout state.

**Routes (\`src/routes/pair.ts\`):**
- \`POST /pair/initiate\` (Clerk-authed): mints code, in-memory per-user rate limit (5/60s).
- \`POST /pair/claim\` (unauthenticated): bcrypt(\`relay_secret\`) into \`relay_secrets_hash\`, records \`pair_claimed\` audit. Bad codes increment a per-IP counter; tiered lockout 1m → 5m → 30m → 60m kicks in after 10 attempts.
- \`GET /pair/status?code=...\`: client polls with their Clerk JWT; returns \`pending\` / \`claimed\` / \`expired\`. Cross-user lookup returns 404.

Wired into \`src/index.ts\` under \`/pair\`. \`FakeD1\` extended with \`pair_codes\` / \`pair_failure_attempts\` / \`relay_secrets_hash\` insert + select handlers.

**Tests (34 cloud tests, was 28):**
- Happy path: initiate → status pending → claim → bcrypt round-trip verified → status claimed.
- Failure paths: unknown code (401 + audit), double-claim (410), expired (410), 10× bad code → 429 lockout with \`retryAfterMs\`.
- Cross-user status visibility: user B cannot see user A's code (404).

## Scope (Out)

- KV-backed per-user initiate counter (in-memory acceptable until clusters).
- Rotation / revocation endpoints — future portal work.
- Addon \`/pair\` Ingress UI → D2.
- Wizard UI on clients → E3, G3.

## Test plan

- [x] \`pnpm --filter @glaon/cloud test\` — 34 passed.
- [x] \`pnpm --filter @glaon/cloud type-check\` + \`lint\` — clean.
- [x] \`pnpm syncpack:lint\` — clean.
- [ ] CI green: typecheck + lint + audit (knip + syncpack), package-contract, conventional-commits, gitleaks, visual regression.

## Acceptance (issue #346)

- [x] Happy path: initiate → claim → both sides receive matching \`homeId\`.
- [x] Code expiry honoured (10min); expired codes return 410.
- [x] Single-use enforced — second claim of same code returns 410.
- [x] Brute-force test: 11 bad codes → IP locked out for the configured window (\`retryAfterMs\` returned).
- [x] Audit log rows present after each path (\`pair_initiated\`, \`pair_claimed\`, \`pair_failed_invalid_code\`, \`pair_expired\`).
- [x] ADR 0021 already merged (#413).

Refs #339 #341
Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)