### PR TITLE
feat(web): link-to-cloud pairing wizard

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -27,3 +27,9 @@ SENTRY_PROJECT=
 # When unset, the cloud sign-in route surfaces a banner and the rest of the
 # app stays in local mode.
 VITE_CLERK_PUBLISHABLE_KEY=
+
+# Glaon cloud relay base URL — used by the cloud-pairing wizard (#354) and,
+# when local mode flips to cloud, the relay client. Defaults to the Glaon
+# production relay; override with the staging URL for QA builds.
+# Allowlisted hosts: relay.glaon.app, relay-staging.glaon.app, localhost:8787.
+VITE_GLAON_CLOUD_URL=

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,10 +9,12 @@ import { AuthCallbackRoute } from './features/auth/local/auth-callback-route';
 import { LoginRoute } from './features/auth/local/login-route';
 import { SignInRoute } from './features/auth/cloud/sign-in-route';
 import { SignUpRoute } from './features/auth/cloud/sign-up-route';
+import { PairWizardRoute } from './features/cloud-pairing/pair-wizard-route';
 import { ModeSelectRoute } from './features/mode-select/mode-select-route';
 import {
   clearModePreference,
   readModePreference,
+  writeModePreference,
   type ModePreference,
 } from './features/mode-select/mode-preference';
 
@@ -94,6 +96,27 @@ function Router({ clerkKey }: RouterProps): ReactNode {
       );
     }
     return path === '/sign-in' ? <SignInRoute /> : <SignUpRoute />;
+  }
+  if (path === '/settings/link-to-cloud') {
+    if (clerkKey === null) {
+      return (
+        <main data-testid="cloud-unavailable">
+          <h1>Cloud pairing unavailable</h1>
+          <p>VITE_CLERK_PUBLISHABLE_KEY is not configured for this build.</p>
+        </main>
+      );
+    }
+    return (
+      <PairWizardRoute
+        onCloudReady={() => {
+          // Promote: persist cloud preference, drop local auth so the
+          // mode-selector flips to cloud on the next reload.
+          writeModePreference({ mode: 'cloud' });
+          void clearAuth();
+          window.location.assign('/');
+        }}
+      />
+    );
   }
   if (mode === null) {
     if (preference === null) {

--- a/apps/web/src/features/cloud-pairing/cloud-api.test.ts
+++ b/apps/web/src/features/cloud-pairing/cloud-api.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createCloudPairClient } from './cloud-api';
+
+function makeFetch(
+  responder: (input: string, init?: RequestInit) => Response | Promise<Response>,
+): typeof fetch {
+  const impl = vi.fn(async (input: string, init?: RequestInit) => responder(input, init));
+  return impl as unknown as typeof fetch;
+}
+
+const TOKEN = 'clerk_session_jwt';
+
+describe('cloud-api initiate', () => {
+  it('returns the parsed code + expiresAt on 201', async () => {
+    const fetchImpl = makeFetch(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ code: '123456', expiresAt: 1234 }), { status: 201 }),
+      ),
+    );
+    const client = createCloudPairClient({ fetchImpl, cloudBase: 'https://relay.glaon.app' });
+    const result = await client.initiate(TOKEN);
+    expect(result).toEqual({ ok: true, data: { code: '123456', expiresAt: 1234 } });
+  });
+
+  it('maps 401 to unauthorized', async () => {
+    const fetchImpl = makeFetch(async () =>
+      Promise.resolve(new Response('{"error":"unauthorized"}', { status: 401 })),
+    );
+    const client = createCloudPairClient({ fetchImpl, cloudBase: 'https://relay.glaon.app' });
+    expect(await client.initiate(TOKEN)).toEqual({ ok: false, err: { kind: 'unauthorized' } });
+  });
+
+  it('maps 429 with retryAfterMs', async () => {
+    const fetchImpl = makeFetch(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'rate-limited', retryAfterMs: 90_000 }), {
+          status: 429,
+        }),
+      ),
+    );
+    const client = createCloudPairClient({ fetchImpl, cloudBase: 'https://relay.glaon.app' });
+    expect(await client.initiate(TOKEN)).toEqual({
+      ok: false,
+      err: { kind: 'rate-limited', retryAfterMs: 90_000 },
+    });
+  });
+
+  it('maps fetch errors to network kind', async () => {
+    const fetchImpl = makeFetch(async () => Promise.reject(new TypeError('disconnect')));
+    const client = createCloudPairClient({ fetchImpl, cloudBase: 'https://relay.glaon.app' });
+    expect(await client.initiate(TOKEN)).toEqual({ ok: false, err: { kind: 'network' } });
+  });
+
+  it('passes the Bearer token in the Authorization header', async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = makeFetch(async (_input, init) => {
+      captured = init;
+      return Promise.resolve(
+        new Response(JSON.stringify({ code: 'A', expiresAt: 1 }), { status: 201 }),
+      );
+    });
+    const client = createCloudPairClient({ fetchImpl, cloudBase: 'https://relay.glaon.app' });
+    await client.initiate(TOKEN);
+    expect(captured?.headers).toMatchObject({ Authorization: `Bearer ${TOKEN}` });
+  });
+});
+
+describe('cloud-api status', () => {
+  it('returns the status payload on 200', async () => {
+    const fetchImpl = makeFetch(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ status: 'claimed', homeId: 'home-X' }), { status: 200 }),
+      ),
+    );
+    const client = createCloudPairClient({ fetchImpl, cloudBase: 'https://relay.glaon.app' });
+    const result = await client.status(TOKEN, 'CODE-1');
+    expect(result).toEqual({ ok: true, data: { status: 'claimed', homeId: 'home-X' } });
+  });
+
+  it('encodes the code into the query string', async () => {
+    let capturedUrl: string | undefined;
+    const fetchImpl = makeFetch(async (input) => {
+      capturedUrl = input;
+      return Promise.resolve(new Response(JSON.stringify({ status: 'pending' }), { status: 200 }));
+    });
+    const client = createCloudPairClient({ fetchImpl, cloudBase: 'https://relay.glaon.app' });
+    await client.status(TOKEN, 'has space');
+    expect(capturedUrl).toBe('https://relay.glaon.app/pair/status?code=has%20space');
+  });
+});

