### PR TITLE
feat(api): structured logger + request id + metrics

### DIFF
--- a/apps/api/src/middleware/observability.test.ts
+++ b/apps/api/src/middleware/observability.test.ts
@@ -1,0 +1,67 @@
+import { Hono } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createLogger } from '../observability/logger';
+import { Metrics } from '../observability/metrics';
+import { observabilityMiddleware } from './observability';
+
+function makeApp() {
+  const lines: string[] = [];
+  const logger = createLogger({
+    level: 'debug',
+    write: (line) => lines.push(line),
+  });
+  const metrics = new Metrics();
+  const newRequestId = vi.fn(() => 'fixed-id');
+  const app = new Hono();
+  app.use('*', observabilityMiddleware({ logger, metrics, newRequestId }));
+  app.get('/probe', (c) => c.json({ ok: true }));
+  app.get('/layouts/:id', (c) => c.json({ id: c.req.param('id') }));
+  app.get('/boom', () => {
+    throw new Error('boom');
+  });
+  return { app, lines, metrics, newRequestId };
+}
+
+describe('observabilityMiddleware', () => {
+  it('echoes X-Request-Id and emits a request log line', async () => {
+    const { app, lines } = makeApp();
+    const res = await app.request('/probe');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Request-Id')).toBe('fixed-id');
+    expect(lines).toHaveLength(1);
+    const firstLine = lines[0];
+    if (firstLine === undefined) throw new Error('expected one log line');
+    const parsed = JSON.parse(firstLine) as Record<string, unknown>;
+    expect(parsed.msg).toBe('request');
+    expect(parsed.method).toBe('GET');
+    expect(parsed.path).toBe('/probe');
+    expect(parsed.status).toBe(200);
+    expect(parsed.request_id).toBe('fixed-id');
+    expect(typeof parsed.duration_ms).toBe('number');
+  });
+
+  it('honours an inbound X-Request-Id when it matches the safe charset', async () => {
+    const { app } = makeApp();
+    const res = await app.request('/probe', {
+      headers: { 'X-Request-Id': 'trace_abc-123' },
+    });
+    expect(res.headers.get('X-Request-Id')).toBe('trace_abc-123');
+  });
+
+  it('rejects an inbound X-Request-Id with unsafe characters', async () => {
+    const { app, newRequestId } = makeApp();
+    const res = await app.request('/probe', {
+      headers: { 'X-Request-Id': '<script>alert(1)</script>' },
+    });
+    expect(res.headers.get('X-Request-Id')).toBe('fixed-id');
+    expect(newRequestId).toHaveBeenCalled();
+  });
+
+  it('collapses param-laden routes to label form for metrics', async () => {
+    const { app, metrics } = makeApp();
+    await app.request('/layouts/abc-123');
+    const output = metrics.render();
+    expect(output).toContain('route="/layouts/:id"');
+  });
+});

