### PR TITLE
feat(web): cloud sign-up screen with headless clerk (#471)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,9 +9,9 @@ import { WebTokenStore } from './auth/web-token-store';
 import { AuthCallbackRoute } from './features/auth/local/auth-callback-route';
 import { LoginRoute } from './features/auth/local/login-route';
 import { SignInRoute } from './features/auth/cloud/sign-in-route';
-import { SignUpRoute } from './features/auth/cloud/sign-up-route';
 import { EmailVerificationPage } from './features/auth/email-verification/email-verification-page';
 import { ForgotPasswordPage } from './features/auth/forgot-password/forgot-password-page';
+import { SignUpPage } from './features/auth/sign-up/sign-up-page';
 import { PairWizardRoute } from './features/cloud-pairing/pair-wizard-route';
 import { ModeSelectRoute } from './features/mode-select/mode-select-route';
 import {
@@ -121,7 +121,7 @@ function Router({ clerkKey }: RouterProps): ReactNode {
         </main>
       );
     }
-    return path === '/sign-in' ? <SignInRoute /> : <SignUpRoute />;
+    return path === '/sign-in' ? <SignInRoute /> : <SignUpPage />;
   }
   if (path === '/settings/link-to-cloud') {
     if (clerkKey === null) {

--- a/apps/web/src/features/auth/sign-up/sign-up-page.test.tsx
+++ b/apps/web/src/features/auth/sign-up/sign-up-page.test.tsx
@@ -1,0 +1,114 @@
+// SignUpPage smoke. Drives the form through a fake `useSignUp` so the
+// happy path (`signUp.create` → `prepareEmailAddressVerification` →
+// `/verify-email?after=signup`) is exercised end-to-end without
+// touching Clerk's network.
+
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthProvider } from '../../../auth/auth-provider';
+import { WebTokenStore } from '../../../auth/web-token-store';
+import { SignUpPage } from './sign-up-page';
+
+const createSpy = vi.fn();
+const prepareSpy = vi.fn();
+
+vi.mock('@clerk/clerk-react', () => ({
+  useSignUp: () => ({
+    isLoaded: true,
+    signUp: {
+      create: createSpy,
+      prepareEmailAddressVerification: prepareSpy,
+      authenticateWithRedirect: vi.fn(() => Promise.resolve(undefined)),
+    },
+  }),
+}));
+
+function renderPage(navigate?: (url: string) => void) {
+  const tokenStore = new WebTokenStore({ logoutEndpoint: '/auth/logout' });
+  const ui = (
+    <AuthProvider tokenStore={tokenStore}>
+      <SignUpPage imageSlot={null} {...(navigate !== undefined ? { navigate } : {})} />
+    </AuthProvider>
+  );
+  return render(ui);
+}
+
+function fillField(formEl: HTMLElement, label: RegExp, value: string) {
+  const input = within(formEl).getByLabelText(label);
+  fireEvent.change(input, { target: { value } });
+}
+
+function fillPassword(formEl: HTMLElement, value: string, index: number) {
+  const inputs = formEl.querySelectorAll<HTMLInputElement>('input[type="password"]');
+  const target = inputs[index];
+  expect(target).toBeDefined();
+  if (target !== undefined) {
+    fireEvent.change(target, { target: { value } });
+  }
+}
+
+describe('SignUpPage', () => {
+  beforeEach(() => {
+    createSpy.mockReset();
+    prepareSpy.mockReset();
+  });
+
+  it('renders the Sign up heading and the form', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { level: 1, name: /sign up/i })).toBeInTheDocument();
+    expect(screen.getByTestId('signup-form')).toBeInTheDocument();
+  });
+
+  it('shows an inline error when passwords do not match', async () => {
+    renderPage();
+    const form = screen.getByTestId('signup-form');
+    fillField(form, /name/i, 'Olivia');
+    fillField(form, /email/i, 'olivia@untitledui.com');
+    fillPassword(form, 'correct-horse', 0);
+    fillPassword(form, 'different-pony', 1);
+    fireEvent.click(within(form).getByRole('button', { name: /get started/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('signup-form')).toBeInTheDocument();
+    });
+    // The mismatch never reaches Clerk.
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects passwords shorter than 8 characters', async () => {
+    renderPage();
+    const form = screen.getByTestId('signup-form');
+    fillField(form, /name/i, 'Olivia');
+    fillField(form, /email/i, 'olivia@untitledui.com');
+    fillPassword(form, 'short', 0);
+    fillPassword(form, 'short', 1);
+    fireEvent.click(within(form).getByRole('button', { name: /get started/i }));
+    await waitFor(() => {
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('submits to Clerk and redirects to the verification page on success', async () => {
+    createSpy.mockResolvedValueOnce(undefined);
+    prepareSpy.mockResolvedValueOnce(undefined);
+    const navigate = vi.fn();
+    renderPage(navigate);
+    const form = screen.getByTestId('signup-form');
+    fillField(form, /name/i, 'Olivia');
+    fillField(form, /email/i, 'olivia@untitledui.com');
+    fillPassword(form, 'correct-horse', 0);
+    fillPassword(form, 'correct-horse', 1);
+    fireEvent.click(within(form).getByRole('button', { name: /get started/i }));
+
+    await waitFor(() => {
+      expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+    const arg = createSpy.mock.calls[0]?.[0] as { emailAddress: string; password: string };
+    expect(arg.emailAddress).toBe('olivia@untitledui.com');
+    expect(arg.password).toBe('correct-horse');
+    expect(prepareSpy).toHaveBeenCalledWith({ strategy: 'email_code' });
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith('/verify-email?after=signup');
+    });
+  });
+});

--- a/apps/web/src/features/auth/sign-up/sign-up-page.tsx
+++ b/apps/web/src/features/auth/sign-up/sign-up-page.tsx
@@ -1,0 +1,186 @@
+// SignUpPage — Glaon-rendered headless Clerk sign-up form (#471).
+// Replaces the legacy `<SignUpRoute>` (Clerk hosted view) with the
+// split-screen Figma design and wires the SDK via `useCloudSignUp`.
+//
+// On success the form navigates to `/verify-email?after=signup`
+// (handled by #473 / F). Until F merges, the route renders a
+// placeholder; this PR's scope ends at the redirect.
+
+import { useEffect, useState, type ReactNode, type SyntheticEvent } from 'react';
+
+import {
+  AuthFooter,
+  AuthLayout,
+  Button,
+  Checkbox,
+  FormField,
+  PasswordInput,
+  SocialButton,
+  useFormFieldDescriptors,
+} from '@glaon/ui';
+
+import { useCloudSignUp } from './use-cloud-sign-up';
+
+interface SignUpPageProps {
+  /** Hero image rendered on the right column (split layout). */
+  imageSlot?: ReactNode;
+  /** Navigation injection — defaults to `window.location.assign`. */
+  navigate?: ((url: string) => void) | undefined;
+}
+
+export function SignUpPage({ imageSlot, navigate }: SignUpPageProps): ReactNode {
+  const [name, setName] = useState<string>('');
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [confirmPassword, setConfirmPassword] = useState<string>('');
+  const [marketingOptIn, setMarketingOptIn] = useState<boolean>(false);
+  const { state, submit, signUpWithSocial, isLoaded } = useCloudSignUp();
+  const nameField = useFormFieldDescriptors('signup-name');
+  const emailField = useFormFieldDescriptors('signup-email');
+
+  useEffect(() => {
+    if (state.status === 'awaiting_verification') {
+      const go =
+        navigate ??
+        ((url: string) => {
+          window.location.assign(url);
+        });
+      go('/verify-email?after=signup');
+    }
+  }, [navigate, state]);
+
+  const onSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void submit({ name, email, password, confirmPassword });
+  };
+
+  const isSubmitting = state.status === 'submitting';
+  const error = state.status === 'error' ? state.error : null;
+  const fieldError = (
+    field: 'name' | 'email' | 'password' | 'confirmPassword',
+  ): string | undefined => (error?.fieldKey === field ? error.message : undefined);
+  const generalError = error !== null && error.fieldKey === undefined ? error.message : undefined;
+
+  return (
+    <AuthLayout
+      variant="split"
+      imageSlot={imageSlot}
+      footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
+    >
+      <header className="flex flex-col gap-2">
+        <h1 className="text-display-sm font-semibold text-primary">Sign up</h1>
+        <p className="text-md text-tertiary">Start your 30-day free trial.</p>
+      </header>
+
+      <form
+        data-testid="signup-form"
+        onSubmit={onSubmit}
+        className="flex flex-col gap-4"
+        noValidate
+      >
+        <FormField
+          label="Name"
+          htmlFor="signup-name"
+          {...(fieldError('name') !== undefined ? { error: fieldError('name') } : {})}
+          isRequired
+        >
+          <input
+            id="signup-name"
+            name="name"
+            type="text"
+            autoComplete="name"
+            required
+            value={name}
+            onChange={(e) => {
+              setName(e.currentTarget.value);
+            }}
+            aria-invalid={fieldError('name') !== undefined}
+            aria-describedby={nameField.describedBy(fieldError('name') !== undefined, false)}
+            className="w-full rounded-lg bg-primary px-3 py-2 text-md text-primary shadow-xs ring-1 ring-primary ring-inset focus:outline-hidden focus:ring-2 focus:ring-brand"
+            placeholder="Enter your name"
+          />
+        </FormField>
+
+        <FormField
+          label="Email"
+          htmlFor="signup-email"
+          {...(fieldError('email') !== undefined ? { error: fieldError('email') } : {})}
+          isRequired
+        >
+          <input
+            id="signup-email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => {
+              setEmail(e.currentTarget.value);
+            }}
+            aria-invalid={fieldError('email') !== undefined}
+            aria-describedby={emailField.describedBy(fieldError('email') !== undefined, false)}
+            className="w-full rounded-lg bg-primary px-3 py-2 text-md text-primary shadow-xs ring-1 ring-primary ring-inset focus:outline-hidden focus:ring-2 focus:ring-brand"
+            placeholder="Enter your email"
+          />
+        </FormField>
+
+        <PasswordInput
+          label="Password"
+          autoComplete="new-password"
+          hint="Must be at least 8 characters."
+          {...(fieldError('password') !== undefined ? { error: fieldError('password') } : {})}
+          value={password}
+          onChange={setPassword}
+          isRequired
+          placeholder="Create a password"
+        />
+
+        <PasswordInput
+          label="Confirm password"
+          autoComplete="new-password"
+          {...(fieldError('confirmPassword') !== undefined
+            ? { error: fieldError('confirmPassword') }
+            : {})}
+          value={confirmPassword}
+          onChange={setConfirmPassword}
+          isRequired
+        />
+
+        <Checkbox
+          isSelected={marketingOptIn}
+          onChange={setMarketingOptIn}
+          label="Send me product updates and announcements (optional)."
+        />
+
+        {generalError !== undefined && (
+          <p role="alert" data-testid="signup-error" className="text-sm text-error">
+            {generalError}
+          </p>
+        )}
+
+        <Button type="submit" size="lg" isLoading={isSubmitting} isDisabled={!isLoaded}>
+          Get started
+        </Button>
+
+        <SocialButton
+          brand="google"
+          onPress={() => {
+            void signUpWithSocial('oauth_google');
+          }}
+        >
+          Sign up with Google
+        </SocialButton>
+        <SocialButton
+          brand="apple"
+          onPress={() => {
+            void signUpWithSocial('oauth_apple');
+          }}
+        >
+          Sign up with Apple
+        </SocialButton>
+
+        <AuthFooter prompt="Already have an account?" linkText="Log in" linkHref="/login" />
+      </form>
+    </AuthLayout>
+  );
+}

