### PR TITLE
chore(i18n): turkish copy + wire mode-select shell to t() (i18n-E)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,5 +1,6 @@
 import { StatusBar } from 'expo-status-bar';
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { AuthProvider, useAuth } from './src/auth/auth-provider';
@@ -55,6 +56,7 @@ function CloudSessionBridge(): ReactNode {
 }
 
 function Root(): ReactNode {
+  const { t } = useTranslation();
   const { mode, clearAuth } = useAuth();
   const clerkKey = getClerkPublishableKey();
   const baseConfig = useMemo<LocalAuthFlowConfig>(
@@ -111,16 +113,16 @@ function Root(): ReactNode {
       if (clerkKey === null) {
         return (
           <View style={styles.cloudUnavailable} testID="cloud-unavailable">
-            <Text style={styles.title}>Cloud sign-in unavailable</Text>
-            <Text style={styles.body}>
-              EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY is not configured for this build.
-            </Text>
+            <Text style={styles.title}>{t('cloudUnavailable.signInTitle')}</Text>
+            <Text style={styles.body}>{t('cloudUnavailable.body')}</Text>
             <Pressable
               testID="switch-mode"
               onPress={() => void switchMode()}
               style={styles.switchModeButton}
             >
-              <Text style={styles.switchModeButtonText}>Pick a different mode</Text>
+              <Text style={styles.switchModeButtonText}>
+                {t('cloudUnavailable.pickDifferentMode')}
+              </Text>
             </Pressable>
             <StatusBar style="auto" />
           </View>
@@ -152,16 +154,15 @@ interface SignedInShellProps {
 }
 
 function SignedInShell({ switchMode, clerkKey }: SignedInShellProps): ReactNode {
+  const { t } = useTranslation();
   const [view, setView] = useState<'home' | 'pair-wizard'>('home');
 
   if (view === 'pair-wizard') {
     if (clerkKey === null) {
       return (
         <View style={styles.cloudUnavailable}>
-          <Text style={styles.title}>Cloud pairing unavailable</Text>
-          <Text style={styles.body}>
-            EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY is not configured for this build.
-          </Text>
+          <Text style={styles.title}>{t('cloudUnavailable.pairingTitle')}</Text>
+          <Text style={styles.body}>{t('cloudUnavailable.body')}</Text>
           <Pressable
             testID="pair-wizard-cancel"
             onPress={() => {
@@ -169,7 +170,7 @@ function SignedInShell({ switchMode, clerkKey }: SignedInShellProps): ReactNode 
             }}
             style={styles.switchModeButton}
           >
-            <Text style={styles.switchModeButtonText}>Back</Text>
+            <Text style={styles.switchModeButtonText}>{t('cloudUnavailable.back')}</Text>
           </Pressable>
           <StatusBar style="auto" />
         </View>
@@ -193,10 +194,8 @@ function SignedInShell({ switchMode, clerkKey }: SignedInShellProps): ReactNode 
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Glaon</Text>
-      <Text style={styles.body}>
-        Signed in. The Phase 2 dashboard lands once #10–#12 wire the HA WebSocket.
-      </Text>
+      <Text style={styles.title}>{t('app.name')}</Text>
+      <Text style={styles.body}>{t('shell.signedInPlaceholder')}</Text>
       {clerkKey !== null ? (
         <Pressable
           testID="link-to-cloud"
@@ -205,7 +204,7 @@ function SignedInShell({ switchMode, clerkKey }: SignedInShellProps): ReactNode 
           }}
           style={styles.switchModeButton}
         >
-          <Text style={styles.switchModeButtonText}>Link to cloud</Text>
+          <Text style={styles.switchModeButtonText}>{t('shell.linkToCloud')}</Text>
         </Pressable>
       ) : null}
       <Pressable
@@ -213,7 +212,7 @@ function SignedInShell({ switchMode, clerkKey }: SignedInShellProps): ReactNode 
         onPress={() => void switchMode()}
         style={styles.switchModeButton}
       >
-        <Text style={styles.switchModeButtonText}>Switch mode</Text>
+        <Text style={styles.switchModeButtonText}>{t('shell.switchMode')}</Text>
       </Pressable>
       <StatusBar style="auto" />
     </View>

--- a/apps/mobile/src/features/mode-select/mode-select-screen.tsx
+++ b/apps/mobile/src/features/mode-select/mode-select-screen.tsx
@@ -7,6 +7,8 @@
 //     `*.local` host (more common on Android)
 
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 
 import { probeLocal, type LocalProbeResult } from './local-probe';
@@ -35,6 +37,7 @@ export function ModeSelectScreen({
   initialPreference = null,
   onChoose,
 }: ModeSelectScreenProps): ReactNode {
+  const { t } = useTranslation();
   const [manualUrl, setManualUrl] = useState<string>('');
   const probeUrl = useMemo(() => {
     if (
@@ -69,19 +72,17 @@ export function ModeSelectScreen({
     onChoose(preference);
   };
 
-  const localMeta = describeLocal(probeState);
+  const localMeta = describeLocal(probeState, t);
 
   return (
     <View testID="mode-select-screen" style={styles.root}>
-      <Text style={styles.heading}>How is Glaon connecting to Home Assistant?</Text>
-      <Text style={styles.subheading}>
-        Pick the option that matches where you are. You can change this later from settings.
-      </Text>
+      <Text style={styles.heading}>{t('modeSelect.heading')}</Text>
+      <Text style={styles.subheading}>{t('modeSelect.subheading')}</Text>
 
       <ModeSelectorCard
         mode="local"
-        title="Local — same Wi-Fi as your home"
-        description="Sign in directly to Home Assistant. Fastest, no Glaon cloud account."
+        title={t('modeSelect.local.title')}
+        description={t('modeSelect.local.description')}
         meta={localMeta}
         onSelect={() => {
           choose('local', probeState.result?.reachable === true ? probeUrl : undefined);
@@ -90,17 +91,17 @@ export function ModeSelectScreen({
 
       <ModeSelectorCard
         mode="cloud"
-        title="Cloud — anywhere on the internet"
-        description="Sign in with your Glaon account. Connects through the Glaon relay."
+        title={t('modeSelect.cloud.title')}
+        description={t('modeSelect.cloud.description')}
         disabled={!cloudAvailable}
-        meta={cloudAvailable ? undefined : 'Cloud is not configured for this build.'}
+        meta={cloudAvailable ? undefined : t('modeSelect.cloud.unavailable')}
         onSelect={() => {
           choose('cloud');
         }}
       />
 
       <View testID="mode-select-manual-url" style={styles.manualSection}>
-        <Text style={styles.manualLabel}>Or enter your Home Assistant URL manually</Text>
+        <Text style={styles.manualLabel}>{t('modeSelect.manual.label')}</Text>
         <TextInput
           testID="mode-select-manual-input"
           value={manualUrl}
@@ -109,14 +110,14 @@ export function ModeSelectScreen({
           autoCorrect={false}
           inputMode="url"
           keyboardType="url"
-          placeholder="http://homeassistant.local:8123"
-          accessibilityLabel="Home Assistant URL"
+          placeholder={t('modeSelect.manual.placeholder')}
+          accessibilityLabel={t('modeSelect.manual.ariaUrl')}
           style={styles.manualInput}
         />
         <Pressable
           testID="mode-select-manual-submit"
           accessibilityRole="button"
-          accessibilityLabel="Use this URL"
+          accessibilityLabel={t('modeSelect.manual.submit')}
           accessibilityState={{ disabled: manualUrl.trim().length === 0 }}
           disabled={manualUrl.trim().length === 0}
           onPress={() => {
@@ -127,20 +128,24 @@ export function ModeSelectScreen({
             manualUrl.trim().length === 0 ? styles.manualButtonDisabled : null,
           ]}
         >
-          <Text style={styles.manualButtonText}>Use this URL</Text>
+          <Text style={styles.manualButtonText}>{t('modeSelect.manual.submit')}</Text>
         </Pressable>
       </View>
     </View>
   );
 }
 
-function describeLocal(state: {
-  status: 'pending' | 'done';
-  result: LocalProbeResult | null;
-}): string {
-  if (state.status === 'pending') return 'Looking for a Home Assistant on your network…';
-  if (state.result?.reachable === true) return `Local instance found at ${state.result.url}`;
-  return "Couldn't auto-detect Home Assistant; pick this option to enter the URL manually.";
+function describeLocal(
+  state: {
+    status: 'pending' | 'done';
+    result: LocalProbeResult | null;
+  },
+  t: TFunction,
+): string {
+  if (state.status === 'pending') return t('modeSelect.local.probing');
+  if (state.result?.reachable === true)
+    return t('modeSelect.local.found', { url: state.result.url });
+  return t('modeSelect.local.notFound');
 }
 
 const styles = StyleSheet.create({

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -20,12 +20,20 @@
     "manual": {
       "label": "Or enter your Home Assistant URL manually",
       "placeholder": "http://homeassistant.local:8123",
-      "submit": "Use this URL"
+      "submit": "Use this URL",
+      "ariaUrl": "Home Assistant URL"
     }
   },
   "shell": {
     "signedInPlaceholder": "Signed in. The Phase 2 dashboard lands once #10–#12 wire the HA WebSocket.",
     "switchMode": "Switch mode",
     "linkToCloud": "Link to cloud"
+  },
+  "cloudUnavailable": {
+    "signInTitle": "Cloud sign-in unavailable",
+    "pairingTitle": "Cloud pairing unavailable",
+    "body": "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY is not configured for this build.",
+    "pickDifferentMode": "Pick a different mode",
+    "back": "Back"
   }
 }

--- a/apps/mobile/src/i18n/locales/tr.json
+++ b/apps/mobile/src/i18n/locales/tr.json
@@ -15,17 +15,25 @@
     "cloud": {
       "title": "Bulut — internetin olduğu her yerden",
       "description": "Glaon hesabınla giriş yap. Glaon relay üzerinden bağlanır.",
-      "unavailable": "Bu build'de bulut yapılandırılmamış."
+      "unavailable": "Bu derlemede bulut yapılandırılmamış."
     },
     "manual": {
       "label": "Ya da Home Assistant URL'ini manuel olarak gir",
       "placeholder": "http://homeassistant.local:8123",
-      "submit": "Bu URL'i kullan"
+      "submit": "Bu URL'i kullan",
+      "ariaUrl": "Home Assistant URL"
     }
   },
   "shell": {
     "signedInPlaceholder": "Giriş yapıldı. Faz 2 panosu #10–#12 HA WebSocket bağlantısını kurduğunda geliyor.",
     "switchMode": "Modu değiştir",
     "linkToCloud": "Buluta bağla"
+  },
+  "cloudUnavailable": {
+    "signInTitle": "Bulut girişi kullanılamıyor",
+    "pairingTitle": "Bulut eşleştirmesi kullanılamıyor",
+    "body": "Bu derleme için EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY ayarlanmamış.",
+    "pickDifferentMode": "Başka bir mod seç",
+    "back": "Geri"
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { AuthProvider, useAuth } from './auth/auth-provider';
 import { CloudAuthProvider, getClerkPublishableKey } from './auth/cloud/clerk-provider';
@@ -51,6 +52,7 @@ interface RouterProps {
 }
 
 function Router({ clerkKey }: RouterProps): ReactNode {
+  const { t } = useTranslation();
   const { mode, clearAuth } = useAuth();
   const path = window.location.pathname;
   const config = useMemo(
@@ -90,8 +92,8 @@ function Router({ clerkKey }: RouterProps): ReactNode {
     if (clerkKey === null) {
       return (
         <main data-testid="cloud-unavailable">
-          <h1>Cloud sign-in unavailable</h1>
-          <p>VITE_CLERK_PUBLISHABLE_KEY is not configured for this build.</p>
+          <h1>{t('cloudUnavailable.signInTitle')}</h1>
+          <p>{t('cloudUnavailable.body')}</p>
         </main>
       );
     }
@@ -101,8 +103,8 @@ function Router({ clerkKey }: RouterProps): ReactNode {
     if (clerkKey === null) {
       return (
         <main data-testid="cloud-unavailable">
-          <h1>Cloud pairing unavailable</h1>
-          <p>VITE_CLERK_PUBLISHABLE_KEY is not configured for this build.</p>
+          <h1>{t('cloudUnavailable.pairingTitle')}</h1>
+          <p>{t('cloudUnavailable.body')}</p>
         </main>
       );
     }
@@ -126,10 +128,10 @@ function Router({ clerkKey }: RouterProps): ReactNode {
       if (clerkKey === null) {
         return (
           <main data-testid="cloud-unavailable">
-            <h1>Cloud sign-in unavailable</h1>
-            <p>VITE_CLERK_PUBLISHABLE_KEY is not configured for this build.</p>
+            <h1>{t('cloudUnavailable.signInTitle')}</h1>
+            <p>{t('cloudUnavailable.body')}</p>
             <button type="button" onClick={() => void switchMode()}>
-              Pick a different mode
+              {t('cloudUnavailable.pickDifferentMode')}
             </button>
           </main>
         );
@@ -148,7 +150,7 @@ function Router({ clerkKey }: RouterProps): ReactNode {
           alignItems: 'center',
         }}
       >
-        <h1>Glaon</h1>
+        <h1>{t('app.name')}</h1>
         <button
           type="button"
           data-testid="switch-mode"
@@ -162,10 +164,10 @@ function Router({ clerkKey }: RouterProps): ReactNode {
             font: 'inherit',
           }}
         >
-          Switch mode
+          {t('shell.switchMode')}
         </button>
       </header>
-      <p>Signed in. The Phase 2 dashboard lands once #10–#12 wire the HA WebSocket.</p>
+      <p>{t('shell.signedInPlaceholder')}</p>
     </main>
   );
 }

--- a/apps/web/src/features/mode-select/mode-select-route.tsx
+++ b/apps/web/src/features/mode-select/mode-select-route.tsx
@@ -8,6 +8,8 @@
 // `http://homeassistant.local:8123` which is HA's default mDNS name.
 
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { probeLocal, type LocalProbeResult } from './local-probe';
 import { ModeSelectorCard } from './mode-selector-card';
@@ -31,6 +33,7 @@ export function ModeSelectRoute({
   defaultLocalUrl = DEFAULT_LOCAL_URL,
   onChoose,
 }: ModeSelectRouteProps): ReactNode {
+  const { t } = useTranslation();
   const [manualUrl, setManualUrl] = useState<string>('');
   const probeUrl = useMemo(() => {
     const stored = readModePreference();
@@ -63,15 +66,12 @@ export function ModeSelectRoute({
     onChoose(preference);
   };
 
-  const localMeta = describeLocal(probeState);
+  const localMeta = describeLocal(probeState, t);
 
   return (
     <main data-testid="mode-select-route">
-      <h1>How is Glaon connecting to Home Assistant?</h1>
-      <p>
-        Pick the option that matches where you are right now. You can change this later from the
-        settings menu.
-      </p>
+      <h1>{t('modeSelect.heading')}</h1>
+      <p>{t('modeSelect.subheading')}</p>
       <div
         style={{
           display: 'grid',
@@ -82,8 +82,8 @@ export function ModeSelectRoute({
       >
         <ModeSelectorCard
           mode="local"
-          title="Local — same Wi-Fi as your home"
-          description="Sign in directly to Home Assistant. Fastest, no Glaon cloud account needed."
+          title={t('modeSelect.local.title')}
+          description={t('modeSelect.local.description')}
           meta={localMeta}
           onSelect={() => {
             choose('local', probeState.result?.reachable === true ? probeUrl : undefined);
@@ -91,10 +91,10 @@ export function ModeSelectRoute({
         />
         <ModeSelectorCard
           mode="cloud"
-          title="Cloud — anywhere on the internet"
-          description="Sign in with your Glaon account. Connects through the Glaon relay."
+          title={t('modeSelect.cloud.title')}
+          description={t('modeSelect.cloud.description')}
           disabled={!cloudAvailable}
-          meta={cloudAvailable ? undefined : 'Cloud is not configured for this build.'}
+          meta={cloudAvailable ? undefined : t('modeSelect.cloud.unavailable')}
           onSelect={() => {
             choose('cloud');
           }}
@@ -104,14 +104,14 @@ export function ModeSelectRoute({
       <section
         data-testid="mode-select-manual-url"
         style={{ marginTop: '1.75rem' }}
-        aria-label="Manual local URL"
+        aria-label={t('modeSelect.manual.ariaLabel')}
       >
         <label style={{ display: 'block', fontWeight: 600, marginBottom: '0.5rem' }}>
-          Or enter your Home Assistant URL manually
+          {t('modeSelect.manual.label')}
           <input
             type="url"
             inputMode="url"
-            placeholder="http://homeassistant.local:8123"
+            placeholder={t('modeSelect.manual.placeholder')}
             value={manualUrl}
             onChange={(event) => {
               setManualUrl(event.target.value);
@@ -144,18 +144,22 @@ export function ModeSelectRoute({
             font: 'inherit',
           }}
         >
-          Use this URL
+          {t('modeSelect.manual.submit')}
         </button>
       </section>
     </main>
   );
 }
 
-function describeLocal(state: {
-  status: 'pending' | 'done';
-  result: LocalProbeResult | null;
-}): string {
-  if (state.status === 'pending') return 'Looking for a Home Assistant on your network…';
-  if (state.result?.reachable === true) return `Local instance found at ${state.result.url}`;
-  return "Couldn't auto-detect Home Assistant; pick this option to enter the URL manually.";
+function describeLocal(
+  state: {
+    status: 'pending' | 'done';
+    result: LocalProbeResult | null;
+  },
+  t: TFunction,
+): string {
+  if (state.status === 'pending') return t('modeSelect.local.probing');
+  if (state.result?.reachable === true)
+    return t('modeSelect.local.found', { url: state.result.url });
+  return t('modeSelect.local.notFound');
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -20,11 +20,18 @@
     "manual": {
       "label": "Or enter your Home Assistant URL manually",
       "placeholder": "http://homeassistant.local:8123",
-      "submit": "Use this URL"
+      "submit": "Use this URL",
+      "ariaLabel": "Manual local URL"
     }
   },
   "shell": {
     "signedInPlaceholder": "Signed in. The Phase 2 dashboard lands once #10–#12 wire the HA WebSocket.",
     "switchMode": "Switch mode"
+  },
+  "cloudUnavailable": {
+    "signInTitle": "Cloud sign-in unavailable",
+    "pairingTitle": "Cloud pairing unavailable",
+    "body": "VITE_CLERK_PUBLISHABLE_KEY is not configured for this build.",
+    "pickDifferentMode": "Pick a different mode"
   }
 }

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -15,16 +15,23 @@
     "cloud": {
       "title": "Bulut — internetin olduğu her yerden",
       "description": "Glaon hesabınla giriş yap. Glaon relay üzerinden bağlanır.",
-      "unavailable": "Bu build'de bulut yapılandırılmamış."
+      "unavailable": "Bu derlemede bulut yapılandırılmamış."
     },
     "manual": {
       "label": "Ya da Home Assistant URL'ini manuel olarak gir",
       "placeholder": "http://homeassistant.local:8123",
-      "submit": "Bu URL'i kullan"
+      "submit": "Bu URL'i kullan",
+      "ariaLabel": "Manuel yerel URL"
     }
   },
   "shell": {
     "signedInPlaceholder": "Giriş yapıldı. Faz 2 panosu #10–#12 HA WebSocket bağlantısını kurduğunda geliyor.",
     "switchMode": "Modu değiştir"
+  },
+  "cloudUnavailable": {
+    "signInTitle": "Bulut girişi kullanılamıyor",
+    "pairingTitle": "Bulut eşleştirmesi kullanılamıyor",
+    "body": "Bu derleme için VITE_CLERK_PUBLISHABLE_KEY ayarlanmamış.",
+    "pickDifferentMode": "Başka bir mod seç"
   }
 }

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,7 +1,33 @@
 import '@testing-library/jest-dom/vitest';
 
 import { cleanup } from '@testing-library/react';
+import i18next from 'i18next';
+import ICU from 'i18next-icu';
+import { initReactI18next } from 'react-i18next';
 import { afterEach } from 'vitest';
+
+import en from '../i18n/locales/en.json';
+import tr from '../i18n/locales/tr.json';
+
+// Initialize the global i18next instance for tests so components that
+// call `useTranslation()` resolve real strings (and probe.toHaveTextContent
+// regexes still match on the EN copy). Production wires its own scoped
+// instance via `<I18nProvider>` in main.tsx — this default is jsdom-only.
+if (!i18next.isInitialized) {
+  void i18next
+    .use(ICU)
+    .use(initReactI18next)
+    .init({
+      lng: 'en',
+      fallbackLng: 'en',
+      resources: {
+        en: { translation: en },
+        tr: { translation: tr },
+      },
+      interpolation: { escapeValue: false },
+      returnNull: false,
+    });
+}
 
 afterEach(() => {
   cleanup();

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,112 @@
+# Çoklu Dil Desteği (i18n)
+
+Glaon hem web hem de mobil tarafta **react-i18next + i18next-icu** üzerinde çalışır. Bu dokümana, dil ekleme / metin ekleme / çeviri kontrol akışlarını koruyabilmek için bakılır.
+
+## Desteklenen Diller
+
+Tek doğru kaynak: [`packages/core/src/i18n/locale-negotiator.ts`](../packages/core/src/i18n/locale-negotiator.ts).
+
+```ts
+export const SUPPORTED_LOCALES = ['en', 'tr'] as const;
+export const FALLBACK_LOCALE: SupportedLocale = 'en';
+```
+
+İngilizce (`en`) ve Türkçe (`tr`) dışında bir BCP-47 etiketi geldiğinde negotiator başlangıç dilini taban koda indirir (`en-US` → `en`, `tr-TR` → `tr`); set dışındaki etiketler `FALLBACK_LOCALE`'a düşer.
+
+## Aktif Dilin Belirlenmesi (Locale Negotiation)
+
+Çalışma anında öncelik sırası:
+
+1. **Açık kullanıcı tercihi** — `apps/api`'de `users.preferences.locale` (#425). Kullanıcı dil seçicisinden yaptığı değişiklik buraya `PATCH /me/preferences` ile yazılır; her cihazdan giriş yapıldığında tekrar uygulanır.
+2. **HA profil dili** — Home Assistant kullanıcı profilinin `language` alanı (i18n-D / #426 ile bağlanacak).
+3. **Cihaz algılaması** — web'de `i18next-browser-languagedetector` (`navigator.language`), mobilde `expo-localization`'ın `getLocales()` çıktısı.
+4. **Fallback** — `en`.
+
+Bu sıralama negotiator içinde `negotiateLocale({ explicit, haProfile, platformDetection })` çağrısıyla uygulanır. Pure logic — `@glaon/core` içinde duruyor; web ve mobil aynı mantığı paylaşıyor.
+
+## Çeviri Dosyaları
+
+```
+apps/web/src/i18n/locales/
+  en.json
+  tr.json
+
+apps/mobile/src/i18n/locales/
+  en.json
+  tr.json
+```
+
+Web ve mobilin ayrı dosyaları olmasının nedeni, ekran metinlerinin platforma göre farklı olabilmesi (mobilde "dokun", webde "tıkla" gibi). Aynı anlamı taşıyan ortak anahtarlar her iki dosyada da bulunmalı; aksi durumda kayıp anahtar fallback dile düşer ve `tr` kullanıcısı İngilizce metin görür.
+
+JSON yapısı `<surface>.<element>` şemasını izler:
+
+```json
+{
+  "modeSelect": {
+    "heading": "How is Glaon connecting to Home Assistant?",
+    "local": {
+      "title": "Local — same Wi-Fi as your home"
+    }
+  }
+}
+```
+
+Daha derin yapılar (örn. `cloudUnavailable.signInTitle`) tek seferlik metinler için kabul edilir; ortak bir yüzey bulunduğunda yeniden gruplanır.
+
+## Komponentlerden Kullanım
+
+```tsx
+import { useTranslation } from 'react-i18next';
+
+export function ModeSelectorCard({ mode }: Props) {
+  const { t } = useTranslation();
+  return <h2>{t('modeSelect.local.title')}</h2>;
+}
+```
+
+ICU değişken interpolasyonu tek süslü parantezle yazılır (`{url}`), iki parantez **kullanılmaz**:
+
+```ts
+t('modeSelect.local.found', { url: 'http://homeassistant.local:8123' });
+// "Local instance found at http://homeassistant.local:8123"
+```
+
+## Eksik Anahtar Davranışı (Missing-Key Fallback)
+
+- Bir anahtar TR dosyasında yok ama EN'de var → kullanıcı EN sürümünü görür (i18next varsayılan davranışı; `fallbackLng: 'en'`).
+- Bir anahtar her iki dosyada da yok → ham anahtar (örn. `modeSelect.local.title`) ekrana basılır. Bu görünür bir bug'dır ve PR açılmadan **CI gate**'inden (i18n-H / #430) yakalanır.
+- HA tarafından serve edilen metinler için (i18n-D / #426) aynı kural HA cevabı için de geçerli: HA bilmediği bir anahtarı geri verirse Glaon ham HA etiketini gösterir.
+
+## Çeviri Kalite Kuralları (Türkçe Özelinde)
+
+- **Brand voice**: arkadaş canlısı, sade, gereksiz resmî dil yok. "Hesabı feshetmek" değil "hesabı kapat".
+- **ICU plural**: birim sayım metinlerinde Türkçe için tek bir form yeterli — CLDR'da Türkçe `other` formuna düşer. Örnek: `{count, plural, other {# cihaz}}`.
+- **Adlandırma**: `Home Assistant` özel ad olarak kalır — çevrilmez. `Wi-Fi`, `URL`, `OAuth` da aynı.
+- **Karakter setleri**: `ı`, `İ`, `ş`, `ş`, `ğ` ve `ç` stringleri JSON'a doğrudan yazılır; escaping yok.
+
+## Yeni Dil Ekleme Süreci (Phase ≥ 3)
+
+1. Yeni dil için ADR aç (negotiator listesini büyütmek normalde sessiz bir değişiklik değildir; market kapsamı + bakım taahhüdü ADR'da netleşir).
+2. `SUPPORTED_LOCALES`'e ekle.
+3. `apps/web/src/i18n/locales/<lng>.json` ve `apps/mobile/src/i18n/locales/<lng>.json` dosyalarını oluştur.
+4. CI'daki missing-key gate (i18n-H) otomatik olarak yeni dili kontrol eder.
+5. Storybook'taki dil seçici (i18n-G) ekrana yansıtır.
+
+Bu adımları kapsamayan bir locale ekleme PR'ı reddedilir.
+
+## Geliştirici Notu
+
+`apps/web` üzerinde `pnpm --filter @glaon/web dev` çalıştırırken locale değiştirmek için tarayıcıda devtools'tan `localStorage.setItem('glaon.locale', 'tr')` + reload yeterli. Apps/api session aktifse aynı tercih `/me/preferences` üzerinden de uygulanır (#425).
+
+## İlgili ADR'lar ve Issues
+
+- [ADR 0023 — i18n library + format](adr/0023-i18n-library.md): kütüphane ve format kararı.
+- #406 (epic): Phase 2 i18n epiği.
+- #424 (i18n-B): runtime foundation.
+- #425 (i18n-C): kullanıcı tercihi persistance (apps/api `/me/preferences`).
+- #426 (i18n-D): HA translations bridge.
+- #427 (i18n-E): TR translation pass — bu sayfa.
+- #428 (i18n-F): RTL audit.
+- #429 (i18n-G): Storybook docs.
+- #430 (i18n-H): translation workflow + missing-key CI gate.
+- #431 (i18n-I): mobil locale wiring.


### PR DESCRIPTION
## Summary

The i18n foundation (#424) seeded the locale JSON files but the components kept their hardcoded English copy — every `useTranslation` call in the codebase before this PR was zero. This PR refactors the surfaces a first-run user actually sees (mode-select route on web + mobile, the cloud-unavailable shell, the signed-in shell) to consume `useTranslation()`, with full Turkish translations that match the brand-voice rules.

The auth/cloud sign-in/up + pair-wizard screens still hardcode their copy — they're a bigger surface and stay as a follow-up, tracked under the i18n epic. This PR closes the gate for "first-run is fully bilingual."

## Scope (In)

- `apps/web/src/features/mode-select/mode-select-route.tsx` — every string + `aria-label` flows through `t()`. The probe state helper takes `TFunction` so it stays test-friendly.
- `apps/mobile/src/features/mode-select/mode-select-screen.tsx` — same treatment, with `accessibilityLabel` localized.
- `apps/web/src/App.tsx` — Router cloud-unavailable branches + signed-in shell switch-mode button + placeholder copy.
- `apps/mobile/App.tsx` — Root + SignedInShell, including pair-wizard cloud-unavailable.
- `apps/web/src/i18n/locales/{en,tr}.json` — new keys: `cloudUnavailable.{signInTitle,pairingTitle,body,pickDifferentMode}`, `modeSelect.manual.ariaLabel`.
- `apps/mobile/src/i18n/locales/{en,tr}.json` — same plus `cloudUnavailable.back`, `modeSelect.manual.ariaUrl`.
- `apps/web/src/test/setup.ts` — initializes the global i18next instance with the production resources so existing `toHaveTextContent(/.../i)` regexes keep matching against the EN copy without each test having to wrap in `<I18nextProvider>`.
- `docs/i18n.md` — precedence chain, missing-key fallback rules, TR brand-voice notes, locale-add process.

## Scope (Out)

- `apps/web/src/features/auth/{local,cloud}` + `apps/mobile/src/features/auth/{local,cloud}` hardcoded strings (sign-in, sign-up, OAuth callback). Separate refactor — same `useTranslation` pattern.
- `apps/web/src/features/cloud-pairing/pair-wizard-route.tsx` + mobile counterpart copy. Same follow-up.
- HA-owned strings via `frontend/get_translations` — i18n-D / #426 (blocked on #10 HaClient).
- Storybook locale switcher demo — i18n-G / #429.
- Missing-key CI gate — i18n-H / #430.

## Translation quality notes

- "Yerel" (local), "Bulut" (cloud), "Ağ" (network) — concise tech-Turkish, no anglicism.
- `Home Assistant` / `Wi-Fi` / `URL` / `OAuth` are kept as proper nouns / well-known acronyms (TR readers expect them; translating them creates friction).
- Tone: friendly + plain second person singular ("değiştirebilirsin"), avoiding corporate "siz" forms — matches the brand voice seeded in #424.
- ICU plural correctness checked: no plural strings in this batch (all 1:1).

## Test plan

- [x] `pnpm --filter @glaon/web type-check`
- [x] `pnpm --filter @glaon/mobile type-check`
- [x] `pnpm --filter @glaon/web test` (71 tests — all green; existing regex assertions still match the EN copy via the global i18next setup)
- [x] `pnpm --filter @glaon/web lint`
- [x] `pnpm --filter @glaon/mobile lint`
- [x] `pnpm exec knip` — no new unused exports
- [ ] CI: web Playwright `@smoke` still resolves the `Glaon` heading + the local-mode flow (no copy change there)

Refs #427 #406 #424