### PR TITLE
docs(storybook,i18n): foundations / i18n mdx + locale toolbar (i18n-G)

### DIFF
--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -71,6 +71,15 @@ pnpm --filter @glaon/ui exec vitest --project=storybook src/components/Button/Bu
 - Flaky bir story'yi geçici olarak `tags: ['!test']` ile koşumdan çıkarabilirsin; ama bu bir düzeltme değildir, bir issue aç ve commit mesajında referansla.
 - Browser context'te `window` ve `document` vardır, `jest-dom` matchers koşum ortamına göre `@testing-library/jest-dom` üzerinden aktif olur.
 
+## Foundations sayfaları
+
+`packages/ui/src/foundations/` altındaki MDX dosyaları toolkit'in yatay (component'siz) konularını belgeler. Toolbar'dan **Foundations** kategorisine açılır.
+
+- [Foundations / Tailwind Smoke](../packages/ui/src/foundations/TailwindSmoke.stories.tsx) — UUI scale + semantic class'larının runtime'da çözüldüğünü doğrulayan sanity story (#219, ADR 0013).
+- [Foundations / i18n](../packages/ui/src/foundations/i18n.mdx) — i18next + ICU yığını, locale precedence chain'i, "yeni anahtar nasıl eklenir" akışı, ICU MessageFormat örnekleri (#429 / i18n-G). Toolbar'daki **Locale** seçicisi her story'de aktif — primitive'ler presentational kaldığı için switch çoğu story'de görsel bir değişiklik yapmaz; gerçek demo Foundations / i18n altındaki `Default` story'de.
+
+Yeni bir foundation sayfası (örn. tipografi, spacing) açıldığında aynı klasöre düşmeli ve bu listeye eklenmeli.
+
 ## Story yazım kuralları
 
 ### Yeni primitive nereden başlar

--- a/packages/ui/.storybook/preview.ts
+++ b/packages/ui/.storybook/preview.ts
@@ -39,17 +39,44 @@ const preview: Preview = {
     }),
     (Story, context) =>
       createElement(
-        ThemeProvider,
-        { theme: context.globals.theme ?? DEFAULT_THEME, tokens },
-        // Wrap every story in `ToastProvider` so stories that call
-        // `useToast()` work without per-story decorators. The
-        // provider mounts a portal to `document.body` lazily on
-        // mount, so non-toast stories pay no cost.
-        createElement(ToastProvider, null, createElement(Story)),
+        'div',
+        { lang: context.globals.locale ?? 'en' },
+        createElement(
+          ThemeProvider,
+          { theme: context.globals.theme ?? DEFAULT_THEME, tokens },
+          // Wrap every story in `ToastProvider` so stories that call
+          // `useToast()` work without per-story decorators. The
+          // provider mounts a portal to `document.body` lazily on
+          // mount, so non-toast stories pay no cost.
+          createElement(ToastProvider, null, createElement(Story)),
+        ),
       ),
   ],
   initialGlobals: {
     theme: DEFAULT_THEME,
+    locale: 'en',
+  },
+  globalTypes: {
+    locale: {
+      // Toolbar locale switcher (i18n-G / #429). Keeps the toolbar in
+      // every story so reviewers can flip between EN and TR while
+      // browsing components. Today the toggle just propagates through
+      // the `lang` attribute on the story wrapper — primitives stay
+      // presentational per the data-fetching boundary, so the demo
+      // story under "Foundations / i18n" is the one that actually
+      // re-renders strings on switch.
+      name: 'Locale',
+      description: 'UI locale (#429)',
+      defaultValue: 'en',
+      toolbar: {
+        icon: 'globe',
+        items: [
+          { value: 'en', title: 'English' },
+          { value: 'tr', title: 'Türkçe' },
+        ],
+        dynamicTitle: true,
+      },
+    },
   },
 };
 

