### PR TITLE
feat(core,api): shared apps/api client + zod schemas

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@glaon/core": "workspace:*",
     "hono": "^4.6.14",
     "jose": "^5.9.6",
     "mongodb": "^6.10.0",

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -10,21 +10,15 @@
 //     revocation list. No-op for non-authenticated callers.
 
 import { Hono } from 'hono';
-import { z } from 'zod';
 
+import {
+  AuthExchangeRequestSchema as ExchangeBody,
+  AuthRefreshRequestSchema as RefreshBody,
+} from '../schemas';
 import { introspectHaToken } from '../auth/ha-bridge';
 import { mintSessionJwt, verifySessionJwt } from '../auth/jwt';
 import type { RevocationStore } from '../auth/revocation';
 import { SESSION_COOKIE_NAME } from '../middleware/require-session';
-
-const ExchangeBody = z.object({
-  haAccessToken: z.string().min(1),
-  haBaseUrl: z.string().url(),
-});
-
-const RefreshBody = z.object({
-  sessionJwt: z.string().min(1),
-});
 
 interface AuthRouterDeps {
   readonly secret: Uint8Array;

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -1,0 +1,10 @@
+// Re-export the canonical Zod schemas from @glaon/core/api-client so
+// `apps/api` route handlers validate incoming bodies with the very
+// definitions the web + mobile clients build their requests against.
+// Adding a schema goes via `packages/core/src/api-client/schemas.ts`;
+// never define new shapes in this file. Response schemas live at
+// `@glaon/core/api-client` directly — server handlers don't re-parse
+// outgoing bodies (the response is what `c.json` ships) so only the
+// request validators are surfaced here.
+
+export { AuthExchangeRequestSchema, AuthRefreshRequestSchema } from '@glaon/core/api-client';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@glaon/core",
   "version": "0.0.0",
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
   "devDependencies": {
     "@glaon/config": "workspace:*",
     "@vitest/coverage-v8": "^4.1.5",
@@ -9,6 +12,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./api-client": "./src/api-client/index.ts",
     "./auth": "./src/auth/index.ts",
     "./ha": "./src/ha/index.ts",
     "./observability": "./src/observability/index.ts",

--- a/packages/core/src/api-client/client.test.ts
+++ b/packages/core/src/api-client/client.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from './client';
+import { ApiError, ApiNetworkError } from './errors';
+
+function makeFetch(
+  responder: (input: string, init?: RequestInit) => Response | Promise<Response>,
+): typeof fetch {
+  const impl = vi.fn(async (input: string, init?: RequestInit) => responder(input, init));
+  return impl as unknown as typeof fetch;
+}
+
+const BASE = 'https://api.glaon.test';
+
+describe('ApiClient — exchange', () => {
+  it('parses a successful response', async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ sessionJwt: 'a.b.c', expiresAt: 1_700_000_000_000 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    );
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    const result = await client.exchange({
+      haAccessToken: 'tok',
+      haBaseUrl: 'http://homeassistant.local:8123',
+    });
+    expect(result).toEqual({ sessionJwt: 'a.b.c', expiresAt: 1_700_000_000_000 });
+  });
+
+  it('rejects bad request bodies before sending', async () => {
+    const fetchImpl = makeFetch(() => new Response());
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await expect(client.exchange({ haAccessToken: '', haBaseUrl: 'not-a-url' })).rejects.toThrow();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('does not attach an Authorization header (skipAuth path)', async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = makeFetch((_input, init) => {
+      captured = init;
+      return Promise.resolve(
+        new Response(JSON.stringify({ sessionJwt: 'x', expiresAt: 1 }), { status: 200 }),
+      );
+    });
+    const client = new ApiClient({
+      baseUrl: BASE,
+      fetchImpl,
+      getSessionJwt: () => 'should-not-be-used',
+    });
+    await client.exchange({
+      haAccessToken: 'tok',
+      haBaseUrl: 'http://h',
+    });
+    const headers = (captured?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+});
+
+describe('ApiClient — logout', () => {
+  it('attaches the Authorization header when getSessionJwt returns a value', async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = makeFetch((_input, init) => {
+      captured = init;
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
+    const client = new ApiClient({
+      baseUrl: BASE,
+      fetchImpl,
+      getSessionJwt: () => 'session-jwt-value',
+    });
+    await client.logout();
+    expect((captured?.headers as Record<string, string>).Authorization).toBe(
+      'Bearer session-jwt-value',
+    );
+  });
+
+  it('omits the Authorization header when no token is configured', async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = makeFetch((_input, init) => {
+      captured = init;
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await client.logout();
+    expect((captured?.headers as Record<string, string>).Authorization).toBeUndefined();
+  });
+});
+
+describe('ApiClient — error mapping', () => {
+  it('throws ApiError with parsed body for 4xx JSON responses', async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'rate-limited', retryAfterMs: 30_000 }), {
+          status: 429,
+        }),
+      ),
+    );
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    let thrown: unknown;
+    try {
+      await client.refresh({ sessionJwt: 'x' });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    if (thrown instanceof ApiError) {
+      expect(thrown.status).toBe(429);
+      expect(thrown.body).toEqual({ error: 'rate-limited', retryAfterMs: 30_000 });
+    }
+  });
+
+  it('throws ApiError with body=null for non-JSON responses', async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(new Response('Internal Server Error', { status: 500 })),
+    );
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    let thrown: unknown;
+    try {
+      await client.logout();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    if (thrown instanceof ApiError) {
+      expect(thrown.status).toBe(500);
+      expect(thrown.body).toBeNull();
+    }
+  });
+
+  it('throws ApiNetworkError when fetch rejects', async () => {
+    const fetchImpl = makeFetch(() => Promise.reject(new TypeError('network')));
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    let thrown: unknown;
+    try {
+      await client.logout();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ApiNetworkError);
+  });
+
+  it('throws ZodError when the server response does not match the schema', async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(new Response(JSON.stringify({ unexpected: 'shape' }), { status: 200 })),
+    );
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await expect(client.logout()).rejects.toThrow();
+  });
+});
+
+describe('ApiClient — base URL handling', () => {
+  it('strips a trailing slash on the baseUrl', async () => {
+    let capturedUrl: string | undefined;
+    const fetchImpl = makeFetch((input) => {
+      capturedUrl = input;
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    });
+    const client = new ApiClient({ baseUrl: `${BASE}/`, fetchImpl });
+    await client.logout();
+    expect(capturedUrl).toBe(`${BASE}/auth/logout`);
+  });
+});

