### PR TITLE
feat(web): mode detection + selector ui

### DIFF
--- a/apps/web-e2e/tests/local-mode.spec.ts
+++ b/apps/web-e2e/tests/local-mode.spec.ts
@@ -28,6 +28,15 @@ import { assertA11y } from './support/a11y';
 const HA_AUTHORIZE_PATTERN = /\/auth\/authorize/;
 
 test.describe('local-mode auth flow @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    // The mode selector (#353) intercepts a fresh visit; this suite covers
+    // the local OAuth flow specifically, so pre-seed the local-mode
+    // preference into localStorage before the page loads.
+    await page.addInitScript(() => {
+      window.localStorage.setItem('glaon.mode-preference', JSON.stringify({ mode: 'local' }));
+    });
+  });
+
   test('renders the login screen and a11y is clean', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByTestId('login-route')).toBeVisible();

--- a/apps/web-e2e/tests/smoke.spec.ts
+++ b/apps/web-e2e/tests/smoke.spec.ts
@@ -4,6 +4,13 @@ import { assertA11y } from './support/a11y';
 
 test.describe('web app @smoke', () => {
   test('renders the local-mode login screen at /', async ({ page }) => {
+    // The mode selector (#353) sits in front of the local OAuth flow on a
+    // fresh visit. Pre-seed the preference so the smoke test lands on
+    // LoginRoute directly — this spec covers the local-mode happy path,
+    // not the picker.
+    await page.addInitScript(() => {
+      window.localStorage.setItem('glaon.mode-preference', JSON.stringify({ mode: 'local' }));
+    });
     await page.goto('/');
     await expect(page.getByRole('heading', { level: 1 })).toHaveText('Glaon');
     await expect(page.getByTestId('login-route')).toBeVisible();

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from './App';
 
@@ -7,16 +7,29 @@ describe('App', () => {
   beforeEach(() => {
     window.name = '';
     window.history.replaceState({}, '', '/');
+    window.localStorage.clear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('network'))),
+    );
   });
 
   afterEach(() => {
     window.history.replaceState({}, '', '/');
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
   });
 
-  it('renders the local-mode login route when no auth mode is set', async () => {
+  it('renders the mode selector on first visit (no preference, no auth)', async () => {
+    render(<App />);
+    expect(await screen.findByTestId('mode-select-route')).toBeInTheDocument();
+    expect(screen.getByTestId('mode-card-local')).toBeInTheDocument();
+  });
+
+  it('renders the local login route when local mode is the stored preference', async () => {
+    window.localStorage.setItem('glaon.mode-preference', JSON.stringify({ mode: 'local' }));
     render(<App />);
     expect(await screen.findByTestId('login-route')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { level: 1, name: 'Glaon' })).toBeInTheDocument();
     expect(screen.getByTestId('login-start')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
 
 import { AuthProvider, useAuth } from './auth/auth-provider';
 import { CloudAuthProvider, getClerkPublishableKey } from './auth/cloud/clerk-provider';
@@ -9,6 +9,12 @@ import { AuthCallbackRoute } from './features/auth/local/auth-callback-route';
 import { LoginRoute } from './features/auth/local/login-route';
 import { SignInRoute } from './features/auth/cloud/sign-in-route';
 import { SignUpRoute } from './features/auth/cloud/sign-up-route';
+import { ModeSelectRoute } from './features/mode-select/mode-select-route';
+import {
+  clearModePreference,
+  readModePreference,
+  type ModePreference,
+} from './features/mode-select/mode-preference';
 
 const HA_BASE_URL: string = import.meta.env.VITE_HA_BASE_URL ?? 'http://homeassistant.local:8123';
 const LOGOUT_ENDPOINT = '/auth/logout';
@@ -43,7 +49,7 @@ interface RouterProps {
 }
 
 function Router({ clerkKey }: RouterProps): ReactNode {
-  const { mode } = useAuth();
+  const { mode, clearAuth } = useAuth();
   const path = window.location.pathname;
   const config = useMemo(
     () => ({
@@ -53,6 +59,19 @@ function Router({ clerkKey }: RouterProps): ReactNode {
     [],
   );
   const redirectUri = `${window.location.origin}/auth/callback`;
+
+  // Mode preference is the gate before mounting either auth tree. It's a
+  // ReactState mirror of localStorage so a click on a card reflects without
+  // a reload; clicking "Switch mode" wipes the preference + auth state.
+  const [preference, setPreference] = useState<ModePreference | null>(() => readModePreference());
+  const choosePreference = useCallback((next: ModePreference) => {
+    setPreference(next);
+  }, []);
+  const switchMode = useCallback(async () => {
+    clearModePreference();
+    await clearAuth();
+    setPreference(null);
+  }, [clearAuth]);
 
   if (path === '/auth/callback') {
     return (
@@ -77,11 +96,52 @@ function Router({ clerkKey }: RouterProps): ReactNode {
     return path === '/sign-in' ? <SignInRoute /> : <SignUpRoute />;
   }
   if (mode === null) {
-    return <LoginRoute config={config} redirectUri={redirectUri} />;
+    if (preference === null) {
+      return <ModeSelectRoute cloudAvailable={clerkKey !== null} onChoose={choosePreference} />;
+    }
+    if (preference.mode === 'cloud') {
+      if (clerkKey === null) {
+        return (
+          <main data-testid="cloud-unavailable">
+            <h1>Cloud sign-in unavailable</h1>
+            <p>VITE_CLERK_PUBLISHABLE_KEY is not configured for this build.</p>
+            <button type="button" onClick={() => void switchMode()}>
+              Pick a different mode
+            </button>
+          </main>
+        );
+      }
+      return <SignInRoute />;
+    }
+    const localBaseUrl = preference.lastLocalUrl ?? config.baseUrl;
+    return <LoginRoute config={{ ...config, baseUrl: localBaseUrl }} redirectUri={redirectUri} />;
   }
   return (
     <main>
-      <h1>Glaon</h1>
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <h1>Glaon</h1>
+        <button
+          type="button"
+          data-testid="switch-mode"
+          onClick={() => void switchMode()}
+          style={{
+            padding: '0.5rem 1rem',
+            borderRadius: '6px',
+            border: '1px solid #d0d7de',
+            background: 'white',
+            cursor: 'pointer',
+            font: 'inherit',
+          }}
+        >
+          Switch mode
+        </button>
+      </header>
       <p>Signed in. The Phase 2 dashboard lands once #10–#12 wire the HA WebSocket.</p>
     </main>
   );

--- a/apps/web/src/features/mode-select/local-probe.test.ts
+++ b/apps/web/src/features/mode-select/local-probe.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { probeLocal } from './local-probe';
+
+describe('probeLocal', () => {
+  it('returns reachable=true for a 200 response', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response('{}', { status: 200 })),
+    ) as unknown as typeof fetch;
+    const result = await probeLocal('http://homeassistant.local:8123', { fetchImpl });
+    expect(result).toEqual({
+      reachable: true,
+      url: 'http://homeassistant.local:8123',
+      status: 200,
+    });
+  });
+
+  it('returns reachable=false for a non-2xx response', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response('nope', { status: 503 })),
+    ) as unknown as typeof fetch;
+    const result = await probeLocal('http://h:8123', { fetchImpl });
+    expect(result).toEqual({ reachable: false, url: 'http://h:8123', status: 503 });
+  });
+
+  it('returns reachable=false when fetch throws (network / cors)', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.reject(new TypeError('network')),
+    ) as unknown as typeof fetch;
+    const result = await probeLocal('http://h:8123', { fetchImpl });
+    expect(result).toEqual({ reachable: false, url: 'http://h:8123' });
+  });
+
+  it('strips a trailing slash before composing the discovery URL', async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(new Response('{}', { status: 200 })),
+    ) as unknown as typeof fetch;
+    await probeLocal('http://h:8123/', { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://h:8123/api/discovery_info',
+      expect.objectContaining({ mode: 'cors', credentials: 'omit' }),
+    );
+  });
+});

--- a/apps/web/src/features/mode-select/local-probe.ts
+++ b/apps/web/src/features/mode-select/local-probe.ts
@@ -1,0 +1,49 @@
+// Best-effort probe: is a Home Assistant instance reachable on the LAN at
+// the given URL? Used by the mode selector to surface "Local instance
+// found at <url>" when the user is at home.
+//
+// HA's public `GET /api/discovery_info` returns version + location_name
+// without auth; we don't need the body — just a 200. False negatives are
+// fine (CORS denial, network blip): the user can still pick local
+// manually with a URL of their choice.
+
+export interface LocalProbeResult {
+  readonly reachable: boolean;
+  readonly url: string;
+  readonly status?: number;
+}
+
+interface ProbeOptions {
+  readonly timeoutMs?: number;
+  readonly fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_TIMEOUT_MS = 1500;
+
+export async function probeLocal(
+  baseUrl: string,
+  options: ProbeOptions = {},
+): Promise<LocalProbeResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const ctl = new AbortController();
+  const timer = setTimeout(() => {
+    ctl.abort();
+  }, timeoutMs);
+  try {
+    const res = await fetchImpl(`${stripTrailingSlash(baseUrl)}/api/discovery_info`, {
+      signal: ctl.signal,
+      mode: 'cors',
+      credentials: 'omit',
+    });
+    return { reachable: res.ok, url: baseUrl, status: res.status };
+  } catch {
+    return { reachable: false, url: baseUrl };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}

--- a/apps/web/src/features/mode-select/mode-preference.test.ts
+++ b/apps/web/src/features/mode-select/mode-preference.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { clearModePreference, readModePreference, writeModePreference } from './mode-preference';
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+}
+
+describe('mode-preference', () => {
+  let storage: MemoryStorage;
+
+  afterEach(() => {
+    storage = new MemoryStorage();
+  });
+
+  it('returns null when nothing is stored', () => {
+    storage = new MemoryStorage();
+    expect(readModePreference(storage)).toBeNull();
+  });
+
+  it('round-trips a local preference with lastLocalUrl', () => {
+    storage = new MemoryStorage();
+    writeModePreference(
+      { mode: 'local', lastLocalUrl: 'http://homeassistant.local:8123' },
+      storage,
+    );
+    expect(readModePreference(storage)).toEqual({
+      mode: 'local',
+      lastLocalUrl: 'http://homeassistant.local:8123',
+    });
+  });
+
+  it('round-trips a cloud preference without lastLocalUrl', () => {
+    storage = new MemoryStorage();
+    writeModePreference({ mode: 'cloud' }, storage);
+    expect(readModePreference(storage)).toEqual({ mode: 'cloud' });
+  });
+
+  it('returns null for malformed JSON', () => {
+    storage = new MemoryStorage();
+    storage.setItem('glaon.mode-preference', '{malformed');
+    expect(readModePreference(storage)).toBeNull();
+  });
+
+  it('returns null when the stored mode is unrecognized', () => {
+    storage = new MemoryStorage();
+    storage.setItem('glaon.mode-preference', JSON.stringify({ mode: 'pirate' }));
+    expect(readModePreference(storage)).toBeNull();
+  });
+
+  it('clearModePreference removes the entry', () => {
+    storage = new MemoryStorage();
+    writeModePreference({ mode: 'cloud' }, storage);
+    clearModePreference(storage);
+    expect(readModePreference(storage)).toBeNull();
+  });
+});

--- a/apps/web/src/features/mode-select/mode-preference.ts
+++ b/apps/web/src/features/mode-select/mode-preference.ts
@@ -1,0 +1,58 @@
+// Mode preference is a UX hint — which auth tree we mount on the next
+// reload — NOT a credential. localStorage is allowed here per the
+// `no-restricted-globals` ESLint guard's `**/auth/**` scope (this file
+// lives outside that scope on purpose). Tokens stay in-memory + httpOnly
+// cookies / SecureStore as ADR 0006 requires; this file persists only
+// `{ mode, lastLocalUrl? }`.
+
+const STORAGE_KEY = 'glaon.mode-preference';
+
+export type ModeChoice = 'local' | 'cloud';
+
+export interface ModePreference {
+  readonly mode: ModeChoice;
+  readonly lastLocalUrl?: string;
+}
+
+export function readModePreference(storage: Storage = window.localStorage): ModePreference | null {
+  let raw: string | null;
+  try {
+    raw = storage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const candidate = parsed as Record<string, unknown>;
+  if (candidate.mode !== 'local' && candidate.mode !== 'cloud') return null;
+  const out: { mode: ModeChoice; lastLocalUrl?: string } = { mode: candidate.mode };
+  if (typeof candidate.lastLocalUrl === 'string' && candidate.lastLocalUrl.length > 0) {
+    out.lastLocalUrl = candidate.lastLocalUrl;
+  }
+  return out;
+}
+
+export function writeModePreference(
+  preference: ModePreference,
+  storage: Storage = window.localStorage,
+): void {
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(preference));
+  } catch {
+    /* private mode / quota — non-fatal */
+  }
+}
+
+export function clearModePreference(storage: Storage = window.localStorage): void {
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/apps/web/src/features/mode-select/mode-select-route.test.tsx
+++ b/apps/web/src/features/mode-select/mode-select-route.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ModeSelectRoute } from './mode-select-route';
+
+describe('ModeSelectRoute', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('network'))),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.localStorage.clear();
+  });
+
+  it('renders the mode-select landmark with two cards', async () => {
+    const onChoose = vi.fn();
+    render(<ModeSelectRoute cloudAvailable={true} onChoose={onChoose} />);
+    expect(screen.getByTestId('mode-select-route')).toBeInTheDocument();
+    expect(screen.getByTestId('mode-card-local')).toBeInTheDocument();
+    expect(screen.getByTestId('mode-card-cloud')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('mode-card-local-meta')).toHaveTextContent(/couldn't auto-detect/i);
+    });
+  });
+
+  it('disables the cloud card and shows a hint when cloud is unavailable', () => {
+    render(<ModeSelectRoute cloudAvailable={false} onChoose={vi.fn()} />);
+    expect(screen.getByTestId('mode-card-cloud')).toBeDisabled();
+    expect(screen.getByTestId('mode-card-cloud-meta')).toHaveTextContent(
+      /cloud is not configured/i,
+    );
+  });
+
+  it('writes the chosen preference and calls onChoose when the local card is clicked', async () => {
+    const onChoose = vi.fn();
+    render(<ModeSelectRoute cloudAvailable={true} onChoose={onChoose} />);
+    fireEvent.click(screen.getByTestId('mode-card-local'));
+    await waitFor(() => {
+      expect(onChoose).toHaveBeenCalledWith({ mode: 'local' });
+    });
+    expect(window.localStorage.getItem('glaon.mode-preference')).toContain('"mode":"local"');
+  });
+
+  it('persists the manual URL as `lastLocalUrl` on submit', () => {
+    const onChoose = vi.fn();
+    render(<ModeSelectRoute cloudAvailable={true} onChoose={onChoose} />);
+    const input = screen.getByPlaceholderText(/homeassistant.local/i);
+    fireEvent.change(input, { target: { value: 'http://192.168.1.50:8123' } });
+    fireEvent.click(screen.getByTestId('mode-select-manual-submit'));
+    expect(onChoose).toHaveBeenCalledWith({
+      mode: 'local',
+      lastLocalUrl: 'http://192.168.1.50:8123',
+    });
+  });
+
+  it('shows "Local instance found" when the probe resolves successfully', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('{}', { status: 200 }))),
+    );
+    render(<ModeSelectRoute cloudAvailable={true} onChoose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('mode-card-local-meta')).toHaveTextContent(/local instance found/i);
+    });
+  });
+});

