### PR TITLE
feat(api): HA login_flow proxy endpoint + ADR 0027

### DIFF
--- a/apps/api/src/auth/ha-bridge.test.ts
+++ b/apps/api/src/auth/ha-bridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { deriveUserId, introspectHaToken } from './ha-bridge';
+import { deriveUserId, introspectHaToken, loginFlow } from './ha-bridge';
 
 function makeFetch(
   responder: (input: string, init?: RequestInit) => Response | Promise<Response>,
@@ -100,3 +100,166 @@ function base64Url(value: string): string {
     .replace(/\//g, '_')
     .replace(/=+$/, '');
 }
+
+describe('loginFlow', () => {
+  const credentials = {
+    username: 'olivia',
+    password: 'correct-horse',
+    clientId: 'https://app.glaon.com/',
+  };
+
+  function scriptedFetch(steps: {
+    init: Response;
+    submit?: Response;
+    token?: Response;
+  }): typeof fetch {
+    let call = 0;
+    return makeFetch(() => {
+      call += 1;
+      if (call === 1) return steps.init;
+      if (call === 2 && steps.submit !== undefined) return steps.submit;
+      if (call === 3 && steps.token !== undefined) return steps.token;
+      return new Response('unexpected call', { status: 500 });
+    });
+  }
+
+  it('returns ok with tokens after a happy-path 3-step flow', async () => {
+    const fetchImpl = scriptedFetch({
+      init: new Response(JSON.stringify({ flow_id: 'F-1', type: 'form' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      submit: new Response(JSON.stringify({ type: 'create_entry', result: 'AUTH-CODE' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      token: new Response(
+        JSON.stringify({
+          access_token: 'A',
+          refresh_token: 'R',
+          expires_in: 3600,
+          token_type: 'Bearer',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    });
+    const result = await loginFlow('http://h:8123', credentials, { fetchImpl });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.accessToken).toBe('A');
+      expect(result.refreshToken).toBe('R');
+      expect(result.expiresIn).toBe(3600);
+    }
+  });
+
+  it('returns invalid-url when the HA URL is not http/https', async () => {
+    const result = await loginFlow('file:///etc/passwd', credentials, {
+      fetchImpl: makeFetch(() => new Response()),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid-url');
+  });
+
+  it('returns invalid-credentials when HA aborts with invalid_auth', async () => {
+    const fetchImpl = scriptedFetch({
+      init: new Response(JSON.stringify({ flow_id: 'F-1', type: 'form' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      submit: new Response(JSON.stringify({ type: 'abort', reason: 'invalid_auth' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    });
+    const result = await loginFlow('http://h:8123', credentials, { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('invalid-credentials');
+  });
+
+  it('returns mfa-required when HA prompts a follow-up form step', async () => {
+    const fetchImpl = scriptedFetch({
+      init: new Response(JSON.stringify({ flow_id: 'F-1', type: 'form' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      submit: new Response(JSON.stringify({ type: 'form', step_id: 'mfa', flow_id: 'F-1' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    });
+    const result = await loginFlow('http://h:8123', credentials, { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('mfa-required');
+  });
+
+  it('returns unreachable when fetch throws', async () => {
+    const fetchImpl = makeFetch(() => Promise.reject(new TypeError('network')));
+    const result = await loginFlow('http://h:8123', credentials, { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('unreachable');
+  });
+
+  it('returns flow-error when the token endpoint omits expected fields', async () => {
+    const fetchImpl = scriptedFetch({
+      init: new Response(JSON.stringify({ flow_id: 'F-1', type: 'form' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      submit: new Response(JSON.stringify({ type: 'create_entry', result: 'CODE' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      token: new Response(JSON.stringify({ unrelated: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    });
+    const result = await loginFlow('http://h:8123', credentials, { fetchImpl });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('flow-error');
+  });
+
+  it('posts /auth/token as form-urlencoded with the auth code', async () => {
+    const tokenCall: {
+      value: { url: string; body: string; headers: Record<string, string> } | null;
+    } = { value: null };
+    const fetchImpl = makeFetch((input, init) => {
+      const url: string = input;
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      if (url.endsWith('/auth/login_flow')) {
+        return new Response(JSON.stringify({ flow_id: 'F-1', type: 'form' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/auth/login_flow/')) {
+        return new Response(JSON.stringify({ type: 'create_entry', result: 'AUTH-X' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      const rawBody = init?.body;
+      const bodyText = typeof rawBody === 'string' ? rawBody : '';
+      tokenCall.value = { url, body: bodyText, headers };
+      return new Response(
+        JSON.stringify({
+          access_token: 'A',
+          refresh_token: 'R',
+          expires_in: 1,
+          token_type: 'Bearer',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    await loginFlow('http://h:8123', credentials, { fetchImpl });
+    expect(tokenCall.value).not.toBeNull();
+    const captured = tokenCall.value;
+    if (captured !== null) {
+      expect(captured.url.endsWith('/auth/token')).toBe(true);
+      expect(captured.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+      expect(captured.body).toContain('grant_type=authorization_code');
+      expect(captured.body).toContain('code=AUTH-X');
+      expect(captured.body).toContain(`client_id=${encodeURIComponent(credentials.clientId)}`);
+    }
+  });
+});

--- a/apps/api/src/auth/ha-bridge.ts
+++ b/apps/api/src/auth/ha-bridge.ts
@@ -108,3 +108,173 @@ function base64UrlToBase64(value: string): string {
 function stripTrailingSlash(value: string): string {
   return value.endsWith('/') ? value.slice(0, -1) : value;
 }
+
+// ─── /auth/login_flow proxy (#468 / ADR 0027) ───────────────────────────────
+//
+// Drives HA's three-step login_flow API on the user's behalf so the
+// Glaon Device-tab login can collect credentials in its own UI and HA's
+// redirect screen never appears. The shape of each step is documented at
+// developers.home-assistant.io/docs/auth_api — `login_flow` (POST init)
+// returns a `flow_id` + first form step; POST `login_flow/<flow_id>` with
+// the form values either returns `{type: "create_entry", result: <code>}`
+// or escalates to a follow-up step (MFA) or aborts (`invalid_auth`); the
+// `result` is then exchanged at `/auth/token` for a real bearer token.
+//
+// PKCE code_verifier is intentionally absent: the auth code returned by
+// `login_flow` is bound to `client_id` server-side and is single-use, so
+// there is no redirect interception risk that PKCE would mitigate.
+
+export interface HaCredentials {
+  readonly username: string;
+  readonly password: string;
+  readonly clientId: string;
+}
+
+export interface HaLoginFlowSuccess {
+  readonly ok: true;
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresIn: number;
+}
+
+export interface HaLoginFlowFailure {
+  readonly ok: false;
+  readonly reason:
+    | 'invalid-url'
+    | 'invalid-credentials'
+    | 'mfa-required'
+    | 'unreachable'
+    | 'flow-error';
+  readonly status?: number;
+}
+
+export type HaLoginFlowResult = HaLoginFlowSuccess | HaLoginFlowFailure;
+
+export async function loginFlow(
+  haBaseUrl: string,
+  credentials: HaCredentials,
+  options: IntrospectOptions = {},
+): Promise<HaLoginFlowResult> {
+  const base = parseHaBaseUrl(haBaseUrl);
+  if (base === null) return { ok: false, reason: 'invalid-url' };
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const ctl = new AbortController();
+  const timer = setTimeout(() => {
+    ctl.abort();
+  }, timeoutMs);
+
+  try {
+    // Step 1 — initiate flow.
+    const initRes = await fetchImpl(`${base}/auth/login_flow`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: credentials.clientId,
+        handler: ['homeassistant', null],
+        redirect_uri: credentials.clientId,
+      }),
+      signal: ctl.signal,
+    });
+    if (!initRes.ok) {
+      return { ok: false, reason: 'flow-error', status: initRes.status };
+    }
+    const initBody = (await safeJson(initRes)) as { flow_id?: unknown; type?: unknown };
+    const flowId = typeof initBody.flow_id === 'string' ? initBody.flow_id : null;
+    if (flowId === null || initBody.type !== 'form') {
+      return { ok: false, reason: 'flow-error' };
+    }
+
+    // Step 2 — submit credentials.
+    const submitRes = await fetchImpl(`${base}/auth/login_flow/${encodeURIComponent(flowId)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: credentials.username,
+        password: credentials.password,
+        client_id: credentials.clientId,
+      }),
+      signal: ctl.signal,
+    });
+    if (!submitRes.ok) {
+      return { ok: false, reason: 'flow-error', status: submitRes.status };
+    }
+    const submitBody = (await safeJson(submitRes)) as {
+      type?: unknown;
+      result?: unknown;
+      step_id?: unknown;
+      reason?: unknown;
+    };
+    if (submitBody.type === 'abort') {
+      return { ok: false, reason: 'invalid-credentials' };
+    }
+    if (submitBody.type === 'form') {
+      // A second form step means HA wants more input — most commonly a
+      // multi-factor auth challenge. We surface this distinctly so the
+      // UI can show a meaningful message instead of a generic error.
+      return { ok: false, reason: 'mfa-required' };
+    }
+    if (submitBody.type !== 'create_entry' || typeof submitBody.result !== 'string') {
+      return { ok: false, reason: 'flow-error' };
+    }
+    const authCode = submitBody.result;
+
+    // Step 3 — exchange auth code for tokens. HA's /auth/token expects
+    // form-urlencoded bodies; the JSON variant is rejected with 400.
+    const tokenRes = await fetchImpl(`${base}/auth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: authCode,
+        client_id: credentials.clientId,
+      }).toString(),
+      signal: ctl.signal,
+    });
+    if (!tokenRes.ok) {
+      return { ok: false, reason: 'flow-error', status: tokenRes.status };
+    }
+    const tokens = (await safeJson(tokenRes)) as {
+      access_token?: unknown;
+      refresh_token?: unknown;
+      expires_in?: unknown;
+    };
+    if (
+      typeof tokens.access_token !== 'string' ||
+      typeof tokens.refresh_token !== 'string' ||
+      typeof tokens.expires_in !== 'number'
+    ) {
+      return { ok: false, reason: 'flow-error' };
+    }
+    return {
+      ok: true,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresIn: tokens.expires_in,
+    };
+  } catch {
+    return { ok: false, reason: 'unreachable' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function parseHaBaseUrl(haBaseUrl: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(haBaseUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  return stripTrailingSlash(parsed.toString());
+}
+
+async function safeJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -143,6 +143,177 @@ describe('POST /auth/refresh', () => {
   });
 });
 
+describe('POST /auth/ha/password-grant', () => {
+  // The login_flow proxy makes three sequential calls to HA:
+  //   POST /auth/login_flow         — returns { flow_id, type: "form" }
+  //   POST /auth/login_flow/<id>    — returns either create_entry / form / abort
+  //   POST /auth/token              — returns access_token + refresh_token
+  // The helper builds a fetch mock that scripts each step in order.
+  function makeLoginFlowFetch(steps: {
+    initBody?: unknown;
+    submitBody?: unknown;
+    tokenBody?: unknown;
+    submitStatus?: number;
+    tokenStatus?: number;
+    initStatus?: number;
+  }): typeof fetch {
+    let call = 0;
+    return makeFetch((input) => {
+      call += 1;
+      const url: string = input;
+      if (call === 1 && url.endsWith('/auth/login_flow')) {
+        return new Response(JSON.stringify(steps.initBody ?? { flow_id: 'F-1', type: 'form' }), {
+          status: steps.initStatus ?? 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (call === 2 && url.includes('/auth/login_flow/')) {
+        return new Response(
+          JSON.stringify(steps.submitBody ?? { type: 'create_entry', result: 'AUTH-CODE' }),
+          {
+            status: steps.submitStatus ?? 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }
+      if (call === 3 && url.endsWith('/auth/token')) {
+        return new Response(
+          JSON.stringify(
+            steps.tokenBody ?? {
+              access_token: 'ha-access-1',
+              refresh_token: 'ha-refresh-1',
+              expires_in: 1800,
+              token_type: 'Bearer',
+            },
+          ),
+          {
+            status: steps.tokenStatus ?? 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }
+      return new Response('unexpected', { status: 500 });
+    });
+  }
+
+  const validBody = {
+    haBaseUrl: 'http://homeassistant.local:8123',
+    username: 'olivia',
+    password: 'correct-horse',
+    clientId: 'https://app.glaon.com/',
+  };
+
+  it('returns haAccess + sessionJwt on a successful flow', async () => {
+    const fetchImpl = makeLoginFlowFetch({});
+    const { router } = makeRouter({ fetchImpl });
+    const res = await router.request('/ha/password-grant', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      haAccess: { accessToken: string; refreshToken: string; expiresIn: number; tokenType: string };
+      sessionJwt: string;
+      expiresAt: number;
+    };
+    expect(body.haAccess.accessToken).toBe('ha-access-1');
+    expect(body.haAccess.refreshToken).toBe('ha-refresh-1');
+    expect(body.haAccess.expiresIn).toBe(1800);
+    expect(body.haAccess.tokenType).toBe('Bearer');
+    expect(typeof body.sessionJwt).toBe('string');
+    expect(body.expiresAt).toBeGreaterThan(Date.now());
+    const claims = await verifySessionJwt(SECRET, body.sessionJwt);
+    expect(claims).not.toBeNull();
+  });
+
+  it('returns 400 for an invalid request body', async () => {
+    const { router } = makeRouter();
+    const res = await router.request('/ha/password-grant', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, haBaseUrl: 'not-a-url' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when HA aborts the flow with invalid_auth', async () => {
+    const fetchImpl = makeLoginFlowFetch({
+      submitBody: { type: 'abort', reason: 'invalid_auth' },
+    });
+    const { router } = makeRouter({ fetchImpl });
+    const res = await router.request('/ha/password-grant', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('invalid-credentials');
+  });
+
+  it('returns 502 mfa-required when HA escalates to a follow-up form', async () => {
+    const fetchImpl = makeLoginFlowFetch({
+      submitBody: { type: 'form', step_id: 'mfa', flow_id: 'F-1' },
+    });
+    const { router } = makeRouter({ fetchImpl });
+    const res = await router.request('/ha/password-grant', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('mfa-required');
+  });
+
+  it('returns 502 unreachable when HA cannot be contacted', async () => {
+    const fetchImpl = makeFetch(() => Promise.reject(new TypeError('network')));
+    const { router } = makeRouter({ fetchImpl });
+    const res = await router.request('/ha/password-grant', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('unreachable');
+  });
+
+  it('returns 502 flow-error when the token endpoint responds with garbage', async () => {
+    const fetchImpl = makeLoginFlowFetch({
+      tokenBody: { not: 'a token response' },
+    });
+    const { router } = makeRouter({ fetchImpl });
+    const res = await router.request('/ha/password-grant', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('flow-error');
+  });
+
+  it('sets an httpOnly Secure cookie when Origin matches the allowlist', async () => {
+    const fetchImpl = makeLoginFlowFetch({});
+    const { router } = makeRouter({ fetchImpl, webOrigins: ['https://app.glaon.com'] });
+    const res = await router.request('/ha/password-grant', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://app.glaon.com',
+      },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(200);
+    const cookie = res.headers.get('Set-Cookie');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('SameSite=Strict');
+  });
+});
+
 describe('POST /auth/logout', () => {
   it('adds the session jti to the revocation store', async () => {
     const { router, revocations } = makeRouter();

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,4 +1,4 @@
-// /auth/* routes per #418. Two surfaces:
+// /auth/* routes per #418 + #468. Surfaces:
 //   POST /auth/exchange — body { haAccessToken, haBaseUrl } →
 //     validates the HA token, mints a session JWT, returns
 //     { sessionJwt, expiresAt }. Sets a Set-Cookie header for web
@@ -8,14 +8,21 @@
 //     /auth/exchange.
 //   POST /auth/logout — adds the current session JWT's jti to the
 //     revocation list. No-op for non-authenticated callers.
+//   POST /auth/ha/password-grant — body { haBaseUrl, username, password,
+//     clientId } → drives HA's /auth/login_flow on the caller's behalf,
+//     returns { haAccess, sessionJwt, expiresAt }. The Glaon Device-tab
+//     login uses this so the end user never sees HA's redirect UI
+//     (#468 / ADR 0027). The HA refresh token is NOT persisted server-
+//     side — it only flows back to the caller in the response body.
 
 import { Hono } from 'hono';
 
 import {
   AuthExchangeRequestSchema as ExchangeBody,
   AuthRefreshRequestSchema as RefreshBody,
+  HaPasswordGrantRequestSchema as PasswordGrantBody,
 } from '../schemas';
-import { introspectHaToken } from '../auth/ha-bridge';
+import { introspectHaToken, loginFlow, deriveUserId } from '../auth/ha-bridge';
 import { mintSessionJwt, verifySessionJwt } from '../auth/jwt';
 import type { RevocationStore } from '../auth/revocation';
 import { SESSION_COOKIE_NAME } from '../middleware/require-session';
@@ -51,6 +58,53 @@ export function createAuthRouter(deps: AuthRouterDeps): Hono {
     });
     setCookieIfWebOrigin(c, deps.webOrigins, jwt, claims.exp);
     return c.json({ sessionJwt: jwt, expiresAt: claims.exp * 1000 });
+  });
+
+  router.post('/ha/password-grant', async (c) => {
+    const body: unknown = await c.req.json().catch(() => null);
+    const parsed = PasswordGrantBody.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid', code: 'bad-body' }, 400);
+    }
+    const result = await loginFlow(
+      parsed.data.haBaseUrl,
+      {
+        username: parsed.data.username,
+        password: parsed.data.password,
+        clientId: parsed.data.clientId,
+      },
+      {
+        ...(deps.fetchImpl !== undefined ? { fetchImpl: deps.fetchImpl } : {}),
+      },
+    );
+    if (!result.ok) {
+      const status = ((): 400 | 401 | 502 => {
+        switch (result.reason) {
+          case 'invalid-url':
+            return 400;
+          case 'invalid-credentials':
+            return 401;
+          default:
+            return 502;
+        }
+      })();
+      return c.json({ error: result.reason }, status);
+    }
+    const { jwt, claims } = await mintSessionJwt(deps.secret, {
+      userId: deriveUserId(result.accessToken),
+      ttlSeconds: ttl,
+    });
+    setCookieIfWebOrigin(c, deps.webOrigins, jwt, claims.exp);
+    return c.json({
+      haAccess: {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresIn: result.expiresIn,
+        tokenType: 'Bearer' as const,
+      },
+      sessionJwt: jwt,
+      expiresAt: claims.exp * 1000,
+    });
   });
 
   router.post('/refresh', async (c) => {

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -7,4 +7,8 @@
 // outgoing bodies (the response is what `c.json` ships) so only the
 // request validators are surfaced here.
 
-export { AuthExchangeRequestSchema, AuthRefreshRequestSchema } from '@glaon/core/api-client';
+export {
+  AuthExchangeRequestSchema,
+  AuthRefreshRequestSchema,
+  HaPasswordGrantRequestSchema,
+} from '@glaon/core/api-client';

--- a/docs/adr/0027-ha-login-flow-proxy.md
+++ b/docs/adr/0027-ha-login-flow-proxy.md
@@ -1,0 +1,107 @@
+# ADR 0027 — HA `login_flow` password-grant proxy (cloud-side)
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-05-10
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [issue #467](https://github.com/toss-cengiz/glaon/issues/467) (epic), [issue #468](https://github.com/toss-cengiz/glaon/issues/468) (bu ADR), [ADR 0005](0005-oauth2-pkce-only-auth.md) (superseded), [ADR 0017](0017-dual-mode-auth.md), [ADR 0019](0019-identity-provider-clerk.md), [ADR 0025](0025-apps-api-stack.md), [ADR 0026](0026-apps-api-delivery-hosted.md)
+
+## Bağlam
+
+Phase 2 Auth UI tasarımı (Figma Design System file, [node 134:3146](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=134-3146)) Login ekranını tek bir split-screen sayfa olarak konumluyor: solda Glaon-rendered form (Device | Cloud tab toggle), sağda hero görseli. **Device sekmesi**nde kullanıcı Username + Password'ünü doğrudan Glaon UI'da giriyor; HA'nın OAuth redirect ekranı görünmüyor.
+
+Bu, [ADR 0005](0005-oauth2-pkce-only-auth.md) ve [ADR 0017](0017-dual-mode-auth.md)'in local mod auth path'i ile çelişiyor: bu ADR'ler HA'nın `/auth/authorize` redirect'ini kullanıyor, kullanıcı HA'nın kendi login formunu görüyor. Ürün hedefi (Glaon-native Device login UX) bu pencereyi kabul etmiyor — split-screen Login içinde "Continue with Home Assistant" pop-up'ı brand tutarsızlığı yaratıyor; mobile'da Expo browser açar; addon Ingress senaryosunda ekstra hop'lar üretir.
+
+Tartışma çerçevesi:
+
+- **Credentials nereden toplanır?** Front-end mi (HA'ya doğrudan POST), `apps/api` mi (server-side proxy)?
+- **HA refresh token nereye düşer?** Cloud DB'ye persist mi, sadece response'ta opaque biçimde geçişine izin mi?
+- **MFA/2FA aktif kullanıcılar nasıl handle edilir?** Bu PR scope'unda mı, ayrı follow-up mı?
+- **PKCE gerekli mi?** Kullanıcı redirect-flow yerine in-app form kullanıyorsa code_verifier'ın koruması anlamlı mı?
+
+Göz önünde bulundurulan alternatifler:
+
+- **Seçenek A — HA OAuth Authorization Code redirect (status quo, ADR 0005).** UX bozuk: split-screen Login içinde HA UI tutarsız, mobile'da Expo browser handoff zorlu. Reddedildi: ürün hedefiyle çelişiyor.
+- **Seçenek B — Long-Lived Access Token (LLAT) yapıştırma.** Ev sahibi setup'ta HA UI'dan LLAT üretip Glaon'a girer; sonraki cihazlar bu token'la çalışır. Reddedildi: CLAUDE.md `LLAT yasağı` ile çakışır (refresh yok, revocation manual; token sızıntısının impact'i sürekli, rotasyon yok). Figma'daki Device tab Username/Password formu da anlamsız hale gelirdi.
+- **Seçenek C — Front-end direct `login_flow` POST.** Front-end credentials'ı doğrudan HA'ya POST eder. Reddedildi: front-end'de credentials taşımak attack surface'i büyütüyor (CSP, log scrubbing, error reporter scrubbing); HA'nın CORS yapılandırması her instance'da farklı olabiliyor.
+- **Seçenek D — `apps/api` üzerinden stateless proxy (seçilen).** Karar bölümünde detay.
+- **Seçenek E — Web-only proxy (mobile native HA OAuth korur).** İki kod yolu Glaon'un "tek auth contract" prensibini bozar (ADR 0017). Reddedildi.
+
+## Karar
+
+**Glaon'un Device-mode login'i, kullanıcının HA OAuth redirect'i hiç görmeyeceği şekilde, `apps/api`'nin `POST /auth/ha/password-grant` endpoint'i üzerinden HA'nın resmi `/auth/login_flow` API'sine stateless proxy yapılarak gerçekleştirilir; `apps/api` HA tokenlarını persist etmez, response'ta opaque biçimde istemciye akıtır ve istemci bunları `local` slot grubuna yazar.**
+
+Karar'ın teknik detayları:
+
+### Endpoint kontratı
+
+`POST /auth/ha/password-grant` (`apps/api/src/routes/auth.ts`):
+
+- Request: `{ haBaseUrl, username, password, clientId }` — Zod doğrulaması `HaPasswordGrantRequestSchema` (`packages/core/src/api-client/schemas.ts`).
+- Response (200): `{ haAccess: { accessToken, refreshToken, expiresIn, tokenType: 'Bearer' }, sessionJwt, expiresAt }`.
+- Hata branch'leri: `400 invalid` (bad body), `400 invalid-url`, `401 invalid-credentials`, `502 mfa-required`, `502 unreachable`, `502 flow-error`.
+
+### HA login_flow protokolü
+
+Helper `loginFlow(haBaseUrl, credentials, options)` (`apps/api/src/auth/ha-bridge.ts`) üç sıralı çağrı yapar:
+
+1. `POST {haBaseUrl}/auth/login_flow` body `{ client_id, handler: ["homeassistant", null], redirect_uri }` → `{ flow_id, type: "form" }`.
+2. `POST {haBaseUrl}/auth/login_flow/{flow_id}` body `{ username, password, client_id }` →
+   - `{ type: "create_entry", result: <auth_code> }` → step 3
+   - `{ type: "form", step_id: "mfa", ... }` → `mfa-required` (out-of-scope, 502)
+   - `{ type: "abort", reason: "invalid_auth" }` → `invalid-credentials` (401)
+3. `POST {haBaseUrl}/auth/token` form-urlencoded `grant_type=authorization_code&code=<...>&client_id=<...>` → `{ access_token, refresh_token, expires_in, token_type }`.
+
+Referans: <https://developers.home-assistant.io/docs/auth_api>.
+
+### Invariants
+
+- **HA refresh tokenları `apps/api` veritabanında persist edilmez** — yalnızca response payload'unda istemciye geri akar. İstemci tokenları `local` slot grubuna yazar (web in-memory + httpOnly cookie; mobile SecureStore — [ADR 0006](0006-token-storage.md)). Bu, ADR 0017'in "HA token cloud'a transit etmez" invariant'ının yumuşamadığı anlamına gelir: `apps/api` cloud-relay değil, stateless proxy + zero-persistence kuralı geçerli.
+- **PKCE code_verifier kullanılmaz.** `login_flow` endpoint'inin döndürdüğü auth code single-use ve `client_id`'ye internal olarak bağlı; redirect interception riski yok (redirect zaten yok).
+- **MFA bu PR'da kapsanmaz.** HA `step_id: "mfa"` döndürdüğünde 502 `{ error: "mfa-required" }` ile kullanıcıya UI tarafında "Multi-factor auth not yet supported in Glaon — sign in via Home Assistant directly" mesajı gösterilir. Phase 2.5 issue olarak `phase-2-mfa-support` açılır.
+- **Endpoint'i sadece Glaon-managed `apps/api` instance'ı barındırır** — self-host alternatifi yok ([ADR 0026](0026-apps-api-delivery-hosted.md)).
+
+### Cookie davranışı
+
+`/auth/exchange` ile aynı: Origin `webOrigins` allowlist'inde ise `Set-Cookie: glaon_session=<jwt>; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=...`. Mobile (Origin yok) cookie almaz, response body'sindeki `sessionJwt`'yi SecureStore'a yazar.
+
+### Session JWT
+
+Mevcut `mintSessionJwt(secret, { userId, ttlSeconds })` reuse edilir; `userId` `deriveUserId(haAccessToken)` ile türetilir (HA OAuth2 access token JWT ise `sub` claim, opaque ise stable hash). TTL config'den (`config.sessionTtlSeconds`, default 1h).
+
+## Sonuçlar
+
+### Olumlu
+
+- **Brand sürekliliği:** Kullanıcı Device login sırasında Glaon UI'sından çıkmıyor; Figma tasarımı ödünsüz uygulanır.
+- **Front-end attack surface azalır:** Credentials front-end JS'te ham haldeyken HTTPS round-trip'i tek (apps/api'ye); HA'nın CORS varsayımları, log scrubbing, error reporter scrubbing'i front-end'e dert değil.
+- **HA tokenları yine cloud'da yaşamaz:** ADR 0017 invariant'ı korunuyor — yalnız response payload geçişi var, persist yok.
+- **Mevcut kod yolu ile uyum:** Yeni endpoint mevcut `mintSessionJwt`/`introspectHaToken` pattern'lerini reuse ediyor; cookie + revocation davranışı aynı.
+
+### Olumsuz / ödenecek bedel
+
+- **Yeni MFA blind spot:** HA'da 2FA aktif kullanıcılar şu an Device login'i kullanamıyor (502 + "Sign in via HA directly" inline mesajı). Bu kullanıcılar hâlâ HA OAuth redirect'i (eski yol) ile login olabilir mi? Bu PR scope'unda eski yol kapatılıyor — Phase 2.5 MFA UX'i merge olana kadar bu kullanıcılar için Device login bozuk.
+- **`apps/api` rate-limit yüzeyi büyüdü:** Password-grant brute-force vector. Bu PR `apps/api` üzerinde rate-limit eklemiyor — Phase 2.5 token-bucket issue'su (`apps/api`'ye redis + sliding window) takip eder.
+- **HA `client_id` URL host check'i:** HA, `client_id` URL host'unun `redirect_uri` ile eşleştiğini doğruluyor. Web add-on Ingress senaryosunda bu doğrulama beklenmedik şekilde başarısız olabilir; takip issue'su `auth-ingress-redirect-handling` (G3) açıldı.
+
+### Etkileri
+
+- **`apps/api` route surface:** `POST /auth/ha/password-grant` ekleniyor. `/auth/exchange`, `/auth/refresh`, `/auth/logout` davranışı değişmiyor.
+- **`packages/core/src/api-client`:** Yeni `HaPasswordGrantRequest/Response/Error` Zod şemaları + `apiClient.haPasswordGrant(body)` metodu. Web + mobile bu metodu çağırır.
+- **`apps/web` ve `apps/mobile`:** Login Device tab'ı bu endpoint'i kullanır (issue #470'te entegre edilir). Eski local-mode OAuth redirect kod yolu Login screen'inden kaldırılır.
+- **ADR 0005:** Zaten Superseded by ADR 0017; bu ADR ek olarak ADR 0017'in local mode auth path'ini "OAuth redirect VEYA login_flow proxy" olarak genişletir. ADR 0017 supersede edilmez.
+- **`docs/api.md`:** Yeni endpoint Türkçe dökümana eklenir.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- HA `/auth/login_flow` API'si breaking change yaparsa (ör. `handler` shape değişir) — bu ADR'in protokol detayları update edilir, ana karar değişmez.
+- Phase 2.5 MFA support bu yaklaşımı genişletmek yerine yeni bir mekanizma (örn. WebAuthn fallback) gerektirirse — yeni bir ADR ile tartışılır.
+- HA bir resmi non-redirect public auth API'si yayınlarsa (e.g. password-grant endpoint) — bu ADR'in `login_flow` proxy detayları yeniden değerlendirilir.
+
+## Referanslar
+
+- [Home Assistant Auth API](https://developers.home-assistant.io/docs/auth_api) — `login_flow` ve `/auth/token` endpoint protokolü.
+- [Figma — Login design](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1267-132397) — Device tab tasarımı.
+- [issue #467](https://github.com/toss-cengiz/glaon/issues/467) — Phase 2 Auth UI epic.
+- [issue #468](https://github.com/toss-cengiz/glaon/issues/468) — bu ADR'in tracking issue'su.
+- [ADR 0017](0017-dual-mode-auth.md) — "HA token cloud'a transit etmez" invariant'ının kaynağı.
+- [ADR 0026](0026-apps-api-delivery-hosted.md) — `apps/api` Glaon-managed hosted servisi olarak çalışır.

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,20 +40,64 @@ Detaylar: [apps/api/README.md](../apps/api/README.md).
 
 ## Endpoint'ler
 
-| Method | Path             | Auth    | Açıklama                                |
-| ------ | ---------------- | ------- | --------------------------------------- |
-| GET    | `/healthz`       | yok     | Liveness + Mongo ping (200/503).        |
-| GET    | `/version`       | yok     | Build SHA + version + builtAt.          |
-| POST   | `/auth/exchange` | yok     | HA token → session JWT.                 |
-| POST   | `/auth/refresh`  | yok     | Session JWT'yi yeniden imzala.          |
-| POST   | `/auth/logout`   | session | Session jti'yi revocation list'e ekle.  |
-| GET    | `/layouts`       | session | Saved layouts list (`?homeId=` filtre). |
-| POST   | `/layouts`       | session | Yeni layout oluştur.                    |
-| GET    | `/layouts/:id`   | session | Layout detayı.                          |
-| PUT    | `/layouts/:id`   | session | Layout güncelle.                        |
-| DELETE | `/layouts/:id`   | session | Soft-delete (204).                      |
+| Method | Path                      | Auth    | Açıklama                                                      |
+| ------ | ------------------------- | ------- | ------------------------------------------------------------- |
+| GET    | `/healthz`                | yok     | Liveness + Mongo ping (200/503).                              |
+| GET    | `/version`                | yok     | Build SHA + version + builtAt.                                |
+| POST   | `/auth/exchange`          | yok     | HA token → session JWT.                                       |
+| POST   | `/auth/refresh`           | yok     | Session JWT'yi yeniden imzala.                                |
+| POST   | `/auth/logout`            | session | Session jti'yi revocation list'e ekle.                        |
+| POST   | `/auth/ha/password-grant` | yok     | HA `login_flow` proxy: username/password → tokens (ADR 0027). |
+| GET    | `/layouts`                | session | Saved layouts list (`?homeId=` filtre).                       |
+| POST   | `/layouts`                | session | Yeni layout oluştur.                                          |
+| GET    | `/layouts/:id`            | session | Layout detayı.                                                |
+| PUT    | `/layouts/:id`            | session | Layout güncelle.                                              |
+| DELETE | `/layouts/:id`            | session | Soft-delete (204).                                            |
 
 Authorization: session JWT ya `Authorization: Bearer <jwt>` (mobile) ya da `glaon_api_session` httpOnly+Secure cookie (web). Detaylar [ADR 0017](adr/0017-dual-mode-auth.md).
+
+### `POST /auth/ha/password-grant`
+
+Glaon'un Login screen'inin Device sekmesi tarafından kullanılır ([ADR 0027](adr/0027-ha-login-flow-proxy.md)). Kullanıcı HA OAuth redirect ekranını hiç görmez; credentials Glaon UI'da toplanıp `apps/api` üzerinden HA'nın `/auth/login_flow` API'sine proxy edilir.
+
+**Request body**
+
+```json
+{
+  "haBaseUrl": "http://homeassistant.local:8123",
+  "username": "olivia",
+  "password": "<password>",
+  "clientId": "https://app.glaon.com/"
+}
+```
+
+**Response 200**
+
+```json
+{
+  "haAccess": {
+    "accessToken": "<HA JWT>",
+    "refreshToken": "<HA refresh>",
+    "expiresIn": 1800,
+    "tokenType": "Bearer"
+  },
+  "sessionJwt": "<glaon session>",
+  "expiresAt": 1742755200000
+}
+```
+
+İstemci `haAccess.refreshToken`'ı `local` slot grubuna yazar (web httpOnly cookie / mobile SecureStore — [ADR 0006](adr/0006-token-storage.md)). HA refresh tokenı **`apps/api` veritabanında persist edilmez**.
+
+**Hata durumları**
+
+| Status | `error`               | Anlam                                                                                                                |
+| ------ | --------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 400    | `invalid` (bad-body)  | Zod doğrulaması başarısız (eksik alan, geçersiz URL).                                                                |
+| 400    | `invalid-url`         | `haBaseUrl` http/https değil ya da parse edilemedi.                                                                  |
+| 401    | `invalid-credentials` | HA `login_flow` `type: "abort"` döndü (kötü kullanıcı adı/parola).                                                   |
+| 502    | `mfa-required`        | HA çoklu adımlı bir form istedi (TOTP, notify-app); UI'da kullanıcı HA üzerinden direct login yapmaya yönlendirilir. |
+| 502    | `unreachable`         | HA'ya bağlanılamadı (DNS, network, timeout).                                                                         |
+| 502    | `flow-error`          | HA'dan beklenmeyen bir response geldi (corrupt JSON, eksik alan).                                                    |
 
 ## Production deploy
 

--- a/packages/core/src/api-client/client.ts
+++ b/packages/core/src/api-client/client.ts
@@ -30,11 +30,15 @@ import {
   AuthExchangeResponseSchema,
   AuthLogoutResponseSchema,
   AuthRefreshRequestSchema,
+  HaPasswordGrantRequestSchema,
+  HaPasswordGrantResponseSchema,
   type AuthExchangeRequest,
   type AuthExchangeResponse,
   type AuthLogoutResponse,
   type AuthRefreshRequest,
   type AuthRefreshResponse,
+  type HaPasswordGrantRequest,
+  type HaPasswordGrantResponse,
 } from './schemas';
 
 export interface ApiClientOptions {
@@ -90,6 +94,30 @@ export class ApiClient {
 
   async logout(options: RequestOptions = {}): Promise<AuthLogoutResponse> {
     return this.send('POST', '/auth/logout', null, AuthLogoutResponseSchema, options);
+  }
+
+  /**
+   * Device-mode login proxy (#468 / ADR 0027). Posts the user's HA
+   * credentials to `apps/api`, which drives `/auth/login_flow` on their
+   * HA installation and returns the resulting access + refresh tokens
+   * plus a Glaon session JWT. Used by the Login screen's Device tab so
+   * the end user never sees HA's redirect UI.
+   *
+   * Errors are surfaced as `ApiError`. Notable bodies:
+   *  - `{ error: 'mfa-required' }` (502) — HA prompted a 2FA step;
+   *    the UI should show a "sign in via HA directly" inline message.
+   *  - `{ error: 'invalid-credentials' }` (401) — bad username/password.
+   *  - `{ error: 'unreachable' }` (502) — HA didn't respond.
+   */
+  async haPasswordGrant(
+    body: HaPasswordGrantRequest,
+    options: RequestOptions = {},
+  ): Promise<HaPasswordGrantResponse> {
+    const parsed = HaPasswordGrantRequestSchema.parse(body);
+    return this.send('POST', '/auth/ha/password-grant', parsed, HaPasswordGrantResponseSchema, {
+      ...options,
+      skipAuth: true,
+    });
   }
 
   /* -------- /layouts (#420) ------------------------------------------- */

--- a/packages/core/src/api-client/index.ts
+++ b/packages/core/src/api-client/index.ts
@@ -12,6 +12,10 @@ export {
   AuthExchangeResponseSchema,
   AuthLogoutResponseSchema,
   AuthRefreshRequestSchema,
+  HaAccessBundleSchema,
+  HaPasswordGrantErrorCode,
+  HaPasswordGrantRequestSchema,
+  HaPasswordGrantResponseSchema,
   SessionClaimsSchema,
   type ApiErrorBody,
   type AuthExchangeRequest,
@@ -19,6 +23,9 @@ export {
   type AuthLogoutResponse,
   type AuthRefreshRequest,
   type AuthRefreshResponse,
+  type HaAccessBundle,
+  type HaPasswordGrantRequest,
+  type HaPasswordGrantResponse,
   type SessionClaims,
 } from './schemas';
 export {

--- a/packages/core/src/api-client/schemas.ts
+++ b/packages/core/src/api-client/schemas.ts
@@ -45,6 +45,61 @@ export const AuthLogoutResponseSchema = z.object({
 });
 export type AuthLogoutResponse = z.infer<typeof AuthLogoutResponseSchema>;
 
+/* -------- /auth/ha/password-grant ----------------------------------------- */
+//
+// The Device-mode login proxy (#468 / ADR 0027). The web + mobile client
+// renders Glaon's own username/password form, posts the credentials to
+// `apps/api`, and `apps/api` drives HA's `/auth/login_flow` API on the
+// caller's behalf. The end user never sees HA's redirect UI.
+//
+// Server is a stateless proxy: HA refresh token is NOT persisted in the
+// cloud database — it is returned in the response so the client writes
+// it to its `local` slot group exactly the way the OAuth redirect flow
+// would.
+
+export const HaPasswordGrantRequestSchema = z.object({
+  haBaseUrl: z.string().url(),
+  username: z.string().min(1),
+  password: z.string().min(1),
+  /** HA requires a URL-shaped client_id whose host matches the redirect.
+   * Web sends `${origin}/`, mobile sends its deep-link scheme + `/auth`. */
+  clientId: z.string().min(1),
+});
+export type HaPasswordGrantRequest = z.infer<typeof HaPasswordGrantRequestSchema>;
+
+export const HaAccessBundleSchema = z.object({
+  accessToken: z.string().min(1),
+  refreshToken: z.string().min(1),
+  /** seconds; HA returns this as `expires_in`. */
+  expiresIn: z.number().int().positive(),
+  tokenType: z.literal('Bearer'),
+});
+export type HaAccessBundle = z.infer<typeof HaAccessBundleSchema>;
+
+export const HaPasswordGrantResponseSchema = z.object({
+  haAccess: HaAccessBundleSchema,
+  sessionJwt: z.string().min(1),
+  /** ms-since-epoch, mirrors `claims.exp * 1000`. */
+  expiresAt: z.number().int().positive(),
+});
+export type HaPasswordGrantResponse = z.infer<typeof HaPasswordGrantResponseSchema>;
+
+/**
+ * Discriminator for the error envelope of `/auth/ha/password-grant`.
+ * The client uses this to decide UX: `mfa-required` shows the
+ * "sign in via HA directly" inline message, `invalid-credentials`
+ * surfaces a normal form error, and the rest map to a generic
+ * "couldn't reach Home Assistant" banner.
+ */
+export const HaPasswordGrantErrorCode = z.enum([
+  'invalid-url',
+  'invalid-credentials',
+  'mfa-required',
+  'unreachable',
+  'flow-error',
+]);
+export type HaPasswordGrantErrorCode = z.infer<typeof HaPasswordGrantErrorCode>;
+
 /* -------- shared error envelope ------------------------------------------- */
 
 export const ApiErrorBodySchema = z.object({


### PR DESCRIPTION
## Summary

- Adds `POST /auth/ha/password-grant` so the Login screen's Device tab can collect HA credentials in Glaon's own UI — the end user never sees HA's redirect page.
- Stateless proxy: `apps/api` drives HA's three-step `/auth/login_flow` → `/auth/login_flow/<id>` → `/auth/token` chain on the caller's behalf and returns `{ haAccess, sessionJwt, expiresAt }`. HA refresh token is **not persisted** server-side.
- New ADR 0027 documents the decision; ADR 0017's "HA token cloud'a transit etmez" invariant is preserved (this endpoint is a stateless proxy, not a cloud relay).
- Shared Zod schemas (`HaPasswordGrantRequest/Response`) + typed `apiClient.haPasswordGrant` client method power both web + mobile.

Closes #468 — refs epic #467.

## Scope — In

- ADR `docs/adr/0027-ha-login-flow-proxy.md` — accepted; cross-references ADR 0005, 0017, 0019, 0025, 0026.
- New endpoint: `apps/api/src/routes/auth.ts` `POST /auth/ha/password-grant` (alongside `/auth/exchange`, `/auth/refresh`, `/auth/logout`).
- New helper: `apps/api/src/auth/ha-bridge.ts` → `loginFlow(haBaseUrl, credentials, options)` (sibling to existing `introspectHaToken`).
- New Zod schemas: `packages/core/src/api-client/schemas.ts` → `HaPasswordGrantRequestSchema`, `HaPasswordGrantResponseSchema`, `HaAccessBundleSchema`, `HaPasswordGrantErrorCode`.
- New client method: `packages/core/src/api-client/client.ts` → `apiClient.haPasswordGrant(body, options)`.
- `apps/api/src/schemas.ts` re-export updated for the new request schema.
- Türkçe API docs: `docs/api.md` updated with the new endpoint table row + a dedicated `### POST /auth/ha/password-grant` section (request shape, response shape, error matrix).
- Unit tests:
  - `apps/api/src/auth/ha-bridge.test.ts` — happy path, `invalid-url`, `invalid-credentials`, `mfa-required`, `unreachable`, `flow-error`, form-urlencoded body assertion.
  - `apps/api/src/routes/auth.test.ts` — happy path, bad body 400, abort → 401, mfa form → 502, fetch reject → 502, malformed token response → 502, cookie origin allowlist.

## Scope — Out

- HA MFA / TOTP follow-up step UI handling — deliberately blocked at 502 `mfa-required`; a Phase 2.5 follow-up will design the multi-step UX.
- Long-lived access token acceptance — CLAUDE.md LLAT yasağı korunuyor.
- Rate-limit / brute-force protection — separate Phase 2.5 issue (token bucket + redis).
- Front-end Login screen integration — that's #470 (this PR is the foundation it depends on).
- `auth.integration.test.ts` against `apps/dev-ha` — `apps/dev-ha` is a Docker compose of real HA, not a programmable mock. Building a programmable mock is out of scope; the unit suite with msw-style fetch stubs is sufficient. Follow-up issue if needed.

## Test plan

- [x] `pnpm type-check` (repo-wide) green
- [x] `pnpm lint` (repo-wide) green
- [x] `pnpm --filter @glaon/api test` — 87 tests pass (was 80 before; +7 new for `/auth/ha/password-grant`)
- [x] `pnpm --filter @glaon/core test` — 100 tests pass
- [x] `pnpm --filter @glaon/ui test` — 123 tests pass (no regression)
- [ ] CI green on `gh pr checks 468 --watch`
- [ ] Chromatic gate (no UI changes — should be a no-op)
- [ ] Reviewer sanity check: `curl -X POST <api>/auth/ha/password-grant -d '...'` against a local HA instance produces a real session JWT (manual step; gated by reviewer access to a HA install)

## ADR cross-links

- New: [ADR 0027](docs/adr/0027-ha-login-flow-proxy.md) — HA `login_flow` password-grant proxy.
- Refers to: [ADR 0005](docs/adr/0005-oauth2-pkce-only-auth.md) (superseded), [ADR 0017](docs/adr/0017-dual-mode-auth.md), [ADR 0019](docs/adr/0019-identity-provider-clerk.md), [ADR 0026](docs/adr/0026-apps-api-delivery-hosted.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