--- a/apps/web/src/features/auth/sign-up/use-cloud-sign-up.ts
+++ b/apps/web/src/features/auth/sign-up/use-cloud-sign-up.ts
@@ -1,0 +1,161 @@
+// `useCloudSignUp` — drives the Sign-up screen via Clerk's headless
+// `useSignUp()` hook. The screen renders the form with Glaon
+// primitives so the UX matches the Figma design pixel-for-pixel; the
+// hook owns the SDK orchestration + state machine.
+//
+// On a successful `signUp.create({...})` call we trigger the
+// email-code verification flow and bubble up "verify" so the page
+// component can navigate to `/verify-email?after=signup` (handled in
+// #473 / F).
+
+import { useSignUp } from '@clerk/clerk-react';
+import { useCallback, useState } from 'react';
+
+// Internal types — only the `useCloudSignUp` hook is consumed
+// outside this module, so knip flags wider exports.
+type CloudSignUpErrorCode =
+  | 'form_param_format_invalid'
+  | 'form_password_pwned'
+  | 'form_password_length_too_short'
+  | 'form_identifier_exists'
+  | 'unknown';
+
+interface CloudSignUpErrorState {
+  readonly code: CloudSignUpErrorCode;
+  readonly fieldKey?: 'name' | 'email' | 'password' | 'confirmPassword';
+  readonly message: string;
+}
+
+type CloudSignUpState =
+  | { readonly status: 'idle' }
+  | { readonly status: 'submitting' }
+  | { readonly status: 'awaiting_verification' }
+  | { readonly status: 'error'; readonly error: CloudSignUpErrorState };
+
+interface CloudSignUpInput {
+  readonly name: string;
+  readonly email: string;
+  readonly password: string;
+  readonly confirmPassword: string;
+}
+
+export function useCloudSignUp(): {
+  state: CloudSignUpState;
+  submit: (input: CloudSignUpInput) => Promise<void>;
+  signUpWithSocial: (strategy: 'oauth_google' | 'oauth_apple') => Promise<void>;
+  reset: () => void;
+  isLoaded: boolean;
+} {
+  const { signUp, isLoaded } = useSignUp();
+  const [state, setState] = useState<CloudSignUpState>({ status: 'idle' });
+
+  const submit = useCallback(
+    async (input: CloudSignUpInput) => {
+      if (!isLoaded) return;
+
+      // Client-side guards before we hit Clerk: matching passwords +
+      // ≥8-character length. Clerk also enforces these but a local
+      // check produces a faster, field-targeted error on the form.
+      if (input.password !== input.confirmPassword) {
+        setState({
+          status: 'error',
+          error: {
+            code: 'form_param_format_invalid',
+            fieldKey: 'confirmPassword',
+            message: "Passwords don't match.",
+          },
+        });
+        return;
+      }
+      if (input.password.length < 8) {
+        setState({
+          status: 'error',
+          error: {
+            code: 'form_password_length_too_short',
+            fieldKey: 'password',
+            message: 'Password must be at least 8 characters.',
+          },
+        });
+        return;
+      }
+
+      setState({ status: 'submitting' });
+      try {
+        const trimmed = input.name.trim();
+        const firstName = trimmed.split(/\s+/)[0] ?? trimmed;
+        const lastName = trimmed.includes(' ') ? trimmed.slice(firstName.length).trim() : undefined;
+        await signUp.create({
+          emailAddress: input.email,
+          password: input.password,
+          firstName,
+          ...(lastName !== undefined && lastName.length > 0 ? { lastName } : {}),
+        });
+        await signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
+        setState({ status: 'awaiting_verification' });
+      } catch (cause) {
+        setState({ status: 'error', error: errorFromCause(cause) });
+      }
+    },
+    [isLoaded, signUp],
+  );
+
+  const signUpWithSocial = useCallback(
+    async (strategy: 'oauth_google' | 'oauth_apple') => {
+      if (!isLoaded) return;
+      setState({ status: 'submitting' });
+      try {
+        await signUp.authenticateWithRedirect({
+          strategy,
+          redirectUrl: '/auth/sso-callback',
+          redirectUrlComplete: '/',
+        });
+      } catch (cause) {
+        setState({ status: 'error', error: errorFromCause(cause) });
+      }
+    },
+    [isLoaded, signUp],
+  );
+
+  const reset = useCallback(() => {
+    setState({ status: 'idle' });
+  }, []);
+
+  return { state, submit, signUpWithSocial, reset, isLoaded };
+}
+
+function errorFromCause(cause: unknown): CloudSignUpErrorState {
+  if (typeof cause === 'object' && cause !== null && 'errors' in cause) {
+    const errors = (cause as { errors?: unknown }).errors;
+    if (Array.isArray(errors) && errors.length > 0) {
+      const first = errors[0] as {
+        code?: unknown;
+        longMessage?: unknown;
+        message?: unknown;
+        meta?: { paramName?: unknown };
+      };
+      const code = (
+        typeof first.code === 'string' ? first.code : 'unknown'
+      ) as CloudSignUpErrorCode;
+      const param = first.meta?.paramName;
+      const fieldKey = mapParamToField(typeof param === 'string' ? param : undefined);
+      const message =
+        typeof first.longMessage === 'string'
+          ? first.longMessage
+          : typeof first.message === 'string'
+            ? first.message
+            : 'Sign up failed.';
+      const error: CloudSignUpErrorState = { code, message };
+      if (fieldKey !== undefined) (error as { fieldKey?: typeof fieldKey }).fieldKey = fieldKey;
+      return error;
+    }
+  }
+  return { code: 'unknown', message: 'Sign up failed. Try again in a moment.' };
+}
+
+function mapParamToField(param: string | undefined): CloudSignUpErrorState['fieldKey'] {
+  if (param === undefined) return undefined;
+  if (param === 'email_address' || param === 'email') return 'email';
+  if (param === 'password') return 'password';
+  if (param === 'first_name' || param === 'last_name' || param === 'name') return 'name';
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Replaces the legacy Clerk-hosted `<SignUp>` view at `/sign-up` with a Glaon-rendered form that drives `useSignUp()` directly. The form mirrors the Figma split-screen design (name + email + password + confirm + marketing opt-in checkbox + Google + Apple); on success the page navigates to `/verify-email?after=signup` (handled by #473 / F).

Closes #471 — refs epic #467.

> **Stacked PR:** depends on #479 (UI primitives — `<AuthLayout>`, `<PasswordInput>`, `<FormField>`, `<AuthFooter>`). Until #479 merges this PR's CI will fail on `@/components/...` imports.

## Scope — In

- `apps/web/src/features/auth/sign-up/sign-up-page.tsx` — split layout via `<AuthLayout>`, fields built on `<FormField>` + `<PasswordInput>`, social via `<SocialButton>`. Field-targeted error rendering from Clerk's `errors[].meta.paramName`.
- `apps/web/src/features/auth/sign-up/use-cloud-sign-up.ts` — drives the Clerk SDK: client-side guards (matching passwords, ≥8-char min) before `signUp.create({...})` + `prepareEmailAddressVerification({strategy: 'email_code'})`.
- `apps/web/src/App.tsx` — `/sign-up` mounts the new page; the Clerk-hosted `<SignUpRoute>` import is removed.
- `apps/web/vitest.config.ts` — gains the `@/` (kit alias) + `react-native` → `react-native-web` aliases (mirrors what the @glaon/ui kit's vitest config does) so jsdom resolves transitive imports (Alert → @/components/base/...).
- Unit tests: heading + form render, password mismatch guard, short-password guard, happy path through stubbed Clerk and `/verify-email?after=signup` redirect.

## Scope — Out

- Email verification step UI — #473 (F).
- Mobile parity — follow-up.
- Username availability check, password strength meter, TOS / Privacy modal — Phase 2.5 polish.
- Storybook page-level story — needs a mock `useSignUp` provider in the .storybook config; deferring to a follow-up so this PR stays focused.
- Playwright `@smoke` for the full flow — runs after F lands and the `/verify-email` route is real.

## Test plan

- [x] `pnpm type-check` (repo-wide) green
- [x] `pnpm lint` (repo-wide) green
- [x] `pnpm --filter @glaon/web test` — 75 tests pass (was 71; +4 SignUpPage scenarios)
- [ ] CI green on `gh pr checks <N> --watch` after #479 merges
- [ ] Manual: `pnpm dev` → `/sign-up` → fill form → mock Clerk's network → page navigates to `/verify-email?after=signup`

## Cross-references

- ADR 0019 — Clerk identity provider.
- ADR 0017 — dual-mode auth (sign-up is cloud-only).
- Figma Sign-up frame — [node 14530:2343](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=14530-2343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
