### PR TITLE
feat(addon): pairing ui ingress route with cloud claim flow

### DIFF
--- a/addon/rootfs/etc/nginx/http.d/glaon.conf
+++ b/addon/rootfs/etc/nginx/http.d/glaon.conf
@@ -20,6 +20,25 @@ server {
         deny all;
     }
 
+    # Pairing UI + endpoints (#349). The agent process listens on 127.0.0.1:8001
+    # and serves /pair (HTML), /pair/pair.css, /pair/pair.js, /pair/status,
+    # /pair/claim. nginx forwards the prefix transparently — the agent owns
+    # auth-of-origin (only the addon container can reach it) and the cloud
+    # claim flow.
+    location /pair {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_buffering off;
+    }
+
+    location /agent/healthz {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/addon/rootfs/run.sh
+++ b/addon/rootfs/run.sh
@@ -3,21 +3,16 @@ set -euo pipefail
 
 bashio::log.info "Starting Glaon add-on..."
 
-# Relay agent: bridges HA WebSocket to the Glaon cloud relay (#348). Boots only
-# when the operator has paired the addon (cloud_url + home_id + relay_secret all
-# present in /data/options.json). The agent process is forked into the
-# background; nginx remains the foreground process so the addon container's
-# liveness still keys on the web server.
+# Agent process always runs — it hosts both the relay bridge (#348) and the
+# /pair Ingress UI (#349). When the addon is unpaired the supervisor loop
+# stays in IDLE; the pair surface stays reachable on /pair via nginx so the
+# user can submit a code. After /pair/claim succeeds the loop wakes up and
+# dials the cloud relay using the freshly-written credentials in
+# /data/options.json. nginx remains the foreground process so the addon
+# container's liveness still keys on the web server.
 if [ -f /opt/glaon/agent/agent.cjs ]; then
-  cloud_url="$(bashio::config 'cloud_url' '')"
-  home_id="$(bashio::config 'home_id' '')"
-  relay_secret="$(bashio::config 'relay_secret' '')"
-  if [ -n "$cloud_url" ] && [ -n "$home_id" ] && [ -n "$relay_secret" ]; then
-    bashio::log.info "Starting relay agent..."
-    node /opt/glaon/agent/agent.cjs &
-  else
-    bashio::log.info "Relay agent skipped — addon not paired yet."
-  fi
+  bashio::log.info "Starting relay agent + pair surface..."
+  node /opt/glaon/agent/agent.cjs &
 fi
 
 exec nginx -g 'daemon off;'

--- a/apps/addon-agent/package.json
+++ b/apps/addon-agent/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/agent.cjs",
   "scripts": {
-    "build": "tsc -b && esbuild src/agent.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/agent.cjs",
+    "build": "tsc -b && esbuild src/agent.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/agent.cjs && cp -R src/static dist/static",
     "clean": "rm -rf dist .turbo coverage",
     "lint": "eslint .",
     "test": "vitest run",

--- a/apps/addon-agent/src/agent.ts
+++ b/apps/addon-agent/src/agent.ts
@@ -1,7 +1,13 @@
 // Glaon addon relay agent — process entry point. Reads addon options
 // (`/data/options.json` is HA Supervisor's standard path), opens the cloud
 // upstream + local HA WS, wires the FrameBridge between them, and surfaces a
-// /agent/healthz HTTP endpoint that nginx proxies under Ingress.
+// /agent/healthz HTTP endpoint plus the /pair Ingress UI (#349) that nginx
+// proxies under Ingress.
+//
+// The agent process is always running — even before the user has paired the
+// addon — because the /pair surface lives in this same Node process. The
+// supervisor loop (`runAgentLoop`) sits in IDLE state until /pair/claim
+// writes credentials and signals it to wake up.
 //
 // Real WebSocket transport is the standard `ws` module; the bridge logic
 // lives in `bridge.ts` and is exercised by unit tests with FakeSockets — the
@@ -10,17 +16,15 @@
 
 import { readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
+import { join } from 'node:path';
 import WebSocket from 'ws';
 
 import { FrameBridge } from './bridge';
 import { FatalRelayAuthError, nextDelay } from './backoff';
+import { createPairHandler } from './pair-server';
 import { scrub } from './scrubber';
-
-interface AddonOptions {
-  readonly cloud_url?: string;
-  readonly home_id?: string;
-  readonly relay_secret?: string;
-}
+import { AgentState } from './state';
+import { FileOptionsStore, isPaired, type AddonOptions } from './options-store';
 
 const OPTIONS_PATH = process.env.GLAON_OPTIONS_PATH ?? '/data/options.json';
 const SUPERVISOR_TOKEN = process.env.SUPERVISOR_TOKEN;
@@ -29,57 +33,79 @@ function log(level: 'info' | 'warn' | 'error', record: Record<string, unknown>):
   const safe = scrub(record);
   // eslint-disable-next-line no-console -- agent logs ship via stdout to the addon supervisor
   console[level === 'error' ? 'error' : 'warn'](
-    JSON.stringify({ level, time: new Date().toISOString(), ...(safe as Record<string, unknown>) }),
+    JSON.stringify({
+      level,
+      time: new Date().toISOString(),
+      ...(safe as Record<string, unknown>),
+    }),
   );
 }
 
-function readOptions(): AddonOptions {
-  try {
-    const raw = readFileSync(OPTIONS_PATH, 'utf-8');
-    return JSON.parse(raw) as AddonOptions;
-  } catch (err) {
-    log('warn', { msg: 'options-read-failed', err: String(err) });
-    return {};
-  }
+function loadStaticAssets(): { html: string; css: string; js: string } {
+  const dir = join(__dirname, 'static');
+  return {
+    html: readFileSync(join(dir, 'pair.html'), 'utf-8'),
+    css: readFileSync(join(dir, 'pair.css'), 'utf-8'),
+    js: readFileSync(join(dir, 'pair.js'), 'utf-8'),
+  };
 }
 
-function startHealthzServer(): void {
+function startHttpServer(state: AgentState, store: FileOptionsStore): void {
   const port = Number(process.env.AGENT_HEALTHZ_PORT ?? '8001');
-  const server = createServer((_req, res) => {
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ status: 'ok' }));
+  const pairHandler = createPairHandler({
+    options: store,
+    state,
+    staticAssets: loadStaticAssets(),
+    logger: log,
+  });
+  const server = createServer((req, res) => {
+    const url = req.url ?? '/';
+    if (url === '/agent/healthz') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', state: state.view().name }));
+      return;
+    }
+    if (url === '/pair' || url.startsWith('/pair/') || url.startsWith('/pair?')) {
+      pairHandler(req, res);
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not-found' }));
   });
   server.listen(port, () => {
-    log('info', { msg: 'healthz-listening', port });
+    log('info', { msg: 'agent-http-listening', port });
   });
 }
 
-async function runAgentLoop(options: AddonOptions): Promise<void> {
-  const cloudUrl = options.cloud_url;
-  const homeId = options.home_id;
-  const relaySecret = options.relay_secret;
-  if (
-    cloudUrl === undefined ||
-    homeId === undefined ||
-    relaySecret === undefined ||
-    SUPERVISOR_TOKEN === undefined
-  ) {
-    log('warn', { msg: 'agent-config-missing', has_cloud: cloudUrl !== undefined });
-    return;
-  }
-
+async function runAgentLoop(state: AgentState, store: FileOptionsStore): Promise<void> {
   let attempt = 0;
   for (;;) {
+    const options = store.read();
+    if (!isPaired(options) || SUPERVISOR_TOKEN === undefined) {
+      state.set({ name: 'idle', homeId: null, attempt: 0 });
+      log('info', {
+        msg: 'agent-idle',
+        reason: SUPERVISOR_TOKEN === undefined ? 'no-supervisor-token' : 'unpaired',
+      });
+      await state.waitForWake();
+      continue;
+    }
+    state.set({ name: 'connecting', homeId: options.home_id ?? null, attempt });
     try {
-      await runOnce(cloudUrl, homeId, relaySecret);
+      await runOnce(options as Required<AddonOptions>, state);
       attempt = 0;
     } catch (err) {
       if (err instanceof FatalRelayAuthError) {
+        state.set({ name: 'fatal', lastError: err.message });
         log('error', { msg: 'fatal-auth', detail: err.message });
-        return; // do not retry-storm on bad relay_secret
+        // Wait for re-pair instead of retry-storming.
+        await state.waitForWake();
+        attempt = 0;
+        continue;
       }
       attempt += 1;
       const delay = nextDelay(attempt);
+      state.set({ name: 'backoff', attempt, lastError: String(err) });
       log('warn', { msg: 'reconnect', attempt, delayMs: delay, err: String(err) });
       await new Promise<void>((r) => setTimeout(r, delay));
     }
@@ -126,12 +152,12 @@ function selectUpstream(cloudUrl: string): string {
   }
 }
 
-async function runOnce(cloudUrl: string, homeId: string, relaySecret: string): Promise<void> {
-  const upstreamUrl = selectUpstream(cloudUrl);
+async function runOnce(options: Required<AddonOptions>, state: AgentState): Promise<void> {
+  const upstreamUrl = selectUpstream(options.cloud_url);
   const cloud = new WebSocket(upstreamUrl, {
     headers: {
-      Authorization: `Bearer ${relaySecret}`,
-      'X-Glaon-Home': homeId,
+      Authorization: `Bearer ${options.relay_secret}`,
+      'X-Glaon-Home': options.home_id,
     },
   });
   const home = new WebSocket('ws://supervisor/core/websocket', {
@@ -139,7 +165,8 @@ async function runOnce(cloudUrl: string, homeId: string, relaySecret: string): P
   });
 
   await Promise.all([waitOpen(cloud, 'cloud'), waitOpen(home, 'home')]);
-  log('info', { msg: 'agent-connected', homeId });
+  state.set({ name: 'running', homeId: options.home_id, lastError: null });
+  log('info', { msg: 'agent-connected', homeId: options.home_id });
 
   const bridge = new FrameBridge(
     {
@@ -152,7 +179,7 @@ async function runOnce(cloudUrl: string, homeId: string, relaySecret: string): P
         home.send(d);
       },
     },
-    { homeId, pinnedSessionId: null },
+    { homeId: options.home_id, pinnedSessionId: null },
   );
 
   cloud.on('message', (data: WebSocket.RawData) => {
@@ -204,6 +231,8 @@ function waitOpen(ws: WebSocket, label: string): Promise<void> {
 }
 
 if (process.env.GLAON_AGENT_BOOT !== '0') {
-  startHealthzServer();
-  void runAgentLoop(readOptions());
+  const state = new AgentState();
+  const store = new FileOptionsStore(OPTIONS_PATH);
+  startHttpServer(state, store);
+  void runAgentLoop(state, store);
 }

--- a/apps/addon-agent/src/options-store.test.ts
+++ b/apps/addon-agent/src/options-store.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { FileOptionsStore, isPaired, type AddonOptions } from './options-store';
+
+function makeStore(): { store: FileOptionsStore; dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'glaon-options-'));
+  const path = join(dir, 'options.json');
+  return { store: new FileOptionsStore(path), dir, path };
+}
+
+describe('FileOptionsStore', () => {
+  it('returns empty object when file is missing', () => {
+    const { store, dir } = makeStore();
+    try {
+      expect(store.read()).toEqual({});
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('round-trips options through write + read', () => {
+    const { store, dir, path } = makeStore();
+    try {
+      const written: AddonOptions = {
+        cloud_url: 'https://relay.glaon.app',
+        home_id: 'home-abc',
+        relay_secret: 'fake-test-value-AAAA',
+      };
+      store.write(written);
+      expect(store.read()).toEqual(written);
+      const stat = statSync(path);
+      // mode 0o600 is the lower 9 bits of the mode field.
+      expect(stat.mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('overwrites existing fields atomically (no .tmp leftover)', () => {
+    const { store, dir, path } = makeStore();
+    try {
+      store.write({ cloud_url: 'a', home_id: 'b', relay_secret: 'c' });
+      store.write({ cloud_url: 'aa', home_id: 'bb', relay_secret: 'cc' });
+      const raw = readFileSync(path, 'utf-8');
+      expect(JSON.parse(raw)).toEqual({ cloud_url: 'aa', home_id: 'bb', relay_secret: 'cc' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty object when JSON is malformed', () => {
+    const { store, dir, path } = makeStore();
+    try {
+      // Write garbage directly bypassing the store API.
+      writeFileSync(path, 'not json', { mode: 0o600 });
+      expect(store.read()).toEqual({});
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('isPaired', () => {
+  it('returns true when all three credential fields are non-empty strings', () => {
+    expect(isPaired({ cloud_url: 'https://x', home_id: 'h', relay_secret: 's' })).toBe(true);
+  });
+
+  it('returns false when any field is missing', () => {
+    expect(isPaired({})).toBe(false);
+    expect(isPaired({ cloud_url: 'https://x' })).toBe(false);
+    expect(isPaired({ cloud_url: 'https://x', home_id: 'h' })).toBe(false);
+  });
+
+  it('returns false when any field is empty', () => {
+    expect(isPaired({ cloud_url: '', home_id: 'h', relay_secret: 's' })).toBe(false);
+    expect(isPaired({ cloud_url: 'x', home_id: '', relay_secret: 's' })).toBe(false);
+    expect(isPaired({ cloud_url: 'x', home_id: 'h', relay_secret: '' })).toBe(false);
+  });
+});

--- a/apps/addon-agent/src/options-store.ts
+++ b/apps/addon-agent/src/options-store.ts
@@ -1,0 +1,78 @@
+// Read/write the addon's `/data/options.json` (HA Supervisor's standard path).
+//
+// Pairing (#349) needs to persist `cloud_url` + `home_id` + `relay_secret`
+// after the cloud accepts the device code. We write atomically (tmp + rename)
+// at mode 0600 to avoid a half-written file if the supervisor restarts the
+// container mid-write — and to keep the relay secret out of world-readable
+// scope. HA Supervisor reads the file via `bashio::config` (the same shell
+// helper used in `run.sh`); the JSON shape mirrors `addon/config.yaml`.
+
+import { closeSync, openSync, readFileSync, renameSync, writeSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+export interface AddonOptions {
+  readonly cloud_url?: string;
+  readonly home_id?: string;
+  readonly relay_secret?: string;
+}
+
+export interface OptionsStore {
+  read(): AddonOptions;
+  write(options: AddonOptions): void;
+}
+
+export class FileOptionsStore implements OptionsStore {
+  constructor(private readonly path: string) {}
+
+  read(): AddonOptions {
+    try {
+      const raw = readFileSync(this.path, 'utf-8');
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed === null || typeof parsed !== 'object') return {};
+      const candidate = parsed as Record<string, unknown>;
+      const out: AddonOptions = {};
+      if (typeof candidate.cloud_url === 'string') {
+        (out as { cloud_url?: string }).cloud_url = candidate.cloud_url;
+      }
+      if (typeof candidate.home_id === 'string') {
+        (out as { home_id?: string }).home_id = candidate.home_id;
+      }
+      if (typeof candidate.relay_secret === 'string') {
+        (out as { relay_secret?: string }).relay_secret = candidate.relay_secret;
+      }
+      return out;
+    } catch {
+      return {};
+    }
+  }
+
+  write(options: AddonOptions): void {
+    const payload = JSON.stringify(options, null, 2);
+    const tmp = `${this.path}.tmp`;
+    // mode 0o600 — owner read/write only. The relay_secret is sensitive and
+    // must not be world-readable even though the addon container is single
+    // tenant; defense-in-depth per ADR 0021 risk mitigations.
+    const fd = openSync(tmp, 'w', 0o600);
+    try {
+      writeSync(fd, payload);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tmp, this.path);
+  }
+}
+
+export function isPaired(options: AddonOptions): boolean {
+  return (
+    typeof options.cloud_url === 'string' &&
+    options.cloud_url.length > 0 &&
+    typeof options.home_id === 'string' &&
+    options.home_id.length > 0 &&
+    typeof options.relay_secret === 'string' &&
+    options.relay_secret.length > 0
+  );
+}
+
+export function pairedDirectoryOf(path: string): string {
+  return dirname(path);
+}

--- a/apps/addon-agent/src/options-store.ts
+++ b/apps/addon-agent/src/options-store.ts
@@ -8,7 +8,6 @@
 // helper used in `run.sh`); the JSON shape mirrors `addon/config.yaml`.
 
 import { closeSync, openSync, readFileSync, renameSync, writeSync } from 'node:fs';
-import { dirname } from 'node:path';
 
 export interface AddonOptions {
   readonly cloud_url?: string;
@@ -71,8 +70,4 @@ export function isPaired(options: AddonOptions): boolean {
     typeof options.relay_secret === 'string' &&
     options.relay_secret.length > 0
   );
-}
-
-export function pairedDirectoryOf(path: string): string {
-  return dirname(path);
 }

--- a/apps/addon-agent/src/pair-server.test.ts
+++ b/apps/addon-agent/src/pair-server.test.ts
@@ -1,0 +1,281 @@
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createPairHandler } from './pair-server';
+import { AgentState } from './state';
+import type { AddonOptions, OptionsStore } from './options-store';
+
+interface MockResponse {
+  statusCode: number;
+  headers: Record<string, string | number>;
+  body: string;
+}
+
+function makeReq(method: string, url: string, body?: string): IncomingMessage {
+  const stream = body !== undefined ? Readable.from([body]) : Readable.from([]);
+  Object.assign(stream, { method, url });
+  return stream as unknown as IncomingMessage;
+}
+
+function makeRes(): { res: ServerResponse; out: MockResponse; done: Promise<void> } {
+  const out: MockResponse = { statusCode: 0, headers: {}, body: '' };
+  let resolveDone!: () => void;
+  const done = new Promise<void>((r) => {
+    resolveDone = r;
+  });
+  const res = new EventEmitter() as unknown as ServerResponse;
+  Object.assign(res, {
+    writeHead(status: number, headers: Record<string, string | number>) {
+      out.statusCode = status;
+      out.headers = headers;
+    },
+    end(chunk?: string) {
+      if (chunk !== undefined) out.body += chunk;
+      resolveDone();
+    },
+  });
+  return { res, out, done };
+}
+
+function makeStore(initial: AddonOptions = {}): OptionsStore & {
+  read: () => AddonOptions;
+  write: (o: AddonOptions) => void;
+  written: AddonOptions[];
+} {
+  let current: AddonOptions = initial;
+  const written: AddonOptions[] = [];
+  return {
+    read: () => current,
+    write: (o: AddonOptions) => {
+      current = o;
+      written.push(o);
+    },
+    written,
+  };
+}
+
+const ASSETS = { html: '<html>pair</html>', css: '.x{}', js: 'console.log(1)' };
+
+function makeDeps(
+  overrides: {
+    store?: ReturnType<typeof makeStore>;
+    state?: AgentState;
+    cloudFetch?: Parameters<typeof createPairHandler>[0]['cloudFetch'];
+    logger?: Parameters<typeof createPairHandler>[0]['logger'];
+  } = {},
+) {
+  return {
+    options: overrides.store ?? makeStore(),
+    state: overrides.state ?? new AgentState(),
+    staticAssets: ASSETS,
+    logger: overrides.logger ?? vi.fn(),
+    cloudFetch: overrides.cloudFetch,
+  };
+}
+
+describe('pair handler — static assets', () => {
+  it('serves the pair HTML on GET /pair', async () => {
+    const deps = makeDeps();
+    const handler = createPairHandler(deps);
+    const { res, out, done } = makeRes();
+    handler(makeReq('GET', '/pair'), res);
+    await done;
+    expect(out.statusCode).toBe(200);
+    expect(out.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(out.body).toContain('pair');
+  });
+
+  it('serves CSS and JS', async () => {
+    const handler = createPairHandler(makeDeps());
+    {
+      const { res, out, done } = makeRes();
+      handler(makeReq('GET', '/pair/pair.css'), res);
+      await done;
+      expect(out.body).toBe('.x{}');
+      expect(out.headers['Content-Type']).toBe('text/css; charset=utf-8');
+    }
+    {
+      const { res, out, done } = makeRes();
+      handler(makeReq('GET', '/pair/pair.js'), res);
+      await done;
+      expect(out.body).toBe('console.log(1)');
+      expect(out.headers['Content-Type']).toBe('application/javascript; charset=utf-8');
+    }
+  });
+});
+
+describe('pair handler — status', () => {
+  it('reports paired:false when options are empty', async () => {
+    const handler = createPairHandler(makeDeps());
+    const { res, out, done } = makeRes();
+    handler(makeReq('GET', '/pair/status'), res);
+    await done;
+    expect(JSON.parse(out.body)).toEqual({ paired: false });
+  });
+
+  it('reports paired:true and discloses non-secret fields', async () => {
+    const store = makeStore({
+      cloud_url: 'https://relay.glaon.app',
+      home_id: 'home-9',
+      relay_secret: 'sekrit-DO-NOT-LEAK',
+    });
+    const handler = createPairHandler(makeDeps({ store }));
+    const { res, out, done } = makeRes();
+    handler(makeReq('GET', '/pair/status'), res);
+    await done;
+    const parsed = JSON.parse(out.body) as Record<string, unknown>;
+    expect(parsed.paired).toBe(true);
+    expect(parsed.homeId).toBe('home-9');
+    expect(parsed.cloudUrl).toBe('https://relay.glaon.app');
+    expect(out.body).not.toContain('sekrit-DO-NOT-LEAK');
+  });
+});
+
+describe('pair handler — claim', () => {
+  it('rejects empty body with 400', async () => {
+    const handler = createPairHandler(makeDeps());
+    const { res, out, done } = makeRes();
+    handler(makeReq('POST', '/pair/claim'), res);
+    await done;
+    expect(out.statusCode).toBe(400);
+  });
+
+  it('rejects malformed JSON with 400', async () => {
+    const handler = createPairHandler(makeDeps());
+    const { res, out, done } = makeRes();
+    handler(makeReq('POST', '/pair/claim', 'not json'), res);
+    await done;
+    expect(out.statusCode).toBe(400);
+  });
+
+  it('rejects missing code field with 400', async () => {
+    const handler = createPairHandler(makeDeps());
+    const { res, out, done } = makeRes();
+    handler(makeReq('POST', '/pair/claim', '{}'), res);
+    await done;
+    expect(out.statusCode).toBe(400);
+    expect(JSON.parse(out.body)).toEqual({ error: 'code-required' });
+  });
+
+  it('persists credentials and signals state on a successful claim', async () => {
+    const store = makeStore();
+    const state = new AgentState();
+    const wake = state.waitForWake();
+    const cloudFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: {
+          homeId: 'home-new',
+          relaySecret: 'fresh-relay-secret',
+          cloudUrl: 'https://relay.glaon.app',
+        },
+      }),
+    );
+    const handler = createPairHandler(makeDeps({ store, state, cloudFetch }));
+    const { res, out, done } = makeRes();
+    handler(makeReq('POST', '/pair/claim', '{"code":"ABC123"}'), res);
+    await done;
+
+    expect(out.statusCode).toBe(200);
+    const body = JSON.parse(out.body) as Record<string, unknown>;
+    expect(body).toEqual({
+      paired: true,
+      homeId: 'home-new',
+      cloudUrl: 'https://relay.glaon.app',
+    });
+    expect(store.written).toEqual([
+      {
+        cloud_url: 'https://relay.glaon.app',
+        home_id: 'home-new',
+        relay_secret: 'fresh-relay-secret',
+      },
+    ]);
+    await wake;
+    expect(cloudFetch).toHaveBeenCalledWith('https://relay.glaon.app', 'ABC123');
+  });
+
+  it('forwards cloud rejection codes (410 expired) with scrubbed body', async () => {
+    const cloudFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: false as const,
+        err: { status: 410, body: { error: 'expired', code: 'code-expired' } },
+      }),
+    );
+    const handler = createPairHandler(makeDeps({ cloudFetch }));
+    const { res, out, done } = makeRes();
+    handler(makeReq('POST', '/pair/claim', '{"code":"WRONG1"}'), res);
+    await done;
+    expect(out.statusCode).toBe(410);
+    expect(JSON.parse(out.body)).toEqual({ error: 'expired', code: 'code-expired' });
+  });
+
+  it('forwards rate-limit (429) with retryAfterMs', async () => {
+    const cloudFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: false as const,
+        err: {
+          status: 429,
+          body: { error: 'rate-limited', code: 'claim-locked', retryAfterMs: 60_000 },
+        },
+      }),
+    );
+    const handler = createPairHandler(makeDeps({ cloudFetch }));
+    const { res, out, done } = makeRes();
+    handler(makeReq('POST', '/pair/claim', '{"code":"BLOCKED"}'), res);
+    await done;
+    expect(out.statusCode).toBe(429);
+    expect(JSON.parse(out.body)).toMatchObject({
+      error: 'rate-limited',
+      retryAfterMs: 60_000,
+    });
+  });
+
+  it('uses the operator-configured cloud_url when host is on the allowlist', async () => {
+    const store = makeStore({
+      cloud_url: 'https://relay-staging.glaon.app',
+    });
+    const cloudFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: {
+          homeId: 'h',
+          relaySecret: 's',
+          cloudUrl: 'https://relay-staging.glaon.app',
+        },
+      }),
+    );
+    const handler = createPairHandler(makeDeps({ store, cloudFetch }));
+    const { res, done } = makeRes();
+    handler(makeReq('POST', '/pair/claim', '{"code":"OK"}'), res);
+    await done;
+    expect(cloudFetch).toHaveBeenCalledWith('https://relay-staging.glaon.app', 'OK');
+  });
+
+  it('falls back to prod when stored cloud_url host is not on the allowlist', async () => {
+    const store = makeStore({ cloud_url: 'https://evil.example.com' });
+    const cloudFetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: { homeId: 'h', relaySecret: 's', cloudUrl: 'https://relay.glaon.app' },
+      }),
+    );
+    const handler = createPairHandler(makeDeps({ store, cloudFetch }));
+    const { res, done } = makeRes();
+    handler(makeReq('POST', '/pair/claim', '{"code":"OK"}'), res);
+    await done;
+    expect(cloudFetch).toHaveBeenCalledWith('https://relay.glaon.app', 'OK');
+  });
+});
+
+describe('pair handler — fallthrough', () => {
+  it('returns 404 for unknown paths', async () => {
+    const handler = createPairHandler(makeDeps());
+    const { res, out, done } = makeRes();
+    handler(makeReq('GET', '/unknown'), res);
+    await done;
+    expect(out.statusCode).toBe(404);
+  });
+});

--- a/apps/addon-agent/src/pair-server.ts
+++ b/apps/addon-agent/src/pair-server.ts
@@ -1,0 +1,295 @@
+// HTTP handlers for the addon's `/pair` Ingress route (#349).
+//
+// Endpoints (all sit under nginx `location /pair { proxy_pass ... }`):
+//   GET  /pair          → static HTML page (vanilla, no build)
+//   GET  /pair/pair.css → stylesheet
+//   GET  /pair/pair.js  → bootstrap script
+//   GET  /pair/status   → { paired: boolean, homeId?: string, cloudUrl?: string }
+//   POST /pair/claim    → { code }: forwards to cloud /pair/claim
+//
+// Why this lives in the agent process: the agent already owns the supervisor
+// state machine and reads/writes `/data/options.json`. Co-locating the pair
+// surface keeps the addon to a single Node process. The state machine wakes
+// up on `pairedSignal()` once /claim succeeds.
+//
+// The cloud claim base URL is read from the addon options (`cloud_url`),
+// defaulting to the Glaon prod relay. The fetch sink is restricted to the
+// same allowlist the WebSocket upstream uses (CodeQL `js/file-access-to-http`
+// disagreed with regex narrowing; we go with literal switch). `home_id` from
+// the cloud response is merged into options and never echoed in logs.
+
+import { request } from 'node:https';
+import { request as requestHttp } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import { scrub } from './scrubber';
+import type { AgentState } from './state';
+import type { AddonOptions, OptionsStore } from './options-store';
+import { isPaired } from './options-store';
+
+interface PairServerDeps {
+  readonly options: OptionsStore;
+  readonly state: AgentState;
+  readonly staticAssets: StaticAssets;
+  readonly logger: (level: 'info' | 'warn' | 'error', record: Record<string, unknown>) => void;
+  readonly cloudFetch?: CloudFetch | undefined;
+}
+
+interface StaticAssets {
+  readonly html: string;
+  readonly css: string;
+  readonly js: string;
+}
+
+interface CloudClaimResponse {
+  readonly homeId: string;
+  readonly relaySecret: string;
+  readonly cloudUrl: string;
+}
+
+interface CloudClaimError {
+  readonly status: number;
+  readonly body: {
+    error?: string | undefined;
+    code?: string | undefined;
+    retryAfterMs?: number | undefined;
+  };
+}
+
+type CloudFetch = (
+  cloudUrl: string,
+  code: string,
+) => Promise<{ ok: true; data: CloudClaimResponse } | { ok: false; err: CloudClaimError }>;
+
+const PROD_CLOUD = 'https://relay.glaon.app';
+const STAGING_CLOUD = 'https://relay-staging.glaon.app';
+
+export function createPairHandler(
+  deps: PairServerDeps,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    const url = req.url ?? '/';
+    const path = url.split('?')[0] ?? '/';
+    if (req.method === 'GET' && (path === '/pair' || path === '/pair/')) {
+      serveStatic(res, 'text/html; charset=utf-8', deps.staticAssets.html);
+      return;
+    }
+    if (req.method === 'GET' && path === '/pair/pair.css') {
+      serveStatic(res, 'text/css; charset=utf-8', deps.staticAssets.css);
+      return;
+    }
+    if (req.method === 'GET' && path === '/pair/pair.js') {
+      serveStatic(res, 'application/javascript; charset=utf-8', deps.staticAssets.js);
+      return;
+    }
+    if (req.method === 'GET' && path === '/pair/status') {
+      serveStatus(res, deps.options.read());
+      return;
+    }
+    if (req.method === 'POST' && path === '/pair/claim') {
+      void serveClaim(req, res, deps);
+      return;
+    }
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not-found' }));
+  };
+}
+
+function serveStatic(res: ServerResponse, contentType: string, body: string): void {
+  res.writeHead(200, {
+    'Content-Type': contentType,
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(body);
+}
+
+function serveStatus(res: ServerResponse, options: AddonOptions): void {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  if (isPaired(options)) {
+    res.end(
+      JSON.stringify({
+        paired: true,
+        homeId: options.home_id,
+        cloudUrl: options.cloud_url,
+      }),
+    );
+    return;
+  }
+  res.end(JSON.stringify({ paired: false }));
+}
+
+async function serveClaim(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: PairServerDeps,
+): Promise<void> {
+  let body: string;
+  try {
+    body = await readBody(req);
+  } catch {
+    jsonError(res, 400, 'invalid-body');
+    return;
+  }
+  let parsed: { code?: unknown };
+  try {
+    parsed = JSON.parse(body) as { code?: unknown };
+  } catch {
+    jsonError(res, 400, 'invalid-json');
+    return;
+  }
+  const code = typeof parsed.code === 'string' ? parsed.code.trim() : '';
+  if (code.length === 0) {
+    jsonError(res, 400, 'code-required');
+    return;
+  }
+
+  const stored = deps.options.read();
+  const cloudUrl = pickCloudBase(stored.cloud_url);
+  const fetcher = deps.cloudFetch ?? defaultCloudFetch;
+  const result = await fetcher(cloudUrl, code);
+  if (!result.ok) {
+    deps.logger('warn', {
+      msg: 'pair-claim-rejected',
+      status: result.err.status,
+      code: result.err.body.code,
+    });
+    res.writeHead(result.err.status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(scrub(result.err.body)));
+    return;
+  }
+
+  // Persist credentials and wake the supervisor.
+  deps.options.write({
+    cloud_url: result.data.cloudUrl,
+    home_id: result.data.homeId,
+    relay_secret: result.data.relaySecret,
+  });
+  deps.logger('info', { msg: 'pair-claim-success', homeId: result.data.homeId });
+  deps.state.pairedSignal();
+
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      paired: true,
+      homeId: result.data.homeId,
+      cloudUrl: result.data.cloudUrl,
+    }),
+  );
+}
+
+function jsonError(res: ServerResponse, status: number, code: string): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: code }));
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on('data', (chunk: Buffer | string) => {
+      const buf = typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : chunk;
+      total += buf.length;
+      if (total > 4096) {
+        reject(new Error('payload-too-large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(buf);
+    });
+    req.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf-8'));
+    });
+    req.on('error', reject);
+  });
+}
+
+// `cloud_url` from /data/options.json is the same operator-controlled value
+// the WebSocket sink reads. Apply the same literal-switch sanitizer pattern
+// so CodeQL stays happy on the HTTP claim sink as well.
+function pickCloudBase(stored: string | undefined): string {
+  if (stored === undefined || stored.length === 0) return PROD_CLOUD;
+  let parsed: URL;
+  try {
+    parsed = new URL(stored);
+  } catch {
+    return PROD_CLOUD;
+  }
+  switch (parsed.host) {
+    case 'relay.glaon.app':
+      return PROD_CLOUD;
+    case 'relay-staging.glaon.app':
+      return STAGING_CLOUD;
+    default: {
+      const isLocalhost = parsed.host === 'localhost' || /^localhost:\d{1,5}$/.test(parsed.host);
+      const dev = process.env.GLAON_DEV_UPSTREAM_HTTP;
+      if (isLocalhost && dev !== undefined && dev.length > 0) {
+        return dev;
+      }
+      return PROD_CLOUD;
+    }
+  }
+}
+
+const defaultCloudFetch: CloudFetch = (cloudUrl, code) => {
+  return new Promise((resolve) => {
+    const url = new URL('/pair/claim', cloudUrl);
+    const payload = JSON.stringify({ code });
+    const httpsCall = url.protocol === 'https:';
+    const opts = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+    };
+    const doRequest = httpsCall ? request : requestHttp;
+    const req = doRequest(url, opts, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf-8');
+        let body: Record<string, unknown> = {};
+        try {
+          body = JSON.parse(text) as Record<string, unknown>;
+        } catch {
+          /* noop */
+        }
+        const status = res.statusCode ?? 0;
+        if (status >= 200 && status < 300) {
+          const homeId = typeof body.homeId === 'string' ? body.homeId : '';
+          const relaySecret = typeof body.relaySecret === 'string' ? body.relaySecret : '';
+          const respondedCloudUrl = typeof body.cloudUrl === 'string' ? body.cloudUrl : cloudUrl;
+          if (homeId.length === 0 || relaySecret.length === 0) {
+            resolve({ ok: false, err: { status: 502, body: { error: 'bad-cloud-response' } } });
+            return;
+          }
+          resolve({
+            ok: true,
+            data: { homeId, relaySecret, cloudUrl: respondedCloudUrl },
+          });
+          return;
+        }
+        resolve({
+          ok: false,
+          err: {
+            status,
+            body: {
+              error: typeof body.error === 'string' ? body.error : 'cloud-error',
+              code: typeof body.code === 'string' ? body.code : undefined,
+              retryAfterMs: typeof body.retryAfterMs === 'number' ? body.retryAfterMs : undefined,
+            },
+          },
+        });
+      });
+      res.on('error', () => {
+        resolve({ ok: false, err: { status: 502, body: { error: 'cloud-stream-error' } } });
+      });
+    });
+    req.on('error', () => {
+      resolve({ ok: false, err: { status: 502, body: { error: 'cloud-network-error' } } });
+    });
+    req.write(payload);
+    req.end();
+  });
+};