--- a/apps/api/src/middleware/observability.ts
+++ b/apps/api/src/middleware/observability.ts
@@ -1,0 +1,73 @@
+// Hono middleware that wires up the per-request observability:
+//   1. Generates a UUID request id (or accepts X-Request-Id from a
+//      trusted proxy — Phase 2 scope assumes clients won't forge it,
+//      but the cloud-relay deploy already gates origin so a malicious
+//      actor can't trivially set it).
+//   2. Stashes the request context into AsyncLocalStorage so log calls
+//      anywhere in the handler chain auto-include it.
+//   3. Echoes `X-Request-Id` back on the response.
+//   4. Emits a single `request` log line on completion with method,
+//      path, status, duration_ms.
+//   5. Records the request in the Metrics counter.
+
+import type { MiddlewareHandler } from 'hono';
+
+import { requestContextStore, type Logger, type RequestContext } from '../observability/logger';
+import type { Metrics } from '../observability/metrics';
+
+interface ObservabilityDeps {
+  readonly logger: Logger;
+  readonly metrics: Metrics;
+  readonly newRequestId?: () => string;
+}
+
+export function observabilityMiddleware(deps: ObservabilityDeps): MiddlewareHandler {
+  const newRequestId = deps.newRequestId ?? (() => crypto.randomUUID());
+  return async (c, next) => {
+    const incoming = c.req.header('X-Request-Id');
+    const requestId =
+      incoming !== undefined && /^[A-Za-z0-9_.-]{8,128}$/.test(incoming)
+        ? incoming
+        : newRequestId();
+    const ctx: RequestContext = {
+      requestId,
+      method: c.req.method,
+      path: c.req.path,
+      startedAt: Date.now(),
+    };
+    c.header('X-Request-Id', requestId);
+    await requestContextStore.run(ctx, async () => {
+      try {
+        await next();
+      } finally {
+        const status = c.res.status;
+        const durationMs = Date.now() - ctx.startedAt;
+        deps.logger.info({
+          msg: 'request',
+          method: ctx.method,
+          path: ctx.path,
+          status,
+          duration_ms: durationMs,
+        });
+        deps.metrics.observeRequest({
+          method: ctx.method,
+          route: routeOf(ctx.path),
+          status,
+        });
+      }
+    });
+  };
+}
+
+// Collapse param-laden paths into a route shape suitable for metric
+// labels. `/layouts/abc-123` → `/layouts/:id`. We intentionally do NOT
+// run the full Hono route registry — keeping a tight allowlist keeps
+// label cardinality bounded.
+const ROUTE_PATTERNS: [RegExp, string][] = [[/^\/layouts\/[^/]+$/, '/layouts/:id']];
+
+function routeOf(path: string): string {
+  for (const [pattern, label] of ROUTE_PATTERNS) {
+    if (pattern.test(path)) return label;
+  }
+  return path;
+}

--- a/apps/api/src/observability/logger.test.ts
+++ b/apps/api/src/observability/logger.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { createLogger, requestContextStore, scrub } from './logger';
+
+function getLine(lines: readonly string[], index: number): string {
+  const value = lines[index];
+  if (value === undefined) throw new Error(`expected log line ${String(index)}`);
+  return value;
+}
+
+function captureLogger(): { lines: string[]; logger: ReturnType<typeof createLogger> } {
+  const lines: string[] = [];
+  const logger = createLogger({
+    level: 'debug',
+    write: (line) => lines.push(line),
+  });
+  return { lines, logger };
+}
+
+describe('logger', () => {
+  it('emits valid JSON with level + time', () => {
+    const { lines, logger } = captureLogger();
+    logger.info({ msg: 'hello' });
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(getLine(lines, 0)) as Record<string, unknown>;
+    expect(parsed.level).toBe('info');
+    expect(typeof parsed.time).toBe('string');
+    expect(parsed.msg).toBe('hello');
+  });
+
+  it('respects the configured level', () => {
+    const lines: string[] = [];
+    const logger = createLogger({ level: 'warn', write: (line) => lines.push(line) });
+    logger.debug({ msg: 'dropped' });
+    logger.info({ msg: 'dropped' });
+    logger.warn({ msg: 'kept' });
+    logger.error({ msg: 'kept' });
+    expect(lines).toHaveLength(2);
+  });
+
+  it('redacts sensitive top-level keys', () => {
+    const { lines, logger } = captureLogger();
+    logger.info({
+      msg: 'auth attempt',
+      ha_access_token: 'leaky',
+      authorization: 'Bearer x',
+      password: 'p',
+    });
+    const parsed = JSON.parse(getLine(lines, 0)) as Record<string, unknown>;
+    expect(parsed.ha_access_token).toBe('[REDACTED]');
+    expect(parsed.authorization).toBe('[REDACTED]');
+    expect(parsed.password).toBe('[REDACTED]');
+    expect(parsed.msg).toBe('auth attempt');
+  });
+
+  it('redacts sensitive keys at any nesting depth', () => {
+    const { lines, logger } = captureLogger();
+    logger.info({
+      headers: { Cookie: 'session=x' },
+      body: { user: { jwt: 'eyJ.X.Y' } },
+      list: [{ session_jwt: 'a.b.c' }],
+    });
+    const parsed = JSON.parse(getLine(lines, 0)) as Record<string, unknown>;
+    expect((parsed.headers as Record<string, string>).Cookie).toBe('[REDACTED]');
+    expect((parsed.body as { user: Record<string, string> }).user.jwt).toBe('[REDACTED]');
+    expect((parsed.list as { session_jwt: string }[])[0]?.session_jwt).toBe('[REDACTED]');
+  });
+
+  it('matches sensitive keys case-insensitively', () => {
+    const { lines, logger } = captureLogger();
+    logger.info({ Authorization: 'Bearer x', SESSION_JWT_SECRET: 's' });
+    const parsed = JSON.parse(getLine(lines, 0)) as Record<string, unknown>;
+    expect(parsed.Authorization).toBe('[REDACTED]');
+    expect(parsed.SESSION_JWT_SECRET).toBe('[REDACTED]');
+  });
+
+  it('auto-includes the request_id from AsyncLocalStorage', () => {
+    const { lines, logger } = captureLogger();
+    requestContextStore.run(
+      {
+        requestId: 'req-42',
+        method: 'GET',
+        path: '/healthz',
+        startedAt: Date.now(),
+      },
+      () => {
+        logger.info({ msg: 'inside' });
+      },
+    );
+    logger.info({ msg: 'outside' });
+    const inside = JSON.parse(getLine(lines, 0)) as Record<string, unknown>;
+    const outside = JSON.parse(getLine(lines, 1)) as Record<string, unknown>;
+    expect(inside.request_id).toBe('req-42');
+    expect(outside.request_id).toBeUndefined();
+  });
+});
+
+describe('scrub', () => {
+  it('returns primitives unchanged', () => {
+    expect(scrub('hi')).toBe('hi');
+    expect(scrub(42)).toBe(42);
+    expect(scrub(null)).toBe(null);
+    expect(scrub(undefined)).toBe(undefined);
+  });
+
+  it('walks arrays', () => {
+    expect(scrub([{ token: 'a' }, { ok: 1 }])).toEqual([{ token: '[REDACTED]' }, { ok: 1 }]);
+  });
+});

