### PR TITLE
feat(api,core): saved layouts crud + shared schemas

### DIFF
--- a/apps/api/src/db/layouts-repo-fake.ts
+++ b/apps/api/src/db/layouts-repo-fake.ts
@@ -1,0 +1,99 @@
+// In-memory LayoutsRepo for unit tests. Mirrors the public surface of
+// the real `LayoutsRepo`. Avoids dragging mongodb-memory-server into
+// the unit-test footprint; integration tests against a real Mongo land
+// with the P2-H workflow (#422).
+
+import type {
+  CreateLayoutInput,
+  ListLayoutOptions,
+  PublicLayout,
+  UpdateLayoutInput,
+} from './layouts-repo';
+
+interface InternalLayout extends PublicLayout {
+  deletedAt: string | null;
+}
+
+export class InMemoryLayoutsRepo {
+  private readonly store = new Map<string, InternalLayout>();
+
+  async create(input: CreateLayoutInput): Promise<PublicLayout> {
+    const layout: InternalLayout = {
+      id: input.id,
+      userId: input.userId,
+      homeId: input.homeId,
+      name: input.name,
+      payload: input.payload,
+      createdAt: input.now.toISOString(),
+      updatedAt: input.now.toISOString(),
+      deletedAt: null,
+    };
+    this.store.set(input.id, layout);
+    await Promise.resolve();
+    return strip(layout);
+  }
+
+  async list(userId: string, options: ListLayoutOptions = {}): Promise<PublicLayout[]> {
+    await Promise.resolve();
+    return Array.from(this.store.values())
+      .filter(
+        (layout) =>
+          layout.userId === userId &&
+          layout.deletedAt === null &&
+          (options.homeId === undefined || layout.homeId === options.homeId),
+      )
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      .map(strip);
+  }
+
+  async getById(id: string, userId: string): Promise<PublicLayout | null> {
+    await Promise.resolve();
+    const layout = this.store.get(id);
+    if (layout?.userId !== userId || layout.deletedAt !== null) {
+      return null;
+    }
+    return strip(layout);
+  }
+
+  async update(id: string, userId: string, input: UpdateLayoutInput): Promise<PublicLayout | null> {
+    await Promise.resolve();
+    const existing = this.store.get(id);
+    if (existing?.userId !== userId || existing.deletedAt !== null) {
+      return null;
+    }
+    const next: InternalLayout = {
+      ...existing,
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.payload !== undefined ? { payload: input.payload } : {}),
+      updatedAt: input.now.toISOString(),
+    };
+    this.store.set(id, next);
+    return strip(next);
+  }
+
+  async softDelete(id: string, userId: string, now: Date): Promise<boolean> {
+    await Promise.resolve();
+    const existing = this.store.get(id);
+    if (existing?.userId !== userId || existing.deletedAt !== null) {
+      return false;
+    }
+    this.store.set(id, {
+      ...existing,
+      deletedAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    });
+    return true;
+  }
+}
+
+function strip(layout: InternalLayout): PublicLayout {
+  return {
+    id: layout.id,
+    userId: layout.userId,
+    homeId: layout.homeId,
+    name: layout.name,
+    payload: layout.payload,
+    createdAt: layout.createdAt,
+    updatedAt: layout.updatedAt,
+  };
+}

