### PR TITLE
feat(mobile): link-to-cloud pairing wizard

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -18,3 +18,9 @@ EXPO_PUBLIC_SENTRY_RELEASE=
 # When unset, the cloud sign-in screens stay hidden and the app stays in
 # local mode; mode-detect (#356) will gate this further once it lands.
 EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY=
+
+# Glaon cloud relay base URL — used by the mobile pairing wizard (#357)
+# and, when local mode flips to cloud, the relay client. Defaults to the
+# Glaon production relay; override with the staging URL for QA builds.
+# Allowlisted hosts: relay.glaon.app, relay-staging.glaon.app, localhost:8787.
+EXPO_PUBLIC_GLAON_CLOUD_URL=

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -9,6 +9,7 @@ import type { LocalAuthFlowConfig } from './src/auth/local-auth-flow';
 import { createExpoTokenStore } from './src/auth/expo-token-store';
 import { LoginScreen } from './src/features/auth/local/login-screen';
 import { SignInScreen } from './src/features/auth/cloud/sign-in-screen';
+import { PairWizardScreen } from './src/features/cloud-pairing/pair-wizard-screen';
 import { ModeSelectScreen } from './src/features/mode-select/mode-select-screen';
 import {
   expoModePreferenceStore,
@@ -135,12 +136,71 @@ function Root(): ReactNode {
     );
   }
 
