### PR TITLE
feat(api,core): /me/preferences locale persistence (i18n-C)

### DIFF
--- a/apps/api/src/db/users-repo-fake.ts
+++ b/apps/api/src/db/users-repo-fake.ts
@@ -1,0 +1,34 @@
+// In-memory UsersRepo for unit tests. Mirrors UsersRepo's public
+// surface and applies the same partial-update semantics: a missing
+// field leaves the existing value alone; `null` clears it.
+
+import type { UserPreferences, UserPreferencesUpdate } from '@glaon/core/api-client';
+
+const DEFAULT_PREFERENCES: UserPreferences = { locale: null };
+
+interface UserRecord {
+  preferences: UserPreferences;
+}
+
+export class InMemoryUsersRepo {
+  private readonly store = new Map<string, UserRecord>();
+
+  async getPreferences(userId: string): Promise<UserPreferences> {
+    await Promise.resolve();
+    const record = this.store.get(userId);
+    return record === undefined ? { ...DEFAULT_PREFERENCES } : { ...record.preferences };
+  }
+
+  async updatePreferences(
+    userId: string,
+    patch: UserPreferencesUpdate,
+    _now: Date,
+  ): Promise<UserPreferences> {
+    await Promise.resolve();
+    const existing = this.store.get(userId)?.preferences ?? { ...DEFAULT_PREFERENCES };
+    const next: UserPreferences = { ...existing };
+    if (patch.locale !== undefined) next.locale = patch.locale;
+    this.store.set(userId, { preferences: next });
+    return { ...next };
+  }
+}

--- a/apps/api/src/db/users-repo.integration.test.ts
+++ b/apps/api/src/db/users-repo.integration.test.ts
@@ -1,0 +1,74 @@
+// Integration test for `UsersRepo` against a real MongoDB. Same gating
+// as the layouts integration test: skipped outside the CI integration
+// job that exports `GLAON_API_INTEGRATION=1`.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { connect } from '../db';
+import { UsersRepo } from './users-repo';
+
+const SHOULD_RUN = process.env.GLAON_API_INTEGRATION === '1';
+const MONGODB_URI = process.env.MONGODB_URI ?? 'mongodb://localhost:27017';
+const MONGODB_DB = `${process.env.MONGODB_DB ?? 'glaon-integration'}-${String(process.pid)}`;
+
+const describeIntegration = SHOULD_RUN ? describe : describe.skip;
+
+describeIntegration('UsersRepo (integration)', () => {
+  let close: (() => Promise<void>) | null = null;
+  let repo: UsersRepo;
+
+  beforeAll(async () => {
+    const bundle = await connect(MONGODB_URI, MONGODB_DB);
+    close = async () => {
+      await bundle.client.close();
+    };
+    repo = new UsersRepo(bundle.db);
+  });
+
+  beforeEach(async () => {
+    if (close === null) return;
+    const bundle = await connect(MONGODB_URI, MONGODB_DB);
+    try {
+      await bundle.db.collection('users').deleteMany({});
+    } finally {
+      await bundle.client.close();
+    }
+  });
+
+  afterAll(async () => {
+    if (close !== null) await close();
+  });
+
+  it('returns default preferences for an unknown user', async () => {
+    expect(await repo.getPreferences('user-A')).toEqual({ locale: null });
+  });
+
+  it('upserts preferences on first update + reads them back', async () => {
+    const now = new Date('2026-05-10T00:00:00.000Z');
+    expect(await repo.updatePreferences('user-A', { locale: 'tr' }, now)).toEqual({ locale: 'tr' });
+    expect(await repo.getPreferences('user-A')).toEqual({ locale: 'tr' });
+  });
+
+  it('partial update leaves untouched fields alone', async () => {
+    const now = new Date();
+    await repo.updatePreferences('user-A', { locale: 'tr' }, now);
+    expect(await repo.updatePreferences('user-A', {}, now)).toEqual({ locale: 'tr' });
+  });
+
+  it('null clears the persisted locale', async () => {
+    const now = new Date();
+    await repo.updatePreferences('user-A', { locale: 'tr' }, now);
+    expect(await repo.updatePreferences('user-A', { locale: null }, now)).toEqual({
+      locale: null,
+    });
+    expect(await repo.getPreferences('user-A')).toEqual({ locale: null });
+  });
+
+  it('preferences are isolated per user', async () => {
+    const now = new Date();
+    await repo.updatePreferences('user-A', { locale: 'tr' }, now);
+    await repo.updatePreferences('user-B', { locale: 'en' }, now);
+    expect(await repo.getPreferences('user-A')).toEqual({ locale: 'tr' });
+    expect(await repo.getPreferences('user-B')).toEqual({ locale: 'en' });
+  });
+});

