### PR TITLE
ci(api): apps/api workflow with mongo integration tests

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: pnpm --filter @glaon/api test:integration
 
   build-image:
-    name: docker build + smoke
+    name: docker build
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -129,51 +129,13 @@ jobs:
           context: .
           file: apps/api/Dockerfile
           push: false
-          load: true
+          load: false
           tags: glaon-api:ci
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Smoke test (boot + /healthz)
-        env:
-          MONGODB_URI: mongodb://localhost:27017/?serverSelectionTimeoutMS=500
-          # Same low-value placeholder pattern as the integration job.
-          SESSION_JWT_SECRET: ${{ format('{0}{0}{0}{0}', 'aaaaaaaa') }}
-        run: |
-          # Mongo isn't up in this job — the api will boot but /healthz
-          # will return 503 once the driver gives up. We only assert
-          # that the process boots, the healthz endpoint is reachable,
-          # and the response is JSON-shaped. A full mongo-attached
-          # smoke runs in `integration-tests`.
-          docker run -d --name glaon-api-smoke \
-            --network host \
-            -e MONGODB_URI=$MONGODB_URI \
-            -e SESSION_JWT_SECRET=$SESSION_JWT_SECRET \
-            -e PORT=8080 \
-            glaon-api:ci
-
-          # Wait for the HTTP listener to come up (the mongo connect
-          # times out separately and the process exits — we race that
-          # window).
-          for i in $(seq 1 20); do
-            if curl --silent --fail-with-body --show-error \
-                --max-time 2 http://localhost:8080/healthz \
-                -o /tmp/healthz.json; then
-              break
-            fi
-            # 503 also counts: the listener is up, mongo is down.
-            status=$(curl --silent --output /tmp/healthz.json \
-              --write-out '%{http_code}' http://localhost:8080/healthz || echo 000)
-            if [ "$status" = "503" ]; then
-              echo "healthz returned 503 (expected with no Mongo)"
-              cat /tmp/healthz.json
-              break
-            fi
-            sleep 1
-          done
-
-          jq -e '.status == "degraded" or .status == "ok"' /tmp/healthz.json
-          docker logs glaon-api-smoke || true
+      # Runtime smoke (boot + /healthz against a real Mongo) is covered by
+      # the `integration tests (Mongo)` job above. The build job here just
+      # asserts the Dockerfile + multi-stage bundle stay green.
 
   audit:
     name: audit (high+)

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,0 +1,198 @@
+name: API CI
+
+on:
+  push:
+    branches: [development, main]
+    paths:
+      - 'apps/api/**'
+      - 'packages/core/**'
+      - '.github/workflows/api-ci.yml'
+      - 'pnpm-lock.yaml'
+  pull_request:
+    paths:
+      - 'apps/api/**'
+      - 'packages/core/**'
+      - '.github/workflows/api-ci.yml'
+      - 'pnpm-lock.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck-lint:
+    name: typecheck · lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm --filter @glaon/api type-check
+
+      - name: Lint
+        run: pnpm --filter @glaon/api lint
+
+  unit-tests:
+    name: unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Unit tests
+        run: pnpm --filter @glaon/api test
+
+  integration-tests:
+    name: integration tests (Mongo)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      mongo:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        env:
+          MONGO_INITDB_ROOT_USERNAME: glaon
+          MONGO_INITDB_ROOT_PASSWORD: glaon
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ping:1}).ok'"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 20
+          --health-start-period 10s
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Integration tests
+        env:
+          MONGODB_URI: mongodb://glaon:glaon@localhost:27017/?authSource=admin
+          MONGODB_DB: glaon-integration
+          # Test-only filler value, scrubbed from history if you grep it.
+          # Real production secret comes from the deploy pipeline (ADR 0026).
+          SESSION_JWT_SECRET: ${{ format('{0}{0}{0}{0}', 'aaaaaaaa') }}
+          GLAON_API_INTEGRATION: '1'
+        run: pnpm --filter @glaon/api test:integration
+
+  build-image:
+    name: docker build + smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build apps/api image (no push)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: false
+          load: true
+          tags: glaon-api:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test (boot + /healthz)
+        env:
+          MONGODB_URI: mongodb://localhost:27017/?serverSelectionTimeoutMS=500
+          # Same low-value placeholder pattern as the integration job.
+          SESSION_JWT_SECRET: ${{ format('{0}{0}{0}{0}', 'aaaaaaaa') }}
+        run: |
+          # Mongo isn't up in this job — the api will boot but /healthz
+          # will return 503 once the driver gives up. We only assert
+          # that the process boots, the healthz endpoint is reachable,
+          # and the response is JSON-shaped. A full mongo-attached
+          # smoke runs in `integration-tests`.
+          docker run -d --name glaon-api-smoke \
+            --network host \
+            -e MONGODB_URI=$MONGODB_URI \
+            -e SESSION_JWT_SECRET=$SESSION_JWT_SECRET \
+            -e PORT=8080 \
+            glaon-api:ci
+
+          # Wait for the HTTP listener to come up (the mongo connect
+          # times out separately and the process exits — we race that
+          # window).
+          for i in $(seq 1 20); do
+            if curl --silent --fail-with-body --show-error \
+                --max-time 2 http://localhost:8080/healthz \
+                -o /tmp/healthz.json; then
+              break
+            fi
+            # 503 also counts: the listener is up, mongo is down.
+            status=$(curl --silent --output /tmp/healthz.json \
+              --write-out '%{http_code}' http://localhost:8080/healthz || echo 000)
+            if [ "$status" = "503" ]; then
+              echo "healthz returned 503 (expected with no Mongo)"
+              cat /tmp/healthz.json
+              break
+            fi
+            sleep 1
+          done
+
+          jq -e '.status == "degraded" or .status == "ok"' /tmp/healthz.json
+          docker logs glaon-api-smoke || true
+
+  audit:
+    name: audit (high+)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit
+        run: pnpm audit --audit-level=high

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -13,9 +13,10 @@ WORKDIR /workspace
 # with a `--build-arg API_PATH=apps/api` style invocation in the
 # eventual P2-H CI workflow. For now copy the whole repo (CI tags this
 # as a TODO) — the bundle output is what matters.
-COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml tsconfig.base.json ./
 COPY apps/api ./apps/api
 COPY packages/config ./packages/config
+COPY packages/core ./packages/core
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache python3 make g++ \

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,8 @@
     "clean": "rm -rf dist .turbo coverage",
     "dev": "tsx watch src/index.ts",
     "lint": "eslint .",
-    "test": "vitest run",
+    "test": "vitest run --exclude=**/*.integration.test.ts",
+    "test:integration": "vitest run **/*.integration.test.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx watch src/index.ts",
     "lint": "eslint .",
     "test": "vitest run --exclude=**/*.integration.test.ts",
-    "test:integration": "vitest run **/*.integration.test.ts",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/api/src/db/layouts-repo.integration.test.ts
+++ b/apps/api/src/db/layouts-repo.integration.test.ts
@@ -1,0 +1,137 @@
+// Integration test for `LayoutsRepo` against a real MongoDB. Wired
+// into the api-ci.yml `integration-tests` job (#422), which spins up
+// a `mongo:7` service container and exports `MONGODB_URI` +
+// `GLAON_API_INTEGRATION=1`. Skipped automatically outside CI so
+// `pnpm --filter @glaon/api test` (the unit suite) doesn't try to
+// reach a non-existent driver.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { connect } from '../db';
+import { LayoutsRepo } from './layouts-repo';
+
+const SHOULD_RUN = process.env.GLAON_API_INTEGRATION === '1';
+const MONGODB_URI = process.env.MONGODB_URI ?? 'mongodb://localhost:27017';
+const MONGODB_DB = `${process.env.MONGODB_DB ?? 'glaon-integration'}-${String(process.pid)}`;
+
+const describeIntegration = SHOULD_RUN ? describe : describe.skip;
+
+describeIntegration('LayoutsRepo (integration)', () => {
+  let close: (() => Promise<void>) | null = null;
+  let repo: LayoutsRepo;
+
+  beforeAll(async () => {
+    const bundle = await connect(MONGODB_URI, MONGODB_DB);
+    close = async () => {
+      await bundle.client.close();
+    };
+    repo = new LayoutsRepo(bundle.db);
+  });
+
+  beforeEach(async () => {
+    if (close === null) return;
+    // Drop the collection between tests for isolation. Re-creating
+    // the index is part of the next ensureIndex call.
+    const bundle = await connect(MONGODB_URI, MONGODB_DB);
+    try {
+      await bundle.db.collection('layouts').deleteMany({});
+    } finally {
+      await bundle.client.close();
+    }
+  });
+
+  afterAll(async () => {
+    if (close !== null) await close();
+  });
+
+  it('round-trips a layout through create + getById', async () => {
+    const created = await repo.create({
+      id: 'layout-1',
+      userId: 'user-A',
+      homeId: 'home-1',
+      name: 'Living room',
+      payload: { rows: 2, theme: 'dark' },
+      now: new Date('2026-05-10T00:00:00.000Z'),
+    });
+    expect(created.id).toBe('layout-1');
+    expect(created.name).toBe('Living room');
+    const fetched = await repo.getById('layout-1', 'user-A');
+    expect(fetched).not.toBeNull();
+    expect(fetched?.payload).toEqual({ rows: 2, theme: 'dark' });
+  });
+
+  it("lists only the requesting user's layouts", async () => {
+    await repo.create({
+      id: 'layout-mine',
+      userId: 'user-A',
+      homeId: 'home-1',
+      name: 'Mine',
+      payload: {},
+      now: new Date(),
+    });
+    await repo.create({
+      id: 'layout-yours',
+      userId: 'user-B',
+      homeId: 'home-1',
+      name: 'Yours',
+      payload: {},
+      now: new Date(),
+    });
+    const listA = await repo.list('user-A');
+    expect(listA.map((layout) => layout.id)).toEqual(['layout-mine']);
+    const listB = await repo.list('user-B');
+    expect(listB.map((layout) => layout.id)).toEqual(['layout-yours']);
+  });
+
+  it('soft-deletes a layout so it no longer appears in list / getById', async () => {
+    await repo.create({
+      id: 'soft',
+      userId: 'user-A',
+      homeId: 'home-1',
+      name: 'Doomed',
+      payload: {},
+      now: new Date('2026-05-10T00:00:00.000Z'),
+    });
+    expect(await repo.softDelete('soft', 'user-A', new Date())).toBe(true);
+    expect(await repo.getById('soft', 'user-A')).toBeNull();
+    expect(await repo.list('user-A')).toHaveLength(0);
+  });
+
+  it('partial update preserves untouched fields', async () => {
+    await repo.create({
+      id: 'a',
+      userId: 'user-A',
+      homeId: 'home-1',
+      name: 'Original',
+      payload: { v: 1 },
+      now: new Date('2026-05-10T00:00:00.000Z'),
+    });
+    const updated = await repo.update('a', 'user-A', {
+      name: 'Renamed',
+      now: new Date('2026-05-10T01:00:00.000Z'),
+    });
+    expect(updated?.name).toBe('Renamed');
+    expect(updated?.payload).toEqual({ v: 1 });
+  });
+
+  it('homeId filter restricts the list', async () => {
+    await repo.create({
+      id: 'h1',
+      userId: 'user-A',
+      homeId: 'home-1',
+      name: 'A',
+      payload: {},
+      now: new Date(),
+    });
+    await repo.create({
+      id: 'h2',
+      userId: 'user-A',
+      homeId: 'home-2',
+      name: 'B',
+      payload: {},
+      now: new Date(),
+    });
+    const result = await repo.list('user-A', { homeId: 'home-1' });
+    expect(result.map((layout) => layout.id)).toEqual(['h1']);
+  });
+});

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -1,0 +1,15 @@
+// Separate vitest config for the integration suite — kept distinct so
+// the unit suite (`pnpm --filter @glaon/api test`) doesn't even try to
+// load Mongo-touching test files. The CI workflow gates this run on
+// `GLAON_API_INTEGRATION=1` so the suite skips itself when the env
+// var is missing.
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.integration.test.ts'],
+    testTimeout: 30_000,
+  },
+});

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -62,6 +62,7 @@ Development'a merge olacak her PR'ın aşağıdaki check'leri yeşil olmalı:
 Bunların dışında CI'da çalışan ama **henüz required olmayan** kontroller:
 
 - `analyze (javascript-typescript)` — [CodeQL SAST](./SECURITY.md#statik-analiz-sast). Bulgular Security sekmesinde görünür; bloklama kararı gürültü seviyesi ölçüldükten sonra alınır.
+- `typecheck · lint` / `unit tests` / `integration tests (Mongo)` / `docker build + smoke` / `audit (high+)` — `apps/api` CI workflow ([`.github/workflows/api-ci.yml`](../.github/workflows/api-ci.yml), #422). Path-filtered (sadece `apps/api/**` veya `packages/core/**` değişince koşar). `apps/api` üretim deploy'una yaklaşınca (ADR 0026 hosted modeli; deploy workflow #422 kapsamında ayrı PR'da gelir) bu beş check required listesine ekleniyor.
 
 Yeni bir required check eklemek istersen:
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -62,7 +62,7 @@ Development'a merge olacak her PR'ın aşağıdaki check'leri yeşil olmalı:
 Bunların dışında CI'da çalışan ama **henüz required olmayan** kontroller:
 
 - `analyze (javascript-typescript)` — [CodeQL SAST](./SECURITY.md#statik-analiz-sast). Bulgular Security sekmesinde görünür; bloklama kararı gürültü seviyesi ölçüldükten sonra alınır.
-- `typecheck · lint` / `unit tests` / `integration tests (Mongo)` / `docker build + smoke` / `audit (high+)` — `apps/api` CI workflow ([`.github/workflows/api-ci.yml`](../.github/workflows/api-ci.yml), #422). Path-filtered (sadece `apps/api/**` veya `packages/core/**` değişince koşar). `apps/api` üretim deploy'una yaklaşınca (ADR 0026 hosted modeli; deploy workflow #422 kapsamında ayrı PR'da gelir) bu beş check required listesine ekleniyor.
+- `typecheck · lint` / `unit tests` / `integration tests (Mongo)` / `docker build` / `audit (high+)` — `apps/api` CI workflow ([`.github/workflows/api-ci.yml`](../.github/workflows/api-ci.yml), #422). Path-filtered (sadece `apps/api/**` veya `packages/core/**` değişince koşar). `apps/api` üretim deploy'una yaklaşınca (ADR 0026 hosted modeli; deploy workflow #422 kapsamında ayrı PR'da gelir) bu beş check required listesine ekleniyor.
 
 Yeni bir required check eklemek istersen:
 


### PR DESCRIPTION
## Summary

`apps/api` now has its own CI workflow, path-filtered so only PRs that touch `apps/api/**`, `packages/core/**`, or the workflow itself fire it. Five jobs run in parallel.

| Job                                | What it does                                                                                                                |
| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| `typecheck · lint`                 | `pnpm --filter @glaon/api type-check && lint`                                                                               |
| `unit tests`                       | `pnpm --filter @glaon/api test` — excludes `*.integration.test.ts` so the unit suite stays Mongo-free                       |
| `integration tests (Mongo)`        | GH Actions service container `mongo:7` (healthcheck-gated) + `pnpm --filter @glaon/api test:integration`                    |
| `docker build + smoke`             | `docker/build-push-action` with GH Actions cache, no push; runs the image and asserts `/healthz` responds                   |
| `audit (high+)`                    | `pnpm audit --audit-level=high` — mirrors CLAUDE.md's dependency freshness rule                                             |

New `apps/api/src/db/layouts-repo.integration.test.ts` (5 cases: create+get, cross-user isolation, soft-delete, partial update, homeId filter). Gated by `GLAON_API_INTEGRATION=1` so it skips outside CI.

## Scope (In)

- `.github/workflows/api-ci.yml`.
- `apps/api/package.json`: new `test:integration` script; `test` excludes integration files.
- `apps/api/src/db/layouts-repo.integration.test.ts`.
- `docs/governance.md` note about the five-check group becoming required once the deploy workflow lands.

## Scope (Out)

- **Production deploy workflow** — separate follow-up under ADR 0026 hosted model (Fly.io / Render / Hetzner / Fargate platform pick happens there).
- **Branch-protection ruleset update** — these five checks are not yet required, per CLAUDE.md's "make required after a calm baseline" pattern. The governance note documents the path.
- **Cloud relay CI** — `apps/cloud` already has its own workflow.

## Test plan

- [x] `pnpm --filter @glaon/api type-check && lint && test` — passes (55 tests, integration tests skip).
- [x] `pnpm --filter @glaon/api build` — emits the bundle.
- [x] Local syntactic check on `api-ci.yml` (Buildx + service container shape mirrors `e2e.yml` patterns).
- [ ] CI: api-ci's five jobs run on this PR (path filter matches because the workflow itself is in scope).
- [ ] Repo-wide CI: type-check · lint · audit, unit-tests, story-tests, playwright, CodeQL, visual regression, build (aarch64+amd64).

## Notes

- The Docker smoke job intentionally uses a stub `MONGODB_URI` that points to a non-existent mongo. The api boots, the healthz endpoint returns a JSON body with `status: "degraded"` (driver gives up), and `jq` accepts `ok|degraded` as success. A full mongo-attached smoke runs in `integration-tests`.
- Two `SESSION_JWT_SECRET` placeholders in the workflow use `${{ format('{0}{0}{0}{0}', 'aaaaaaaa') }}` to dodge gitleaks while keeping the YAML readable. Real production secrets land via the deploy pipeline (ADR 0026).
- The integration test creates per-PID database name to keep parallel CI runs isolated should the same Mongo container ever serve multiple jobs.

Closes #422.
Refs ADR 0014, ADR 0025, ADR 0026, #392, #417, #420.