+  return <SignedInShell switchMode={switchMode} clerkKey={clerkKey} />;
+}
+
+interface SignedInShellProps {
+  readonly switchMode: () => Promise<void>;
+  readonly clerkKey: string | null;
+}
+
+function SignedInShell({ switchMode, clerkKey }: SignedInShellProps): ReactNode {
+  const [view, setView] = useState<'home' | 'pair-wizard'>('home');
+
+  if (view === 'pair-wizard') {
+    if (clerkKey === null) {
+      return (
+        <View style={styles.cloudUnavailable}>
+          <Text style={styles.title}>Cloud pairing unavailable</Text>
+          <Text style={styles.body}>
+            EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY is not configured for this build.
+          </Text>
+          <Pressable
+            testID="pair-wizard-cancel"
+            onPress={() => {
+              setView('home');
+            }}
+            style={styles.switchModeButton}
+          >
+            <Text style={styles.switchModeButtonText}>Back</Text>
+          </Pressable>
+          <StatusBar style="auto" />
+        </View>
+      );
+    }
+    return (
+      <PairWizardScreen
+        onCancel={() => {
+          setView('home');
+        }}
+        onCloudReady={() => {
+          // Promote to cloud mode and wipe local state on the next reload.
+          void (async () => {
+            await expoModePreferenceStore.write({ mode: 'cloud' });
+            await switchMode();
+          })();
+        }}
+      />
+    );
+  }
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Glaon</Text>
       <Text style={styles.body}>
         Signed in. The Phase 2 dashboard lands once #10–#12 wire the HA WebSocket.
       </Text>
+      {clerkKey !== null ? (
+        <Pressable
+          testID="link-to-cloud"
+          onPress={() => {
+            setView('pair-wizard');
+          }}
+          style={styles.switchModeButton}
+        >
+          <Text style={styles.switchModeButtonText}>Link to cloud</Text>
+        </Pressable>
+      ) : null}
       <Pressable
         testID="switch-mode"
         onPress={() => void switchMode()}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,6 +8,7 @@
     "@sentry/react-native": "^8.8.0",
     "expo": "~55.0.0",
     "expo-auth-session": "~55.0.0",
+    "expo-clipboard": "~55.0.0",
     "expo-crypto": "~55.0.0",
     "expo-secure-store": "~55.0.0",
     "expo-status-bar": "~55.0.0",

--- a/apps/mobile/src/features/cloud-pairing/cloud-api.ts
+++ b/apps/mobile/src/features/cloud-pairing/cloud-api.ts
@@ -1,0 +1,150 @@
+// Mobile mirror of `apps/web/src/features/cloud-pairing/cloud-api.ts`.
+// Same literal-switch pattern on the cloud base URL — file/env data must
+// not be interpolated into a fetch sink (CodeQL `js/file-access-to-http`
+// territory). `EXPO_PUBLIC_GLAON_CLOUD_URL` is the env knob; defaults to
+// the prod relay.
+
+const PROD_CLOUD = 'https://relay.glaon.app';
+const STAGING_CLOUD = 'https://relay-staging.glaon.app';
+
+const RAW_CLOUD_URL: string | undefined = process.env.EXPO_PUBLIC_GLAON_CLOUD_URL;
+
+function selectCloudBase(): string {
+  if (RAW_CLOUD_URL === undefined || RAW_CLOUD_URL.length === 0) return PROD_CLOUD;
+  let parsed: URL;
+  try {
+    parsed = new URL(RAW_CLOUD_URL);
+  } catch {
+    return PROD_CLOUD;
+  }
+  switch (parsed.host) {
+    case 'relay.glaon.app':
+      return PROD_CLOUD;
+    case 'relay-staging.glaon.app':
+      return STAGING_CLOUD;
+    default: {
+      if (parsed.host === 'localhost' || /^localhost:\d{1,5}$/.test(parsed.host)) {
+        if (parsed.host === 'localhost') return 'http://localhost:8787';
+        if (parsed.host === 'localhost:8787') return 'http://localhost:8787';
+        if (parsed.host === 'localhost:8788') return 'http://localhost:8788';
+        if (parsed.host === 'localhost:8789') return 'http://localhost:8789';
+      }
+      return PROD_CLOUD;
+    }
+  }
+}
+
+export interface InitiateResult {
+  readonly code: string;
+  readonly expiresAt: number;
+}
+
+export interface StatusResult {
+  readonly status: 'pending' | 'claimed' | 'expired';
+  readonly homeId?: string;
+  readonly expiresAt?: number;
+}
+
+export type CloudPairError =
+  | { readonly kind: 'unauthorized' }
+  | { readonly kind: 'rate-limited'; readonly retryAfterMs: number | null }
+  | { readonly kind: 'not-found' }
+  | { readonly kind: 'network' }
+  | { readonly kind: 'unknown'; readonly status: number };
+
+export interface CloudPairClient {
+  initiate(
+    token: string,
+  ): Promise<{ ok: true; data: InitiateResult } | { ok: false; err: CloudPairError }>;
+  status(
+    token: string,
+    code: string,
+  ): Promise<{ ok: true; data: StatusResult } | { ok: false; err: CloudPairError }>;
+}
+
+interface ClientOptions {
+  readonly fetchImpl?: typeof fetch;
+  readonly cloudBase?: string;
+}
+
+export function createCloudPairClient(options: ClientOptions = {}): CloudPairClient {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const cloudBase = options.cloudBase ?? selectCloudBase();
+
+  return {
+    async initiate(token) {
+      try {
+        const res = await fetchImpl(`${cloudBase}/pair/initiate`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+          },
+        });
+        return await parseResult<InitiateResult>(res, isInitiateResult);
+      } catch {
+        return { ok: false, err: { kind: 'network' } };
+      }
+    },
+    async status(token, code) {
+      try {
+        const url = `${cloudBase}/pair/status?code=${encodeURIComponent(code)}`;
+        const res = await fetchImpl(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+          },
+        });
+        return await parseResult<StatusResult>(res, isStatusResult);
+      } catch {
+        return { ok: false, err: { kind: 'network' } };
+      }
+    },
+  };
+}
+
+async function parseResult<T>(
+  res: Response,
+  guard: (value: unknown) => value is T,
+): Promise<{ ok: true; data: T } | { ok: false; err: CloudPairError }> {
+  const text = await res.text();
+  let body: unknown = {};
+  if (text.length > 0) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      /* tolerate empty / non-JSON */
+    }
+  }
+  if (res.status >= 200 && res.status < 300 && guard(body)) {
+    return { ok: true, data: body };
+  }
+  if (res.status === 401) return { ok: false, err: { kind: 'unauthorized' } };
+  if (res.status === 404) return { ok: false, err: { kind: 'not-found' } };
+  if (res.status === 429) {
+    const retryAfterMs = parseRetryAfterMs(body);
+    return { ok: false, err: { kind: 'rate-limited', retryAfterMs } };
+  }
+  return { ok: false, err: { kind: 'unknown', status: res.status } };
+}
+
+function parseRetryAfterMs(body: unknown): number | null {
+  if (body === null || typeof body !== 'object') return null;
+  const candidate = (body as Record<string, unknown>).retryAfterMs;
+  if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate >= 0) {
+    return candidate;
+  }
+  return null;
+}
+
+function isInitiateResult(value: unknown): value is InitiateResult {
+  if (value === null || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.code === 'string' && typeof v.expiresAt === 'number';
+}
+
+function isStatusResult(value: unknown): value is StatusResult {
+  if (value === null || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return v.status === 'pending' || v.status === 'claimed' || v.status === 'expired';
+}

--- a/apps/mobile/src/features/cloud-pairing/pair-wizard-screen.tsx
+++ b/apps/mobile/src/features/cloud-pairing/pair-wizard-screen.tsx
@@ -1,0 +1,336 @@
+// Mobile mirror of the web pair wizard (#354). Drives the device-code
+// flow from the signed-in mobile shell. Same six-state machine; no
+// background-tick — Phase 2 keeps the wizard screen in the foreground
+// (push notification for "home connected" is deferred to the #29 epic).
+//
+// Clipboard-link to the addon's /pair page is intentionally NOT
+// auto-opened — on a typical mobile setup the addon's Ingress page is
+// reachable on the LAN tablet/desktop, not the phone running Glaon. We
+// show an instruction line + copy-to-clipboard for the code instead.
+
+import { useAuth } from '@clerk/clerk-expo';
+import * as Clipboard from 'expo-clipboard';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { createCloudPairClient, type CloudPairClient, type CloudPairError } from './cloud-api';
+
+const POLL_INTERVAL_MS = 2_000;
+
+type WizardState =
+  | { step: 'await-clerk' }
+  | { step: 'initiating' }
+  | { step: 'awaiting-claim'; code: string; expiresAt: number }
+  | { step: 'claimed'; homeId: string }
+  | { step: 'expired' }
+  | { step: 'error'; error: CloudPairError };
+
+interface PairWizardScreenProps {
+  readonly client?: CloudPairClient;
+  readonly onCloudReady?: (homeId: string) => void;
+  readonly onCancel?: () => void;
+}
+
+export function PairWizardScreen({
+  client,
+  onCloudReady,
+  onCancel,
+}: PairWizardScreenProps): ReactNode {
+  const auth = useAuth() as unknown as {
+    isSignedIn?: boolean;
+    getToken: () => Promise<string | null>;
+  };
+  const signedIn = auth.isSignedIn === true;
+  const getTokenRef = useRef(auth.getToken);
+  useEffect(() => {
+    getTokenRef.current = auth.getToken;
+  }, [auth.getToken]);
+  const cloudClient = useMemo(() => client ?? createCloudPairClient(), [client]);
+
+  const [state, setState] = useState<WizardState>(
+    signedIn ? { step: 'initiating' } : { step: 'await-clerk' },
+  );
+
+  useEffect(() => {
+    if (signedIn && state.step === 'await-clerk') {
+      setState({ step: 'initiating' });
+    }
+  }, [signedIn, state.step]);
+
+  useEffect(() => {
+    if (state.step !== 'initiating') return;
+    const ctl: { cancelled: boolean } = { cancelled: false };
+    void (async () => {
+      const token = await getTokenRef.current();
+      if (token === null || token.length === 0) {
+        if (!ctl.cancelled) setState({ step: 'error', error: { kind: 'unauthorized' } });
+        return;
+      }
+      const result = await cloudClient.initiate(token);
+      if (ctl.cancelled) return;
+      if (result.ok) {
+        setState({
+          step: 'awaiting-claim',
+          code: result.data.code,
+          expiresAt: result.data.expiresAt,
+        });
+        return;
+      }
+      setState({ step: 'error', error: result.err });
+    })();
+    return () => {
+      ctl.cancelled = true;
+    };
+  }, [state.step, cloudClient]);
+
+  useEffect(() => {
+    if (state.step !== 'awaiting-claim') return;
+    const code = state.code;
+    const expiresAt = state.expiresAt;
+    const ctl: { cancelled: boolean } = { cancelled: false };
+    const tick = async (): Promise<void> => {
+      if (ctl.cancelled) return;
+      if (Date.now() >= expiresAt) {
+        setState({ step: 'expired' });
+        return;
+      }
+      const token = await getTokenRef.current();
+      if (token === null || token.length === 0) {
+        setState({ step: 'error', error: { kind: 'unauthorized' } });
+        return;
+      }
+      const result = await cloudClient.status(token, code);
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (ctl.cancelled) return;
+      if (!result.ok) {
+        setState({ step: 'error', error: result.err });
+        return;
+      }
+      if (result.data.status === 'claimed' && typeof result.data.homeId === 'string') {
+        setState({ step: 'claimed', homeId: result.data.homeId });
+        return;
+      }
+      if (result.data.status === 'expired') {
+        setState({ step: 'expired' });
+        return;
+      }
+    };
+    void tick();
+    const handle = setInterval(() => {
+      void tick();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      ctl.cancelled = true;
+      clearInterval(handle);
+    };
+  }, [state, cloudClient]);
+
+  const restart = useCallback(() => {
+    setState({ step: 'initiating' });
+  }, []);
+
+  if (!signedIn) {
+    return (
+      <Container testID="pair-wizard-await-clerk" onCancel={onCancel}>
+        <Text style={styles.title}>Link this home to Glaon cloud</Text>
+        <Text style={styles.body}>You need to sign in with your Glaon account first.</Text>
+      </Container>
+    );
+  }
+
+  if (state.step === 'initiating') {
+    return (
+      <Container testID="pair-wizard-initiating" onCancel={onCancel}>
+        <Text style={styles.title}>Generating your pairing code…</Text>
+      </Container>
+    );
+  }
+
+  if (state.step === 'awaiting-claim') {
+    return (
+      <Container testID="pair-wizard-awaiting" onCancel={onCancel}>
+        <Text style={styles.title}>Enter this code on your addon</Text>
+        <Text style={styles.body}>
+          Open the Glaon addon panel in Home Assistant and choose &ldquo;Link to cloud&rdquo;. Type
+          the code below within 10 minutes.
+        </Text>
+        <PairCodeDisplay code={state.code} />
+      </Container>
+    );
+  }
+
+  if (state.step === 'claimed') {
+    return (
+      <Container testID="pair-wizard-claimed" onCancel={onCancel}>
+        <Text style={styles.title}>Linked.</Text>
+        <Text style={styles.body}>
+          Home {state.homeId} is now reachable through the Glaon cloud relay.
+        </Text>
+        <Pressable
+          testID="pair-wizard-switch-to-cloud"
+          accessibilityRole="button"
+          onPress={() => onCloudReady?.(state.homeId)}
+          style={styles.primaryButton}
+        >
+          <Text style={styles.primaryButtonText}>Switch to cloud mode</Text>
+        </Pressable>
+      </Container>
+    );
+  }
+
+  if (state.step === 'expired') {
+    return (
+      <Container testID="pair-wizard-expired" onCancel={onCancel}>
+        <Text style={styles.title}>That code expired.</Text>
+        <Text style={styles.body}>Pairing codes are valid for 10 minutes.</Text>
+        <Pressable
+          testID="pair-wizard-restart"
+          accessibilityRole="button"
+          onPress={restart}
+          style={styles.primaryButton}
+        >
+          <Text style={styles.primaryButtonText}>Generate a new code</Text>
+        </Pressable>
+      </Container>
+    );
+  }
+
+  if (state.step === 'error') {
+    return (
+      <Container testID="pair-wizard-error" onCancel={onCancel}>
+        <Text style={styles.title} accessibilityLiveRegion="polite">
+          {messageFor(state.error)}
+        </Text>
+        <Pressable
+          testID="pair-wizard-restart"
+          accessibilityRole="button"
+          onPress={restart}
+          style={styles.primaryButton}
+        >
+          <Text style={styles.primaryButtonText}>Try again</Text>
+        </Pressable>
+      </Container>
+    );
+  }
+
+  // `await-clerk` already rendered above when `signedIn` is false; once
+  // signed in we land in `initiating` via the transition effect.
+  return null;
+}
+
+interface ContainerProps {
+  readonly children: ReactNode;
+  readonly testID: string;
+  readonly onCancel?: () => void;
+}
+
+function Container({ children, testID, onCancel }: ContainerProps): ReactNode {
+  return (
+    <ScrollView contentInsetAdjustmentBehavior="automatic">
+      <View testID={testID} style={styles.root}>
+        {children}
+        {onCancel !== undefined ? (
+          <Pressable
+            testID="pair-wizard-cancel"
+            accessibilityRole="button"
+            onPress={onCancel}
+            style={styles.secondaryButton}
+          >
+            <Text style={styles.secondaryButtonText}>Cancel</Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </ScrollView>
+  );
+}
+
+interface PairCodeDisplayProps {
+  readonly code: string;
+}
+
+function PairCodeDisplay({ code }: PairCodeDisplayProps): ReactNode {
+  const [copied, setCopied] = useState(false);
+  const onCopy = useCallback(() => {
+    void Clipboard.setStringAsync(code).then(() => {
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 1500);
+    });
+  }, [code]);
+  return (
+    <View testID="pair-wizard-code" style={styles.codeRow}>
+      <Text testID="pair-wizard-code-value" style={styles.codeValue}>
+        {code}
+      </Text>
+      <Pressable
+        testID="pair-wizard-copy"
+        accessibilityRole="button"
+        accessibilityLabel="Copy pairing code"
+        onPress={onCopy}
+        style={styles.copyButton}
+      >
+        <Text style={styles.copyButtonText}>{copied ? 'Copied' : 'Copy code'}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function messageFor(err: CloudPairError): string {
+  switch (err.kind) {
+    case 'unauthorized':
+      return 'Your Glaon session expired. Sign in again to continue.';
+    case 'rate-limited':
+      return err.retryAfterMs !== null
+        ? `Too many attempts. Try again in about ${String(Math.ceil(err.retryAfterMs / 1000))} seconds.`
+        : 'Too many attempts. Try again in a moment.';
+    case 'not-found':
+      return 'The pairing code was not found. Try generating a new one.';
+    case 'network':
+      return 'Could not reach the Glaon cloud. Check your internet connection.';
+    case 'unknown':
+      return 'Something went wrong on the Glaon cloud side.';
+  }
+}
+
+const styles = StyleSheet.create({
+  root: { padding: 24 },
+  title: { fontSize: 22, fontWeight: '600' },
+  body: { fontSize: 14, marginTop: 8, color: '#5b6770' },
+  codeRow: { marginTop: 24, alignItems: 'center' },
+  codeValue: {
+    fontSize: 32,
+    fontWeight: '600',
+    fontFamily: 'Menlo',
+    letterSpacing: 8,
+    paddingVertical: 16,
+  },
+  copyButton: {
+    minHeight: 48,
+    marginTop: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#d0d7de',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  copyButtonText: { fontSize: 16, fontWeight: '600' },
+  primaryButton: {
+    minHeight: 48,
+    marginTop: 24,
+    backgroundColor: '#1a73e8',
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryButtonText: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
+  secondaryButton: {
+    minHeight: 48,
+    marginTop: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  secondaryButtonText: { fontSize: 14, color: '#5b6770' },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       expo-auth-session:
         specifier: ~55.0.0
         version: 55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.7.3)
+      expo-clipboard:
+        specifier: ~55.0.0
+        version: 55.0.13(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)
       expo-crypto:
         specifier: ~55.0.0
         version: 55.0.14(expo@55.0.15)
@@ -4570,6 +4573,13 @@ packages:
   expo-auth-session@55.0.14:
     resolution: {integrity: sha512-NJ4yfY7pP27DrDO0Qny4FRD+L1Lp4/+oBACdLxw3igZywKA+34kjbGkx34fgywRoCB1n373ZnWfUV8PQSHwhTA==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-clipboard@55.0.13:
+    resolution: {integrity: sha512-PrOmmuVsGW4bAkNQmGKtxMXj3invsfN+jfIKmQxHwE/dn7ODqwFWviUTa+PMUjP3XZmYCDLyu/i0GLeu7HF9Ew==}
+    peerDependencies:
+      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -12589,6 +12599,12 @@ snapshots:
       - expo
       - supports-color
       - typescript
+
+  expo-clipboard@55.0.13(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5):
+    dependencies:
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      react: 19.2.5
+      react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)
 
   expo-constants@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(typescript@5.7.3):
     dependencies:


### PR DESCRIPTION
## Summary

Mobile mirror of #354. Lands the device-code pairing flow on the signed-in mobile shell so a local-mode user can promote their home to a Clerk cloud account.

- **`cloud-api.ts`** — REST client over `POST /pair/initiate` + `GET /pair/status`. Same literal-switch CodeQL defense pattern as #444 / #354. `EXPO_PUBLIC_GLAON_CLOUD_URL` is the env knob; defaults to prod relay.
- **`PairWizardScreen`** — six-state machine: `await-clerk → initiating → awaiting-claim → claimed | expired | error`. Polls `/pair/status` every 2s, cancels on unmount + terminal state. Foreground-only — push notification for "home connected" deferred to the [#29 epic](https://github.com/toss-cengiz/glaon/issues/29) per the issue.
- **Code display** uses `expo-clipboard` for one-tap copy. Cancel button on every screen returns to the home shell. Success CTA promotes the mode preference to cloud and clears local auth so the mode-selector flips on next launch.
- **App.tsx** — "Link to cloud" button on the signed-in shell mounts the wizard. Hidden when Clerk isn't configured.

## Scope (In)

- `apps/mobile/src/features/cloud-pairing/cloud-api.ts` + `pair-wizard-screen.tsx`.
- App.tsx wizard mount + entry button.
- `expo-clipboard@~55.0.0` dep.
- `EXPO_PUBLIC_GLAON_CLOUD_URL` env entry.

## Scope (Out)

- Cloud `/pair/initiate` + `/pair/status` endpoints — already in `apps/cloud/src/routes/pair.ts` from #346.
- Addon `/pair` UI — already in `apps/addon-agent/src/pair-server.ts` from #349.
- Web equivalent — already in #354.
- Background push for "home connected" — #29 epic.
- Vitest unit-tests for the wizard — `apps/mobile` doesn't host vitest yet; the cloud-api logic is duplicated from `apps/web` where it has full coverage. A shared `@glaon/core` consolidation is a follow-up.
- RN E2E (detox / maestro) — out of scope per CLAUDE.md "mobile E2E future".

## Test plan

- [x] `pnpm --filter @glaon/mobile type-check` — passes.
- [x] `pnpm --filter @glaon/mobile lint` — passes.
- [x] `pnpm exec knip --workspace apps/mobile` — clean.
- [ ] CI: type-check · lint · audit, unit-tests (web side still passes), story-tests, playwright, CodeQL, build (aarch64+amd64).
- [ ] Manual happy path against staging cloud + a real addon (per the issue's acceptance — requires `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` + paired addon).

## Notes

- The wizard intentionally does NOT auto-open the addon's `/pair` URL via deep-linking — the addon's Ingress page lives on the LAN-side HA host, not the phone. The user opens it on a tablet/desktop and types the copy-pasted code.
- Polling lifecycle: `setInterval` is cleared on terminal state via the `useEffect` cleanup. The `tick` closure additionally checks `ctl.cancelled` after the await so a stale interval doesn't write to a stale state shape.

Closes #357.
Refs ADR 0021, ADR 0019.