### PR TITLE
docs(adr): 0026 — apps/api delivery is glaon-hosted

### DIFF
--- a/docs/adr/0026-apps-api-delivery-hosted.md
+++ b/docs/adr/0026-apps-api-delivery-hosted.md
@@ -1,0 +1,94 @@
+# ADR 0026 — apps/api delivery: Glaon-managed hosted service
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-05-10
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [ADR 0014](0014-apps-api-over-nextjs.md), [ADR 0017](0017-dual-mode-auth.md), [ADR 0020](0020-cloud-hosting-platform.md), [ADR 0025](0025-apps-api-stack.md), [issue #421](https://github.com/toss-cengiz/glaon/issues/421), [issue #392](https://github.com/toss-cengiz/glaon/issues/392)
+
+## Bağlam
+
+[ADR 0014](0014-apps-api-over-nextjs.md) `apps/api`'ı ayrı bir backend service olarak konumlandırdı. [ADR 0025](0025-apps-api-stack.md) stack'i kilitledi (Hono + native MongoDB + Zod). Geriye **nerede çalışacak** sorusu kaldı:
+
+| Model                                      | Veri konumu           | Operasyonel sorumluluk  | Multi-device sync |
+| ------------------------------------------ | --------------------- | ----------------------- | ----------------- |
+| **Sidecar** — HA Add-on container'ı içinde | Kullanıcının donanımı | Kullanıcı (kendi)       | Tek cihaz / LAN   |
+| **Hosted** — Glaon-managed cloud           | Glaon servers         | Glaon ekibi             | Yerleşik          |
+| **Hybrid** — config switch ile her iki yol | İkisi de              | Hem kullanıcı hem Glaon | Hosted yolu açık  |
+
+`apps/api` Phase 2 kapsamında saklayacağı veri:
+
+- Saved dashboard layouts (#420) — UI tercihleri.
+- (İlerideki) saved scenes, theme overrides, user prefs.
+
+Bu veriler kullanıcının cihazları arasında senkron olmalı (cloud-mode UX'inin satış noktası). HA'nın kendisi bu veriyi storage API üzerinde tutabilir, ama:
+
+1. HA storage API client-side senkron değil (her cihazın kendi indirip aktarması gerekir).
+2. Cloud-mode kullanıcısı bağlandığı cihazdan başka bir cihaza geçince HA storage'a doğrudan erişim yok (cloud relay üzerinden indirmek karmaşık).
+3. Layout schema'larının HA-language değil, Glaon-language olması bekleniyor.
+
+## Karar
+
+**`apps/api` Glaon-managed hosted service olarak çalışır.** Mongo Atlas (cloud-managed) `apps/api`'a state sağlar; deploy pipeline ile container image push edilir. Sidecar opsiyonu **şimdilik kapsam dışı** — Phase 5'te self-host ihtiyacı olan kullanıcılar için ayrı ADR ile yeniden açılır.
+
+Operasyonel parametreler:
+
+- **Container runtime**: Docker image, [apps/api/Dockerfile](../../apps/api/Dockerfile) tarafından üretilir. Multi-stage; runtime stage `node:22-alpine` üstünde non-root `node` user ile çalışır. `HEALTHCHECK` `wget /healthz`.
+- **Hosting platformu**: Container runtime gerektiriyor (native MongoDB driver Cloudflare Workers'a uymaz, ADR 0020'nin Workers kararı `apps/cloud`'a özgü). Fly.io, Render, Hetzner Cloud, AWS Fargate; final platform pick'i deploy workflow'u (P2-H, #422) ile karara bağlanır. Bu ADR sadece "container-on-VM/PaaS" modelini kilitler.
+- **Veritabanı**: Mongo Atlas paid tier (M10 minimum, üç-replika set). Self-host alternatifini reddetmenin sebebi: TLS, replica set, backup, monitoring tooling Atlas'ta yerleşik; Phase 2 ekibinde DBA yok.
+- **Secrets**: `MONGODB_URI`, `SESSION_JWT_SECRET`, `SENTRY_DSN` deploy pipeline tarafından platform secret store'una inject edilir. Secret rotation prosedürü `docs/api.md`'de.
+
+Cloud-mode + apps/api topolojisi:
+
+```
+apps/web ──┐
+           ├── HTTPS ──► apps/api  (saved layouts, prefs)
+apps/mobile ┘                │
+                             ▼
+                        Mongo Atlas
+
+apps/web ──┐
+           ├── WSS ──► apps/cloud (relay)
+apps/mobile ┘                │
+                             ▼
+                          HA add-on
+```
+
+İki ayrı service. `apps/cloud` short-lived WebSocket session'ları yönetir (HA frame relay); `apps/api` long-lived persistence'ı tutar. Bunları aynı service yapma fikri reddedildi — runtime modelleri farklı (Workers + Durable Objects vs. Node + Mongo) ve sorumluluk ayrımı sağlıklı.
+
+## Sonuçlar
+
+### Olumlu
+
+- **Multi-device sync built-in** — cloud-mode UX'inin headline'ı için zorunlu olan tek model bu.
+- **Operasyonel tutarlılık** — Glaon ekibi zaten `apps/cloud`'u operate ediyor; `apps/api` aynı pipeline + monitoring + alerting'i kullanır.
+- **Sidecar açık door** — Phase 5'te self-host topluluğu için ayrı ADR ile ele alınır; bu ADR onu kapatmıyor.
+- **Production-grade Mongo** — Atlas backup, replica set, TLS, monitoring hazır gelir.
+
+### Olumsuz / ödenecek bedel
+
+- **Hosting maliyeti** — apps/api + Mongo Atlas tier'ı sabit aylık gider. Free-tier kullanıcılar için subsidize edilir; paid tier'lar pricing modelinde explicit (Phase 5 monetization).
+- **Veri konumu** — kullanıcının layout tercihleri Glaon servers'ta. ToS + privacy policy bunu açıkça belirtmeli; data export endpoint'i (#? Phase 3) gelecek.
+- **Tek nokta arıza** — `apps/cloud` ile aynı kategoride; uptime SLO için status page + alerting (#423 P2-I observability).
+- **Sidecar kullanıcısı yok** — gerçekten LAN-only çalıştırmak isteyen güçlük çekecek; LAN-only kullanıcı zaten layout sync'e ihtiyaç duymadığı için lokal `localStorage` fallback'i (apps/web tarafında) Phase 3 cleanup turunda eklenir.
+
+### Etkileri
+
+- **P2-H workflow** (#422): GitHub Actions → container registry push (GHCR) → platform-specific deploy. Platform pick PR #422 içinde detaylanır.
+- **secrets**: env-driven (`MONGODB_URI`, `SESSION_JWT_SECRET`, `SENTRY_DSN`, `WEB_ORIGINS`). Üretim deploy pipeline'ı bunları repo secret'larından inject eder; lokal dev `apps/api/.env`'den yiyor (`apps/api/docker-compose.yml` Mongo'yu sibling container olarak çalıştırıyor).
+- **`addon/config.yaml`** değişmiyor — addon hâlâ sadece web bundle + relay agent içeriyor (`apps/api` addon içinde değil).
+- **Privacy policy / ToS** Phase 5 monetization işiyle birlikte güncellenir.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- **Topluluk talebi self-host'a yoğun yönelirse** — Phase 5'te sidecar ADR'i (Mongo'yu hafif bir alternatif olan SQLite'a indirme dahil) yeniden açılır.
+- **Mongo Atlas pricing değişirse** — self-managed Mongo (DigitalOcean managed DB, Hetzner) alternatifi değerlendirilir; ADR 0026 update'i gerekmez (operasyonel detay).
+- **Workers Containers veya Bun/Deno-on-edge production-ready hale gelirse** — `apps/api` runtime'ı Edge'e taşıma fizibilitesi yeniden bakılır; mevcut Hono codebase taşınabilir (ADR 0025 buna açık).
+
+## Referanslar
+
+- [Mongo Atlas pricing](https://www.mongodb.com/pricing)
+- [apps/api Dockerfile](../../apps/api/Dockerfile)
+- [apps/api/docker-compose.yml](../../apps/api/docker-compose.yml) — local dev
+- [docs/api.md](../api.md) — bootstrap, deploy, secrets, troubleshoot
+- [ADR 0020](0020-cloud-hosting-platform.md) — `apps/cloud` Workers kararı
+- [ADR 0022](0022-cloud-deployment-secrets.md) — `apps/cloud` deploy + secrets

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,6 +72,7 @@ Deprecated durumu, kararı yapılacak işin dışına çıkarttığımızda kull
 | 0023 | [i18n library + file format + RTL strategy](0023-i18n-library-format-rtl.md)            | Accepted           | 2026-05-07 |
 | 0024 | [Lokal keşif: HA hostname'ine bağ kal](0024-local-discovery-rely-on-ha-hostname.md)     | Accepted           | 2026-05-08 |
 | 0025 | [apps/api stack pick — Hono + native MongoDB + Zod](0025-apps-api-stack.md)             | Accepted           | 2026-05-09 |
+| 0026 | [apps/api delivery: Glaon-managed hosted](0026-apps-api-delivery-hosted.md)             | Accepted           | 2026-05-10 |
 
 ## Konvansiyonlar
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,108 @@
+# apps/api — Glaon backend service
+
+`apps/api` Glaon'un HA-external persistence katmanıdır: saved layouts, user prefs, ve gelecek feature'lar için durabilirlik. ADR ailesi:
+
+- [ADR 0014](adr/0014-apps-api-over-nextjs.md) — `apps/api` ayrı service kararı.
+- [ADR 0025](adr/0025-apps-api-stack.md) — Hono + native MongoDB + Zod stack pick.
+- [ADR 0026](adr/0026-apps-api-delivery-hosted.md) — Glaon-managed hosted delivery model.
+- [Epic #392](https://github.com/toss-cengiz/glaon/issues/392) — bütün apps/api iş ailesi.
+
+## Lokal geliştirme
+
+`apps/api` içinde:
+
+```bash
+cp .env.example .env
+# .env dosyasını doldur: en azından SESSION_JWT_SECRET set et
+# (üretim için: openssl rand -hex 32)
+
+# Mongo + apps/api birlikte
+docker compose up --build
+```
+
+Servis `localhost:8080`'de çalışır. Smoke test:
+
+```bash
+curl http://localhost:8080/healthz
+# {"status":"ok","mongo":{"ok":true,"latencyMs":3}}
+
+curl http://localhost:8080/version
+# {"version":"0.0.0-dev","commit":"unknown","builtAt":""}
+```
+
+Sadece Node tarafını watch mode'da çalıştırmak (Mongo zaten ayağa kalkmış):
+
+```bash
+pnpm --filter @glaon/api dev
+```
+
+Detaylar: [apps/api/README.md](../apps/api/README.md).
+
+## Endpoint'ler
+
+| Method | Path             | Auth    | Açıklama                                |
+| ------ | ---------------- | ------- | --------------------------------------- |
+| GET    | `/healthz`       | yok     | Liveness + Mongo ping (200/503).        |
+| GET    | `/version`       | yok     | Build SHA + version + builtAt.          |
+| POST   | `/auth/exchange` | yok     | HA token → session JWT.                 |
+| POST   | `/auth/refresh`  | yok     | Session JWT'yi yeniden imzala.          |
+| POST   | `/auth/logout`   | session | Session jti'yi revocation list'e ekle.  |
+| GET    | `/layouts`       | session | Saved layouts list (`?homeId=` filtre). |
+| POST   | `/layouts`       | session | Yeni layout oluştur.                    |
+| GET    | `/layouts/:id`   | session | Layout detayı.                          |
+| PUT    | `/layouts/:id`   | session | Layout güncelle.                        |
+| DELETE | `/layouts/:id`   | session | Soft-delete (204).                      |
+
+Authorization: session JWT ya `Authorization: Bearer <jwt>` (mobile) ya da `glaon_api_session` httpOnly+Secure cookie (web). Detaylar [ADR 0017](adr/0017-dual-mode-auth.md).
+
+## Production deploy
+
+Hosting modeli ADR 0026 ile sabitlenmiş **Glaon-managed hosted**. Üretim akışı:
+
+1. **CI** — `apps/api/Dockerfile` multi-arch image üretir, GHCR'ye push eder.
+2. **Deploy** — Platform-specific workflow (Fly.io / Render / Hetzner — final pick #422 ile gelir) image'ı çeker, secret'ları inject eder, rolling restart ile çalıştırır.
+3. **Mongo** — Atlas M10 cluster (üç-node replica set), apps/api `MONGODB_URI`'yle bağlanır. TLS Atlas tarafında zorunlu.
+
+### Secrets runbook
+
+Tüm secret'lar deploy pipeline'ı tarafından platform secret store'una inject edilir; repo'da `.env` ya da kod içinde **asla** tutulmaz. ADR 0022'nin `apps/cloud` paterni `apps/api` için aynen geçerli.
+
+| Secret               | Source                        | Rotation                                         |
+| -------------------- | ----------------------------- | ------------------------------------------------ |
+| `MONGODB_URI`        | Atlas → repo secret           | Atlas connection string regenerate; redeploy.    |
+| `SESSION_JWT_SECRET` | `openssl rand -hex 32`        | Yılda en az bir kez. Rotation prosedürü altında. |
+| `SENTRY_DSN`         | Sentry project                | Project recreate gerekirse.                      |
+| `WEB_ORIGINS`        | Manuel — prod web origin'leri | Web bundle host değişimi.                        |
+
+#### `SESSION_JWT_SECRET` rotation
+
+1. Yeni secret üret: `openssl rand -hex 32`.
+2. Platform secret store'a yeni değeri yaz (eski değer hâlâ aktif).
+3. Deploy: Yeni instance'lar yeni secret'ı kullanır, eski JWT'ler 401 döner — istemciler `/auth/refresh` ile yeni session alır. Refresh `sessionJwt`'yi yeni secret ile imzaladığı için yeni secret aktif olduktan sonra bu yol kapanır; bu durumda istemci `/auth/exchange` ile baştan auth olur (HA token'ı ile).
+4. Pratik tutmak için bir grace window (eski + yeni secret birlikte kabul) gerekirse `apps/api/src/auth/jwt.ts` içinde dual-key verification eklenir. Şu an kapsam dışı; kullanıcı sayısı arttığında değerlendirilir.
+
+### Healthcheck + liveness
+
+- `GET /healthz` Mongo'ya `{ ping: 1 }` admin command atar; 200/503 döner.
+- LB / orchestrator'ın healthcheck endpoint'i `/healthz`'i 30s aralıkla yoklar.
+- Container içinde Dockerfile'ın `HEALTHCHECK` direktifi aynı endpoint'i kullanır.
+
+## Sorun giderme
+
+| Belirti                                                       | Çözüm                                                                                                         |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Boot sırasında "MONGODB_URI is required"                      | `.env` dosyasında `MONGODB_URI` set değil. `cp .env.example .env`, doldur.                                    |
+| Boot sırasında "SESSION_JWT_SECRET must be at least 32 bytes" | Secret 32 byte'tan kısa. `openssl rand -hex 32` ile üret.                                                     |
+| `/healthz` 503 + `mongo.ok=false`                             | Mongo erişilemez. Connection string + network + Atlas IP allowlist'i kontrol et.                              |
+| `/auth/exchange` 401                                          | HA token geçersiz veya HA URL yanlış. `MONGODB_URI` veya cookie değil; HA reachability problemi.              |
+| `/auth/exchange` 502                                          | apps/api HA'a ulaşamıyor. HA Add-on tarafının dış erişimi varsa CORS / DNS problemi.                          |
+| Session JWT 401 / "revoked-session"                           | Logout edilmiş JWT yeniden kullanılıyor. Client `/auth/exchange` ile yeniden oturum açmalı.                   |
+| Mongo TTL index "session_revocations" temizliği               | Mongo monitor'i 60s aralıklarla çalışır; expire'ı geçen entry'ler otomatik silinir. Manuel müdahale gerekmez. |
+
+Daha derin debug için Sentry breadcrumbs (#423 P2-I observability) sonrası tracing ile bağlam alınır.
+
+## İlişkili dokümanlar
+
+- [apps/api/README.md](../apps/api/README.md) — workspace-level README.
+- [ADR 0014](adr/0014-apps-api-over-nextjs.md), [ADR 0017](adr/0017-dual-mode-auth.md), [ADR 0025](adr/0025-apps-api-stack.md), [ADR 0026](adr/0026-apps-api-delivery-hosted.md).
+- [Epic #392](https://github.com/toss-cengiz/glaon/issues/392), sub-issues #417–#423.


### PR DESCRIPTION
## Summary

Locks the delivery model for `apps/api` per #421: a Glaon-managed hosted service. Sidecar / self-host stays as a Phase 5 follow-up if a community demand emerges. Mongo Atlas is the chosen DB per the same ADR.

- **`docs/adr/0026-apps-api-delivery-hosted.md`** — full rationale + topology sketch + secret runbook reference + reconsideration triggers.
- **`docs/api.md`** — bootstrap, endpoint surface, secrets runbook (incl. `SESSION_JWT_SECRET` rotation), healthcheck behaviour, and a troubleshooting matrix.
- **ADR README** index updated.

## Why hosted

- **Multi-device sync built-in** — cloud-mode UX headline; only model that delivers it without per-user infra duplication.
- **Operational consistency** with `apps/cloud` — same deploy pipeline, monitoring, alerting, status page.
- **Production-grade Mongo** — Atlas (replica set, TLS, backup, monitoring) is hard to match self-hosted on a Pi.

## Scope (Out / deferred)

- **Hosting platform pick** (Fly.io / Render / Hetzner / Fargate) — landed with the deploy workflow in P2-H (#422). This ADR locks "container-on-VM/PaaS"; the platform-specific runbook lives in `docs/api.md` (and updates with P2-H).
- **Self-host / sidecar revisit** — Phase 5 follow-up if community demand surfaces. ADR explicitly leaves the door open.
- **Privacy policy / ToS update** — Phase 5 monetization track.

## Test plan

- [x] Pure docs PR — no code, no dependency added.
- [x] `pnpm exec prettier --check docs/` — passes.
- [x] ADR cross-references valid (0014, 0017, 0020, 0025, 0026).
- [ ] CI: conventional-commits, gitleaks, dependency-review (no deps), CodeQL, build (aarch64+amd64), playwright, story-tests, type-check · lint · audit, visual regression, Storybook.

Closes #421.
Refs ADR 0014, ADR 0017, ADR 0020, ADR 0025, #392, #417, #422.