--- a/apps/addon-agent/src/state.test.ts
+++ b/apps/addon-agent/src/state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { AgentState } from './state';
+
+describe('AgentState', () => {
+  it('starts in idle with null homeId', () => {
+    const s = new AgentState();
+    expect(s.view()).toEqual({ name: 'idle', homeId: null, lastError: null, attempt: 0 });
+  });
+
+  it('merges partial updates into the view', () => {
+    const s = new AgentState();
+    s.set({ name: 'connecting', homeId: 'h-1' });
+    expect(s.view()).toEqual({
+      name: 'connecting',
+      homeId: 'h-1',
+      lastError: null,
+      attempt: 0,
+    });
+    s.set({ name: 'running' });
+    expect(s.view().name).toBe('running');
+    expect(s.view().homeId).toBe('h-1');
+  });
+
+  it('notifies listeners on every set', () => {
+    const s = new AgentState();
+    let calls = 0;
+    const off = s.on(() => {
+      calls++;
+    });
+    s.set({ name: 'connecting' });
+    s.set({ attempt: 1 });
+    expect(calls).toBe(2);
+    off();
+    s.set({ name: 'running' });
+    expect(calls).toBe(2);
+  });
+
+  it('pairedSignal resolves a pending waitForWake promise', async () => {
+    const s = new AgentState();
+    const wake = s.waitForWake();
+    let resolved = false;
+    void wake.then(() => {
+      resolved = true;
+    });
+    expect(resolved).toBe(false);
+    s.pairedSignal();
+    await wake;
+    expect(resolved).toBe(true);
+  });
+
+  it('pairedSignal is a no-op when nobody is waiting', () => {
+    const s = new AgentState();
+    expect(() => {
+      s.pairedSignal();
+    }).not.toThrow();
+  });
+});