--- a/apps/api/src/observability/logger.ts
+++ b/apps/api/src/observability/logger.ts
@@ -1,0 +1,126 @@
+// Structured JSON logger for apps/api per ADR 0007 + #423. Same shape
+// as `apps/cloud/src/logger.ts` so a future shared `@glaon/core/log`
+// can subsume both — the duplication is intentional during Phase 2 to
+// keep stack-specific logging primitives (CF Workers vs Node) loose.
+//
+// Output is a single JSON line per emit. The PII scrubber redacts
+// values whose key matches the sensitive set (case-insensitive); the
+// per-request id from AsyncLocalStorage is auto-merged when set.
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const SENSITIVE_KEYS = new Set([
+  'access_token',
+  'refresh_token',
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'password',
+  'secret',
+  'token',
+  'jwt',
+  'session',
+  'session_jwt',
+  'session_jwt_secret',
+  'pair_code',
+  'pair_secret',
+  'relay_secret',
+  'sentry_dsn',
+  'mongodb_uri',
+  'ha_access_token',
+]);
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+function isLogLevel(value: string): value is LogLevel {
+  return value === 'debug' || value === 'info' || value === 'warn' || value === 'error';
+}
+
+export interface RequestContext {
+  readonly requestId: string;
+  readonly method: string;
+  readonly path: string;
+  readonly startedAt: number;
+}
+
+export const requestContextStore = new AsyncLocalStorage<RequestContext>();
+
+export interface Logger {
+  debug(record: Record<string, unknown>): void;
+  info(record: Record<string, unknown>): void;
+  warn(record: Record<string, unknown>): void;
+  error(record: Record<string, unknown>): void;
+}
+
+interface LoggerOptions {
+  readonly level: string;
+  readonly write?: (line: string) => void;
+}
+
+const defaultWrite = (line: string): void => {
+  process.stdout.write(`${line}\n`);
+};
+
+export function createLogger(options: LoggerOptions): Logger {
+  const minLevel = isLogLevel(options.level) ? LEVEL_ORDER[options.level] : LEVEL_ORDER.info;
+  const write = options.write ?? defaultWrite;
+
+  function emit(level: LogLevel, record: Record<string, unknown>): void {
+    if (LEVEL_ORDER[level] < minLevel) return;
+    const scrubbed = scrubRecord(record);
+    const ctx = requestContextStore.getStore();
+    const envelope: Record<string, unknown> = {
+      level,
+      time: new Date().toISOString(),
+      ...scrubbed,
+    };
+    if (ctx !== undefined) {
+      envelope.request_id = ctx.requestId;
+    }
+    write(JSON.stringify(envelope));
+  }
+
+  return {
+    debug: (r) => {
+      emit('debug', r);
+    },
+    info: (r) => {
+      emit('info', r);
+    },
+    warn: (r) => {
+      emit('warn', r);
+    },
+    error: (r) => {
+      emit('error', r);
+    },
+  };
+}
+
+function scrubRecord(input: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      out[key] = '[REDACTED]';
+      continue;
+    }
+    out[key] = scrub(value);
+  }
+  return out;
+}
+
+/**
+ * Recursively scrub values; keys matching the sensitive set are
+ * replaced with `[REDACTED]`. Arrays + nested objects walked.
+ * Exported for the unit suite.
+ */
+export function scrub(input: unknown): unknown {
+  if (input === null || typeof input !== 'object') return input;
+  if (Array.isArray(input)) return input.map(scrub);
+  return scrubRecord(input as Record<string, unknown>);
+}

