### PR TITLE
ci(cloud): auto-deploy + rollback workflow (b5)

### DIFF
--- a/.github/workflows/cloud-deploy.yml
+++ b/.github/workflows/cloud-deploy.yml
@@ -1,0 +1,147 @@
+name: cloud-deploy
+
+# apps/cloud auto-deploy pipeline per ADR 0022. Staging deploys on every push to
+# `development`; production deploys on every push to `main` (release-please tag
+# merges land here). The same workflow handles manual rollbacks via
+# `workflow_dispatch` inputs.
+#
+# Secrets the workflow consumes (per ADR 0022 — set via GH Actions environment
+# secrets, scoped to `staging` / `production`):
+#   - CF_API_TOKEN          (Wrangler auth)
+#   - CF_ACCOUNT_ID         (target account)
+#   - CLERK_SECRET_KEY      (per-env)
+#   - CLERK_ISSUER          (per-env, public-ish; piped through env so the
+#                            Worker reads it from `c.env.CLERK_ISSUER`)
+#   - SENTRY_DSN            (per-env, optional in staging)
+#   - PAIR_BCRYPT_SECRET    (#346 lockout pepper, optional)
+# The deploy step pipes secrets in via `wrangler secret put` over stdin —
+# values never appear in argv or logs (ADR 0022 invariant).
+
+on:
+  push:
+    branches: [development, main]
+    paths:
+      - 'apps/cloud/**'
+      - '.github/workflows/cloud-deploy.yml'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Target environment'
+        type: choice
+        required: true
+        options:
+          - staging
+          - production
+        default: staging
+      rollback_to:
+        description: 'Wrangler deployment id to roll back to (optional)'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloud-deploy-${{ github.event.inputs.target || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: deploy ${{ github.event.inputs.target || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.target || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
+    env:
+      WRANGLER_ENV: ${{ github.event.inputs.target || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Test gate (cloud)
+        if: github.event.inputs.rollback_to == ''
+        run: pnpm --filter @glaon/cloud test
+
+      - name: Build (dry-run check)
+        if: github.event.inputs.rollback_to == ''
+        run: pnpm --filter @glaon/cloud build
+
+      # ---------- Rollback path ----------
+      - name: Roll back deployment
+        if: github.event.inputs.rollback_to != ''
+        working-directory: apps/cloud
+        run: |
+          echo "rolling back $WRANGLER_ENV to deployment ${{ github.event.inputs.rollback_to }}"
+          pnpm wrangler rollback "${{ github.event.inputs.rollback_to }}" --env "$WRANGLER_ENV"
+
+      # ---------- Forward path: secrets → migrations → deploy ----------
+      - name: Pipe secrets into Worker env
+        if: github.event.inputs.rollback_to == ''
+        working-directory: apps/cloud
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          CLERK_ISSUER: ${{ secrets.CLERK_ISSUER }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          PAIR_BCRYPT_SECRET: ${{ secrets.PAIR_BCRYPT_SECRET }}
+        run: |
+          # Pipe each secret via stdin so the value never lands in argv/logs.
+          pipe_secret() {
+            local name="$1"
+            local value="$2"
+            if [ -z "$value" ]; then
+              echo "skipping $name (not set)"
+              return 0
+            fi
+            printf '%s' "$value" | pnpm wrangler secret put "$name" --env "$WRANGLER_ENV"
+          }
+          pipe_secret CLERK_SECRET_KEY "$CLERK_SECRET_KEY"
+          pipe_secret CLERK_ISSUER "$CLERK_ISSUER"
+          pipe_secret SENTRY_DSN "$SENTRY_DSN"
+          pipe_secret PAIR_BCRYPT_SECRET "$PAIR_BCRYPT_SECRET"
+
+      - name: Apply D1 migrations
+        if: github.event.inputs.rollback_to == ''
+        working-directory: apps/cloud
+        run: |
+          db_name="glaon-${WRANGLER_ENV}"
+          pnpm wrangler d1 migrations apply "$db_name" --env "$WRANGLER_ENV" --remote
+
+      - name: Deploy Worker
+        if: github.event.inputs.rollback_to == ''
+        working-directory: apps/cloud
+        env:
+          GIT_SHA: ${{ github.sha }}
+          BUILD_TIME: ${{ github.event.head_commit.timestamp || github.run_id }}
+          SENTRY_RELEASE: ${{ github.sha }}
+        run: pnpm wrangler deploy --env "$WRANGLER_ENV"
+
+      - name: Smoke test /healthz
+        run: |
+          if [ "$WRANGLER_ENV" = "production" ]; then
+            url="https://relay.glaon.app/healthz"
+          else
+            url="https://relay-staging.glaon.app/healthz"
+          fi
+          for attempt in 1 2 3 4 5 6; do
+            echo "attempt $attempt — GET $url"
+            status=$(curl -s -o /tmp/healthz.body -w "%{http_code}" "$url" || true)
+            if [ "$status" = "200" ]; then
+              echo "healthz ok"
+              cat /tmp/healthz.body
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "healthz did not return 200 after 6 attempts; failing the deploy"
+          exit 1

--- a/apps/cloud/README.md
+++ b/apps/cloud/README.md
@@ -48,6 +48,53 @@ pnpm --filter @glaon/cloud build
 Production + staging secrets live in CF Worker env, set via `wrangler secret put`
 through the deploy workflow (ADR 0022). Local dev reads `.env` (gitignored).
 
+The deploy workflow ([`.github/workflows/cloud-deploy.yml`](../../.github/workflows/cloud-deploy.yml))
+pipes each secret in over stdin so the value never lands in argv or logs. Secrets
+the workflow expects, scoped to GH Actions environment `staging` / `production`:
+
+| Secret               | Required | Notes                                   |
+| -------------------- | -------- | --------------------------------------- |
+| `CF_API_TOKEN`       | yes      | Wrangler auth                           |
+| `CF_ACCOUNT_ID`      | yes      | Target account                          |
+| `CLERK_SECRET_KEY`   | yes      | Per-env                                 |
+| `CLERK_ISSUER`       | yes      | Per-env (publicly known but env-scoped) |
+| `SENTRY_DSN`         | optional | Per-env, optional in staging            |
+| `PAIR_BCRYPT_SECRET` | optional | #346 lockout pepper                     |
+
+## Deploy & rollback
+
+Per ADR 0022, deploys are **automatic from `development` (staging) and `main`
+(production)**. Manual rollback uses `workflow_dispatch`.
+
+**Auto deploy:**
+
+- Push to `development` → staging deploys via `wrangler deploy --env staging`,
+  D1 migrations applied, healthz smoke verified.
+- Push to `main` → production deploy with the same gates.
+
+**Forward-only schema:** D1 migrations live in [`migrations/`](./migrations/);
+they apply with `wrangler d1 migrations apply` before the Worker deploys (so
+the new Worker reads the new schema). Schema changes follow ADR 0022's
+add → migrate → drop pattern; backward-compat is on the author.
+
+**Manual rollback:**
+
+1. Find the deployment id you want to revert to via `wrangler deployments list --env <env>`
+   (or in the Cloudflare dashboard under Workers → Deployments).
+2. Trigger the workflow from GitHub Actions → "cloud-deploy" → "Run workflow".
+3. Pick the target environment, paste the deployment id into the
+   `rollback_to` input. The workflow skips the test / build / migration steps
+   and runs `wrangler rollback <id>` directly.
+
+> **Hot fix vs. rollback:** for code-only regressions a rollback is fast (≈2 min
+> per ADR 0022 MTTR). For schema-coupled regressions, write a compensating
+> forward migration first, then deploy that — rollback alone will leave the
+> Worker reading the new schema.
+
+**Local dry-run:** `pnpm --filter @glaon/cloud build` runs `wrangler deploy
+--dry-run --outdir=dist` and produces the deployable artefact without touching
+production.
+
 ## References
 
 - [ADR 0017 — dual-mode auth](../../docs/adr/0017-dual-mode-auth.md)


### PR DESCRIPTION
## Summary

Lands \`cloud-deploy.yml\` per [ADR 0022](https://github.com/toss-cengiz/glaon/blob/development/docs/adr/0022-cloud-deployment-secrets.md) + issue #347. Staging auto-deploys on every push to \`development\`; production auto-deploys on every push to \`main\` (release-please tag merges land here). Same workflow handles manual rollback via \`workflow_dispatch\`.

## Scope (In)

**Forward pipeline:**
- \`pnpm install --frozen-lockfile\`
- \`pnpm --filter @glaon/cloud test\` (gate)
- \`pnpm --filter @glaon/cloud build\` (wrangler dry-run; surfaces config issues without touching prod)
- \`wrangler secret put\` for \`CLERK_SECRET_KEY\` / \`CLERK_ISSUER\` / \`SENTRY_DSN\` / \`PAIR_BCRYPT_SECRET\`. Each value piped via **stdin** — never in argv or logs (ADR 0022 invariant)
- \`wrangler d1 migrations apply glaon-<env> --remote\` (forward-only; fails the deploy on migration error)
- \`wrangler deploy --env <env>\` with \`GIT_SHA\` + \`BUILD_TIME\` + \`SENTRY_RELEASE\` exposed to the Worker
- \`curl /healthz\` post-deploy with 6×5s retries; non-200 fails the run

**Rollback path:**
- \`workflow_dispatch\` with \`target=staging|production\` + \`rollback_to=<deployment-id>\`
- Skips test / build / migration / secret-put steps; runs \`wrangler rollback\` directly
- README documents the lookup procedure

**Concurrency:** per-target group so two pushes to \`development\` don't race. \`cancel-in-progress: false\` — never abandon a half-deployed Worker.

**\`apps/cloud/README.md\` gains:**
- Secret table (which CF / Clerk / Sentry secrets the workflow expects, scoped to the GH Actions environment).
- Deploy & rollback section: auto-deploy triggers, forward-only migration discipline, manual rollback steps, hot-fix vs. rollback note for schema-coupled regressions.

## Scope (Out)

- **Hosting choice** — locked by ADR 0020 (#412 ✓).
- **Deployment policy decisions** — locked by ADR 0022 (#414 ✓).
- **Cloud code** — already shipped by B1–B4 (#343, #344, #345, #346 ✓).
- **Glaon client env split** (\`VITE_GLAON_CLOUD_URL\` staging vs prod) — apps/web side; tracked alongside the first cloud-mode UI feature (#352 / #353).
- **Real CF deploy verification** — needs a paired CF account + secrets in the GH Actions environment; runs the first time the workflow fires after merge.

## Test plan

- [x] YAML parse: \`yaml.safe_load\` clean (Python).
- [x] Prettier check + format.
- [ ] CI green: typecheck + lint + audit (knip + syncpack), conventional-commits, gitleaks.
- [ ] First fire on merge: workflow appears in GitHub Actions → "cloud-deploy"; staging deploy runs end-to-end (deferred to post-merge with the user's CF credentials).

## Acceptance (issue #347)

- [x] Staging auto-deploys on \`development\` push within 5 min — workflow trigger \`on push: branches: [development]\`, paths-filtered to \`apps/cloud/**\` + this workflow file.
- [x] Prod auto-deploys on release tag — \`on push: branches: [main]\`; release-please squash to main triggers it.
- [x] Failed migration aborts deploy — \`wrangler d1 migrations apply\` precedes \`wrangler deploy\`; non-zero exit fails the job.
- [x] Healthz smoke aborts deploy on bad build — 6 retries then fail.
- [x] Rollback workflow restores previous SHA — \`workflow_dispatch\` rollback path.
- [x] Secrets never appear in logs — stdin-piped via \`printf '%s' | wrangler secret put\`.
- [x] ADR 0022 already merged (#414).

Refs #340 #342 #343
Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)