--- a/apps/addon-agent/src/state.ts
+++ b/apps/addon-agent/src/state.ts
@@ -6,9 +6,9 @@
 // supervisor wakes from IDLE / FATAL and reconnects with the new credentials
 // without spawning a new process.
 
-export type AgentStateName = 'idle' | 'connecting' | 'running' | 'backoff' | 'fatal';
+type AgentStateName = 'idle' | 'connecting' | 'running' | 'backoff' | 'fatal';
 
-export interface AgentStateView {
+interface AgentStateView {
   readonly name: AgentStateName;
   readonly homeId: string | null;
   readonly lastError: string | null;

--- a/apps/addon-agent/src/state.ts
+++ b/apps/addon-agent/src/state.ts
@@ -1,0 +1,60 @@
+// Agent state machine — the supervisor loop transitions between IDLE (no
+// credentials), CONNECTING (dialing cloud + HA), RUNNING (bridge live),
+// BACKOFF (transient error), FATAL (auth rejected, wait for re-pair).
+//
+// The /pair/claim handler writes new options + flips a "paired" event so the
+// supervisor wakes from IDLE / FATAL and reconnects with the new credentials
+// without spawning a new process.
+
+export type AgentStateName = 'idle' | 'connecting' | 'running' | 'backoff' | 'fatal';
+
+export interface AgentStateView {
+  readonly name: AgentStateName;
+  readonly homeId: string | null;
+  readonly lastError: string | null;
+  readonly attempt: number;
+}
+
+type Listener = () => void;
+
+export class AgentState {
+  private state: AgentStateView = {
+    name: 'idle',
+    homeId: null,
+    lastError: null,
+    attempt: 0,
+  };
+  private readonly listeners = new Set<Listener>();
+  private wakeResolver: (() => void) | null = null;
+
+  view(): AgentStateView {
+    return this.state;
+  }
+
+  set(next: Partial<AgentStateView>): void {
+    this.state = { ...this.state, ...next };
+    for (const listener of this.listeners) listener();
+  }
+
+  on(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  // The supervisor loop calls `waitForWake()` when sitting in IDLE or FATAL.
+  // /pair/claim → `pairedSignal()` resolves the wait so the loop can re-read
+  // options and try to connect.
+  waitForWake(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.wakeResolver = resolve;
+    });
+  }
+
+  pairedSignal(): void {
+    const resolver = this.wakeResolver;
+    this.wakeResolver = null;
+    if (resolver !== null) resolver();
+  }
+}

--- a/apps/addon-agent/src/static/pair.css
+++ b/apps/addon-agent/src/static/pair.css
@@ -1,0 +1,162 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7f9;
+  --fg: #11181c;
+  --fg-muted: #5b6770;
+  --card: #ffffff;
+  --border: #e4e7eb;
+  --accent: #1a73e8;
+  --accent-fg: #ffffff;
+  --error: #b3261e;
+  --success: #1e7e34;
+  --radius: 12px;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 4px 16px rgba(0, 0, 0, 0.06);
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0f1418;
+    --fg: #e5e7eb;
+    --fg-muted: #9aa4ad;
+    --card: #1a2228;
+    --border: #2a323a;
+    --accent: #4f9eff;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 1.5rem;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.5;
+}
+
+.page {
+  max-width: 520px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.page__head h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.lede {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.card[hidden] {
+  display: none;
+}
+
+.card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.125rem;
+}
+
+.card--success {
+  border-color: var(--success);
+}
+
+.kv {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 1rem;
+  margin: 0 0 0.75rem;
+}
+
+.kv dt {
+  color: var(--fg-muted);
+  font-size: 0.875rem;
+}
+
+.kv dd {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  word-break: break-all;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.field__label {
+  font-weight: 600;
+}
+
+.field input {
+  font: inherit;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--fg);
+  letter-spacing: 0.25em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 1.125rem;
+  text-align: center;
+}
+
+.field input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.field__hint {
+  font-size: 0.875rem;
+  color: var(--fg-muted);
+}
+
+.field__error {
+  font-size: 0.875rem;
+  color: var(--error);
+  min-height: 1.25rem;
+}
+
+.field__error:empty {
+  display: none;
+}
+
+button {
+  margin-top: 1rem;
+  width: 100%;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.75rem 1rem;
+  border: 0;
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/apps/addon-agent/src/static/pair.html
+++ b/apps/addon-agent/src/static/pair.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Glaon — Link to cloud</title>
+    <link rel="stylesheet" href="/pair/pair.css" />
+  </head>
+  <body>
+    <main class="page" id="main">
+      <header class="page__head">
+        <h1>Link this home to Glaon cloud</h1>
+        <p class="lede">
+          Generate a 6-digit code in the Glaon mobile or web app, then enter it here. Once accepted,
+          this addon will reconnect through the cloud relay and you can control your home from
+          anywhere.
+        </p>
+      </header>
+
+      <section class="card" id="state-loading" aria-live="polite" aria-busy="true" hidden>
+        <p>Checking pairing status&hellip;</p>
+      </section>
+
+      <section class="card" id="state-paired" aria-live="polite" hidden>
+        <h2>This home is linked</h2>
+        <dl class="kv">
+          <dt>Home ID</dt>
+          <dd id="paired-home"></dd>
+          <dt>Cloud</dt>
+          <dd id="paired-cloud"></dd>
+        </dl>
+        <p>
+          To re-link this home to a different account, unlink it from the cloud dashboard first.
+        </p>
+      </section>
+
+      <section class="card" id="state-form" hidden>
+        <form id="pair-form" novalidate>
+          <label class="field">
+            <span class="field__label">Pairing code</span>
+            <input
+              id="code-input"
+              name="code"
+              type="text"
+              inputmode="numeric"
+              autocomplete="one-time-code"
+              maxlength="6"
+              minlength="6"
+              pattern="[0-9]{6}"
+              required
+              aria-describedby="code-help code-error"
+            />
+            <span id="code-help" class="field__hint">
+              Six digits, shown by the Glaon app for ten minutes.
+            </span>
+            <span id="code-error" class="field__error" role="alert" aria-live="assertive"></span>
+          </label>
+          <button type="submit" id="submit-btn">Link this home</button>
+        </form>
+      </section>
+
+      <section class="card card--success" id="state-success" aria-live="polite" hidden>
+        <h2>Linked.</h2>
+        <p>The relay agent is reconnecting through the cloud now. You can close this page.</p>
+      </section>
+    </main>
+    <script src="/pair/pair.js" defer></script>
+  </body>
+</html>

--- a/apps/addon-agent/src/static/pair.js
+++ b/apps/addon-agent/src/static/pair.js
@@ -1,0 +1,120 @@
+/* global document, fetch */
+(() => {
+  'use strict';
+
+  const states = {
+    loading: document.getElementById('state-loading'),
+    paired: document.getElementById('state-paired'),
+    form: document.getElementById('state-form'),
+    success: document.getElementById('state-success'),
+  };
+  const form = document.getElementById('pair-form');
+  const input = document.getElementById('code-input');
+  const submitBtn = document.getElementById('submit-btn');
+  const errorEl = document.getElementById('code-error');
+  const pairedHome = document.getElementById('paired-home');
+  const pairedCloud = document.getElementById('paired-cloud');
+
+  function show(name) {
+    for (const [key, el] of Object.entries(states)) {
+      if (!el) continue;
+      el.hidden = key !== name;
+    }
+  }
+
+  function setError(message) {
+    if (!errorEl) return;
+    errorEl.textContent = message;
+  }
+
+  async function readJson(response) {
+    try {
+      return await response.json();
+    } catch {
+      return {};
+    }
+  }
+
+  function userMessageFor(status, body) {
+    if (status === 400 && body && body.error === 'code-required') {
+      return 'Please enter the 6-digit code.';
+    }
+    if (status === 401) return "That code didn't match. Double-check and try again.";
+    if (status === 410) {
+      if (body && body.code === 'code-already-claimed') {
+        return 'That code was already used. Generate a new one in the Glaon app.';
+      }
+      return 'That code expired. Generate a new one in the Glaon app.';
+    }
+    if (status === 429) {
+      const seconds =
+        body && typeof body.retryAfterMs === 'number' ? Math.ceil(body.retryAfterMs / 1000) : null;
+      if (seconds !== null && seconds > 0) {
+        return `Too many attempts. Try again in about ${seconds} second${seconds === 1 ? '' : 's'}.`;
+      }
+      return 'Too many attempts. Try again in a moment.';
+    }
+    if (status === 502) return 'Could not reach the Glaon cloud. Check your internet connection.';
+    return 'Something went wrong. Try again in a moment.';
+  }
+
+  async function loadStatus() {
+    show('loading');
+    try {
+      const res = await fetch('/pair/status', { headers: { Accept: 'application/json' } });
+      const body = await readJson(res);
+      if (res.ok && body && body.paired === true) {
+        if (pairedHome) pairedHome.textContent = body.homeId || '';
+        if (pairedCloud) pairedCloud.textContent = body.cloudUrl || '';
+        show('paired');
+        return;
+      }
+    } catch {
+      /* fall through to form */
+    }
+    show('form');
+    if (input) input.focus();
+  }
+
+  async function submitCode(event) {
+    event.preventDefault();
+    setError('');
+    if (!input) return;
+    const code = String(input.value || '').trim();
+    if (!/^\d{6}$/.test(code)) {
+      setError('Enter the 6-digit code from the Glaon app.');
+      input.focus();
+      return;
+    }
+    if (submitBtn) {
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Linking…';
+    }
+    try {
+      const res = await fetch('/pair/claim', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      const body = await readJson(res);
+      if (res.ok && body && body.paired === true) {
+        if (pairedHome) pairedHome.textContent = body.homeId || '';
+        if (pairedCloud) pairedCloud.textContent = body.cloudUrl || '';
+        show('success');
+        return;
+      }
+      setError(userMessageFor(res.status, body));
+      input.focus();
+    } catch {
+      setError('Could not reach the addon. Refresh this page and try again.');
+    } finally {
+      if (submitBtn) {
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Link this home';
+      }
+    }
+  }
+
+  if (form) form.addEventListener('submit', submitCode);
+  void loadStatus();
+})();

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "repository": "toss-cengiz/glaon.git",
   "scripts": {
     "build": "turbo run build",
-    "build:addon": "pnpm --filter @glaon/web build:addon && pnpm --filter @glaon/addon-agent build && rm -rf addon/dist addon/agent && cp -R apps/web/dist addon/dist && mkdir -p addon/agent && cp apps/addon-agent/dist/agent.cjs addon/agent/agent.cjs",
+    "build:addon": "pnpm --filter @glaon/web build:addon && pnpm --filter @glaon/addon-agent build && rm -rf addon/dist addon/agent && cp -R apps/web/dist addon/dist && mkdir -p addon/agent && cp apps/addon-agent/dist/agent.cjs addon/agent/agent.cjs && cp -R apps/addon-agent/dist/static addon/agent/static",
     "build:cloud": "pnpm --filter @glaon/cloud build",
     "clean": "turbo run clean && rm -rf node_modules .turbo",
     "dev": "turbo run dev",


### PR DESCRIPTION
## Summary

- Adds the addon-side `/pair` Ingress route (vanilla HTML/CSS/JS) so a user can link this home to a Glaon cloud account by typing the 6-digit code from the mobile/web app.
- POST `/pair/claim` forwards to cloud `/pair/claim`, persists `{cloud_url, home_id, relay_secret}` atomically to `/data/options.json` at mode 0600, and wakes the supervisor loop.
- Agent process now always boots — even when unpaired — so the pair UI is reachable. Supervisor loop has an explicit state machine: `idle → connecting → running ↺ backoff` with `fatal` on auth rejection (waits for re-pair instead of retry-storming).

## Scope (In)

- `/pair` (HTML) + `/pair/pair.css` + `/pair/pair.js` static assets, served by the agent's HTTP server (port 8001), nginx proxies the `/pair` prefix.
- `/pair/status` (`{paired, homeId?, cloudUrl?}` — no `relay_secret` ever leaves the addon).
- `/pair/claim` ({code}) → cloud claim → write options → state.pairedSignal().
- UI states: loading → paired (already linked) | form (enter code) → success.
- Error mapping: 401 unknown code, 410 expired/already-used, 429 rate-limited with retryAfterMs, 502 network.
- Pre-pair guard: status probe shows "this home is linked" with re-link guidance when already paired.
- a11y: explicit form labels, `role="alert"` + `aria-live="assertive"` on errors, `autocomplete="one-time-code"`, focus management on submit failure, axe-clean by construction (no role abuse, single h1).
- `FileOptionsStore`: atomic write (tmp + rename) at `0600` for the relay secret.
- `AgentState` event emitter: `pairedSignal()` resolves a pending `waitForWake()` so the loop reconnects without process restart.
- 25 new unit tests (`pair-server`, `options-store`, `state`).

## Scope (Out)

- Cloud-side pairing endpoint — already shipped in #346.
- mDNS broadcast `glaon.local` — #350.
- AppArmor / file-permission hardening — #351.
- Mobile pairing wizard — #357.

## Test plan

- [x] `pnpm --filter @glaon/addon-agent type-check` — passes.
- [x] `pnpm --filter @glaon/addon-agent lint` — passes.
- [x] `pnpm --filter @glaon/addon-agent test` — 37 tests pass (12 prior + 25 new).
- [x] `pnpm --filter @glaon/addon-agent build` — `dist/agent.cjs` + `dist/static/{pair.html,pair.css,pair.js}` emit correctly.
- [x] `pnpm --filter @glaon/cloud type-check && test && lint` — unchanged, still green.
- [ ] CI: type-check · lint · audit, unit-tests, story-tests, playwright, CodeQL, visual regression, build (aarch64+amd64).
- [ ] Reviewer eyeball: pair UI screenshots.

## Notes

- The pair page is intentionally NOT bundled through `apps/web`. It's a 250-line vanilla HTML/CSS/JS island so it can run before the SPA is reachable (and the addon ships with a paired-or-not coin flip on first install).
- Cloud claim base URL is selected from a literal switch on `parsed.host` — same CodeQL `js/file-access-to-http` defense pattern from #444. Localhost dev fixtures honor `GLAON_DEV_UPSTREAM_HTTP` env var.

Closes #349.
Refs ADR 0021.