--- a/apps/api/src/db/layouts-repo.ts
+++ b/apps/api/src/db/layouts-repo.ts
@@ -1,0 +1,142 @@
+// Mongo repository for the `layouts` collection (#420).
+//
+// Document shape:
+//   {
+//     _id: string (uuid),       — id surfaced to clients
+//     userId: string,           — owner; authorization key
+//     homeId: string,           — multi-home scoping
+//     name: string,             — user-visible name
+//     payload: Record<string,unknown>,
+//     createdAt: Date,
+//     updatedAt: Date,
+//     deletedAt: Date | null,   — soft-delete marker
+//   }
+//
+// Indexes:
+//   { userId: 1, deletedAt: 1 } — primary list query.
+//   { userId: 1, homeId: 1, deletedAt: 1 } — homeId-filtered list.
+
+import type { Collection, Db } from 'mongodb';
+
+interface LayoutDoc {
+  _id: string;
+  userId: string;
+  homeId: string;
+  name: string;
+  payload: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export interface CreateLayoutInput {
+  readonly id: string;
+  readonly userId: string;
+  readonly homeId: string;
+  readonly name: string;
+  readonly payload: Record<string, unknown>;
+  readonly now: Date;
+}
+
+export interface UpdateLayoutInput {
+  readonly name?: string;
+  readonly payload?: Record<string, unknown>;
+  readonly now: Date;
+}
+
+export interface ListLayoutOptions {
+  readonly homeId?: string;
+}
+
+export interface PublicLayout {
+  readonly id: string;
+  readonly userId: string;
+  readonly homeId: string;
+  readonly name: string;
+  readonly payload: Record<string, unknown>;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export class LayoutsRepo {
+  private readonly collection: Collection<LayoutDoc>;
+  private indexEnsured = false;
+
+  constructor(db: Db) {
+    this.collection = db.collection<LayoutDoc>('layouts');
+  }
+
+  async ensureIndex(): Promise<void> {
+    if (this.indexEnsured) return;
+    await this.collection.createIndex({ userId: 1, deletedAt: 1 });
+    await this.collection.createIndex({ userId: 1, homeId: 1, deletedAt: 1 });
+    this.indexEnsured = true;
+  }
+
+  async create(input: CreateLayoutInput): Promise<PublicLayout> {
+    await this.ensureIndex();
+    const doc: LayoutDoc = {
+      _id: input.id,
+      userId: input.userId,
+      homeId: input.homeId,
+      name: input.name,
+      payload: input.payload,
+      createdAt: input.now,
+      updatedAt: input.now,
+      deletedAt: null,
+    };
+    await this.collection.insertOne(doc);
+    return toPublic(doc);
+  }
+
+  async list(userId: string, options: ListLayoutOptions = {}): Promise<PublicLayout[]> {
+    await this.ensureIndex();
+    const filter: Partial<LayoutDoc> & { deletedAt: null } = {
+      userId,
+      deletedAt: null,
+    };
+    if (options.homeId !== undefined) filter.homeId = options.homeId;
+    const docs = await this.collection.find(filter).sort({ updatedAt: -1 }).toArray();
+    return docs.map(toPublic);
+  }
+
+  async getById(id: string, userId: string): Promise<PublicLayout | null> {
+    await this.ensureIndex();
+    const doc = await this.collection.findOne({ _id: id, userId, deletedAt: null });
+    return doc === null ? null : toPublic(doc);
+  }
+
+  async update(id: string, userId: string, input: UpdateLayoutInput): Promise<PublicLayout | null> {
+    await this.ensureIndex();
+    const set: Partial<LayoutDoc> = { updatedAt: input.now };
+    if (input.name !== undefined) set.name = input.name;
+    if (input.payload !== undefined) set.payload = input.payload;
+    const result = await this.collection.findOneAndUpdate(
+      { _id: id, userId, deletedAt: null },
+      { $set: set },
+      { returnDocument: 'after' },
+    );
+    return result === null ? null : toPublic(result);
+  }
+
+  async softDelete(id: string, userId: string, now: Date): Promise<boolean> {
+    await this.ensureIndex();
+    const result = await this.collection.updateOne(
+      { _id: id, userId, deletedAt: null },
+      { $set: { deletedAt: now, updatedAt: now } },
+    );
+    return result.modifiedCount === 1;
+  }
+}
+
+function toPublic(doc: LayoutDoc): PublicLayout {
+  return {
+    id: doc._id,
+    userId: doc.userId,
+    homeId: doc.homeId,
+    name: doc.name,
+    payload: doc.payload,
+    createdAt: doc.createdAt.toISOString(),
+    updatedAt: doc.updatedAt.toISOString(),
+  };
+}

--- a/apps/api/src/routes/layouts.test.ts
+++ b/apps/api/src/routes/layouts.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeSecret, mintSessionJwt } from '../auth/jwt';
+import { InMemoryRevocationStore } from '../auth/revocation';
+import { InMemoryLayoutsRepo } from '../db/layouts-repo-fake';
+import { createLayoutsRouter } from './layouts';
+
+const SECRET = decodeSecret('a'.repeat(32));
+
+async function withAuth(userId: string): Promise<{
+  router: ReturnType<typeof createLayoutsRouter>;
+  repo: InMemoryLayoutsRepo;
+  authHeader: string;
+}> {
+  const repo = new InMemoryLayoutsRepo();
+  const revocations = new InMemoryRevocationStore();
+  const router = createLayoutsRouter({
+    db: {} as never,
+    secret: SECRET,
+    revocations,
+    repo,
+    now: () => new Date('2026-05-10T00:00:00.000Z'),
+    newId: () => 'layout-1',
+  });
+  const { jwt } = await mintSessionJwt(SECRET, { userId, ttlSeconds: 600 });
+  return { router, repo, authHeader: `Bearer ${jwt}` };
+}
+
+describe('GET /layouts', () => {
+  it('returns 401 without a session', async () => {
+    const { router } = await withAuth('user-1');
+    const res = await router.request('/');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the user layouts list', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.create({
+      id: 'a',
+      userId: 'user-1',
+      homeId: 'home-1',
+      name: 'Living room',
+      payload: { rows: 2 },
+      now: new Date('2026-05-09T00:00:00.000Z'),
+    });
+    const res = await router.request('/', { headers: { Authorization: authHeader } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { layouts: { id: string; name: string }[] };
+    expect(body.layouts).toHaveLength(1);
+    expect(body.layouts[0]?.name).toBe('Living room');
+  });
+
+  it('filters by homeId when provided', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.create({
+      id: 'a',
+      userId: 'user-1',
+      homeId: 'home-1',
+      name: 'A',
+      payload: {},
+      now: new Date(),
+    });
+    await repo.create({
+      id: 'b',
+      userId: 'user-1',
+      homeId: 'home-2',
+      name: 'B',
+      payload: {},
+      now: new Date(),
+    });
+    const res = await router.request('/?homeId=home-1', {
+      headers: { Authorization: authHeader },
+    });
+    const body = (await res.json()) as { layouts: { id: string }[] };
+    expect(body.layouts.map((layout) => layout.id)).toEqual(['a']);
+  });
+
+  it("never surfaces another user's layouts", async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.create({
+      id: 'foreign',
+      userId: 'user-2',
+      homeId: 'home-1',
+      name: 'Not yours',
+      payload: {},
+      now: new Date(),
+    });
+    const res = await router.request('/', { headers: { Authorization: authHeader } });
+    const body = (await res.json()) as { layouts: unknown[] };
+    expect(body.layouts).toHaveLength(0);
+  });
+});
+
+describe('POST /layouts', () => {
+  it('persists the layout and returns 201 + the canonical doc', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    const res = await router.request('/', {
+      method: 'POST',
+      headers: {
+        Authorization: authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        homeId: 'home-1',
+        name: 'Kitchen',
+        payload: { theme: 'dark' },
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; userId: string; name: string };
+    expect(body.id).toBe('layout-1');
+    expect(body.userId).toBe('user-1');
+    const stored = await repo.getById('layout-1', 'user-1');
+    expect(stored?.name).toBe('Kitchen');
+  });
+
+  it('rejects an invalid body with 400', async () => {
+    const { router, authHeader } = await withAuth('user-1');
+    const res = await router.request('/', {
+      method: 'POST',
+      headers: {
+        Authorization: authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: '' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /layouts/:id', () => {
+  it('returns 404 for an id the user does not own', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.create({
+      id: 'foreign',
+      userId: 'user-2',
+      homeId: 'home-1',
+      name: 'Not yours',
+      payload: {},
+      now: new Date(),
+    });
+    const res = await router.request('/foreign', {
+      headers: { Authorization: authHeader },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the layout for an id the user owns', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.create({
+      id: 'a',
+      userId: 'user-1',
+      homeId: 'home-1',
+      name: 'Living',
+      payload: {},
+      now: new Date(),
+    });
+    const res = await router.request('/a', { headers: { Authorization: authHeader } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string };
+    expect(body.id).toBe('a');
+  });
+});
+
+describe('PUT /layouts/:id', () => {
+  it('updates the name + payload', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.create({
+      id: 'a',
+      userId: 'user-1',
+      homeId: 'home-1',
+      name: 'Old',
+      payload: { v: 1 },
+      now: new Date('2026-05-08T00:00:00.000Z'),
+    });
+    const res = await router.request('/a', {
+      method: 'PUT',
+      headers: {
+        Authorization: authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'New', payload: { v: 2 } }),
+    });
+    expect(res.status).toBe(200);
+    const stored = await repo.getById('a', 'user-1');
+    expect(stored?.name).toBe('New');
+    expect(stored?.payload).toEqual({ v: 2 });
+  });
+
+  it('returns 404 when the layout does not exist or belongs to another user', async () => {
+    const { router, authHeader } = await withAuth('user-1');
+    const res = await router.request('/missing', {
+      method: 'PUT',
+      headers: {
+        Authorization: authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: 'x' }),
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /layouts/:id', () => {
+  it('soft-deletes and returns 204', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.create({
+      id: 'a',
+      userId: 'user-1',
+      homeId: 'home-1',
+      name: 'A',
+      payload: {},
+      now: new Date(),
+    });
+    const res = await router.request('/a', {
+      method: 'DELETE',
+      headers: { Authorization: authHeader },
+    });
+    expect(res.status).toBe(204);
+    expect(await repo.getById('a', 'user-1')).toBeNull();
+  });
+
+  it('returns 404 for an unknown id', async () => {
+    const { router, authHeader } = await withAuth('user-1');
+    const res = await router.request('/missing', {
+      method: 'DELETE',
+      headers: { Authorization: authHeader },
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/api/src/routes/layouts.ts
+++ b/apps/api/src/routes/layouts.ts
@@ -1,0 +1,121 @@
+// Saved dashboard layouts endpoints (#420). The first concrete domain
+// surface for apps/api — proves the route + Zod parse + driver call +
+// authorization shape that subsequent feature endpoints will follow.
+//
+// Authorization: every route is gated by the `require-session`
+// middleware; the user id from the session JWT is the sole filter on
+// every database query — user A cannot read or modify user B's
+// layouts even when guessing an id.
+//
+// Soft-delete: DELETE sets `deletedAt`; the list query filters by
+// `deletedAt: null`. The collection grows over time but is bounded by
+// per-user retention (Phase 5 cleanup job).
+
+import { Hono } from 'hono';
+import type { Db } from 'mongodb';
+
+import { CreateLayoutRequestSchema, UpdateLayoutRequestSchema } from '@glaon/core/api-client';
+
+import { LayoutsRepo, type PublicLayout } from '../db/layouts-repo';
+import { requireSession, type SessionVariables } from '../middleware/require-session';
+import type { RevocationStore } from '../auth/revocation';
+
+interface LayoutsRepoLike {
+  list(userId: string, options?: { homeId?: string }): Promise<PublicLayout[]>;
+  getById(id: string, userId: string): Promise<PublicLayout | null>;
+  create(input: {
+    id: string;
+    userId: string;
+    homeId: string;
+    name: string;
+    payload: Record<string, unknown>;
+    now: Date;
+  }): Promise<PublicLayout>;
+  update(
+    id: string,
+    userId: string,
+    input: { name?: string; payload?: Record<string, unknown>; now: Date },
+  ): Promise<PublicLayout | null>;
+  softDelete(id: string, userId: string, now: Date): Promise<boolean>;
+}
+
+interface LayoutsRouterDeps {
+  readonly db: Db;
+  readonly secret: Uint8Array;
+  readonly revocations: RevocationStore;
+  readonly repo?: LayoutsRepoLike;
+  readonly now?: () => Date;
+  readonly newId?: () => string;
+}
+
+export function createLayoutsRouter(deps: LayoutsRouterDeps): Hono<{
+  Variables: SessionVariables;
+}> {
+  const router = new Hono<{ Variables: SessionVariables }>();
+  const repo: LayoutsRepoLike = deps.repo ?? new LayoutsRepo(deps.db);
+  const now = deps.now ?? (() => new Date());
+  const newId = deps.newId ?? (() => crypto.randomUUID());
+
+  router.use('*', requireSession({ secret: deps.secret, revocations: deps.revocations }));
+
+  router.get('/', async (c) => {
+    const homeId = c.req.query('homeId');
+    const layouts = await repo.list(c.get('userId'), {
+      ...(homeId !== undefined && homeId.length > 0 ? { homeId } : {}),
+    });
+    return c.json({ layouts });
+  });
+
+  router.post('/', async (c) => {
+    const body: unknown = await c.req.json().catch(() => null);
+    const parsed = CreateLayoutRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid', code: 'bad-body' }, 400);
+    }
+    const layout = await repo.create({
+      id: newId(),
+      userId: c.get('userId'),
+      homeId: parsed.data.homeId,
+      name: parsed.data.name,
+      payload: parsed.data.payload,
+      now: now(),
+    });
+    return c.json(asResponse(layout), 201);
+  });
+
+  router.get('/:id', async (c) => {
+    const layout = await repo.getById(c.req.param('id'), c.get('userId'));
+    if (layout === null) return c.json({ error: 'not-found' }, 404);
+    return c.json(asResponse(layout));
+  });
+
+  router.put('/:id', async (c) => {
+    const body: unknown = await c.req.json().catch(() => null);
+    const parsed = UpdateLayoutRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid', code: 'bad-body' }, 400);
+    }
+    const layout = await repo.update(c.req.param('id'), c.get('userId'), {
+      ...(parsed.data.name !== undefined ? { name: parsed.data.name } : {}),
+      ...(parsed.data.payload !== undefined ? { payload: parsed.data.payload } : {}),
+      now: now(),
+    });
+    if (layout === null) return c.json({ error: 'not-found' }, 404);
+    return c.json(asResponse(layout));
+  });
+
+  router.delete('/:id', async (c) => {
+    const ok = await repo.softDelete(c.req.param('id'), c.get('userId'), now());
+    if (!ok) return c.json({ error: 'not-found' }, 404);
+    return c.body(null, 204);
+  });
+
+  return router;
+}
+
+// Re-shape the repo's `PublicLayout` to the on-the-wire schema. They
+// happen to be identical today; keeping the conversion explicit makes
+// future divergence (e.g. computed fields) trivial.
+function asResponse(layout: PublicLayout): PublicLayout {
+  return layout;
+}

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -5,8 +5,21 @@ import { createServer, type ServerDeps } from './server';
 import { InMemoryRevocationStore } from './auth/revocation';
 
 function makeDeps(overrides: { dbCommand?: () => Promise<unknown> } = {}): ServerDeps {
+  // The /layouts router mounted by createServer asks the Db for a
+  // collection at construct time (and again to ensure indexes).
+  // Server-level tests don't exercise /layouts; stub the collection
+  // surface with no-op promises so the wiring doesn't blow up.
+  const collection = {
+    createIndex: () => Promise.resolve(),
+    insertOne: () => Promise.resolve({ insertedId: 'x' }),
+    find: () => ({ sort: () => ({ toArray: () => Promise.resolve([]) }) }),
+    findOne: () => Promise.resolve(null),
+    findOneAndUpdate: () => Promise.resolve(null),
+    updateOne: () => Promise.resolve({ modifiedCount: 0, upsertedCount: 0 }),
+  };
   const db = {
     command: overrides.dbCommand ?? (() => Promise.resolve({ ok: 1 })),
+    collection: () => collection,
   } as unknown as ServerDeps['db'];
   const config: ServerDeps['config'] = {
     port: 8080,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -10,6 +10,7 @@ import { pingDb } from './db';
 import { decodeSecret } from './auth/jwt';
 import { MongoRevocationStore, type RevocationStore } from './auth/revocation';
 import { createAuthRouter } from './routes/auth';
+import { createLayoutsRouter } from './routes/layouts';
 
 export interface ServerDeps {
   readonly db: Db;
@@ -33,6 +34,8 @@ export function createServer(deps: ServerDeps): Hono {
       ...(deps.fetchImpl !== undefined ? { fetchImpl: deps.fetchImpl } : {}),
     }),
   );
+
+  app.route('/layouts', createLayoutsRouter({ db: deps.db, secret, revocations }));
 
   // Liveness probe with Mongo ping. Returns 200 when the driver
   // command succeeds, 503 otherwise so a load balancer can drop the

--- a/packages/core/src/api-client/client.ts
+++ b/packages/core/src/api-client/client.ts
@@ -14,6 +14,17 @@ import type { z } from 'zod';
 
 import { ApiError, ApiNetworkError } from './errors';
 import {
+  CreateLayoutRequestSchema,
+  LayoutListResponseSchema,
+  LayoutSchema,
+  UpdateLayoutRequestSchema,
+  type CreateLayoutRequest,
+  type Layout,
+  type LayoutListQuery,
+  type LayoutListResponse,
+  type UpdateLayoutRequest,
+} from './layouts';
+import {
   ApiErrorBodySchema,
   AuthExchangeRequestSchema,
   AuthExchangeResponseSchema,
@@ -77,15 +88,50 @@ export class ApiClient {
     });
   }
 
-  logout(options: RequestOptions = {}): Promise<AuthLogoutResponse> {
+  async logout(options: RequestOptions = {}): Promise<AuthLogoutResponse> {
     return this.send('POST', '/auth/logout', null, AuthLogoutResponseSchema, options);
+  }
+
+  /* -------- /layouts (#420) ------------------------------------------- */
+
+  async listLayouts(
+    query: LayoutListQuery = {},
+    options: RequestOptions = {},
+  ): Promise<LayoutListResponse> {
+    const path =
+      query.homeId !== undefined && query.homeId.length > 0
+        ? `/layouts?homeId=${encodeURIComponent(query.homeId)}`
+        : '/layouts';
+    return this.send('GET', path, null, LayoutListResponseSchema, options);
+  }
+
+  async getLayout(id: string, options: RequestOptions = {}): Promise<Layout> {
+    return this.send('GET', `/layouts/${encodeURIComponent(id)}`, null, LayoutSchema, options);
+  }
+
+  async createLayout(body: CreateLayoutRequest, options: RequestOptions = {}): Promise<Layout> {
+    const parsed = CreateLayoutRequestSchema.parse(body);
+    return this.send('POST', '/layouts', parsed, LayoutSchema, options);
+  }
+
+  async updateLayout(
+    id: string,
+    body: UpdateLayoutRequest,
+    options: RequestOptions = {},
+  ): Promise<Layout> {
+    const parsed = UpdateLayoutRequestSchema.parse(body);
+    return this.send('PUT', `/layouts/${encodeURIComponent(id)}`, parsed, LayoutSchema, options);
+  }
+
+  async deleteLayout(id: string, options: RequestOptions = {}): Promise<void> {
+    await this.sendNoContent('DELETE', `/layouts/${encodeURIComponent(id)}`, null, options);
   }
 
   // The send() helper is `protected` so feature-specific subclasses (or
   // ad-hoc extensions in @glaon/core later) can add domain endpoints
   // without re-implementing the auth + parse + error pipeline.
   protected async send<TResponse>(
-    method: 'GET' | 'POST' | 'DELETE',
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
     path: string,
     body: unknown,
     responseSchema: z.ZodType<TResponse>,
@@ -137,6 +183,58 @@ export class ApiClient {
       );
     }
     return responseSchema.parse(parsedBody);
+  }
+
+  // Same pipeline as send() but for endpoints that respond 204 No
+  // Content (DELETE /layouts/:id). We don't try to JSON-parse the body
+  // and we tolerate any 2xx status.
+  protected async sendNoContent(
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+    path: string,
+    body: unknown,
+    options: RequestOptions,
+  ): Promise<void> {
+    const headers: Record<string, string> = {};
+    if (body !== null) {
+      headers['Content-Type'] = 'application/json';
+    }
+    if (options.skipAuth !== true) {
+      const token = await this.getSessionJwt();
+      if (token !== null && token.length > 0) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+    }
+
+    const init: RequestInit = {
+      method,
+      headers,
+      ...(body !== null ? { body: JSON.stringify(body) } : {}),
+      ...(options.signal !== undefined ? { signal: options.signal } : {}),
+    };
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseUrl}${path}`, init);
+    } catch (cause) {
+      throw new ApiNetworkError(`apps/api ${method} ${path} failed`, cause);
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      let parsedBody: unknown = null;
+      if (text.length > 0) {
+        try {
+          parsedBody = JSON.parse(text);
+        } catch {
+          /* ignore */
+        }
+      }
+      const errorBody = ApiErrorBodySchema.safeParse(parsedBody);
+      throw new ApiError(
+        `apps/api ${method} ${path} returned ${String(response.status)}`,
+        response.status,
+        errorBody.success ? errorBody.data : null,
+      );
+    }
   }
 }
 

--- a/packages/core/src/api-client/index.ts
+++ b/packages/core/src/api-client/index.ts
@@ -21,3 +21,17 @@ export {
   type AuthRefreshResponse,
   type SessionClaims,
 } from './schemas';
+export {
+  CreateLayoutRequestSchema,
+  LayoutListQuerySchema,
+  LayoutListResponseSchema,
+  LayoutPayloadSchema,
+  LayoutSchema,
+  UpdateLayoutRequestSchema,
+  type CreateLayoutRequest,
+  type Layout,
+  type LayoutListQuery,
+  type LayoutListResponse,
+  type LayoutPayload,
+  type UpdateLayoutRequest,
+} from './layouts';

--- a/packages/core/src/api-client/layouts.test.ts
+++ b/packages/core/src/api-client/layouts.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from './client';
+import type { Layout } from './layouts';
+
+function makeFetch(
+  responder: (input: string, init?: RequestInit) => Response | Promise<Response>,
+): typeof fetch {
+  const impl = vi.fn(async (input: string, init?: RequestInit) => responder(input, init));
+  return impl as unknown as typeof fetch;
+}
+
+const SAMPLE_LAYOUT: Layout = {
+  id: 'layout-1',
+  userId: 'user-1',
+  homeId: 'home-1',
+  name: 'Living room',
+  payload: { rows: 2 },
+  createdAt: '2026-05-09T00:00:00.000Z',
+  updatedAt: '2026-05-09T00:00:00.000Z',
+};
+
+const BASE = 'https://api.glaon.test';
+
+describe('ApiClient — listLayouts', () => {
+  it('hits GET /layouts when no homeId is provided', async () => {
+    let captured: { url: string; init: RequestInit | undefined } | undefined;
+    const fetchImpl = makeFetch((url, init) => {
+      captured = { url, init };
+      return Promise.resolve(
+        new Response(JSON.stringify({ layouts: [SAMPLE_LAYOUT] }), { status: 200 }),
+      );
+    });
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    const result = await client.listLayouts();
+    expect(captured?.url).toBe(`${BASE}/layouts`);
+    expect(captured?.init?.method).toBe('GET');
+    expect(result.layouts).toHaveLength(1);
+  });
+
+  it('encodes the homeId into the query string', async () => {
+    let capturedUrl: string | undefined;
+    const fetchImpl = makeFetch((url) => {
+      capturedUrl = url;
+      return Promise.resolve(new Response(JSON.stringify({ layouts: [] }), { status: 200 }));
+    });
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await client.listLayouts({ homeId: 'home a/b' });
+    expect(capturedUrl).toBe(`${BASE}/layouts?homeId=home%20a%2Fb`);
+  });
+});
+
+describe('ApiClient — createLayout', () => {
+  it('POSTs the body and parses the response', async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = makeFetch((_url, init) => {
+      captured = init;
+      return Promise.resolve(new Response(JSON.stringify(SAMPLE_LAYOUT), { status: 201 }));
+    });
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    const result = await client.createLayout({
+      homeId: 'home-1',
+      name: 'Living room',
+      payload: { rows: 2 },
+    });
+    expect(captured?.method).toBe('POST');
+    expect(JSON.parse(captured?.body as string)).toEqual({
+      homeId: 'home-1',
+      name: 'Living room',
+      payload: { rows: 2 },
+    });
+    expect(result.id).toBe('layout-1');
+  });
+
+  it('rejects bad request bodies before sending', async () => {
+    const fetchImpl = makeFetch(() => new Response());
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await expect(client.createLayout({ homeId: '', name: '', payload: {} })).rejects.toThrow();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('ApiClient — getLayout / updateLayout / deleteLayout', () => {
+  it('encodes the id into the path on GET', async () => {
+    let capturedUrl: string | undefined;
+    const fetchImpl = makeFetch((url) => {
+      capturedUrl = url;
+      return Promise.resolve(new Response(JSON.stringify(SAMPLE_LAYOUT), { status: 200 }));
+    });
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await client.getLayout('layout/1');
+    expect(capturedUrl).toBe(`${BASE}/layouts/layout%2F1`);
+  });
+
+  it('PUTs partial updates', async () => {
+    let captured: { url: string; init: RequestInit | undefined } | undefined;
+    const fetchImpl = makeFetch((url, init) => {
+      captured = { url, init };
+      return Promise.resolve(new Response(JSON.stringify(SAMPLE_LAYOUT), { status: 200 }));
+    });
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await client.updateLayout('layout-1', { name: 'New' });
+    expect(captured?.init?.method).toBe('PUT');
+    expect(JSON.parse(captured?.init?.body as string)).toEqual({ name: 'New' });
+  });
+
+  it('issues DELETE and resolves on 204', async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = makeFetch((_url, init) => {
+      captured = init;
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await expect(client.deleteLayout('layout-1')).resolves.toBeUndefined();
+    expect(captured?.method).toBe('DELETE');
+  });
+
+  it('throws ApiError on 404 from delete', async () => {
+    const fetchImpl = makeFetch(() =>
+      Promise.resolve(new Response(JSON.stringify({ error: 'not-found' }), { status: 404 })),
+    );
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await expect(client.deleteLayout('missing')).rejects.toThrow(/404/);
+  });
+});

--- a/packages/core/src/api-client/layouts.ts
+++ b/packages/core/src/api-client/layouts.ts
@@ -1,0 +1,45 @@
+// Saved dashboard layouts — first domain endpoint (#420). The shape is
+// deliberately minimal: a payload `record` opaque to apps/api, scoped
+// per { userId, homeId }. Frontend owns the layout grammar (which card
+// goes where, what colour, etc.); apps/api just persists + serves.
+
+import { z } from 'zod';
+
+const Iso8601 = z.string().datetime({ offset: true });
+
+export const LayoutPayloadSchema = z.record(z.unknown());
+export type LayoutPayload = z.infer<typeof LayoutPayloadSchema>;
+
+export const LayoutSchema = z.object({
+  id: z.string().min(1),
+  userId: z.string().min(1),
+  homeId: z.string().min(1),
+  name: z.string().min(1).max(120),
+  payload: LayoutPayloadSchema,
+  createdAt: Iso8601,
+  updatedAt: Iso8601,
+});
+export type Layout = z.infer<typeof LayoutSchema>;
+
+export const CreateLayoutRequestSchema = z.object({
+  homeId: z.string().min(1),
+  name: z.string().min(1).max(120),
+  payload: LayoutPayloadSchema,
+});
+export type CreateLayoutRequest = z.infer<typeof CreateLayoutRequestSchema>;
+
+export const UpdateLayoutRequestSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  payload: LayoutPayloadSchema.optional(),
+});
+export type UpdateLayoutRequest = z.infer<typeof UpdateLayoutRequestSchema>;
+
+export const LayoutListResponseSchema = z.object({
+  layouts: z.array(LayoutSchema),
+});
+export type LayoutListResponse = z.infer<typeof LayoutListResponseSchema>;
+
+export const LayoutListQuerySchema = z.object({
+  homeId: z.string().min(1).optional(),
+});
+export type LayoutListQuery = z.infer<typeof LayoutListQuerySchema>;


### PR DESCRIPTION
## Summary

First concrete domain feature for `apps/api`. Proves the architecture shape — Hono route → Zod parse → MongoDB driver call → Zod-shaped response — that subsequent feature endpoints follow.

- **Server** (`apps/api`): `LayoutsRepo` over the `layouts` Mongo collection (soft-delete via `deletedAt`, `{userId, deletedAt}` + `{userId, homeId, deletedAt}` indexes ensure-once on first request). 5-route CRUD: `GET /layouts` (with optional `homeId` filter), `POST /layouts`, `GET /layouts/:id`, `PUT /layouts/:id`, `DELETE /layouts/:id` (204). All gated by `require-session`; every query keys on the session's `userId` so user A can never read or write user B's layouts.
- **Shared client** (`@glaon/core/api-client`): `LayoutSchema`, `CreateLayoutRequest`, `UpdateLayoutRequest`, `LayoutListResponse`, `LayoutListQuery` — same Zod definitions the server validates against. `ApiClient` gains `listLayouts` / `getLayout` / `createLayout` / `updateLayout` / `deleteLayout`. `send()` learns `'PUT'`; new `sendNoContent()` helper handles the 204 from `deleteLayout`.

## Scope (In)

- `apps/api/src/db/layouts-repo.ts` (Mongo) + `layouts-repo-fake.ts` (in-memory test fixture).
- `apps/api/src/routes/layouts.ts` mounted from `server.ts` under `/layouts`.
- `packages/core/src/api-client/layouts.ts` schemas + `ApiClient` methods.
- 21 new vitest unit tests (12 server-side route tests + 9 client tests).

## Scope (Out / deferred to follow-up)

- **Web TanStack Query hooks + `/layouts` page UI** — the foundation is ready; the feature pickup lands in a follow-up alongside the cloud-mode UI shell. Playwright `@smoke` for the full user flow lands with that follow-up.
- **Mobile UI** for layouts — separate issue (Phase 2 mobile pickup).
- **Real-time push** of layout changes between devices — out of #392 scope; clients poll / refetch on focus once the web pickup adds TanStack Query.
- **Schema migrations** — for now Mongo `updateMany` + Zod schema versioning at the app boundary; #422 P2-H may pull in a more formal runner.

## Test plan

- [x] `pnpm --filter @glaon/api type-check && lint && test` — passes (55 tests, 21 new).
- [x] `pnpm --filter @glaon/core type-check && lint && test` — passes (93 tests, 9 new).
- [x] `pnpm --filter @glaon/api build` — emits the 1.9 MB single-file CJS bundle.
- [x] `pnpm exec knip` on both workspaces — clean.
- [ ] CI: type-check · lint · audit, unit-tests, story-tests, playwright, CodeQL, visual regression, build (aarch64+amd64), package-contract.

## Notes

- The repo's `PublicLayout` shape and the wire `LayoutSchema` are identical today. Conversion is explicit (`asResponse`) so future divergence (computed fields, server-only metadata) doesn't quietly leak into the response.
- `LayoutsRouterDeps.repo` is injectable; tests pass an `InMemoryLayoutsRepo` to keep the unit suite Mongo-free. The integration test against a real ephemeral Mongo lands with the P2-H workflow (#422).
- The ApiClient's `send()` helper now also accepts `PUT`; `sendNoContent()` is a sibling for endpoints that respond 204. Both are `protected` so future feature subclasses can compose on them.

Refs ADR 0017, ADR 0025, #392, #418, #419, #420.