--- a/apps/web/src/features/cloud-pairing/cloud-api.ts
+++ b/apps/web/src/features/cloud-pairing/cloud-api.ts
@@ -1,0 +1,157 @@
+// Thin REST client for the Glaon cloud pair endpoints (#346):
+//   POST /pair/initiate          → { code, expiresAt }
+//   GET  /pair/status?code=...   → { status: 'pending' | 'claimed' | 'expired', homeId?, expiresAt? }
+//
+// Same defense pattern as the addon-agent's `selectUpstream()` (#444): the
+// destination URL is selected from a closed switch on the env-provided
+// host so file/env data does not get interpolated into the network sink
+// the CodeQL `js/file-access-to-http` rule watches. `VITE_GLAON_CLOUD_URL`
+// from the env defaults to the Glaon prod relay.
+
+const PROD_CLOUD = 'https://relay.glaon.app';
+const STAGING_CLOUD = 'https://relay-staging.glaon.app';
+
+const RAW_CLOUD_URL: string | undefined = import.meta.env.VITE_GLAON_CLOUD_URL;
+
+function selectCloudBase(): string {
+  if (RAW_CLOUD_URL === undefined || RAW_CLOUD_URL.length === 0) return PROD_CLOUD;
+  let parsed: URL;
+  try {
+    parsed = new URL(RAW_CLOUD_URL);
+  } catch {
+    return PROD_CLOUD;
+  }
+  switch (parsed.host) {
+    case 'relay.glaon.app':
+      return PROD_CLOUD;
+    case 'relay-staging.glaon.app':
+      return STAGING_CLOUD;
+    default: {
+      // Dev fixtures may set a localhost URL; we mirror only the explicit
+      // host string so CodeQL sees a fixed set of literals.
+      if (parsed.host === 'localhost' || /^localhost:\d{1,5}$/.test(parsed.host)) {
+        // Pick the actual host from a literal map rather than re-interpolating.
+        if (parsed.host === 'localhost') return 'http://localhost:8787';
+        if (parsed.host === 'localhost:8787') return 'http://localhost:8787';
+        if (parsed.host === 'localhost:8788') return 'http://localhost:8788';
+        if (parsed.host === 'localhost:8789') return 'http://localhost:8789';
+      }
+      return PROD_CLOUD;
+    }
+  }
+}
+
+export interface InitiateResult {
+  readonly code: string;
+  readonly expiresAt: number;
+}
+
+export interface StatusResult {
+  readonly status: 'pending' | 'claimed' | 'expired';
+  readonly homeId?: string;
+  readonly expiresAt?: number;
+}
+
+export type CloudPairError =
+  | { readonly kind: 'unauthorized' }
+  | { readonly kind: 'rate-limited'; readonly retryAfterMs: number | null }
+  | { readonly kind: 'not-found' }
+  | { readonly kind: 'network' }
+  | { readonly kind: 'unknown'; readonly status: number };
+
+export interface CloudPairClient {
+  initiate(
+    token: string,
+  ): Promise<{ ok: true; data: InitiateResult } | { ok: false; err: CloudPairError }>;
+  status(
+    token: string,
+    code: string,
+  ): Promise<{ ok: true; data: StatusResult } | { ok: false; err: CloudPairError }>;
+}
+
+interface ClientOptions {
+  readonly fetchImpl?: typeof fetch;
+  readonly cloudBase?: string;
+}
+
+export function createCloudPairClient(options: ClientOptions = {}): CloudPairClient {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const cloudBase = options.cloudBase ?? selectCloudBase();
+
+  return {
+    async initiate(token) {
+      try {
+        const res = await fetchImpl(`${cloudBase}/pair/initiate`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+          },
+        });
+        return await parseResult<InitiateResult>(res, isInitiateResult);
+      } catch {
+        return { ok: false, err: { kind: 'network' } };
+      }
+    },
+    async status(token, code) {
+      try {
+        const url = `${cloudBase}/pair/status?code=${encodeURIComponent(code)}`;
+        const res = await fetchImpl(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+          },
+        });
+        return await parseResult<StatusResult>(res, isStatusResult);
+      } catch {
+        return { ok: false, err: { kind: 'network' } };
+      }
+    },
+  };
+}
+
+async function parseResult<T>(
+  res: Response,
+  guard: (value: unknown) => value is T,
+): Promise<{ ok: true; data: T } | { ok: false; err: CloudPairError }> {
+  const text = await res.text();
+  let body: unknown = {};
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      /* tolerate empty / non-JSON */
+    }
+  }
+  if (res.status >= 200 && res.status < 300 && guard(body)) {
+    return { ok: true, data: body };
+  }
+  if (res.status === 401) return { ok: false, err: { kind: 'unauthorized' } };
+  if (res.status === 404) return { ok: false, err: { kind: 'not-found' } };
+  if (res.status === 429) {
+    const retryAfterMs = parseRetryAfterMs(body);
+    return { ok: false, err: { kind: 'rate-limited', retryAfterMs } };
+  }
+  return { ok: false, err: { kind: 'unknown', status: res.status } };
+}
+
+function parseRetryAfterMs(body: unknown): number | null {
+  if (body === null || typeof body !== 'object') return null;
+  const candidate = (body as Record<string, unknown>).retryAfterMs;
+  if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate >= 0) {
+    return candidate;
+  }
+  return null;
+}
+
+function isInitiateResult(value: unknown): value is InitiateResult {
+  if (value === null || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.code === 'string' && typeof v.expiresAt === 'number';
+}
+
+function isStatusResult(value: unknown): value is StatusResult {
+  if (value === null || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return v.status === 'pending' || v.status === 'claimed' || v.status === 'expired';
+}

--- a/apps/web/src/features/cloud-pairing/pair-wizard-route.test.tsx
+++ b/apps/web/src/features/cloud-pairing/pair-wizard-route.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CloudPairClient } from './cloud-api';
+import { PairWizardRoute } from './pair-wizard-route';
+
+type InitiateReturn = Awaited<ReturnType<CloudPairClient['initiate']>>;
+
+const SIGNED_IN_AUTH = { isSignedIn: true, getToken: () => Promise.resolve('clerk-token') };
+const SIGNED_OUT_AUTH = { isSignedIn: false, getToken: () => Promise.resolve(null) };
+
+let mockedAuth: typeof SIGNED_IN_AUTH | typeof SIGNED_OUT_AUTH = SIGNED_IN_AUTH;
+
+vi.mock('@clerk/clerk-react', () => ({
+  useAuth: () => mockedAuth,
+}));
+
+function makeClient(overrides: Partial<CloudPairClient> = {}): CloudPairClient {
+  return {
+    initiate: vi.fn(() =>
+      Promise.resolve({
+        ok: true as const,
+        data: { code: '123456', expiresAt: Date.now() + 60_000 },
+      }),
+    ),
+    status: vi.fn(() =>
+      Promise.resolve({ ok: true as const, data: { status: 'pending' as const } }),
+    ),
+    ...overrides,
+  };
+}
+
+describe('PairWizardRoute', () => {
+  beforeEach(() => {
+    mockedAuth = SIGNED_IN_AUTH;
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the sign-in CTA when Clerk reports signed-out', () => {
+    mockedAuth = SIGNED_OUT_AUTH;
+    render(<PairWizardRoute client={makeClient()} />);
+    expect(screen.getByTestId('pair-wizard-await-clerk')).toBeInTheDocument();
+    expect(screen.getByTestId('pair-wizard-sign-in-cta')).toHaveAttribute('href', '/sign-in');
+  });
+
+  it('renders the code after a successful initiate', async () => {
+    const client = makeClient();
+    render(<PairWizardRoute client={client} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pair-wizard-awaiting')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('pair-wizard-code-value')).toHaveTextContent('123456');
+  });
+
+  it('flips to claimed when status reports a homeId', async () => {
+    const client = makeClient({
+      status: vi.fn(() =>
+        Promise.resolve({
+          ok: true as const,
+          data: { status: 'claimed' as const, homeId: 'home-7' },
+        }),
+      ),
+    });
+    render(<PairWizardRoute client={client} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pair-wizard-claimed')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/home-7/)).toBeInTheDocument();
+  });
+
+  it('flips to expired when initiate returns an already-expired code', async () => {
+    const client = makeClient({
+      initiate: vi.fn(() =>
+        Promise.resolve({
+          ok: true as const,
+          data: { code: '999999', expiresAt: Date.now() - 5_000 },
+        }),
+      ),
+    });
+    render(<PairWizardRoute client={client} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pair-wizard-expired')).toBeInTheDocument();
+    });
+  });
+
+  it('surfaces an unauthorized error from initiate', async () => {
+    const unauthorized: InitiateReturn = { ok: false, err: { kind: 'unauthorized' } };
+    const client = makeClient({
+      initiate: vi.fn(() => Promise.resolve(unauthorized)),
+    });
+    render(<PairWizardRoute client={client} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pair-wizard-error')).toHaveTextContent(/session expired/i);
+    });
+  });
+
+  it('surfaces a rate-limit error with the retry hint', async () => {
+    const rateLimited: InitiateReturn = {
+      ok: false,
+      err: { kind: 'rate-limited', retryAfterMs: 60_000 },
+    };
+    const client = makeClient({
+      initiate: vi.fn(() => Promise.resolve(rateLimited)),
+    });
+    render(<PairWizardRoute client={client} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pair-wizard-error')).toHaveTextContent(/60 seconds/i);
+    });
+  });
+
+  it('"try again" restarts the initiate flow', async () => {
+    const networkErr: InitiateReturn = { ok: false, err: { kind: 'network' } };
+    const success: InitiateReturn = {
+      ok: true,
+      data: { code: 'AAAAAA', expiresAt: Date.now() + 60_000 },
+    };
+    const responses = [networkErr, success];
+    const initiate = vi.fn<CloudPairClient['initiate']>(() => {
+      const next = responses.shift();
+      if (next === undefined) throw new Error('initiate called more than expected');
+      return Promise.resolve(next);
+    });
+    const client = makeClient({ initiate });
+    render(<PairWizardRoute client={client} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pair-wizard-error')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('pair-wizard-restart'));
+    await waitFor(() => {
+      expect(screen.getByTestId('pair-wizard-awaiting')).toBeInTheDocument();
+    });
+    expect(initiate).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls onCloudReady when the user clicks "switch to cloud mode"', async () => {
+    const client = makeClient({
+      status: vi.fn(() =>
+        Promise.resolve({
+          ok: true as const,
+          data: { status: 'claimed' as const, homeId: 'home-12' },
+        }),
+      ),
+    });
+    const onCloudReady = vi.fn();
+    render(<PairWizardRoute client={client} onCloudReady={onCloudReady} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pair-wizard-claimed')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('pair-wizard-switch-to-cloud'));
+    expect(onCloudReady).toHaveBeenCalledWith('home-12');
+  });
+});

--- a/apps/web/src/features/cloud-pairing/pair-wizard-route.tsx
+++ b/apps/web/src/features/cloud-pairing/pair-wizard-route.tsx
@@ -1,0 +1,278 @@
+// "Link to cloud" wizard (#354) — drives the device-code flow from the
+// signed-in local-mode app. Steps:
+//
+//   1. Sign in with Clerk (handled outside the wizard; we render a CTA to
+//      `/sign-in` if the user lands here unauthenticated).
+//   2. POST /pair/initiate → display the 6-digit code with copy.
+//   3. Tell the user to enter the code on the addon's `/pair` page; poll
+//      GET /pair/status every 2s until claimed / expired / 10-min code TTL.
+//   4. Success: confirmation; deep-link "switch to cloud mode" updates the
+//      mode-preference and triggers a sign-out of the local session so the
+//      mode-selector flips on next reload.
+//
+// The wizard owns its own minimal state machine; once the apps/api +
+// TanStack-Query layer arrive in #392 / #11, this surface gets refactored
+// to consume those instead. For now a hand-rolled hook keeps the unit
+// tests deterministic and the cloud round-trip mockable.
+
+import { useAuth } from '@clerk/clerk-react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+
+import { createCloudPairClient, type CloudPairClient, type CloudPairError } from './cloud-api';
+
+const POLL_INTERVAL_MS = 2_000;
+
+type WizardState =
+  | { step: 'await-clerk' }
+  | { step: 'initiating' }
+  | { step: 'awaiting-claim'; code: string; expiresAt: number }
+  | { step: 'claimed'; homeId: string }
+  | { step: 'expired' }
+  | { step: 'error'; error: CloudPairError };
+
+interface PairWizardRouteProps {
+  readonly client?: CloudPairClient;
+  readonly onCloudReady?: (homeId: string) => void;
+}
+
+export function PairWizardRoute({ client, onCloudReady }: PairWizardRouteProps): ReactNode {
+  // Clerk's discriminated union — narrow via cast (see #352 bridge for the
+  // same workaround). `getToken` returns null when signed out.
+  const auth = useAuth() as unknown as {
+    isSignedIn?: boolean;
+    getToken: () => Promise<string | null>;
+  };
+  const signedIn = auth.isSignedIn === true;
+  const getTokenRef = useRef(auth.getToken);
+  useEffect(() => {
+    getTokenRef.current = auth.getToken;
+  }, [auth.getToken]);
+  const cloudClient = useMemo(() => client ?? createCloudPairClient(), [client]);
+
+  const [state, setState] = useState<WizardState>(
+    signedIn ? { step: 'initiating' } : { step: 'await-clerk' },
+  );
+
+  // Step transition: signed-in but still on await-clerk → initiate.
+  useEffect(() => {
+    if (signedIn && state.step === 'await-clerk') {
+      setState({ step: 'initiating' });
+    }
+  }, [signedIn, state.step]);
+
+  // Initiate: fetch a fresh code.
+  useEffect(() => {
+    if (state.step !== 'initiating') return;
+    const ctl: { cancelled: boolean } = { cancelled: false };
+    void (async () => {
+      const token = await getTokenRef.current();
+      if (token === null || token.length === 0) {
+        if (!ctl.cancelled) setState({ step: 'error', error: { kind: 'unauthorized' } });
+        return;
+      }
+      const result = await cloudClient.initiate(token);
+      if (ctl.cancelled) return;
+      if (result.ok) {
+        setState({
+          step: 'awaiting-claim',
+          code: result.data.code,
+          expiresAt: result.data.expiresAt,
+        });
+        return;
+      }
+      setState({ step: 'error', error: result.err });
+    })();
+    return () => {
+      ctl.cancelled = true;
+    };
+  }, [state.step, cloudClient]);
+
+  // Polling: tick every 2s while we're awaiting a claim. Stops on terminal
+  // state (the next render unmounts the interval).
+  useEffect(() => {
+    if (state.step !== 'awaiting-claim') return;
+    const code = state.code;
+    const expiresAt = state.expiresAt;
+    const ctl: { cancelled: boolean } = { cancelled: false };
+    const tick = async (): Promise<void> => {
+      if (ctl.cancelled) return;
+      if (Date.now() >= expiresAt) {
+        setState({ step: 'expired' });
+        return;
+      }
+      const token = await getTokenRef.current();
+      if (token === null || token.length === 0) {
+        setState({ step: 'error', error: { kind: 'unauthorized' } });
+        return;
+      }
+      const result = await cloudClient.status(token, code);
+      // ctl.cancelled flips in the cleanup function below; ESLint's
+      // no-unnecessary-condition cannot see closure mutations from the
+      // outer cleanup so suppress only the second check (after the await).
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (ctl.cancelled) return;
+      if (!result.ok) {
+        setState({ step: 'error', error: result.err });
+        return;
+      }
+      if (result.data.status === 'claimed' && typeof result.data.homeId === 'string') {
+        setState({ step: 'claimed', homeId: result.data.homeId });
+        return;
+      }
+      if (result.data.status === 'expired') {
+        setState({ step: 'expired' });
+        return;
+      }
+    };
+    void tick();
+    const handle = setInterval(() => {
+      void tick();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      ctl.cancelled = true;
+      clearInterval(handle);
+    };
+  }, [state, cloudClient]);
+
+  const restart = useCallback(() => {
+    setState({ step: 'initiating' });
+  }, []);
+
+  if (!signedIn) {
+    return (
+      <main data-testid="pair-wizard-await-clerk">
+        <h1>Link this home to Glaon cloud</h1>
+        <p>You need to sign in with your Glaon account first.</p>
+        <a href="/sign-in" data-testid="pair-wizard-sign-in-cta">
+          Sign in
+        </a>
+      </main>
+    );
+  }
+
+  if (state.step === 'initiating') {
+    return (
+      <main data-testid="pair-wizard-initiating" aria-busy="true" aria-live="polite">
+        <h1>Generating your pairing code…</h1>
+      </main>
+    );
+  }
+
+  if (state.step === 'awaiting-claim') {
+    return (
+      <main data-testid="pair-wizard-awaiting">
+        <h1>Enter this code on your addon</h1>
+        <p>
+          Open the Glaon addon panel in Home Assistant and choose <em>Link to cloud</em>. Type the
+          code below within 10 minutes.
+        </p>
+        <PairCodeDisplay code={state.code} />
+        <p data-testid="pair-wizard-awaiting-hint">
+          We&rsquo;ll automatically advance to the next step once the addon accepts the code.
+        </p>
+      </main>
+    );
+  }
+
+  if (state.step === 'claimed') {
+    return (
+      <main data-testid="pair-wizard-claimed">
+        <h1>Linked.</h1>
+        <p>
+          Home <code>{state.homeId}</code> is now reachable through the Glaon cloud relay.
+        </p>
+        <button
+          type="button"
+          data-testid="pair-wizard-switch-to-cloud"
+          onClick={() => onCloudReady?.(state.homeId)}
+        >
+          Switch to cloud mode
+        </button>
+      </main>
+    );
+  }
+
+  if (state.step === 'expired') {
+    return (
+      <main data-testid="pair-wizard-expired">
+        <h1>That code expired.</h1>
+        <p>Pairing codes are valid for 10 minutes.</p>
+        <button type="button" data-testid="pair-wizard-restart" onClick={restart}>
+          Generate a new code
+        </button>
+      </main>
+    );
+  }
+
+  if (state.step === 'error') {
+    return (
+      <main data-testid="pair-wizard-error" role="alert">
+        <h1>{messageFor(state.error)}</h1>
+        <button type="button" data-testid="pair-wizard-restart" onClick={restart}>
+          Try again
+        </button>
+      </main>
+    );
+  }
+
+  // `await-clerk` is handled by the early-return above when `signedIn` is
+  // false; once signed in we land in `initiating` via the transition effect.
+  // The render returns null for the brief tick between the two.
+  return null;
+}
+
+function messageFor(err: CloudPairError): string {
+  switch (err.kind) {
+    case 'unauthorized':
+      return 'Your Glaon session expired. Sign in again to continue.';
+    case 'rate-limited':
+      return err.retryAfterMs !== null
+        ? `Too many attempts. Try again in about ${String(Math.ceil(err.retryAfterMs / 1000))} seconds.`
+        : 'Too many attempts. Try again in a moment.';
+    case 'not-found':
+      return 'The pairing code was not found. Try generating a new one.';
+    case 'network':
+      return 'Could not reach the Glaon cloud. Check your internet connection.';
+    case 'unknown':
+      return 'Something went wrong on the Glaon cloud side.';
+  }
+}
+
+interface PairCodeDisplayProps {
+  readonly code: string;
+}
+
+function PairCodeDisplay({ code }: PairCodeDisplayProps): ReactNode {
+  const [copied, setCopied] = useState(false);
+  const onCopy = useCallback(() => {
+    void navigator.clipboard.writeText(code).then(() => {
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 1500);
+    });
+  }, [code]);
+  return (
+    <div data-testid="pair-wizard-code">
+      <output
+        data-testid="pair-wizard-code-value"
+        style={{
+          display: 'block',
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          fontSize: '2rem',
+          letterSpacing: '0.5rem',
+          padding: '1rem',
+          border: '1px solid #d0d7de',
+          borderRadius: '8px',
+          textAlign: 'center',
+          marginBlock: '1rem',
+        }}
+      >
+        {code}
+      </output>
+      <button type="button" data-testid="pair-wizard-copy" onClick={onCopy}>
+        {copied ? 'Copied' : 'Copy code'}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -8,6 +8,7 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_ENVIRONMENT?: string;
   readonly VITE_SENTRY_RELEASE?: string;
   readonly VITE_CLERK_PUBLISHABLE_KEY?: string;
+  readonly VITE_GLAON_CLOUD_URL?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Drives the device-code pairing flow client-side per [ADR 0021](docs/adr/0021-pairing-and-relay-credentials.md). Without it a local-mode user has no way to promote their home to a Clerk cloud account; the cloud relay endpoint (#346) and the addon `/pair` UI (#349) have nothing on the web side to feed them.

- `cloud-api.ts` — thin REST client over `POST /pair/initiate` + `GET /pair/status`. Literal-switch host selection (`relay.glaon.app` / `relay-staging.glaon.app` / localhost dev fixtures) — same CodeQL `js/file-access-to-http` defense pattern as #444.
- `pair-wizard-route.tsx` — 6-state machine: `await-clerk → initiating → awaiting-claim → claimed | expired | error`. Polls `/pair/status` every 2s, cancels on terminal state + unmount.
- `/settings/link-to-cloud` route mounted in App.tsx with friendly fallback when Clerk publishable key is missing.
- Code display + copy-to-clipboard; success CTA promotes the mode preference to cloud, clears local auth, and navigates home so the mode-selector flips on the next render.

## Scope (In)

- `apps/web/src/features/cloud-pairing/cloud-api.ts` + 9 unit tests.
- `apps/web/src/features/cloud-pairing/pair-wizard-route.tsx` + 6 unit tests.
- App router wiring + `VITE_GLAON_CLOUD_URL` env.
- 15 new tests total.

## Scope (Out)

- Cloud `/pair/initiate` + `/pair/status` endpoints — already in [apps/cloud/src/routes/pair.ts](apps/cloud/src/routes/pair.ts) from #346.
- Addon `/pair` UI — already in [apps/addon-agent/src/pair-server.ts](apps/addon-agent/src/pair-server.ts) from #349.
- Mobile equivalent — #357.
- Storybook stories — `apps/web` doesn't host Storybook (the local LoginRoute, Clerk routes, and mode selector follow the same precedent).
- Rotation / unlink — future portal work.

## Test plan

- [x] `pnpm --filter @glaon/web type-check` — passes.
- [x] `pnpm --filter @glaon/web lint` — passes.
- [x] `pnpm --filter @glaon/web test` — 71 tests pass (56 prior + 15 new).
- [x] `pnpm exec knip --workspace apps/web` — clean.
- [ ] CI: type-check · lint · audit, unit-tests, story-tests, playwright, CodeQL, visual regression, build (aarch64+amd64).
- [ ] Manual happy path against staging cloud + a real addon (per the issue's acceptance — requires `VITE_CLERK_PUBLISHABLE_KEY` + paired addon).

## Notes

- Polling lifecycle: the `setInterval` is cleared on terminal state via the `useEffect` cleanup. The inner `tick` closure additionally checks `ctl.cancelled` after every async hop so a mid-flight rejection from a stale interval doesn't write to a stale state shape.
- Cloud base URL is selected via literal switch on the env-provided host. CodeQL flags any string interpolation from env / file data into `fetch()`'s URL; the literal-set return keeps the data-flow rule satisfied.

Closes #354.
Refs ADR 0021, ADR 0019.