--- a/packages/ui/src/foundations/I18nDemo.stories.tsx
+++ b/packages/ui/src/foundations/I18nDemo.stories.tsx
@@ -1,0 +1,79 @@
+// Locale switcher demo (#429 / i18n-G). Reads the toolbar `locale`
+// global and flips between two hand-rolled string maps so the
+// Foundations / i18n MDX page can show the switcher actually doing
+// something. Production translations live in apps/web + apps/mobile
+// /locales/<lng>.json — this catalog is intentionally tiny and
+// scoped to the demo so @glaon/ui doesn't take a dep on react-i18next
+// (the package stays presentational; primitives are translated by
+// the consumer feature layer per the data-fetching boundary).
+
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import type { ReactNode } from 'react';
+
+interface DemoStrings {
+  readonly heading: string;
+  readonly description: string;
+  readonly cta: string;
+  readonly hint: string;
+}
+
+const STRINGS: Record<'en' | 'tr', DemoStrings> = {
+  en: {
+    heading: 'Locale-aware demo',
+    description:
+      'Flip the toolbar Locale switcher (top-right) and watch the strings below re-render.',
+    cta: 'Switch language',
+    hint: 'This demo uses an inline catalog. Real apps consume react-i18next via useTranslation().',
+  },
+  tr: {
+    heading: 'Locale duyarlı demo',
+    description:
+      'Sağ üstteki Locale değiştiriciyi kullanın; aşağıdaki metinler yeniden render eder.',
+    cta: 'Dili değiştir',
+    hint: 'Bu demo gömülü bir sözlük kullanır. Gerçek uygulamalar react-i18next + useTranslation() üzerinden okur.',
+  },
+};
+
+function I18nDemo({ locale }: { readonly locale: 'en' | 'tr' }): ReactNode {
+  const t = STRINGS[locale];
+  return (
+    <div className="flex max-w-md flex-col gap-4 p-6">
+      <h2 className="text-xl font-semibold text-fg-primary">{t.heading}</h2>
+      <p className="text-sm text-fg-secondary">{t.description}</p>
+      <button
+        type="button"
+        className="self-start rounded-md bg-brand-solid px-4 py-2 text-sm font-medium text-white"
+      >
+        {t.cta}
+      </button>
+      <p className="text-xs text-fg-tertiary">{t.hint}</p>
+      <code className="rounded bg-secondary px-2 py-1 text-xs text-fg-tertiary">
+        active locale: <strong>{locale}</strong>
+      </code>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Foundations/i18n',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Toolbar-driven locale demo. The story reads `globals.locale` and renders the string catalog for the active language.',
+      },
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Single story; the locale axis lives on the toolbar so a reviewer
+// flips it interactively (and Chromatic captures the EN baseline).
+export const Default: Story = {
+  render: (_args, { globals }) => {
+    const locale = (globals.locale as 'en' | 'tr' | undefined) ?? 'en';
+    return <I18nDemo locale={locale} />;
+  },
+};

--- a/packages/ui/src/foundations/i18n.mdx
+++ b/packages/ui/src/foundations/i18n.mdx
@@ -1,0 +1,153 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as I18nDemoStories from './I18nDemo.stories';
+
+<Meta title="Foundations/i18n" />
+
+# i18n
+
+Glaon ships in English (`en`) and Turkish (`tr`); both are fully populated, with `en` as the fallback. This page is the single contributor reference: the stack we run, how the active locale is decided, how to add a new key, and the conventions a translator picks up cold.
+
+## Stack
+
+- `react-i18next` + `i18next-icu` — runtime translation + ICU MessageFormat parsing.
+- ICU JSON resource files — `apps/web/src/i18n/locales/{en,tr}.json` and `apps/mobile/src/i18n/locales/{en,tr}.json`.
+- `i18next-browser-languagedetector` (web) / `expo-localization` (mobile) — platform-detected fallback.
+- `@glaon/core/i18n` — the closed `SupportedLocale` set and the `negotiateLocale` precedence helper, shared by web and mobile.
+
+Decision history: [ADR 0023 — i18n library + format](https://github.com/toss-cengiz/glaon/blob/main/docs/adr/0023-i18n-library.md).
+
+## Locale precedence
+
+`negotiateLocale({ explicit, haProfile, platformDetection })` picks the first hit from this chain:
+
+1. **Explicit user preference** — persisted server-side in `apps/api` `users.preferences.locale` (#425). Same user on a different device reads it back on login.
+2. **HA profile language** — Home Assistant's `language` user attribute, surfaced through the WebSocket connection (i18n-D / #426).
+3. **Platform detection** — `navigator.language` on web, `getLocales()[0].languageCode` on mobile.
+4. **Fallback** — `en`.
+
+Anything outside the closed `SUPPORTED_LOCALES` set (`['en', 'tr']`) collapses to its base (`en-US` → `en`) or the fallback. Adding a new locale requires editing `packages/core/src/i18n/locale-negotiator.ts` plus a JSON file per app — see "Adding a locale" below.
+
+## Toolbar switcher
+
+This Storybook surfaces a **Locale** dropdown in the top-right toolbar (next to the theme switcher). It propagates the chosen locale through `globals.locale` and stamps a `lang` attribute on every story wrapper, so:
+
+- **DevTools** shows the active language at the wrapper level (useful for `:lang(tr)` CSS or screen-reader announcements).
+- **Demo stories** that explicitly read `globals.locale` re-render their string catalog on switch.
+- **Primitive stories** stay presentational — Glaon UI primitives don't consume i18n internally per the data-fetching boundary; the consumer feature layer translates and passes strings as props.
+
+The demo below is wired up to the toolbar. Switch to **Türkçe** and watch the strings flip.
+
+<Canvas of={I18nDemoStories.Default} />
+
+## Adding a translation key
+
+The five-step workflow:
+
+1. **Use it in the component.** Add `useTranslation()` and the call:
+
+   ```tsx
+   import { useTranslation } from 'react-i18next';
+
+   export function SaveButton() {
+     const { t } = useTranslation();
+     return <button>{t('settings.save')}</button>;
+   }
+   ```
+
+2. **Add to `en.json`** under the matching surface key:
+
+   ```json
+   {
+     "settings": {
+       "save": "Save changes"
+     }
+   }
+   ```
+
+3. **Add to `tr.json`** with reviewed Turkish copy:
+
+   ```json
+   {
+     "settings": {
+       "save": "Değişiklikleri kaydet"
+     }
+   }
+   ```
+
+4. **Verify in the toolbar.** Run the dev server (`pnpm --filter @glaon/web dev`) or this Storybook; flip the Locale toolbar and confirm both languages render.
+
+5. **Verify the missing-key CI gate.** It refuses a PR where `tr.json` lacks any key present in `en.json` (i18n-H / #430).
+
+## ICU MessageFormat
+
+`i18next-icu` handles ICU syntax. Single-brace interpolation:
+
+```ts
+t('login.welcome', { name: 'Ada' });
+// "Welcome back, Ada"
+```
+
+Pluralization (CLDR rules — Turkish only has `other`):
+
+```ts
+t('devices.count', { count: 0 });   // "No devices"   / "Cihaz yok"
+t('devices.count', { count: 1 });   // "1 device"     / "1 cihaz"
+t('devices.count', { count: 12 });  // "12 devices"   / "12 cihaz"
+```
+
+JSON entry:
+
+```json
+{
+  "devices": {
+    "count": "{count, plural, =0 {No devices} one {# device} other {# devices}}"
+  }
+}
+```
+
+> **Note:** Use single braces (`{count}`), not the i18next default `{{count}}`. ICU rejects double-brace interpolation.
+
+## Namespace conventions
+
+Glaon uses a single namespace today (`translation`). When the bundle outgrows it (Phase 3), the surfaces split:
+
+- `ui` — primitives in `@glaon/ui` (defaults baked into wraps; consumer can override via prop).
+- `web` — `apps/web` features.
+- `mobile` — `apps/mobile` features.
+- `ha` — Home Assistant strings, populated at runtime via `frontend/get_translations`. Glaon **never** re-translates HA-owned content; the `ha` namespace is read-only on our side (i18n-D / #426).
+
+Until that split happens, all keys live under the default `translation` namespace and follow `<surface>.<element>` JSON nesting (e.g. `modeSelect.local.title`).
+
+## HA translations
+
+Home Assistant ships per-locale labels for device classes, state names, area names, and service descriptions. We ask HA in the active locale and merge the result into i18next under the `ha` namespace; we do not duplicate HA's strings inside `en.json` / `tr.json`. If HA can't translate a key, the raw HA-side label renders — never an empty string.
+
+The bridge lives in `packages/core/src/i18n/ha-bridge.ts` (lands with i18n-D / #426).
+
+## Adding a locale
+
+Beyond `en` and `tr`, every new locale must:
+
+1. Have a real adoption signal — a user request, a stakeholder push, or a Phase 3 "international ready" milestone. We don't ship locales speculatively (the maintenance cost is non-trivial).
+2. Land an ADR or an ADR addendum motivating the addition.
+3. Extend `SUPPORTED_LOCALES` in `packages/core/src/i18n/locale-negotiator.ts`.
+4. Add `apps/web/src/i18n/locales/<lng>.json` and `apps/mobile/src/i18n/locales/<lng>.json` with full key coverage.
+5. Pass the missing-key CI gate (i18n-H / #430).
+6. Add the toolbar toolbar entry in `packages/ui/.storybook/preview.ts` (this file).
+
+RTL languages additionally trigger the i18n-F audit — see [#428](https://github.com/toss-cengiz/glaon/issues/428).
+
+## Common pitfalls
+
+- **Hardcoded strings.** Every user-visible label must read from i18next; the i18n-H CI gate will catch new untranslated strings.
+- **Double-brace interpolation.** `{{name}}` works in plain i18next but breaks under `i18next-icu`. Use single braces.
+- **Missing TR plural form.** Turkish only needs `other`; including `one` is harmless but `=0` should be explicit when the zero copy diverges (e.g. "No devices" vs "0 devices").
+- **Translating HA-owned strings.** `state.switch.off` lives in HA's catalog, not ours. Reach for `frontend/get_translations` before adding a key.
+- **`Home Assistant`, `Wi-Fi`, `URL`, `OAuth`** stay as proper nouns / well-known acronyms across locales. Don't translate them.
+
+## See also
+
+- [docs/i18n.md](https://github.com/toss-cengiz/glaon/blob/main/docs/i18n.md) — Turkish-language reference for the same material, with brand-voice notes for translators.
+- [ADR 0023](https://github.com/toss-cengiz/glaon/blob/main/docs/adr/0023-i18n-library.md) — library + format decision.
+- Tracking issues: [#406](https://github.com/toss-cengiz/glaon/issues/406) (epic), [#424](https://github.com/toss-cengiz/glaon/issues/424) (foundation), [#425](https://github.com/toss-cengiz/glaon/issues/425) (persistence), [#427](https://github.com/toss-cengiz/glaon/issues/427) (TR pass), [#430](https://github.com/toss-cengiz/glaon/issues/430) (CI gate), [#431](https://github.com/toss-cengiz/glaon/issues/431) (mobile wiring).


### PR DESCRIPTION
## Summary

Adds the **Foundations / i18n** Storybook docs page so a contributor picking up the project cold can see the whole i18n system on one page: the stack (react-i18next + i18next-icu), the four-layer locale precedence chain, the 5-step "how to add a key" workflow, ICU MessageFormat examples (with the single-brace gotcha), namespace conventions, and the HA-translations invariant.

The Storybook toolbar now has a **Locale** dropdown (en + tr) that propagates to every story via `globals.locale`. The new `Foundations / i18n` demo story reads the global and re-renders its inline string catalog when the toolbar flips — reviewers get a tangible "yes the switcher works" demo without `@glaon/ui` having to take a runtime dep on react-i18next (UI primitives stay presentational per the data-fetching boundary, so the consumer feature layer is what actually translates). For all other stories the locale propagates as a `lang` attribute on the wrapper — useful for devtools / screen-reader announcements — but they don't change visually.

## Scope (In)

- `packages/ui/src/foundations/i18n.mdx` — full docs page (Stack, Locale precedence, Toolbar switcher, Adding a key, ICU MessageFormat, Namespace conventions, HA translations, Adding a locale, Common pitfalls, See also).
- `packages/ui/src/foundations/I18nDemo.stories.tsx` — single demo story under `Foundations/i18n` that reads `globals.locale` and renders an EN/TR catalog. Hand-rolled inline catalog (no react-i18next dep added to the UI package).
- `packages/ui/.storybook/preview.ts` — `globalTypes.locale` toolbar entry + decorator that stamps `lang` on the wrapper of every story.
- `docs/storybook.md` — Foundations sayfaları section linking to the new MDX page (Turkish, per the language policy).

## Scope (Out)

- Adding `react-i18next` as a `@glaon/ui` runtime dep — UI primitives stay presentational. The consumer feature layer translates strings and passes them as props.
- Mobile-side Storybook decorator — the issue explicitly defers (mobile uses RN Storybook in a separate stack, if at all).
- ESLint rule for hardcoded strings — already in i18n-B / #424.
- Missing-key CI gate — i18n-H / #430.

## Test plan

- [x] `pnpm --filter @glaon/ui type-check`
- [x] `pnpm --filter @glaon/ui lint`
- [x] `pnpm --filter @glaon/ui test` (123 story tests, all pass)
- [x] `pnpm --filter @glaon/ui build-storybook` — MDX compiles, demo story renders
- [x] `pnpm exec knip` — no new unused exports
- [ ] CI: storybook-tests workflow runs all stories on the renamed Foundations tree
- [ ] Manual smoke: open Storybook locally, flip the Locale toolbar on `Foundations / i18n / Default`, then on Button + Card + Modal + Toast — they don't visually change, no story crashes

## Acceptance mapping (from #429)

- [x] `Foundations / i18n` page renders in Storybook with all sections.
- [x] Toolbar locale switcher works on every story (decorator wraps every story; demo proves the switch is observable; primitives stay presentational by design).
- [x] `docs/storybook.md` links to the MDX page.
- [x] Contribution doc explains "how to add a translation key" in 5 steps (single-glance section).
- [ ] Chromatic baseline accepted for the new MDX page + demo story (lands when CI publishes the build).

Closes #429
Refs #406 #424