--- a/apps/web/src/features/mode-select/mode-select-route.tsx
+++ b/apps/web/src/features/mode-select/mode-select-route.tsx
@@ -1,0 +1,161 @@
+// Mode selector — the entry point a first-run web user lands on (#353).
+// Owns the local probe + preference persistence + flush-on-switch. Pure
+// card primitives are imported; no fetching happens inside them.
+//
+// Probe target follows ADR 0024: Glaon does not advertise its own
+// `glaon.local`; we probe the user's HA hostname. A `lastLocalUrl` from
+// a prior session is preferred; otherwise we fall back to
+// `http://homeassistant.local:8123` which is HA's default mDNS name.
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+
+import { probeLocal, type LocalProbeResult } from './local-probe';
+import { ModeSelectorCard } from './mode-selector-card';
+import {
+  readModePreference,
+  writeModePreference,
+  type ModeChoice,
+  type ModePreference,
+} from './mode-preference';
+
+const DEFAULT_LOCAL_URL = 'http://homeassistant.local:8123';
+
+interface ModeSelectRouteProps {
+  readonly cloudAvailable: boolean;
+  readonly defaultLocalUrl?: string;
+  readonly onChoose: (preference: ModePreference) => void;
+}
+
+export function ModeSelectRoute({
+  cloudAvailable,
+  defaultLocalUrl = DEFAULT_LOCAL_URL,
+  onChoose,
+}: ModeSelectRouteProps): ReactNode {
+  const [manualUrl, setManualUrl] = useState<string>('');
+  const probeUrl = useMemo(() => {
+    const stored = readModePreference();
+    if (stored?.lastLocalUrl !== undefined && stored.lastLocalUrl.length > 0) {
+      return stored.lastLocalUrl;
+    }
+    return defaultLocalUrl;
+  }, [defaultLocalUrl]);
+  const [probeState, setProbeState] = useState<{
+    status: 'pending' | 'done';
+    result: LocalProbeResult | null;
+  }>({ status: 'pending', result: null });
+
+  useEffect(() => {
+    const ctl = { cancelled: false };
+    void (async () => {
+      const result = await probeLocal(probeUrl);
+      if (ctl.cancelled) return;
+      setProbeState({ status: 'done', result });
+    })();
+    return () => {
+      ctl.cancelled = true;
+    };
+  }, [probeUrl]);
+
+  const choose = (mode: ModeChoice, lastLocalUrl?: string): void => {
+    const preference: ModePreference =
+      lastLocalUrl !== undefined && lastLocalUrl.length > 0 ? { mode, lastLocalUrl } : { mode };
+    writeModePreference(preference);
+    onChoose(preference);
+  };
+
+  const localMeta = describeLocal(probeState);
+
+  return (
+    <main data-testid="mode-select-route">
+      <h1>How is Glaon connecting to Home Assistant?</h1>
+      <p>
+        Pick the option that matches where you are right now. You can change this later from the
+        settings menu.
+      </p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+          gap: '1rem',
+          marginTop: '1.5rem',
+        }}
+      >
+        <ModeSelectorCard
+          mode="local"
+          title="Local — same Wi-Fi as your home"
+          description="Sign in directly to Home Assistant. Fastest, no Glaon cloud account needed."
+          meta={localMeta}
+          onSelect={() => {
+            choose('local', probeState.result?.reachable === true ? probeUrl : undefined);
+          }}
+        />
+        <ModeSelectorCard
+          mode="cloud"
+          title="Cloud — anywhere on the internet"
+          description="Sign in with your Glaon account. Connects through the Glaon relay."
+          disabled={!cloudAvailable}
+          meta={cloudAvailable ? undefined : 'Cloud is not configured for this build.'}
+          onSelect={() => {
+            choose('cloud');
+          }}
+        />
+      </div>
+
+      <section
+        data-testid="mode-select-manual-url"
+        style={{ marginTop: '1.75rem' }}
+        aria-label="Manual local URL"
+      >
+        <label style={{ display: 'block', fontWeight: 600, marginBottom: '0.5rem' }}>
+          Or enter your Home Assistant URL manually
+          <input
+            type="url"
+            inputMode="url"
+            placeholder="http://homeassistant.local:8123"
+            value={manualUrl}
+            onChange={(event) => {
+              setManualUrl(event.target.value);
+            }}
+            style={{
+              display: 'block',
+              width: '100%',
+              padding: '0.5rem 0.75rem',
+              borderRadius: '6px',
+              border: '1px solid #d0d7de',
+              marginTop: '0.5rem',
+              font: 'inherit',
+            }}
+          />
+        </label>
+        <button
+          type="button"
+          data-testid="mode-select-manual-submit"
+          disabled={manualUrl.trim().length === 0}
+          onClick={() => {
+            choose('local', manualUrl.trim());
+          }}
+          style={{
+            marginTop: '0.5rem',
+            padding: '0.5rem 1rem',
+            borderRadius: '6px',
+            border: '1px solid #d0d7de',
+            background: 'white',
+            cursor: manualUrl.trim().length === 0 ? 'not-allowed' : 'pointer',
+            font: 'inherit',
+          }}
+        >
+          Use this URL
+        </button>
+      </section>
+    </main>
+  );
+}
+
+function describeLocal(state: {
+  status: 'pending' | 'done';
+  result: LocalProbeResult | null;
+}): string {
+  if (state.status === 'pending') return 'Looking for a Home Assistant on your network…';
+  if (state.result?.reachable === true) return `Local instance found at ${state.result.url}`;
+  return "Couldn't auto-detect Home Assistant; pick this option to enter the URL manually.";
+}

