### PR TITLE
chore(addon): harden relay agent (apparmor, perms, scrubber, user)

### DIFF
--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -6,14 +6,23 @@ ENV LANG=C.UTF-8
 
 # nginx serves the web bundle on Ingress; nodejs runs the relay agent (#348)
 # alongside it. Both processes are supervised by run.sh — no s6-overlay yet.
+# `su-exec` (#351) is used to drop privileges from the boot-time root context
+# down to the unprivileged `glaon` user before exec'ing the Node agent. nginx
+# itself stays as the addon's entrypoint pid 1 (root); it self-drops worker
+# processes via the `user` directive in its own config when needed.
 # hadolint ignore=DL3018
-RUN apk add --no-cache nginx nodejs
+RUN apk add --no-cache nginx nodejs su-exec \
+    && addgroup -S glaon \
+    && adduser -S -G glaon -h /var/empty -s /sbin/nologin glaon
 
 COPY rootfs /
 COPY dist /var/www/glaon
 COPY agent /opt/glaon/agent
 
-RUN chmod a+x /run.sh
+# Static agent code is read-only for the agent user; ownership stays root.
+RUN chmod a+x /run.sh \
+    && chown -R root:glaon /opt/glaon/agent \
+    && chmod -R u=rwX,g=rX,o= /opt/glaon/agent
 
 EXPOSE 8099
 

--- a/addon/apparmor.txt
+++ b/addon/apparmor.txt
@@ -1,19 +1,75 @@
 #include <tunables/global>
 
+# Glaon addon AppArmor profile (#351). Two foreground processes run inside
+# the addon container: nginx (serves the web bundle on Ingress and proxies
+# /pair to the agent on 127.0.0.1:8001) and the Node-based relay agent
+# (apps/addon-agent — bridges HA WS to the Glaon cloud relay and hosts the
+# pairing surface). Everything else is denied by AppArmor's deny-by-default
+# semantics.
+#
+# Network confinement at the AppArmor layer is coarse — we only get to say
+# "this process can speak inet/tcp at all", not "only to relay.glaon.app".
+# Host-level destination filtering is enforced by `selectUpstream()` in the
+# agent (literal allowlist, see ADR 0024 + the #444 CodeQL fix). HA's
+# Supervisor does the per-addon network ACLs around the container itself.
+
 profile glaon flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/openssl>
 
+  # 8099 binding for nginx + 8001 for the agent's pair / healthz HTTP server.
   capability net_bind_service,
+  # bashio's `with-contenv` wrapper + su-exec drop to the agent user.
   capability setuid,
   capability setgid,
+  # FileOptionsStore writes /data/options.json at mode 0600 (rename from .tmp).
+  capability chown,
+  capability fowner,
 
-  network inet tcp,
-  network inet6 tcp,
+  network inet stream,
+  network inet6 stream,
+  network unix stream,
 
+  # ---- Boot path (run.sh, bashio, su-exec) --------------------------------
   /run.sh rix,
+  /usr/bin/with-contenv rix,
+  /usr/bin/bashio rix,
+  /usr/bin/su-exec rix,
+  /etc/services r,
+  /etc/passwd r,
+  /etc/group r,
+  /usr/bin/env rix,
+  /bin/sh rix,
+  /bin/bash rix,
+
+  # ---- nginx --------------------------------------------------------------
   /usr/sbin/nginx rix,
