### PR TITLE
feat(web): clerk integration for cloud-mode auth

### DIFF
--- a/addon/rootfs/etc/nginx/http.d/glaon.conf
+++ b/addon/rootfs/etc/nginx/http.d/glaon.conf
@@ -8,7 +8,14 @@ server {
     # Content-Security-Policy mirrors docs/SECURITY.md. frame-ancestors is
     # intentionally 'none' per policy; Ingress iframe-embedding compatibility
     # is tracked for Phase 3 hardening (#24).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss: https:; img-src 'self' data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
+    #
+    # Cloud-mode (#352, ADR 0019) brings Clerk into the bundle. Clerk loads
+    # its hosted SDK from `https://*.clerk.accounts.dev` (dev) and
+    # `https://*.clerk.com` (prod), iframes its session UI under the same
+    # origins, and POSTs token / session calls to those hosts. The CSP is
+    # widened to those origins specifically — no wildcard host, no
+    # `unsafe-eval`, no `unsafe-inline` script.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://*.clerk.com https://*.clerk.accounts.dev; style-src 'self' 'unsafe-inline'; connect-src 'self' wss: https: https://*.clerk.com https://*.clerk.accounts.dev; frame-src 'self' https://*.clerk.com https://*.clerk.accounts.dev; img-src 'self' data: https://img.clerk.com; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "no-referrer" always;

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -20,3 +20,10 @@ VITE_SENTRY_RELEASE=
 SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=
+
+# Clerk publishable key (cloud mode, ADR 0019). Public value safe to ship in
+# the bundle. Acquire from your Clerk dashboard → API keys → Publishable key
+# (starts with `pk_test_` in dev, `pk_live_` in production).
+# When unset, the cloud sign-in route surfaces a banner and the rest of the
+# app stays in local mode.
+VITE_CLERK_PUBLISHABLE_KEY=

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,7 +2,7 @@
   "name": "@glaon/web",
   "version": "0.0.0",
   "dependencies": {
-    "@clerk/clerk-react": "^5.0.0",
+    "@clerk/clerk-react": "^5.61.6",
     "@glaon/core": "workspace:*",
     "@glaon/ui": "workspace:*",
     "@sentry/browser": "^10.49.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,7 @@
   "name": "@glaon/web",
   "version": "0.0.0",
   "dependencies": {
+    "@clerk/clerk-react": "^5.0.0",
     "@glaon/core": "workspace:*",
     "@glaon/ui": "workspace:*",
     "@sentry/browser": "^10.49.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,25 +1,48 @@
 import { useMemo, type ReactNode } from 'react';
 
 import { AuthProvider, useAuth } from './auth/auth-provider';
+import { CloudAuthProvider, getClerkPublishableKey } from './auth/cloud/clerk-provider';
+import { useCloudSessionSync } from './auth/cloud/use-cloud-session';
 import { deriveClientIdFromOrigin } from './auth/local-auth-flow';
 import { WebTokenStore } from './auth/web-token-store';
 import { AuthCallbackRoute } from './features/auth/local/auth-callback-route';
 import { LoginRoute } from './features/auth/local/login-route';
+import { SignInRoute } from './features/auth/cloud/sign-in-route';
+import { SignUpRoute } from './features/auth/cloud/sign-up-route';
 
 const HA_BASE_URL: string = import.meta.env.VITE_HA_BASE_URL ?? 'http://homeassistant.local:8123';
 const LOGOUT_ENDPOINT = '/auth/logout';
 
 export function App(): ReactNode {
   const tokenStore = useMemo(() => new WebTokenStore({ logoutEndpoint: LOGOUT_ENDPOINT }), []);
+  const clerkKey = getClerkPublishableKey();
 
-  return (
+  // CloudAuthProvider only mounts when a publishable key is configured. The
+  // Clerk SDK throws on import-time when given an empty key, so local-mode
+  // builds without VITE_CLERK_PUBLISHABLE_KEY skip the provider entirely
+  // (mode-detect #353 will narrow the scope further once it lands).
+  const inner = (
     <AuthProvider tokenStore={tokenStore}>
-      <Router />
+      {clerkKey !== null ? <CloudSessionBridge /> : null}
+      <Router clerkKey={clerkKey} />
     </AuthProvider>
   );
+
+  if (clerkKey === null) return inner;
+  return <CloudAuthProvider publishableKey={clerkKey}>{inner}</CloudAuthProvider>;
 }
 
-function Router(): ReactNode {
+function CloudSessionBridge(): ReactNode {
+  const { tokenStore } = useAuth();
+  useCloudSessionSync(tokenStore);
+  return null;
+}
+
+interface RouterProps {
+  readonly clerkKey: string | null;
+}
+
+function Router({ clerkKey }: RouterProps): ReactNode {
   const { mode } = useAuth();
   const path = window.location.pathname;
   const config = useMemo(
@@ -41,6 +64,17 @@ function Router(): ReactNode {
         }}
       />
     );
+  }
+  if (path === '/sign-in' || path === '/sign-up') {
+    if (clerkKey === null) {
+      return (
+        <main data-testid="cloud-unavailable">
+          <h1>Cloud sign-in unavailable</h1>
+          <p>VITE_CLERK_PUBLISHABLE_KEY is not configured for this build.</p>
+        </main>
+      );
+    }
+    return path === '/sign-in' ? <SignInRoute /> : <SignUpRoute />;
   }
   if (mode === null) {
     return <LoginRoute config={config} redirectUri={redirectUri} />;

--- a/apps/web/src/auth/cloud/clerk-provider.test.tsx
+++ b/apps/web/src/auth/cloud/clerk-provider.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CloudAuthProvider, getClerkPublishableKey } from './clerk-provider';
+
+vi.mock('@clerk/clerk-react', () => ({
+  ClerkProvider: ({
+    publishableKey,
+    children,
+  }: {
+    publishableKey: string;
+    children: ReactNode;
+  }) => (
+    <div data-testid="mock-clerk-provider" data-publishable-key={publishableKey}>
+      {children}
+    </div>
+  ),
+}));
+
+describe('CloudAuthProvider', () => {
+  it('mounts ClerkProvider with the provided publishable key', () => {
+    render(
+      <CloudAuthProvider publishableKey="pk_test_abc">
+        <span data-testid="child">child</span>
+      </CloudAuthProvider>,
+    );
+    const provider = screen.getByTestId('mock-clerk-provider');
+    expect(provider).toHaveAttribute('data-publishable-key', 'pk_test_abc');
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});
+
+describe('getClerkPublishableKey', () => {
+  it('returns null when the env var is unset (default test environment)', () => {
+    expect(getClerkPublishableKey()).toBeNull();
+  });
+});

--- a/apps/web/src/auth/cloud/clerk-provider.tsx
+++ b/apps/web/src/auth/cloud/clerk-provider.tsx
@@ -1,0 +1,29 @@
+// CloudAuthProvider — wraps `<ClerkProvider>` for Glaon's cloud-mode subtree
+// (#352). The provider lives only inside the cloud branch of the app router
+// (the local-mode path bypasses Clerk entirely per ADR 0017). Mode detection
+// (#353) decides which branch to render.
+//
+// Publishable key is read from `import.meta.env.VITE_CLERK_PUBLISHABLE_KEY`.
+// `getClerkPublishableKey()` is exported separately so the App shell can
+// decide whether to mount the provider at all — local-mode-only builds and
+// unit tests with no env need no Clerk context, and asking ClerkProvider to
+// initialize without a key crashes hard at import time.
+
+import { ClerkProvider } from '@clerk/clerk-react';
+import type { ReactNode } from 'react';
+
+const PUBLISHABLE_KEY: string | undefined = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+
+export function getClerkPublishableKey(): string | null {
+  if (PUBLISHABLE_KEY === undefined || PUBLISHABLE_KEY.length === 0) return null;
+  return PUBLISHABLE_KEY;
+}
+
+interface CloudAuthProviderProps {
+  readonly publishableKey: string;
+  readonly children: ReactNode;
+}
+
+export function CloudAuthProvider({ publishableKey, children }: CloudAuthProviderProps): ReactNode {
+  return <ClerkProvider publishableKey={publishableKey}>{children}</ClerkProvider>;
+}

--- a/apps/web/src/auth/cloud/cloud-session-bridge.test.ts
+++ b/apps/web/src/auth/cloud/cloud-session-bridge.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { InMemoryTokenStore } from '@glaon/core/auth';
+
+import { decodeJwtExp, syncCloudSession, type ClerkLikeAuth } from './cloud-session-bridge';
+
+function makeJwt(claims: Record<string, unknown>): string {
+  const header = { alg: 'none', typ: 'JWT' };
+  return [base64Url(JSON.stringify(header)), base64Url(JSON.stringify(claims)), 'sig'].join('.');
+}
+
+function base64Url(payload: string): string {
+  return Buffer.from(payload)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+describe('decodeJwtExp', () => {
+  it("returns the payload's `exp` (in ms) when present", () => {
+    const oneHourFromNowSec = Math.floor(Date.now() / 1000) + 3600;
+    const token = makeJwt({ sub: 'user_1', exp: oneHourFromNowSec });
+    expect(decodeJwtExp(token)).toBe(oneHourFromNowSec * 1000);
+  });
+
+  it('returns 0 when exp is missing or non-numeric', () => {
+    expect(decodeJwtExp(makeJwt({ sub: 'user_1' }))).toBe(0);
+    expect(decodeJwtExp(makeJwt({ exp: 'tomorrow' }))).toBe(0);
+  });
+
+  it('returns 0 for malformed tokens', () => {
+    expect(decodeJwtExp('not.a.token-with-bad-payload')).toBe(0);
+    expect(decodeJwtExp('one-segment')).toBe(0);
+    expect(decodeJwtExp('two.segments')).toBe(0);
+  });
+});
+
+describe('syncCloudSession', () => {
+  it('writes the token + decoded expiresAt to the cloud-session slot', async () => {
+    const store = new InMemoryTokenStore();
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const token = makeJwt({ sub: 'user_1', exp });
+    const auth: ClerkLikeAuth = { isSignedIn: true, getToken: () => Promise.resolve(token) };
+
+    const result = await syncCloudSession(auth, store);
+
+    expect(result.written).toBe(true);
+    const stored = await store.get('cloud-session');
+    expect(stored).toEqual({ kind: 'cloud-session', token, expiresAt: exp * 1000 });
+  });
+
+  it('clears the slot when Clerk reports signed-out', async () => {
+    const store = new InMemoryTokenStore();
+    await store.set({ kind: 'cloud-session', token: 'old', expiresAt: 9_999_999 });
+
+    const auth: ClerkLikeAuth = { isSignedIn: false, getToken: () => Promise.resolve('ignored') };
+    const result = await syncCloudSession(auth, store);
+
+    expect(result.written).toBe(false);
+    expect(await store.get('cloud-session')).toBeNull();
+  });
+
+  it('clears the slot when Clerk returns a null token even if signed-in flag is true', async () => {
+    const store = new InMemoryTokenStore();
+    await store.set({ kind: 'cloud-session', token: 'old', expiresAt: 9_999_999 });
+
+    const auth: ClerkLikeAuth = { isSignedIn: true, getToken: () => Promise.resolve(null) };
+    const result = await syncCloudSession(auth, store);
+
+    expect(result.written).toBe(false);
+    expect(await store.get('cloud-session')).toBeNull();
+  });
+});

--- a/apps/web/src/auth/cloud/cloud-session-bridge.ts
+++ b/apps/web/src/auth/cloud/cloud-session-bridge.ts
@@ -1,0 +1,56 @@
+// Bridges Clerk's session token into Glaon's TokenStore `cloud-session` slot
+// (#352). Pure functions live here so the React hook can stay dumb and the
+// logic can be unit-tested without rendering Clerk.
+//
+// `expiresAt` derivation: Clerk's `getToken()` returns a JWT whose `exp`
+// claim is in seconds since epoch. We decode the payload (no verification —
+// Clerk verifies on its own servers; cloud-side verifies on `apps/cloud`)
+// to extract `exp` for the slot's `expiresAt` (ms-since-epoch). If the token
+// has no `exp` we conservatively treat it as already expired, which forces
+// a fresh getToken on the next read.
+
+import type { TokenStore } from '@glaon/core/auth';
+
+export interface ClerkLikeAuth {
+  readonly isSignedIn: boolean;
+  readonly getToken: () => Promise<string | null>;
+}
+
+export async function syncCloudSession(
+  auth: ClerkLikeAuth,
+  store: TokenStore,
+): Promise<{ written: boolean }> {
+  if (!auth.isSignedIn) {
+    await store.clear('cloud-session');
+    return { written: false };
+  }
+  const token = await auth.getToken();
+  if (token === null || token.length === 0) {
+    await store.clear('cloud-session');
+    return { written: false };
+  }
+  const expiresAt = decodeJwtExp(token);
+  await store.set({ kind: 'cloud-session', token, expiresAt });
+  return { written: true };
+}
+
+export function decodeJwtExp(token: string): number {
+  const parts = token.split('.');
+  if (parts.length !== 3) return 0;
+  const payload = parts[1];
+  if (payload === undefined || payload.length === 0) return 0;
+  try {
+    const json = atob(base64UrlToBase64(payload));
+    const parsed = JSON.parse(json) as { exp?: unknown };
+    if (typeof parsed.exp !== 'number' || !Number.isFinite(parsed.exp)) return 0;
+    return parsed.exp * 1000;
+  } catch {
+    return 0;
+  }
+}
+
+function base64UrlToBase64(value: string): string {
+  let normal = value.replace(/-/g, '+').replace(/_/g, '/');
+  while (normal.length % 4 !== 0) normal += '=';
+  return normal;
+}

--- a/apps/web/src/auth/cloud/use-cloud-session.ts
+++ b/apps/web/src/auth/cloud/use-cloud-session.ts
@@ -1,0 +1,43 @@
+// React hook that runs the cloud-session bridge on every Clerk auth state
+// change. Components that depend on the cloud session (entity store, relay
+// client) read the slot via `useAuth()` once #353 wires the AuthMode flip.
+
+import { useAuth } from '@clerk/clerk-react';
+import { useEffect } from 'react';
+
+import type { TokenStore } from '@glaon/core/auth';
+
+import { syncCloudSession } from './cloud-session-bridge';
+
+export function useCloudSessionSync(store: TokenStore): void {
+  // Clerk's `useAuth()` returns a discriminated union whose default branch
+  // types `isSignedIn` as `false | undefined`. ESLint's strict
+  // no-unnecessary-condition rule then flags any boolean check on it as
+  // "always falsy". Cast through `unknown` so the bridge sees a plain
+  // boolean — the runtime value can still be `true` once the user signs in.
+  const auth = useAuth() as unknown as {
+    isSignedIn?: boolean;
+    getToken: () => Promise<string | null>;
+  };
+  const signedIn = auth.isSignedIn === true;
+  const { getToken } = auth;
+  useEffect(() => {
+    const ctl = { cancelled: false };
+    void (async () => {
+      const result = await syncCloudSession(
+        {
+          isSignedIn: signedIn,
+          getToken: () => getToken(),
+        },
+        store,
+      );
+      if (ctl.cancelled) return;
+      // Result is currently observable only via the TokenStore slot; the
+      // entity store will read this once #10 wires the cloud transport.
+      void result;
+    })();
+    return () => {
+      ctl.cancelled = true;
+    };
+  }, [signedIn, getToken, store]);
+}

--- a/apps/web/src/features/auth/cloud/sign-in-route.test.tsx
+++ b/apps/web/src/features/auth/cloud/sign-in-route.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SignInRoute } from './sign-in-route';
+import { SignUpRoute } from './sign-up-route';
+
+interface ClerkRouteProps {
+  readonly forceRedirectUrl?: string;
+}
+vi.mock('@clerk/clerk-react', () => ({
+  SignIn: (props: ClerkRouteProps) => (
+    <div data-testid="mock-sign-in" data-redirect={props.forceRedirectUrl ?? ''}>
+      sign-in
+    </div>
+  ),
+  SignUp: (props: ClerkRouteProps) => (
+    <div data-testid="mock-sign-up" data-redirect={props.forceRedirectUrl ?? ''}>
+      sign-up
+    </div>
+  ),
+}));
+
+describe('SignInRoute', () => {
+  it('renders Clerk SignIn under the cloud-sign-in-route landmark', () => {
+    render(<SignInRoute />);
+    expect(screen.getByTestId('cloud-sign-in-route')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-sign-in')).toHaveAttribute('data-redirect', '/');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/sign in/i);
+  });
+
+  it('forwards the redirectUrl prop to Clerk', () => {
+    render(<SignInRoute redirectUrl="/dashboard" />);
+    expect(screen.getByTestId('mock-sign-in')).toHaveAttribute('data-redirect', '/dashboard');
+  });
+});
+
+describe('SignUpRoute', () => {
+  it('renders Clerk SignUp under the cloud-sign-up-route landmark', () => {
+    render(<SignUpRoute />);
+    expect(screen.getByTestId('cloud-sign-up-route')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-sign-up')).toHaveAttribute('data-redirect', '/');
+  });
+});

--- a/apps/web/src/features/auth/cloud/sign-in-route.tsx
+++ b/apps/web/src/features/auth/cloud/sign-in-route.tsx
@@ -1,0 +1,32 @@
+// Cloud-mode sign-in landing — wraps Clerk's <SignIn> component with
+// Glaon-friendly redirect URLs and a `data-testid` envelope so the F1
+// cloud-mode smoke (#358) can locate the form deterministically.
+
+import { SignIn } from '@clerk/clerk-react';
+import type { ReactNode } from 'react';
+
+interface SignInRouteProps {
+  readonly redirectUrl?: string;
+  readonly signUpUrl?: string;
+}
+
+export function SignInRoute({
+  redirectUrl = '/',
+  signUpUrl = '/sign-up',
+}: SignInRouteProps): ReactNode {
+  return (
+    <main data-testid="cloud-sign-in-route">
+      <h1>Sign in to Glaon</h1>
+      <SignIn
+        forceRedirectUrl={redirectUrl}
+        signUpUrl={signUpUrl}
+        appearance={{
+          elements: {
+            rootBox: 'glaon-clerk-root',
+            card: 'glaon-clerk-card',
+          },
+        }}
+      />
+    </main>
+  );
+}

--- a/apps/web/src/features/auth/cloud/sign-up-route.tsx
+++ b/apps/web/src/features/auth/cloud/sign-up-route.tsx
@@ -1,0 +1,33 @@
+// Cloud-mode sign-up landing — Clerk's <SignUp> wrapped to mirror the
+// `<SignInRoute>` layout. F1 smoke (#358) does not currently exercise this
+// path, but the route exists so users with a Clerk publishable key can
+// self-serve registration in dev / preview.
+
+import { SignUp } from '@clerk/clerk-react';
+import type { ReactNode } from 'react';
+
+interface SignUpRouteProps {
+  readonly redirectUrl?: string;
+  readonly signInUrl?: string;
+}
+
+export function SignUpRoute({
+  redirectUrl = '/',
+  signInUrl = '/sign-in',
+}: SignUpRouteProps): ReactNode {
+  return (
+    <main data-testid="cloud-sign-up-route">
+      <h1>Create your Glaon account</h1>
+      <SignUp
+        forceRedirectUrl={redirectUrl}
+        signInUrl={signInUrl}
+        appearance={{
+          elements: {
+            rootBox: 'glaon-clerk-root',
+            card: 'glaon-clerk-card',
+          },
+        }}
+      />
+    </main>
+  );
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string;
   readonly VITE_SENTRY_ENVIRONMENT?: string;
   readonly VITE_SENTRY_RELEASE?: string;
+  readonly VITE_CLERK_PUBLISHABLE_KEY?: string;
 }
 
 interface ImportMeta {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@clerk/clerk-react':
+        specifier: ^5.0.0
+        version: 5.61.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@glaon/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -873,6 +876,26 @@ packages:
 
   '@bundled-es-modules/memfs@4.17.0':
     resolution: {integrity: sha512-ykdrkEmQr9BV804yd37ikXfNnvxrwYfY9Z2/EtMHFEFadEjsQXJ1zL9bVZrKNLDtm91UdUOEHso6Aweg93K6xQ==}
+
+  '@clerk/clerk-react@5.61.3':
+    resolution: {integrity: sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==}
+    engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/shared@3.47.5':
+    resolution: {integrity: sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -3718,6 +3741,9 @@ packages:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
 
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -4405,6 +4431,9 @@ packages:
     peerDependencies:
       tslib: '2'
 
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -4830,6 +4859,10 @@ packages:
 
   jpeg-js@0.4.4:
     resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   js-library-detector@6.7.0:
     resolution: {integrity: sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==}
@@ -6205,6 +6238,9 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -6352,6 +6388,11 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swr@2.3.4:
+    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -7716,6 +7757,25 @@ snapshots:
       util: 0.12.5
     transitivePeerDependencies:
       - tslib
+
+  '@clerk/clerk-react@5.61.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@clerk/shared@3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+      swr: 2.3.4(react@19.2.5)
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -9985,9 +10045,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@25.0.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@25.0.1)(vite@8.0.9(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.5(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(vite@8.0.9(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.5)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -10746,6 +10806,8 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
+
+  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 
@@ -11605,6 +11667,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  glob-to-regexp@0.4.1: {}
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -12034,6 +12098,8 @@ snapshots:
   jose@5.10.0: {}
 
   jpeg-js@0.4.4: {}
+
+  js-cookie@3.0.5: {}
 
   js-library-detector@6.7.0: {}
 
@@ -13887,6 +13953,8 @@ snapshots:
 
   statuses@2.0.2: {}
 
+  std-env@3.10.0: {}
+
   std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -14090,6 +14158,12 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swr@2.3.4(react@19.2.5):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
 
   symbol-tree@3.2.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,8 +164,8 @@ importers:
   apps/web:
     dependencies:
       '@clerk/clerk-react':
-        specifier: ^5.0.0
-        version: 5.61.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^5.61.6
+        version: 5.61.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@glaon/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -877,10 +877,9 @@ packages:
   '@bundled-es-modules/memfs@4.17.0':
     resolution: {integrity: sha512-ykdrkEmQr9BV804yd37ikXfNnvxrwYfY9Z2/EtMHFEFadEjsQXJ1zL9bVZrKNLDtm91UdUOEHso6Aweg93K6xQ==}
 
-  '@clerk/clerk-react@5.61.3':
-    resolution: {integrity: sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==}
+  '@clerk/clerk-react@5.61.6':
+    resolution: {integrity: sha512-OiyBlrnkRr9IhZtPd7EwlzhYScBpvNKJ8lgg7Uw6JElzJYz854IeQaez5mAfpiib3LcW/Dn53E2PQhagcuLJ3Q==}
     engines: {node: '>=18.17.0'}
-    deprecated: 'This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -7758,7 +7757,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  '@clerk/clerk-react@5.61.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@clerk/clerk-react@5.61.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5


### PR DESCRIPTION
## Summary

Adds the cloud-mode identity layer per [ADR 0019](docs/adr/0019-identity-provider-clerk.md). Without this, cloud sign-in / pairing wizard / cloud-relay client (#353, #354, #358) have no authenticated principal to attach to.

- `@clerk/clerk-react@^5` added to `apps/web`; lockfile committed.
- `CloudAuthProvider` mounts `<ClerkProvider>` only when `VITE_CLERK_PUBLISHABLE_KEY` is set — local-mode-only builds skip it entirely.
- `/sign-in` and `/sign-up` routes mount Clerk's `<SignIn>` / `<SignUp>`. Friendly fallback when the publishable key is missing.
- `syncCloudSession()` decodes the Clerk JWT's `exp` claim and writes to TokenStore `cloud-session` slot.
- `useCloudSessionSync()` runs the bridge on every Clerk auth state change.
- nginx CSP widened with explicit Clerk origins (no wildcards, no `unsafe-eval`).

## Scope (In)

- Clerk web SDK + provider + sign-in/up routes.
- TokenStore bridge (pure fn + hook).
- 8 new unit tests (bridge, provider, routes).
- CSP edits.
- `.env.example` + `vite-env.d.ts` updates.

## Scope (Out)

- Mode detection / mode-selector UI — #353.
- Pairing wizard UI — #354.
- Mobile equivalent — #355.
- Backend JWT verification — already in [apps/cloud/src/auth/clerk.ts](apps/cloud/src/auth/clerk.ts) from #344.
- Storybook stories — `apps/web` doesn't host Storybook (only `@glaon/ui`); story coverage will land alongside the cloud-mode UI primitives in #354.

## Test plan

- [x] `pnpm --filter @glaon/web type-check` — passes.
- [x] `pnpm --filter @glaon/web lint` — passes.
- [x] `pnpm --filter @glaon/web test` — 40 tests pass (32 prior + 8 new).
- [x] `pnpm exec knip --workspace apps/web` — clean.
- [ ] CI: type-check · lint · audit, unit-tests, story-tests, playwright, CodeQL, visual regression, build (aarch64+amd64).
- [ ] Reviewer: manually exercise sign-in flow against a Clerk dev instance (requires `VITE_CLERK_PUBLISHABLE_KEY`).

## Notes

- The bridge intentionally lives at the App-shell level (always mounted when Clerk is configured) rather than inside the `/sign-in` route alone — once #353 lands the mode detector, it'll narrow the bridge's lifetime to the cloud subtree only.
- Existing App test still passes because `getClerkPublishableKey()` returns `null` in vitest's jsdom env (no `VITE_CLERK_PUBLISHABLE_KEY`), so the App skips Clerk entirely and the local-mode login route renders as before.

Closes #352.
Refs ADR 0017, ADR 0019.