--- a/apps/api/src/observability/metrics.test.ts
+++ b/apps/api/src/observability/metrics.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Metrics } from './metrics';
+
+describe('Metrics', () => {
+  it('renders the prom text format with the static + dynamic counters', () => {
+    const metrics = new Metrics();
+    metrics.observeRequest({ method: 'GET', route: '/healthz', status: 200 });
+    metrics.observeRequest({ method: 'GET', route: '/healthz', status: 200 });
+    metrics.observeRequest({ method: 'POST', route: '/layouts', status: 201 });
+    metrics.setMongoPing(7);
+    const output = metrics.render();
+    expect(output).toContain('# HELP process_uptime_seconds');
+    expect(output).toContain('# TYPE process_uptime_seconds gauge');
+    expect(output).toContain('http_requests_total{method="GET",route="/healthz",status="200"} 2');
+    expect(output).toContain('http_requests_total{method="POST",route="/layouts",status="201"} 1');
+    expect(output).toContain('mongo_ping_milliseconds 7');
+  });
+
+  it('emits NaN for the mongo ping gauge when no observation has been made', () => {
+    const metrics = new Metrics();
+    expect(metrics.render()).toContain('mongo_ping_milliseconds NaN');
+  });
+
+  it('reports a non-negative process uptime', () => {
+    vi.useFakeTimers();
+    const metrics = new Metrics();
+    vi.advanceTimersByTime(2_500);
+    const output = metrics.render();
+    vi.useRealTimers();
+    expect(output).toMatch(/process_uptime_seconds [0-9]+/);
+  });
+
+  it('escapes label values with quotes / backslashes / newlines', () => {
+    const metrics = new Metrics();
+    metrics.observeRequest({ method: 'GET', route: '/weird"path\\', status: 200 });
+    const output = metrics.render();
+    expect(output).toContain('route="/weird\\"path\\\\"');
+  });
+});