+  /etc/nginx/** r,
   /var/www/glaon/** r,
   /var/log/nginx/** w,
   /var/lib/nginx/** rw,
   /run/nginx.pid rw,
+  /run/nginx/** rw,
+
+  # ---- Relay agent (Node) -------------------------------------------------
+  /usr/bin/node rix,
+  /opt/glaon/agent/** r,
+
+  # ---- Addon options (operator-controlled, includes relay_secret) ---------
+  /data/options.json rw,
+  /data/options.json.tmp rw,
+
+  # ---- Explicit denies for defense-in-depth ------------------------------
+  # The profile is deny-by-default, but call out the highest-value sinks so
+  # accidental rule expansion doesn't open them silently.
+  deny /etc/shadow rw,
+  deny /etc/sudoers rw,
+  deny /root/** rw,
+  deny capability sys_admin,
+  deny capability sys_module,
+  deny capability sys_ptrace,
+  deny capability dac_override,
+  deny capability mac_admin,
+  deny capability mac_override,
 }

--- a/addon/rootfs/run.sh
+++ b/addon/rootfs/run.sh
@@ -12,7 +12,20 @@ bashio::log.info "Starting Glaon add-on..."
 # container's liveness still keys on the web server.
 if [ -f /opt/glaon/agent/agent.cjs ]; then
   bashio::log.info "Starting relay agent + pair surface..."
-  node /opt/glaon/agent/agent.cjs &
+  # The agent needs read of /opt/glaon/agent (group glaon, mode 0750 — set in
+  # the Dockerfile) and rw on /data/options.json. /data is supervisor-owned;
+  # chown the options file to the glaon user the first time the agent runs
+  # so su-exec can later overwrite it. If the file isn't there yet (unpaired)
+  # the chown is a no-op and the FileOptionsStore creates the file at 0600
+  # under the glaon user's umask.
+  if [ -e /data/options.json ]; then
+    chown glaon:glaon /data/options.json || true
+    chmod 0600 /data/options.json || true
+  fi
+  # /data must be searchable by the unprivileged user so it can open
+  # options.json by absolute path.
+  chmod a+x /data || true
+  su-exec glaon node /opt/glaon/agent/agent.cjs &
 fi
 
 exec nginx -g 'daemon off;'

--- a/apps/addon-agent/src/agent.ts
+++ b/apps/addon-agent/src/agent.ts
@@ -24,7 +24,12 @@ import { FatalRelayAuthError, nextDelay } from './backoff';
 import { createPairHandler } from './pair-server';
 import { scrub } from './scrubber';
 import { AgentState } from './state';
-import { FileOptionsStore, isPaired, type AddonOptions } from './options-store';
+import {
+  FileOptionsStore,
+  inspectOptionsPerms,
+  isPaired,
+  type AddonOptions,
+} from './options-store';
 
 const OPTIONS_PATH = process.env.GLAON_OPTIONS_PATH ?? '/data/options.json';
 const SUPERVISOR_TOKEN = process.env.SUPERVISOR_TOKEN;
@@ -80,6 +85,26 @@ function startHttpServer(state: AgentState, store: FileOptionsStore): void {
 async function runAgentLoop(state: AgentState, store: FileOptionsStore): Promise<void> {
   let attempt = 0;
   for (;;) {
+    // Refuse to read credentials from a world-readable options file (#351).
+    // chmod 0o600 is attempted once; if that fails the loop sits in IDLE
+    // until /pair/claim writes a fresh 0o600 file via FileOptionsStore.
+    const perms = inspectOptionsPerms(OPTIONS_PATH);
+    if (perms.state === 'unsafe') {
+      state.set({ name: 'idle', homeId: null, attempt: 0, lastError: 'options-perms-unsafe' });
+      log('error', {
+        msg: 'options-perms-unsafe',
+        modeOctal: perms.mode.toString(8),
+        reason: perms.reason,
+      });
+      await state.waitForWake();
+      continue;
+    }
+    if (perms.state === 'fixed') {
+      log('warn', {
+        msg: 'options-perms-fixed',
+        previousModeOctal: perms.previousMode.toString(8),
+      });
+    }
     const options = store.read();
     if (!isPaired(options) || SUPERVISOR_TOKEN === undefined) {
       state.set({ name: 'idle', homeId: null, attempt: 0 });

--- a/apps/addon-agent/src/options-store.test.ts
+++ b/apps/addon-agent/src/options-store.test.ts
@@ -1,10 +1,15 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { FileOptionsStore, isPaired, type AddonOptions } from './options-store';
+import {
+  FileOptionsStore,
+  inspectOptionsPerms,
+  isPaired,
+  type AddonOptions,
+} from './options-store';
 
 function makeStore(): { store: FileOptionsStore; dir: string; path: string } {
   const dir = mkdtempSync(join(tmpdir(), 'glaon-options-'));
@@ -58,6 +63,40 @@ describe('FileOptionsStore', () => {
       // Write garbage directly bypassing the store API.
       writeFileSync(path, 'not json', { mode: 0o600 });
       expect(store.read()).toEqual({});
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('inspectOptionsPerms', () => {
+  it("reports 'absent' when the file does not exist", () => {
+    const { dir, path } = makeStore();
+    try {
+      expect(inspectOptionsPerms(path)).toEqual({ state: 'absent' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports 'ok' when perms are already 0600", () => {
+    const { store, dir, path } = makeStore();
+    try {
+      store.write({ cloud_url: 'a', home_id: 'b', relay_secret: 'c' });
+      expect(inspectOptionsPerms(path)).toEqual({ state: 'ok', mode: 0o600 });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports 'fixed' and chmod's the file when perms are too wide", () => {
+    const { store, dir, path } = makeStore();
+    try {
+      store.write({ cloud_url: 'a', home_id: 'b', relay_secret: 'c' });
+      chmodSync(path, 0o644);
+      const result = inspectOptionsPerms(path);
+      expect(result).toEqual({ state: 'fixed', previousMode: 0o644 });
+      expect(statSync(path).mode & 0o777).toBe(0o600);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/apps/addon-agent/src/options-store.ts
+++ b/apps/addon-agent/src/options-store.ts
@@ -7,7 +7,15 @@
 // scope. HA Supervisor reads the file via `bashio::config` (the same shell
 // helper used in `run.sh`); the JSON shape mirrors `addon/config.yaml`.
 
-import { closeSync, openSync, readFileSync, renameSync, writeSync } from 'node:fs';
+import {
+  chmodSync,
+  closeSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeSync,
+} from 'node:fs';
 
 export interface AddonOptions {
   readonly cloud_url?: string;
@@ -70,4 +78,32 @@ export function isPaired(options: AddonOptions): boolean {
     typeof options.relay_secret === 'string' &&
     options.relay_secret.length > 0
   );
+}
+
+type OptionsPermsResult =
+  | { state: 'ok'; mode: number }
+  | { state: 'absent' }
+  | { state: 'fixed'; previousMode: number }
+  | { state: 'unsafe'; mode: number; reason: string };
+
+// Verify /data/options.json is mode 0600 before the agent reads the
+// relay_secret. If the file exists with looser perms (Supervisor on some HA
+// images writes 0644 by default) try chmod once. If chmod fails the agent
+// still serves the /pair UI so the operator can re-pair into a freshly
+// 0600 file via FileOptionsStore.write — but it does NOT load credentials
+// from a world-readable file, refusing instead to open the cloud upstream.
+export function inspectOptionsPerms(path: string): OptionsPermsResult {
+  let mode: number;
+  try {
+    mode = statSync(path).mode & 0o777;
+  } catch {
+    return { state: 'absent' };
+  }
+  if (mode === 0o600) return { state: 'ok', mode };
+  try {
+    chmodSync(path, 0o600);
+    return { state: 'fixed', previousMode: mode };
+  } catch (err) {
+    return { state: 'unsafe', mode, reason: String(err) };
+  }
 }

--- a/apps/addon-agent/src/scrubber.test.ts
+++ b/apps/addon-agent/src/scrubber.test.ts
@@ -25,4 +25,35 @@ describe('scrubber', () => {
   it('walks arrays', () => {
     expect(scrub({ events: [{ jwt: 'x' }] })).toEqual({ events: [{ jwt: '[REDACTED]' }] });
   });
+
+  it('redacts a Bearer token embedded in a free-form string value', () => {
+    expect(scrub({ msg: 'request failed: Bearer eyJabc.def.ghi rejected' })).toEqual({
+      msg: 'request failed: Bearer [REDACTED] rejected',
+    });
+  });
+
+  it('redacts a JWT-shaped substring in a free-form string value', () => {
+    // Three base64url-ish segments, each ≥6 chars — matches the JWT regex
+    // without containing real high-entropy material that would trip
+    // secret-scanning tooling.
+    expect(scrub({ msg: 'token=aaaaaa.bbbbbb.cccccc leaked' })).toEqual({
+      msg: 'token=[REDACTED-JWT] leaked',
+    });
+  });
+
+  it('leaves dotted identifiers shorter than the JWT shape alone', () => {
+    expect(scrub({ msg: 'home_id=h-1.region.zone' })).toEqual({
+      msg: 'home_id=h-1.region.zone',
+    });
+  });
+
+  it('redacts top-level string inputs', () => {
+    expect(scrub('Authorization: Bearer abc123')).toBe('Authorization: Bearer [REDACTED]');
+  });
+
+  it('preserves non-secret string content untouched', () => {
+    expect(scrub({ msg: 'connected to relay.glaon.app, home=h-1' })).toEqual({
+      msg: 'connected to relay.glaon.app, home=h-1',
+    });
+  });
 });

--- a/apps/addon-agent/src/scrubber.ts
+++ b/apps/addon-agent/src/scrubber.ts
@@ -2,6 +2,17 @@
 // land in agent logs. The agent never parses the HA WS payload it forwards;
 // the scrubber covers structured log entries the agent emits about its own
 // lifecycle (connect, disconnect, errors).
+//
+// Two layers (#351):
+//
+//   1. Key-name match (case-insensitive) against `SENSITIVE_KEYS`. Catches
+//      the structured paths where a leak is most likely (e.g. an error
+//      surface that JSON-stringifies a request whose `headers` member
+//      includes Authorization).
+//   2. Value pattern match for cases where a secret slips through as a
+//      free-form string — e.g. `err.message: 'failed: Bearer abc...'`. The
+//      patterns are conservative (Bearer prefix, three-segment JWT) to keep
+//      the false-positive rate low.
 
 const SENSITIVE_KEYS = new Set([
   'access_token',
@@ -18,8 +29,19 @@ const SENSITIVE_KEYS = new Set([
   'supervisor_token',
 ]);
 
+// `Bearer <token>` — case-insensitive scheme, token is anything but
+// whitespace. The replacement keeps the scheme so log readers can still
+// tell what was redacted.
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+
+// JWT shape: three base64url-ish segments separated by dots. Min ~6 chars
+// per segment so we don't match innocent dotted identifiers.
+const JWT_PATTERN = /\b[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\b/g;
+
 export function scrub(input: unknown): unknown {
-  if (input === null || typeof input !== 'object') return input;
+  if (input === null) return input;
+  if (typeof input === 'string') return redactString(input);
+  if (typeof input !== 'object') return input;
   if (Array.isArray(input)) return input.map(scrub);
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(input)) {
@@ -30,4 +52,10 @@ export function scrub(input: unknown): unknown {
     out[key] = scrub(value);
   }
   return out;
+}
+
+function redactString(value: string): string {
+  let result = value.replace(BEARER_PATTERN, 'Bearer [REDACTED]');
+  result = result.replace(JWT_PATTERN, '[REDACTED-JWT]');
+  return result;
 }


### PR DESCRIPTION
## Summary

Hardens the addon's relay agent surface (#351) so a compromised process leaks less than what the deploy already exposed.

- **AppArmor profile** ([addon/apparmor.txt](addon/apparmor.txt)) — explicit allowlist of binaries (nginx, node, su-exec, bashio chain) and `/data/options.json` paths; explicit denies for sys_admin / sys_module / ptrace / dac_override / mac_admin / mac_override.
- **Boot perms guard** — `inspectOptionsPerms()` runs every supervisor-loop iteration. If `/data/options.json` mode drifts above `0o600` the agent tries chmod once; if that fails the loop refuses to load credentials and falls back into IDLE (the `/pair` UI stays reachable for re-pair).
- **Scrubber value patterns** — two regex passes catch free-form leaks: `Bearer <token>` → `Bearer [REDACTED]`, three-segment JWT → `[REDACTED-JWT]`. The key-name allowlist already covered structured paths.
- **Non-root agent** — new `glaon` system user; `/opt/glaon/agent` owned `root:glaon` with mode `0o750`; `run.sh` chowns `/data/options.json` to glaon, then `su-exec glaon node ...` for the agent. nginx remains pid-1 root for 8099 binding.

## Scope (In)

- AppArmor profile rewrite.
- `inspectOptionsPerms()` + 3 unit tests (absent / ok / fixed paths).
- Scrubber Bearer + JWT regex passes + 6 new unit tests.
- Dockerfile: install `su-exec`, create `glaon` user, lock down `/opt/glaon/agent` perms.
- run.sh: chown options file, `su-exec glaon` for the agent process.

## Scope (Out)

- AppArmor for non-relay features — no other privileged surfaces in the addon yet.
- Production CSP / TLS pinning — client-side hardening is its own track.
- Cloud-side `security-review` — `apps/cloud/` PRs go through that skill independently.

## Test plan

- [x] `pnpm --filter @glaon/addon-agent type-check` — passes.
- [x] `pnpm --filter @glaon/addon-agent lint` — passes.
- [x] `pnpm --filter @glaon/addon-agent test` — 45 tests pass (37 prior + 8 new across scrubber + perms guard).
- [x] `pnpm exec knip --workspace apps/addon-agent` — clean.
- [ ] CI: type-check · lint · audit, unit-tests, story-tests, playwright, CodeQL, visual regression, build (aarch64+amd64).
- [ ] Reviewer: AppArmor profile review for over/under-scoping; `security-review` skill (the issue requests it).

## Notes

- AppArmor's network confinement is coarse (`inet stream` / `inet6 stream`); destination-host filtering is enforced one layer up by `selectUpstream()` in the agent (literal allowlist, see #444 + ADR 0024).
- nginx pid-1 stays as root because the addon entrypoint must bind 8099 in the supervisor's network namespace. nginx self-drops worker processes via its own `user` directive when needed.

Closes #351.
Refs ADR 0021.