--- a/apps/api/src/db/users-repo.ts
+++ b/apps/api/src/db/users-repo.ts
@@ -1,0 +1,68 @@
+// Mongo repository for the `users` collection (#425).
+//
+// Today the users document only carries `preferences.locale`. We keep
+// the document shape forward-extensible: every preference Glaon adds
+// later (theme, density, default-home, etc.) lands as another field
+// under `preferences`, and the partial-update endpoint stays compatible.
+//
+// Document shape:
+//   {
+//     _id: string,             — apps/api session `sub` (HA user id or
+//                                hashed LLAT — see auth/ha-bridge.ts)
+//     preferences: {
+//       locale: 'en' | 'tr' | null,
+//     },
+//     createdAt: Date,
+//     updatedAt: Date,
+//   }
+//
+// Indexes: the `_id` is the lookup key for every operation; no extra
+// indexes today.
+
+import type { Collection, Db } from 'mongodb';
+
+import type { UserPreferences, UserPreferencesUpdate } from '@glaon/core/api-client';
+
+interface UserDoc {
+  _id: string;
+  preferences: UserPreferences;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DEFAULT_PREFERENCES: UserPreferences = { locale: null };
+
+export class UsersRepo {
+  private readonly collection: Collection<UserDoc>;
+
+  constructor(db: Db) {
+    this.collection = db.collection<UserDoc>('users');
+  }
+
+  async getPreferences(userId: string): Promise<UserPreferences> {
+    const doc = await this.collection.findOne({ _id: userId });
+    return doc === null
+      ? { ...DEFAULT_PREFERENCES }
+      : { ...DEFAULT_PREFERENCES, ...doc.preferences };
+  }
+
+  async updatePreferences(
+    userId: string,
+    patch: UserPreferencesUpdate,
+    now: Date,
+  ): Promise<UserPreferences> {
+    const set: Record<string, unknown> = { updatedAt: now };
+    for (const [key, value] of Object.entries(patch)) {
+      set[`preferences.${key}`] = value;
+    }
+    await this.collection.updateOne(
+      { _id: userId },
+      {
+        $set: set,
+        $setOnInsert: { _id: userId, createdAt: now },
+      },
+      { upsert: true },
+    );
+    return this.getPreferences(userId);
+  }
+}

--- a/apps/api/src/routes/me.test.ts
+++ b/apps/api/src/routes/me.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { decodeSecret, mintSessionJwt } from '../auth/jwt';
+import { InMemoryRevocationStore } from '../auth/revocation';
+import { InMemoryUsersRepo } from '../db/users-repo-fake';
+import { createMeRouter } from './me';
+
+const SECRET = decodeSecret('a'.repeat(32));
+
+async function withAuth(userId: string): Promise<{
+  router: ReturnType<typeof createMeRouter>;
+  repo: InMemoryUsersRepo;
+  authHeader: string;
+}> {
+  const repo = new InMemoryUsersRepo();
+  const revocations = new InMemoryRevocationStore();
+  const router = createMeRouter({
+    db: {} as never,
+    secret: SECRET,
+    revocations,
+    repo,
+    now: () => new Date('2026-05-10T00:00:00.000Z'),
+  });
+  const { jwt } = await mintSessionJwt(SECRET, { userId, ttlSeconds: 600 });
+  return { router, repo, authHeader: `Bearer ${jwt}` };
+}
+
+describe('GET /me/preferences', () => {
+  it('returns 401 without a session', async () => {
+    const { router } = await withAuth('user-1');
+    const res = await router.request('/preferences');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns the default preferences for a fresh user', async () => {
+    const { router, authHeader } = await withAuth('user-1');
+    const res = await router.request('/preferences', { headers: { Authorization: authHeader } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ locale: null });
+  });
+
+  it('returns the persisted locale once set', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.updatePreferences('user-1', { locale: 'tr' }, new Date());
+    const res = await router.request('/preferences', { headers: { Authorization: authHeader } });
+    expect(await res.json()).toEqual({ locale: 'tr' });
+  });
+
+  it("never surfaces another user's preferences", async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.updatePreferences('user-2', { locale: 'tr' }, new Date());
+    const res = await router.request('/preferences', { headers: { Authorization: authHeader } });
+    expect(await res.json()).toEqual({ locale: null });
+  });
+});
+
+describe('PATCH /me/preferences', () => {
+  it('returns 401 without a session', async () => {
+    const { router } = await withAuth('user-1');
+    const res = await router.request('/preferences', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ locale: 'tr' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('persists a supported locale and returns the next state', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    const res = await router.request('/preferences', {
+      method: 'PATCH',
+      headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ locale: 'tr' }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ locale: 'tr' });
+    expect(await repo.getPreferences('user-1')).toEqual({ locale: 'tr' });
+  });
+
+  it('clears the preference when locale is null', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    await repo.updatePreferences('user-1', { locale: 'tr' }, new Date());
+    const res = await router.request('/preferences', {
+      method: 'PATCH',
+      headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ locale: null }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ locale: null });
+    expect(await repo.getPreferences('user-1')).toEqual({ locale: null });
+  });
+
+  it('rejects an unsupported locale with 400', async () => {
+    const { router, repo, authHeader } = await withAuth('user-1');
+    const res = await router.request('/preferences', {
+      method: 'PATCH',
+      headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ locale: 'fr' }),
+    });
+    expect(res.status).toBe(400);
+    expect(await repo.getPreferences('user-1')).toEqual({ locale: null });
+  });
+
+  it('rejects unknown extra fields with 400 (strict)', async () => {
+    const { router, authHeader } = await withAuth('user-1');
+    const res = await router.request('/preferences', {
+      method: 'PATCH',
+      headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ locale: 'tr', theme: 'dark' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a non-JSON body with 400', async () => {
+    const { router, authHeader } = await withAuth('user-1');
+    const res = await router.request('/preferences', {
+      method: 'PATCH',
+      headers: { Authorization: authHeader, 'Content-Type': 'application/json' },
+      body: 'not-json',
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -1,0 +1,61 @@
+// `/me/*` endpoints (#425) — per-user metadata that survives sessions.
+//
+// Today's surface is `/me/preferences` only (locale persistence). Every
+// route is gated by `require-session`; the user id from the session JWT
+// is the sole filter on every database call — there is no "look up
+// another user's preferences" code path on the server.
+
+import { Hono } from 'hono';
+import type { Db } from 'mongodb';
+
+import {
+  UserPreferencesUpdateSchema,
+  type UserPreferences,
+  type UserPreferencesUpdate,
+} from '@glaon/core/api-client';
+
+import type { RevocationStore } from '../auth/revocation';
+import { UsersRepo } from '../db/users-repo';
+import { requireSession, type SessionVariables } from '../middleware/require-session';
+
+interface UsersRepoLike {
+  getPreferences(userId: string): Promise<UserPreferences>;
+  updatePreferences(
+    userId: string,
+    patch: UserPreferencesUpdate,
+    now: Date,
+  ): Promise<UserPreferences>;
+}
+
+interface MeRouterDeps {
+  readonly db: Db;
+  readonly secret: Uint8Array;
+  readonly revocations: RevocationStore;
+  readonly repo?: UsersRepoLike;
+  readonly now?: () => Date;
+}
+
+export function createMeRouter(deps: MeRouterDeps): Hono<{ Variables: SessionVariables }> {
+  const router = new Hono<{ Variables: SessionVariables }>();
+  const repo: UsersRepoLike = deps.repo ?? new UsersRepo(deps.db);
+  const now = deps.now ?? (() => new Date());
+
+  router.use('*', requireSession({ secret: deps.secret, revocations: deps.revocations }));
+
+  router.get('/preferences', async (c) => {
+    const preferences = await repo.getPreferences(c.get('userId'));
+    return c.json(preferences);
+  });
+
+  router.patch('/preferences', async (c) => {
+    const body: unknown = await c.req.json().catch(() => null);
+    const parsed = UserPreferencesUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid', code: 'bad-body' }, 400);
+    }
+    const next = await repo.updatePreferences(c.get('userId'), parsed.data, now());
+    return c.json(next);
+  });
+
+  return router;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -14,6 +14,7 @@ import { createLogger, type Logger } from './observability/logger';
 import { Metrics } from './observability/metrics';
 import { createAuthRouter } from './routes/auth';
 import { createLayoutsRouter } from './routes/layouts';
+import { createMeRouter } from './routes/me';
 
 export interface ServerDeps {
   readonly db: Db;
@@ -45,6 +46,8 @@ export function createServer(deps: ServerDeps): Hono {
   );
 
   app.route('/layouts', createLayoutsRouter({ db: deps.db, secret, revocations }));
+
+  app.route('/me', createMeRouter({ db: deps.db, secret, revocations }));
 
   // Liveness probe with Mongo ping. Returns 200 when the driver
   // command succeeds, 503 otherwise so a load balancer can drop the

--- a/packages/core/src/api-client/client.ts
+++ b/packages/core/src/api-client/client.ts
@@ -25,6 +25,12 @@ import {
   type UpdateLayoutRequest,
 } from './layouts';
 import {
+  UserPreferencesSchema,
+  UserPreferencesUpdateSchema,
+  type UserPreferences,
+  type UserPreferencesUpdate,
+} from './me';
+import {
   ApiErrorBodySchema,
   AuthExchangeRequestSchema,
   AuthExchangeResponseSchema,
@@ -127,11 +133,25 @@ export class ApiClient {
     await this.sendNoContent('DELETE', `/layouts/${encodeURIComponent(id)}`, null, options);
   }
 
+  /* -------- /me/preferences (#425) ------------------------------------ */
+
+  async getMyPreferences(options: RequestOptions = {}): Promise<UserPreferences> {
+    return this.send('GET', '/me/preferences', null, UserPreferencesSchema, options);
+  }
+
+  async updateMyPreferences(
+    body: UserPreferencesUpdate,
+    options: RequestOptions = {},
+  ): Promise<UserPreferences> {
+    const parsed = UserPreferencesUpdateSchema.parse(body);
+    return this.send('PATCH', '/me/preferences', parsed, UserPreferencesSchema, options);
+  }
+
   // The send() helper is `protected` so feature-specific subclasses (or
   // ad-hoc extensions in @glaon/core later) can add domain endpoints
   // without re-implementing the auth + parse + error pipeline.
   protected async send<TResponse>(
-    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
     path: string,
     body: unknown,
     responseSchema: z.ZodType<TResponse>,
@@ -189,7 +209,7 @@ export class ApiClient {
   // Content (DELETE /layouts/:id). We don't try to JSON-parse the body
   // and we tolerate any 2xx status.
   protected async sendNoContent(
-    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
     path: string,
     body: unknown,
     options: RequestOptions,

--- a/packages/core/src/api-client/index.ts
+++ b/packages/core/src/api-client/index.ts
@@ -35,3 +35,9 @@ export {
   type LayoutPayload,
   type UpdateLayoutRequest,
 } from './layouts';
+export {
+  UserPreferencesSchema,
+  UserPreferencesUpdateSchema,
+  type UserPreferences,
+  type UserPreferencesUpdate,
+} from './me';

--- a/packages/core/src/api-client/me.client.test.ts
+++ b/packages/core/src/api-client/me.client.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ApiClient } from './client';
+
+function makeFetch(
+  responder: (input: string, init?: RequestInit) => Response | Promise<Response>,
+): typeof fetch {
+  const impl = vi.fn(async (input: string, init?: RequestInit) => responder(input, init));
+  return impl as unknown as typeof fetch;
+}
+
+const BASE = 'https://api.glaon.test';
+
+describe('ApiClient — getMyPreferences', () => {
+  it('GETs /me/preferences and parses the response', async () => {
+    let captured: { url: string; init: RequestInit | undefined } | undefined;
+    const fetchImpl = makeFetch((url, init) => {
+      captured = { url, init };
+      return Promise.resolve(
+        new Response(JSON.stringify({ locale: 'tr' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+    const client = new ApiClient({
+      baseUrl: BASE,
+      fetchImpl,
+      getSessionJwt: () => 'session-jwt',
+    });
+    const result = await client.getMyPreferences();
+    expect(result).toEqual({ locale: 'tr' });
+    expect(captured?.url).toBe(`${BASE}/me/preferences`);
+    expect(captured?.init?.method).toBe('GET');
+    expect((captured?.init?.headers as Record<string, string>).Authorization).toBe(
+      'Bearer session-jwt',
+    );
+  });
+});
+
+describe('ApiClient — updateMyPreferences', () => {
+  it('PATCHes /me/preferences with the parsed body', async () => {
+    let captured: { url: string; init: RequestInit | undefined } | undefined;
+    const fetchImpl = makeFetch((url, init) => {
+      captured = { url, init };
+      return Promise.resolve(
+        new Response(JSON.stringify({ locale: 'tr' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    const result = await client.updateMyPreferences({ locale: 'tr' });
+    expect(result).toEqual({ locale: 'tr' });
+    expect(captured?.url).toBe(`${BASE}/me/preferences`);
+    expect(captured?.init?.method).toBe('PATCH');
+    expect(captured?.init?.body).toBe('{"locale":"tr"}');
+  });
+
+  it('rejects unsupported locales locally before sending', async () => {
+    const fetchImpl = makeFetch(() => new Response());
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await expect(client.updateMyPreferences({ locale: 'fr' as unknown as 'tr' })).rejects.toThrow();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects extra fields locally before sending (strict)', async () => {
+    const fetchImpl = makeFetch(() => new Response());
+    const client = new ApiClient({ baseUrl: BASE, fetchImpl });
+    await expect(
+      client.updateMyPreferences({ locale: 'tr', extra: 1 } as unknown as { locale: 'tr' }),
+    ).rejects.toThrow();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/api-client/me.test.ts
+++ b/packages/core/src/api-client/me.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { UserPreferencesSchema, UserPreferencesUpdateSchema } from './me';
+
+describe('UserPreferencesSchema', () => {
+  it('accepts a supported locale', () => {
+    expect(UserPreferencesSchema.parse({ locale: 'tr' })).toEqual({ locale: 'tr' });
+    expect(UserPreferencesSchema.parse({ locale: 'en' })).toEqual({ locale: 'en' });
+  });
+
+  it('accepts null (no preference)', () => {
+    expect(UserPreferencesSchema.parse({ locale: null })).toEqual({ locale: null });
+  });
+
+  it('rejects unsupported locales', () => {
+    expect(UserPreferencesSchema.safeParse({ locale: 'fr' }).success).toBe(false);
+    expect(UserPreferencesSchema.safeParse({ locale: 'TR' }).success).toBe(false);
+    expect(UserPreferencesSchema.safeParse({ locale: 'en-US' }).success).toBe(false);
+  });
+
+  it('requires the locale field to be present', () => {
+    expect(UserPreferencesSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe('UserPreferencesUpdateSchema', () => {
+  it('accepts a partial update with locale', () => {
+    expect(UserPreferencesUpdateSchema.parse({ locale: 'tr' })).toEqual({ locale: 'tr' });
+  });
+
+  it('accepts clearing the preference via null', () => {
+    expect(UserPreferencesUpdateSchema.parse({ locale: null })).toEqual({ locale: null });
+  });
+
+  it('accepts the empty object (no-op update)', () => {
+    expect(UserPreferencesUpdateSchema.parse({})).toEqual({});
+  });
+
+  it('rejects unsupported locales', () => {
+    expect(UserPreferencesUpdateSchema.safeParse({ locale: 'fr' }).success).toBe(false);
+  });
+
+  it('rejects unknown extra fields (strict)', () => {
+    expect(UserPreferencesUpdateSchema.safeParse({ locale: 'tr', extra: 1 }).success).toBe(false);
+  });
+});

--- a/packages/core/src/api-client/me.ts
+++ b/packages/core/src/api-client/me.ts
@@ -1,0 +1,26 @@
+// Per-user preferences (i18n-C / #425). The preferences document is the
+// long-lived companion to the per-session JWT: it follows the user across
+// devices and HA reinstalls (e.g. their chosen UI language).
+//
+// `locale` is intentionally typed as the closed `SupportedLocale` set
+// (mirrors `@glaon/core/i18n`). The server rejects anything outside the
+// set with a 400 — we don't store BCP-47 tags we can't actually render.
+
+import { z } from 'zod';
+
+import { SUPPORTED_LOCALES } from '../i18n/locale-negotiator';
+
+export const UserPreferencesSchema = z.object({
+  locale: z.enum(SUPPORTED_LOCALES).nullable(),
+});
+export type UserPreferences = z.infer<typeof UserPreferencesSchema>;
+
+export const UserPreferencesUpdateSchema = z
+  .object({
+    // `null` clears the preference; omitted leaves it untouched. Treating
+    // them as distinct lets the language switcher say "follow the
+    // device" without changing the rest of the document.
+    locale: z.enum(SUPPORTED_LOCALES).nullable().optional(),
+  })
+  .strict();
+export type UserPreferencesUpdate = z.infer<typeof UserPreferencesUpdateSchema>;


### PR DESCRIPTION
## Summary

Lands the persistence layer behind i18n-C: an apps/api `/me/preferences` surface that survives sessions and devices, plus the shared schemas + typed ApiClient methods that web/mobile consume from `@glaon/core/api-client`.

This is the second consumer beyond P2-D (auth bridge, #418) + P2-F (layouts, #420). The pattern (Zod schema in core → repo with `RepoLike` injection → router gated by `requireSession` → in-memory fake for unit tests + Mongo integration test) is now repeating, which is the point.

## Scope (In)

- `packages/core/src/api-client/me.ts` — `UserPreferencesSchema` + `UserPreferencesUpdateSchema` (closed `SupportedLocale` enum, `.strict()` on the patch shape).
- `apps/api/src/db/users-repo.ts` — Mongo repo on `users` collection. `getPreferences` returns defaults for unknown ids; `updatePreferences` upserts via `$set: { 'preferences.locale': ... }` so partial updates don't trample siblings.
- `apps/api/src/db/users-repo-fake.ts` — `InMemoryUsersRepo` mirroring the same surface.
- `apps/api/src/routes/me.ts` — `GET /me/preferences` + `PATCH /me/preferences` mounted at `/me`. Both gated by `requireSession`. PATCH `safeParse` failure returns the structured 400 envelope (`{ error: 'invalid', code: 'bad-body' }`).
- `apps/api/src/server.ts` — wires the new router.
- `ApiClient.getMyPreferences()` + `ApiClient.updateMyPreferences()` (same auth + parse + error pipeline as the layouts methods). `send()` widened to accept `'PATCH'`.
- Unit tests for schemas, ApiClient methods, and route behavior (auth, isolation, validation, partial-update semantics).
- Integration test (`users-repo.integration.test.ts`) gated by `GLAON_API_INTEGRATION=1`; runs in the existing `api-ci.yml` Mongo job.

## Scope (Out)

- **Web/mobile UI consumer wiring** — apps/web and apps/mobile don't yet have an apps/api session producer wired into their AuthProvider, and TanStack Query isn't installed in either app. The on-login fetch + language-switcher UI lands together with the apps/api session integration (separate follow-up under #392) and the i18n-G Storybook docs (#429).
- **HA profile language** — i18n-D / #426.
- **TR translation pass** — i18n-E / #427.

The locale negotiator (#424) already exposes the `explicit` slot at the top of its precedence chain, so once the consumer fetches `/me/preferences` and feeds the result through, no negotiator change is needed.

## Acceptance mapping

- "Logged-in user changes language → PATCH /me/preferences → DB updated → reload → language persists" — **server data path covered** (PATCH 200 + repo persists + GET returns new value, integration-tested). Switcher UI defers to i18n-G + session wiring.
- "Same user logs in on a second device → server-side preference applied automatically" — **server data path covered** (per-userId isolation + cross-process upsert). Client-side fetch defers to session wiring.
- "User without preference set → falls back to next layer in precedence chain" — covered by #424; `getPreferences` returns `{ locale: null }` for unknown users which the negotiator skips.
- "Invalid locale tag → 400 with structured error" — **covered** (test: `rejects an unsupported locale with 400`).
- "Logout clears the in-memory preference but DB record stays" — DB record stays by design (no DELETE path); in-memory clear is the AuthProvider's cleanup story (already handled by `clearAuth`).

## Test plan

- [x] `pnpm --filter @glaon/core test` (113 tests, +13 net) — all green
- [x] `pnpm --filter @glaon/api test` (83 tests, +10 net) — all green
- [x] `pnpm --filter @glaon/core type-check`
- [x] `pnpm --filter @glaon/api type-check` (`exactOptionalPropertyTypes` clean)
- [x] `pnpm --filter @glaon/core lint`
- [x] `pnpm --filter @glaon/api lint`
- [x] `pnpm --filter @glaon/core package-contract` — all subpaths green
- [x] `pnpm exec knip` — no new unused exports
- [ ] CI: api-ci.yml integration job runs `users-repo.integration.test.ts` against `mongo:7`

Closes #425
Refs #406 #424 #418 #420