--- a/apps/api/src/observability/metrics.ts
+++ b/apps/api/src/observability/metrics.ts
@@ -1,0 +1,59 @@
+// Process-level counters for the /metrics endpoint (#423). The format
+// is Prometheus text exposition v0 — minimal subset that
+// scrapers + Grafana Agent both understand. We avoid pulling in a
+// metrics library to keep the bundle small; if cardinality grows past
+// a few labels we'll revisit.
+
+interface RequestMetricLabels {
+  readonly method: string;
+  readonly route: string;
+  readonly status: number;
+}
+
+export class Metrics {
+  private readonly bootTime = Date.now();
+  private readonly requestCounts = new Map<string, number>();
+  private mongoPingMs: number | null = null;
+
+  observeRequest(labels: RequestMetricLabels): void {
+    const key = `${labels.method}|${labels.route}|${String(labels.status)}`;
+    this.requestCounts.set(key, (this.requestCounts.get(key) ?? 0) + 1);
+  }
+
+  setMongoPing(latencyMs: number): void {
+    this.mongoPingMs = latencyMs;
+  }
+
+  render(): string {
+    const lines: string[] = [];
+    const uptime = Math.floor((Date.now() - this.bootTime) / 1000);
+    lines.push('# HELP process_uptime_seconds Seconds since the apps/api process started.');
+    lines.push('# TYPE process_uptime_seconds gauge');
+    lines.push(`process_uptime_seconds ${String(uptime)}`);
+
+    lines.push('# HELP http_requests_total Total HTTP requests served, by method/route/status.');
+    lines.push('# TYPE http_requests_total counter');
+    if (this.requestCounts.size === 0) {
+      lines.push('http_requests_total{method="",route="",status=""} 0');
+    } else {
+      for (const [key, count] of this.requestCounts) {
+        const [method, route, status] = key.split('|');
+        lines.push(
+          `http_requests_total{method="${escape(method ?? '')}",route="${escape(route ?? '')}",status="${escape(status ?? '')}"} ${String(count)}`,
+        );
+      }
+    }
+
+    lines.push('# HELP mongo_ping_milliseconds Last observed Mongo ping latency in ms.');
+    lines.push('# TYPE mongo_ping_milliseconds gauge');
+    lines.push(
+      `mongo_ping_milliseconds ${this.mongoPingMs === null ? 'NaN' : String(this.mongoPingMs)}`,
+    );
+
+    return `${lines.join('\n')}\n`;
+  }
+}
+
+function escape(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -87,4 +87,29 @@ describe('createServer wiring', () => {
     await app.request('/healthz');
     expect(command).toHaveBeenCalledTimes(2);
   });
+
+  it('echoes X-Request-Id on every response (observability middleware)', async () => {
+    const app = createServer(makeDeps());
+    const res = await app.request('/healthz');
+    const requestId = res.headers.get('X-Request-Id');
+    expect(requestId).toBeTruthy();
+    expect(requestId).toMatch(/^[A-Za-z0-9_.-]+$/);
+  });
+});
+
+describe('GET /metrics', () => {
+  it('returns the prometheus text format with mongo + request counters populated', async () => {
+    const app = createServer(makeDeps());
+    // Drive at least one request through the observability middleware so
+    // the request counter has a row.
+    await app.request('/version');
+    await app.request('/healthz');
+    const res = await app.request('/metrics');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toContain('text/plain');
+    const body = await res.text();
+    expect(body).toContain('process_uptime_seconds');
+    expect(body).toContain('http_requests_total');
+    expect(body).toMatch(/mongo_ping_milliseconds [0-9]+/);
+  });
 });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -5,10 +5,13 @@
 import { Hono } from 'hono';
 import type { Db } from 'mongodb';
 
-import type { Config } from './config';
-import { pingDb } from './db';
 import { decodeSecret } from './auth/jwt';
 import { MongoRevocationStore, type RevocationStore } from './auth/revocation';
+import type { Config } from './config';
+import { pingDb } from './db';
+import { observabilityMiddleware } from './middleware/observability';
+import { createLogger, type Logger } from './observability/logger';
+import { Metrics } from './observability/metrics';
 import { createAuthRouter } from './routes/auth';
 import { createLayoutsRouter } from './routes/layouts';
 
@@ -17,12 +20,18 @@ export interface ServerDeps {
   readonly config: Config;
   readonly revocations?: RevocationStore;
   readonly fetchImpl?: typeof fetch;
+  readonly logger?: Logger;
+  readonly metrics?: Metrics;
 }
 
 export function createServer(deps: ServerDeps): Hono {
   const app = new Hono();
   const secret = decodeSecret(deps.config.sessionJwtSecret);
   const revocations = deps.revocations ?? new MongoRevocationStore(deps.db);
+  const logger = deps.logger ?? createLogger({ level: deps.config.logLevel });
+  const metrics = deps.metrics ?? new Metrics();
+
+  app.use('*', observabilityMiddleware({ logger, metrics }));
 
   app.route(
     '/auth',
@@ -39,10 +48,20 @@ export function createServer(deps: ServerDeps): Hono {
 
   // Liveness probe with Mongo ping. Returns 200 when the driver
   // command succeeds, 503 otherwise so a load balancer can drop the
-  // instance from rotation.
+  // instance from rotation. The metrics gauge is updated on every
+  // call so /metrics surfaces the latest observation.
   app.get('/healthz', async (c) => {
     const result = await pingDb(deps.db);
-    return c.json({ status: result.ok ? 'ok' : 'degraded', mongo: result }, result.ok ? 200 : 503);
+    metrics.setMongoPing(result.latencyMs);
+    return c.json(
+      {
+        status: result.ok ? 'ok' : 'degraded',
+        mongo: result,
+        version: deps.config.buildInfo.version,
+        commit: deps.config.buildInfo.commit,
+      },
+      result.ok ? 200 : 503,
+    );
   });
 
   // Build info — useful for the deploy pipeline + manual debugging.
@@ -52,6 +71,12 @@ export function createServer(deps: ServerDeps): Hono {
       commit: deps.config.buildInfo.commit,
       builtAt: deps.config.buildInfo.builtAt,
     });
+  });
+
+  // Prometheus-style text exposition (#423). Minimal subset — process
+  // uptime, request counts (method/route/status), latest mongo ping.
+  app.get('/metrics', (c) => {
+    return c.text(metrics.render(), 200, { 'Content-Type': 'text/plain; version=0.0.4' });
   });
 
   return app;