--- a/packages/core/src/api-client/client.ts
+++ b/packages/core/src/api-client/client.ts
@@ -1,0 +1,145 @@
+// Typed REST client over `apps/api`. The same Zod schemas the server
+// validates against are reused here for request + response parsing —
+// schema drift between server and client is an impossibility unless the
+// schema definition itself changes.
+//
+// Lifecycle decisions kept simple per #419 acceptance:
+//   - No retry / backoff in this layer; feature code wraps with TanStack
+//     Query (web/mobile) which owns retry policy.
+//   - No automatic refresh on 401; the AuthProvider handles that path.
+//   - No timeout in this layer; callers pass an `AbortSignal` if they want
+//     one (TanStack Query does this by default).
+
+import type { z } from 'zod';
+
+import { ApiError, ApiNetworkError } from './errors';
+import {
+  ApiErrorBodySchema,
+  AuthExchangeRequestSchema,
+  AuthExchangeResponseSchema,
+  AuthLogoutResponseSchema,
+  AuthRefreshRequestSchema,
+  type AuthExchangeRequest,
+  type AuthExchangeResponse,
+  type AuthLogoutResponse,
+  type AuthRefreshRequest,
+  type AuthRefreshResponse,
+} from './schemas';
+
+export interface ApiClientOptions {
+  readonly baseUrl: string;
+  /**
+   * Returns the current session JWT (or `null` for unauthenticated calls
+   * like `/auth/exchange`). The client calls this on every request so
+   * token rotation in the AuthProvider takes effect without re-creating
+   * the client.
+   */
+  readonly getSessionJwt?: () => string | null | Promise<string | null>;
+  readonly fetchImpl?: typeof fetch;
+}
+
+interface RequestOptions {
+  readonly signal?: AbortSignal;
+  readonly skipAuth?: boolean;
+}
+
+export class ApiClient {
+  private readonly baseUrl: string;
+  private readonly getSessionJwt: () => string | null | Promise<string | null>;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: ApiClientOptions) {
+    this.baseUrl = stripTrailingSlash(options.baseUrl);
+    this.getSessionJwt = options.getSessionJwt ?? (() => null);
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async exchange(
+    body: AuthExchangeRequest,
+    options: RequestOptions = {},
+  ): Promise<AuthExchangeResponse> {
+    const parsed = AuthExchangeRequestSchema.parse(body);
+    return this.send('POST', '/auth/exchange', parsed, AuthExchangeResponseSchema, {
+      ...options,
+      skipAuth: true,
+    });
+  }
+
+  async refresh(
+    body: AuthRefreshRequest,
+    options: RequestOptions = {},
+  ): Promise<AuthRefreshResponse> {
+    const parsed = AuthRefreshRequestSchema.parse(body);
+    // /auth/refresh response shape is identical to /auth/exchange.
+    return this.send('POST', '/auth/refresh', parsed, AuthExchangeResponseSchema, {
+      ...options,
+      skipAuth: true,
+    });
+  }
+
+  logout(options: RequestOptions = {}): Promise<AuthLogoutResponse> {
+    return this.send('POST', '/auth/logout', null, AuthLogoutResponseSchema, options);
+  }
+
+  // The send() helper is `protected` so feature-specific subclasses (or
+  // ad-hoc extensions in @glaon/core later) can add domain endpoints
+  // without re-implementing the auth + parse + error pipeline.
+  protected async send<TResponse>(
+    method: 'GET' | 'POST' | 'DELETE',
+    path: string,
+    body: unknown,
+    responseSchema: z.ZodType<TResponse>,
+    options: RequestOptions,
+  ): Promise<TResponse> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+    };
+    if (body !== null) {
+      headers['Content-Type'] = 'application/json';
+    }
+    if (options.skipAuth !== true) {
+      const token = await this.getSessionJwt();
+      if (token !== null && token.length > 0) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+    }
+
+    const init: RequestInit = {
+      method,
+      headers,
+      ...(body !== null ? { body: JSON.stringify(body) } : {}),
+      ...(options.signal !== undefined ? { signal: options.signal } : {}),
+    };
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseUrl}${path}`, init);
+    } catch (cause) {
+      throw new ApiNetworkError(`apps/api ${method} ${path} failed`, cause);
+    }
+
+    const text = await response.text();
+    let parsedBody: unknown = null;
+    if (text.length > 0) {
+      try {
+        parsedBody = JSON.parse(text);
+      } catch {
+        /* tolerate non-JSON body — falls into ApiError unknown branch */
+      }
+    }
+
+    if (!response.ok) {
+      const errorBody = ApiErrorBodySchema.safeParse(parsedBody);
+      throw new ApiError(
+        `apps/api ${method} ${path} returned ${String(response.status)}`,
+        response.status,
+        errorBody.success ? errorBody.data : null,
+      );
+    }
+    return responseSchema.parse(parsedBody);
+  }
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}

--- a/packages/core/src/api-client/errors.ts
+++ b/packages/core/src/api-client/errors.ts
@@ -1,0 +1,35 @@
+// Typed errors thrown by `ApiClient`. The class hierarchy is shallow on
+// purpose — callers usually only need to know "did the request succeed",
+// "did the server reject it" (4xx with parsed body), or "did something
+// go wrong on the way" (network / timeout / non-JSON response).
+
+import type { ApiErrorBody } from './schemas';
+
+export class ApiError extends Error {
+  /** HTTP status code returned by `apps/api`. */
+  readonly status: number;
+  /** Parsed `{ error, code?, retryAfterMs? }` body when the response was JSON. */
+  readonly body: ApiErrorBody | null;
+
+  constructor(message: string, status: number, body: ApiErrorBody | null) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+/**
+ * `fetch` rejected (DNS failure, abort, TLS error) before the server
+ * could respond. Distinct from `ApiError` so retry policies can target
+ * transient transport faults specifically.
+ */
+export class ApiNetworkError extends Error {
+  override readonly cause: unknown;
+
+  constructor(message: string, cause: unknown) {
+    super(message);
+    this.name = 'ApiNetworkError';
+    this.cause = cause;
+  }
+}

--- a/packages/core/src/api-client/index.ts
+++ b/packages/core/src/api-client/index.ts
@@ -1,0 +1,23 @@
+// Public surface of @glaon/core/api-client. Both apps/web and apps/mobile
+// consume it for typed calls into apps/api; apps/api re-exports the
+// schemas from `apps/api/src/schemas.ts` so the server validates with
+// the same Zod definitions the clients build their requests against.
+
+export { ApiClient } from './client';
+export type { ApiClientOptions } from './client';
+export { ApiError, ApiNetworkError } from './errors';
+export {
+  ApiErrorBodySchema,
+  AuthExchangeRequestSchema,
+  AuthExchangeResponseSchema,
+  AuthLogoutResponseSchema,
+  AuthRefreshRequestSchema,
+  SessionClaimsSchema,
+  type ApiErrorBody,
+  type AuthExchangeRequest,
+  type AuthExchangeResponse,
+  type AuthLogoutResponse,
+  type AuthRefreshRequest,
+  type AuthRefreshResponse,
+  type SessionClaims,
+} from './schemas';

--- a/packages/core/src/api-client/schemas.test.ts
+++ b/packages/core/src/api-client/schemas.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ApiErrorBodySchema,
+  AuthExchangeRequestSchema,
+  AuthExchangeResponseSchema,
+  AuthLogoutResponseSchema,
+  AuthRefreshRequestSchema,
+  SessionClaimsSchema,
+} from './schemas';
+
+describe('AuthExchangeRequestSchema', () => {
+  it('accepts a well-formed request', () => {
+    expect(
+      AuthExchangeRequestSchema.parse({
+        haAccessToken: 'tok',
+        haBaseUrl: 'http://homeassistant.local:8123',
+      }),
+    ).toEqual({ haAccessToken: 'tok', haBaseUrl: 'http://homeassistant.local:8123' });
+  });
+
+  it('rejects an empty haAccessToken', () => {
+    expect(
+      AuthExchangeRequestSchema.safeParse({ haAccessToken: '', haBaseUrl: 'http://h' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a non-URL haBaseUrl', () => {
+    expect(
+      AuthExchangeRequestSchema.safeParse({ haAccessToken: 'x', haBaseUrl: 'not-a-url' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('AuthExchangeResponseSchema', () => {
+  it('round-trips the server response shape', () => {
+    const data = { sessionJwt: 'a.b.c', expiresAt: 1_700_000_000_000 };
+    expect(AuthExchangeResponseSchema.parse(data)).toEqual(data);
+  });
+
+  it('rejects negative expiresAt', () => {
+    expect(AuthExchangeResponseSchema.safeParse({ sessionJwt: 'x', expiresAt: -1 }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('AuthRefreshRequestSchema', () => {
+  it('requires a non-empty sessionJwt', () => {
+    expect(AuthRefreshRequestSchema.safeParse({ sessionJwt: '' }).success).toBe(false);
+    expect(AuthRefreshRequestSchema.safeParse({ sessionJwt: 'x' }).success).toBe(true);
+  });
+});
+
+describe('AuthLogoutResponseSchema', () => {
+  it('only matches { ok: true }', () => {
+    expect(AuthLogoutResponseSchema.safeParse({ ok: true }).success).toBe(true);
+    expect(AuthLogoutResponseSchema.safeParse({ ok: false }).success).toBe(false);
+  });
+});
+
+describe('ApiErrorBodySchema', () => {
+  it('parses a minimal error envelope', () => {
+    expect(ApiErrorBodySchema.parse({ error: 'unauthorized' })).toEqual({ error: 'unauthorized' });
+  });
+
+  it('parses the full error envelope with retry hint', () => {
+    const data = { error: 'rate-limited', code: 'too-many', retryAfterMs: 30_000 };
+    expect(ApiErrorBodySchema.parse(data)).toEqual(data);
+  });
+
+  it('rejects negative retryAfterMs', () => {
+    expect(ApiErrorBodySchema.safeParse({ error: 'x', retryAfterMs: -1 }).success).toBe(false);
+  });
+});
+
+describe('SessionClaimsSchema', () => {
+  it('round-trips canonical claims', () => {
+    const claims = { sub: 'u', jti: 'j', iat: 1, exp: 2 };
+    expect(SessionClaimsSchema.parse(claims)).toEqual(claims);
+  });
+
+  it('rejects non-integer exp', () => {
+    expect(SessionClaimsSchema.safeParse({ sub: 'u', jti: 'j', iat: 1, exp: 1.5 }).success).toBe(
+      false,
+    );
+  });
+});

--- a/packages/core/src/api-client/schemas.ts
+++ b/packages/core/src/api-client/schemas.ts
@@ -1,0 +1,66 @@
+// Zod schemas shared between `apps/api` (server) and `apps/web` +
+// `apps/mobile` (clients) — issue #419 / ADR 0025. Single source of
+// truth: server validates request bodies + persisted documents +
+// response shapes through the same definitions the client uses to
+// type-check its calls.
+//
+// `@glaon/core` stays platform-agnostic per ADR 0004; the schemas use
+// only Zod + plain JS values. No DOM, no react-native, no Node-only
+// modules sneak in via this file.
+
+import { z } from 'zod';
+
+/* -------- /auth/exchange -------------------------------------------------- */
+
+export const AuthExchangeRequestSchema = z.object({
+  haAccessToken: z.string().min(1),
+  haBaseUrl: z.string().url(),
+});
+export type AuthExchangeRequest = z.infer<typeof AuthExchangeRequestSchema>;
+
+export const AuthExchangeResponseSchema = z.object({
+  sessionJwt: z.string().min(1),
+  /** ms-since-epoch, mirrors `claims.exp * 1000` */
+  expiresAt: z.number().int().positive(),
+});
+export type AuthExchangeResponse = z.infer<typeof AuthExchangeResponseSchema>;
+
+/* -------- /auth/refresh --------------------------------------------------- */
+
+export const AuthRefreshRequestSchema = z.object({
+  sessionJwt: z.string().min(1),
+});
+export type AuthRefreshRequest = z.infer<typeof AuthRefreshRequestSchema>;
+
+// The /auth/refresh response shape is identical to /auth/exchange — the
+// server re-mints a session JWT with a fresh exp. Callers consume
+// AuthExchangeResponseSchema for both endpoints; we expose a type
+// alias here so the API surface reads cleanly at call sites.
+export type AuthRefreshResponse = AuthExchangeResponse;
+
+/* -------- /auth/logout ---------------------------------------------------- */
+
+export const AuthLogoutResponseSchema = z.object({
+  ok: z.literal(true),
+});
+export type AuthLogoutResponse = z.infer<typeof AuthLogoutResponseSchema>;
+
+/* -------- shared error envelope ------------------------------------------- */
+
+export const ApiErrorBodySchema = z.object({
+  error: z.string(),
+  code: z.string().optional(),
+  retryAfterMs: z.number().int().nonnegative().optional(),
+});
+export type ApiErrorBody = z.infer<typeof ApiErrorBodySchema>;
+
+/* -------- session JWT decode (client-side; verification stays server) ----- */
+
+/** Claims the apps/api server stamps on the session JWT (#418). */
+export const SessionClaimsSchema = z.object({
+  sub: z.string().min(1),
+  jti: z.string().min(1),
+  iat: z.number().int().nonnegative(),
+  exp: z.number().int().nonnegative(),
+});
+export type SessionClaims = z.infer<typeof SessionClaimsSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@glaon/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       hono:
         specifier: ^4.6.14
         version: 4.12.18
@@ -305,6 +308,10 @@ importers:
         version: 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.7.3)
 
   packages/core:
+    dependencies:
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
     devDependencies:
       '@glaon/config':
         specifier: workspace:*
@@ -9972,7 +9979,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.84.3(bufferutil@4.1.0)
-      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.3(bufferutil@4.1.0)
       metro-core: 0.84.3
       semver: 7.7.4
     transitivePeerDependencies:
@@ -14047,6 +14054,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  metro-config@0.84.3(bufferutil@4.1.0):
+    dependencies:
+      connect: 3.7.0
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.84.3(bufferutil@4.1.0)
+      metro-cache: 0.84.3
+      metro-core: 0.84.3
+      metro-runtime: 0.84.3
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-config@0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -14335,7 +14357,7 @@ snapshots:
       metro-babel-transformer: 0.84.3
       metro-cache: 0.84.3
       metro-cache-key: 0.84.3
-      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.3(bufferutil@4.1.0)
       metro-core: 0.84.3
       metro-file-map: 0.84.3
       metro-resolver: 0.84.3


### PR DESCRIPTION
## Summary

Lands the contract layer for `apps/api` per [ADR 0025](docs/adr/0025-apps-api-stack.md). `apps/web` + `apps/mobile` will consume `@glaon/core/api-client` for typed calls; `apps/api` re-uses the same Zod schemas to validate incoming bodies. Schema drift between server and client is now a single-file edit story rather than a "reconcile two TS interfaces" hunt.

- **`@glaon/core/api-client`** — new export entry. `Zod` + plain JS only; ADR 0004's platform-agnostic boundary holds (no DOM, no RN).
- **`ApiClient`** with `exchange()` / `refresh()` / `logout()`. `getSessionJwt` callback supplies the bearer on every request so token rotation takes effect without re-instantiating the client.
- **`ApiError`** carries the parsed `{ error, code?, retryAfterMs? }` body for 4xx/5xx; **`ApiNetworkError`** separates transport faults so retry policies can target them.
- **`apps/api/src/schemas.ts`** re-exports the request validators from `@glaon/core/api-client`; routes/auth.ts uses them so server + client lock-step.

## Scope (In)

- `packages/core/src/api-client/{schemas,client,errors,index}.ts` + tests.
- `packages/core/package.json`: new `./api-client` export, `zod ^3.24.0` as the first runtime dep.
- `apps/api/src/schemas.ts` re-export bridge.
- `apps/api` adopts shared schemas in `routes/auth.ts`.
- 18 new unit tests across schemas + client.

## Scope (Out)

- TanStack Query hooks consuming `ApiClient` — feature layer in `apps/web` / `apps/mobile` (per CLAUDE.md data-fetching boundary).
- First domain endpoint schemas (saved layouts) — P2-F (#420).
- Server framework — already locked in ADR 0025 / P2-B (#416).
- Retry / backoff inside `ApiClient` — TanStack Query owns retry policy.

## Test plan

- [x] `pnpm --filter @glaon/core type-check && lint && test` — passes (85 tests, 18 new).
- [x] `pnpm --filter @glaon/api type-check && lint && test` — passes (43 tests).
- [x] `pnpm --filter @glaon/api build` — 1.9 MB single-file CJS bundle.
- [x] `pnpm exec knip --workspace packages/core` + `apps/api` — clean.
- [ ] CI: type-check · lint · audit, unit-tests, story-tests, playwright, CodeQL, visual regression, build (aarch64+amd64), package-contract.

## Notes

- The /auth/refresh response shape is identical to /auth/exchange. We expose `AuthRefreshResponse` as a TS alias of `AuthExchangeResponse` rather than duplicating the Zod schema (knip flagged the alias as a duplicate export — fair, types are the same).
- `ApiClient.send()` is `protected` so feature subclasses can plug into the same auth + parse + error pipeline when more endpoints land in P2-F (#420).
- `apps/api/src/schemas.ts` only re-exports the request validators because the server uses Zod to parse incoming bodies but writes responses via `c.json(...)` (no parse on the way out).

Closes #419.
Refs ADR 0004, ADR 0017, ADR 0025.