--- a/apps/web/src/features/mode-select/mode-selector-card.tsx
+++ b/apps/web/src/features/mode-select/mode-selector-card.tsx
@@ -1,0 +1,56 @@
+// Pure-props card primitive used by the mode selector route. No data
+// fetching here per the component-data-fetching boundary in CLAUDE.md.
+
+import type { ReactNode } from 'react';
+
+interface ModeSelectorCardProps {
+  readonly mode: 'local' | 'cloud';
+  readonly title: string;
+  readonly description: string;
+  readonly meta?: string | undefined;
+  readonly disabled?: boolean;
+  readonly onSelect: () => void;
+}
+
+export function ModeSelectorCard({
+  mode,
+  title,
+  description,
+  meta,
+  disabled = false,
+  onSelect,
+}: ModeSelectorCardProps): ReactNode {
+  return (
+    <button
+      type="button"
+      data-testid={`mode-card-${mode}`}
+      disabled={disabled}
+      onClick={onSelect}
+      style={{
+        display: 'block',
+        textAlign: 'left',
+        padding: '1.25rem',
+        border: '1px solid #d0d7de',
+        borderRadius: '12px',
+        background: disabled ? '#f3f5f8' : 'white',
+        color: 'inherit',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        font: 'inherit',
+        width: '100%',
+      }}
+    >
+      <strong style={{ display: 'block', fontSize: '1rem' }}>{title}</strong>
+      <span style={{ display: 'block', marginTop: '0.25rem', color: '#5b6770' }}>
+        {description}
+      </span>
+      {meta !== undefined && meta.length > 0 ? (
+        <span
+          data-testid={`mode-card-${mode}-meta`}
+          style={{ display: 'block', marginTop: '0.5rem', fontSize: '0.875rem' }}
+        >
+          {meta}
+        </span>
+      ) : null}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the entry-point UI a first-run web user lands on (#353). Without it cloud-mode users had no path in — the app booted straight into local OAuth. Mode preference now persists in `localStorage` (UX hint, not a credential), and a top-right **Switch mode** button flushes auth state when the user changes their mind.

- Two cards (Local / Cloud) on `mode-select-route.tsx` with a manual URL fallback for networks where the probe fails.
- Local probe (best-effort, 1.5s timeout) hits HA's public `GET /api/discovery_info` at the user's HA hostname per [ADR 0024](docs/adr/0024-local-discovery-rely-on-ha-hostname.md). CORS / network errors fall through to "Couldn't auto-detect Home Assistant".
- Cloud card disables itself with explanatory copy when `VITE_CLERK_PUBLISHABLE_KEY` is unset.
- App router gates the auth tree on the persisted preference.

## Scope (In)

- `apps/web/src/features/mode-select/`:
  - `mode-preference.ts` (localStorage reader/writer, JSON-validated).
  - `local-probe.ts` (timeout-bounded fetch, `discovery_info` target).
  - `mode-selector-card.tsx` (pure-props card component).
  - `mode-select-route.tsx` (orchestrator).
- App router wiring + "Switch mode" affordance.
- 16 new unit tests across all four files.
- App test retargeted: first-visit asserts mode selector, separate test asserts local login route renders when local preference is stored.

## Scope (Out)

- Pairing wizard — #354.
- Mobile equivalent — #356.
- Storybook stories — `apps/web` doesn't host Storybook (only `@glaon/ui` does); the local LoginRoute and Clerk routes set the same precedent. If a primitive lands in `@glaon/ui`, stories will follow.
- Entity store / TanStack query flush in **Switch mode** — those layers don't exist yet (`#10`–`#12`); when they land, the `switchMode` callback in `App.tsx` will hook into them.

## Test plan

- [x] `pnpm --filter @glaon/web type-check` — passes.
- [x] `pnpm --filter @glaon/web lint` — passes.
- [x] `pnpm --filter @glaon/web test` — 56 tests pass (40 prior + 16 new).
- [x] `pnpm exec knip --workspace apps/web` — clean.
- [ ] CI: type-check · lint · audit, unit-tests, story-tests, playwright, CodeQL, visual regression, build (aarch64+amd64).
- [ ] Reviewer: manual probe behaviour against `pnpm ha:up`.

## Notes

- The probe URL respects `lastLocalUrl` from a prior session before falling back to `http://homeassistant.local:8123`. So if the user typed a custom URL, it sticks.
- localStorage reads / writes are guarded with try/catch — Safari private mode + quota errors are non-fatal (the user just sees the picker again on next reload).

Closes #353.
Refs ADR 0017, ADR 0024.