### PR DESCRIPTION
## Summary

Phase-2 observability baseline for `apps/api` per [ADR 0007](docs/adr/0007-sentry-observability.md). Drops in the same JSON-line + scrub pattern `apps/cloud` already uses, plus an async-local request id, a `/metrics` endpoint, and a `/healthz` extension.

- **`logger.ts`** — single-line JSON via `process.stdout.write`. PII scrubber inherits `apps/cloud`'s `SENSITIVE_KEYS` set and adds `apps/api`-specific keys (`session_jwt`, `mongodb_uri`, `ha_access_token`). `AsyncLocalStorage` carries the per-request context so any `logger.info()` from a handler auto-stamps `request_id`.
- **`observabilityMiddleware`** generates a UUID request id (or accepts an inbound `X-Request-Id` matching `[A-Za-z0-9_.-]{8,128}`); echoes it on the response; logs a single `request` line on completion with `method`, `path`, `status`, `duration_ms`. Param-laden routes collapse to a `:id` label shape so metric cardinality stays bounded.
- **`Metrics`** — minimal Prometheus text exposition: `process_uptime_seconds` (gauge), `http_requests_total` (counter labeled `method/route/status`), `mongo_ping_milliseconds` (gauge, fed by `/healthz`).
- **`server.ts`** mounts `GET /metrics` (text/plain v0.0.4) and extends `/healthz` with `version` + `commit` plus the metrics gauge update.

## Scope (In)

- `apps/api/src/observability/{logger,metrics}.ts` + tests.
- `apps/api/src/middleware/observability.ts` + tests.
- `server.ts` wiring (middleware mount, `/metrics`, `/healthz` extension).
- 18 new unit tests; existing 55 still pass (73 total).

## Scope (Out / deferred)

- **`@sentry/node` SDK integration** — DSN already wired through config but the runtime hookup + source-map upload land alongside the deploy workflow under ADR 0026 (P2-G follow-up). Phase-2 logging-+-metrics base is sufficient for the scope here.
- **OpenTelemetry tracing** — out per the issue; logs + metrics suffice for v0.
- **Log aggregation backend / dashboards / alerting rules** — Phase 5 ops hardening.
- **`apps/api/src/observability/sentry.ts`** stub already lives in `apps/cloud` — we'll lift it into the workspace once the platform pick is finalized.

## Test plan

- [x] `pnpm --filter @glaon/api type-check && lint && test` — passes (73 tests, 18 new).
- [x] `pnpm exec knip --workspace apps/api` — clean.
- [x] `pnpm --filter @glaon/api build` — bundle emits.
- [x] `apps/api`'s integration tests (Mongo) job continues to pass.
- [ ] CI: api-ci's five jobs + repo-wide checks (type-check · lint · audit, unit-tests, story-tests, playwright, CodeQL, visual regression, build).

## Notes

- The middleware's `X-Request-Id` charset gate `[A-Za-z0-9_.-]{8,128}` rejects anything the upstream proxy didn't sanitize — we only want to honour ids that look like our own UUIDs or correlation ids the addon-relay sets. Anything else generates a fresh id.
- `Metrics.render()` emits NaN for the mongo gauge until the first `/healthz` probe seeds it — Prometheus scrapers tolerate that. We could pre-seed but the runtime cost is negligible.
- Config already had `LOG_LEVEL`, `SENTRY_DSN`, etc. wired through Zod; no env shape changes in this PR.

Closes #423.
Refs ADR 0007, ADR 0017, ADR 0025, #392, #417.