### PR TITLE
feat(web): cloud forgot-password 4-step flow (#472)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ import { LoginRoute } from './features/auth/local/login-route';
 import { SignInRoute } from './features/auth/cloud/sign-in-route';
 import { SignUpRoute } from './features/auth/cloud/sign-up-route';
 import { EmailVerificationPage } from './features/auth/email-verification/email-verification-page';
+import { ForgotPasswordPage } from './features/auth/forgot-password/forgot-password-page';
 import { PairWizardRoute } from './features/cloud-pairing/pair-wizard-route';
 import { ModeSelectRoute } from './features/mode-select/mode-select-route';
 import {
@@ -88,6 +89,17 @@ function Router({ clerkKey }: RouterProps): ReactNode {
         }}
       />
     );
+  }
+  if (path === '/forgot-password') {
+    if (clerkKey === null) {
+      return (
+        <main data-testid="cloud-unavailable">
+          <h1>Password reset unavailable</h1>
+          <p>VITE_CLERK_PUBLISHABLE_KEY is not configured for this build.</p>
+        </main>
+      );
+    }
+    return <ForgotPasswordPage />;
   }
   if (path === '/verify-email') {
     if (clerkKey === null) {

--- a/apps/web/src/features/auth/forgot-password/forgot-password-page.tsx
+++ b/apps/web/src/features/auth/forgot-password/forgot-password-page.tsx
@@ -1,0 +1,307 @@
+// ForgotPasswordPage — 4-step Glaon-rendered password reset flow
+// (#472). Drives Clerk's `reset_password_email_code` strategy via
+// `useForgotPassword`. Renders the Figma centered-card layout with
+// per-step icon slot:
+//
+//   step 1 (email)        — `Key01` icon, "Forgot password?"
+//   step 2 (check-email)  — `Mail01` icon, "Check your email"
+//   step 3 (reset)        — `Lock01` icon, "Set new password"
+//   step 4 (success)      — `CheckCircle` icon, "Password reset"
+//
+// On success the page navigates to `/login` after a 2s delay (or the
+// user can click "Sign in" immediately).
+
+import { useEffect, useState, type ReactNode, type SyntheticEvent } from 'react';
+
+import {
+  AuthFooter,
+  AuthLayout,
+  Button,
+  FormField,
+  PasswordInput,
+  VerificationCodeInput,
+  useFormFieldDescriptors,
+} from '@glaon/ui';
+
+import { useForgotPassword } from './use-forgot-password';
+
+const SUCCESS_AUTOREDIRECT_MS = 2000;
+
+interface ForgotPasswordPageProps {
+  navigate?: ((url: string) => void) | undefined;
+}
+
+// Inline SVG icons keyed off the step. Using inline SVG avoids the
+// `@untitledui/icons` dependency leaking into apps/web (only @glaon/ui
+// imports the kit's icon set).
+const ICON_PATHS = {
+  key: 'M16.5 9.5a4.5 4.5 0 1 1-4.95-4.477A4.5 4.5 0 0 1 16.5 9.5Zm-4.5 4.5l5 5m-1-1 2 2m-2-4 2 2',
+  mail: 'm3 7 8.165 5.71a1.5 1.5 0 0 0 1.67 0L21 7M5 18h14a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2Z',
+  lock: 'M16 11V7a4 4 0 1 0-8 0v4M5 11h14a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-6a2 2 0 0 1 2-2Z',
+  check: 'M9 12l2 2 4-4m6 2a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z',
+} as const;
+
+function FeaturedIcon({ name }: { name: keyof typeof ICON_PATHS }): ReactNode {
+  return (
+    <div className="flex size-14 items-center justify-center rounded-xl ring-1 ring-primary">
+      <svg
+        className="size-7 text-secondary"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d={ICON_PATHS[name]} />
+      </svg>
+    </div>
+  );
+}
+
+export function ForgotPasswordPage({ navigate }: ForgotPasswordPageProps): ReactNode {
+  const { state, requestReset, resendCode, goToReset, resetPassword, isLoaded } =
+    useForgotPassword();
+
+  useEffect(() => {
+    if (state.step !== 'success') return;
+    const go =
+      navigate ??
+      ((url: string) => {
+        window.location.assign(url);
+      });
+    const timer = setTimeout(() => {
+      go('/login');
+    }, SUCCESS_AUTOREDIRECT_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [navigate, state.step]);
+
+  const goToLogin = () => {
+    const go =
+      navigate ??
+      ((url: string) => {
+        window.location.assign(url);
+      });
+    go('/login');
+  };
+
+  if (state.step === 'email') {
+    return (
+      <ForgotPasswordLayout icon={<FeaturedIcon name="key" />}>
+        <Heading
+          title="Forgot password?"
+          subtitle="No worries, we'll send you reset instructions."
+        />
+        <EmailStep
+          isLoaded={isLoaded}
+          isSubmitting={state.status === 'submitting'}
+          error={state.error?.message}
+          onSubmit={(email) => {
+            void requestReset(email);
+          }}
+        />
+        <AuthFooter linkText="Back to log in" linkHref="/login" iconLeading="arrow-left" />
+      </ForgotPasswordLayout>
+    );
+  }
+
+  if (state.step === 'check-email') {
+    return (
+      <ForgotPasswordLayout icon={<FeaturedIcon name="mail" />}>
+        <Heading
+          title="Check your email"
+          subtitle={`We sent a password reset link to ${state.email}.`}
+        />
+        <div className="flex w-full flex-col gap-3">
+          <Button size="lg" onClick={goToReset}>
+            Enter reset code
+          </Button>
+          <Button
+            size="lg"
+            color="secondary"
+            isLoading={state.status === 'submitting'}
+            onClick={() => {
+              void resendCode();
+            }}
+          >
+            Resend email
+          </Button>
+        </div>
+        <AuthFooter linkText="Back to log in" linkHref="/login" iconLeading="arrow-left" />
+      </ForgotPasswordLayout>
+    );
+  }
+
+  if (state.step === 'reset') {
+    return (
+      <ForgotPasswordLayout icon={<FeaturedIcon name="lock" />}>
+        <Heading title="Set new password" subtitle={`Enter the code we sent to ${state.email}.`} />
+        <ResetStep
+          isLoaded={isLoaded}
+          isSubmitting={state.status === 'submitting'}
+          error={state.error?.message}
+          onSubmit={(input) => {
+            void resetPassword(input);
+          }}
+        />
+        <AuthFooter linkText="Back to log in" linkHref="/login" iconLeading="arrow-left" />
+      </ForgotPasswordLayout>
+    );
+  }
+
+  // success
+  return (
+    <ForgotPasswordLayout icon={<FeaturedIcon name="check" />}>
+      <Heading
+        title="Password reset"
+        subtitle="Your password has been updated. Sign in to continue."
+      />
+      <Button size="lg" onClick={goToLogin}>
+        Sign in
+      </Button>
+    </ForgotPasswordLayout>
+  );
+}
+
+function ForgotPasswordLayout({
+  icon,
+  children,
+}: {
+  icon: ReactNode;
+  children: ReactNode;
+}): ReactNode {
+  return (
+    <AuthLayout
+      variant="centered"
+      iconSlot={icon}
+      footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
+    >
+      {children}
+    </AuthLayout>
+  );
+}
+
+function Heading({ title, subtitle }: { title: string; subtitle: string }): ReactNode {
+  return (
+    <div>
+      <h1 className="text-display-sm font-semibold text-primary">{title}</h1>
+      <p className="mt-2 text-md text-tertiary">{subtitle}</p>
+    </div>
+  );
+}
+
+function EmailStep({
+  isLoaded,
+  isSubmitting,
+  error,
+  onSubmit,
+}: {
+  isLoaded: boolean;
+  isSubmitting: boolean;
+  error: string | undefined;
+  onSubmit: (email: string) => void;
+}): ReactNode {
+  const [email, setEmail] = useState('');
+  const emailField = useFormFieldDescriptors('forgot-email');
+  const submit = (event: SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit(email);
+  };
+  return (
+    <form
+      data-testid="forgot-email-form"
+      onSubmit={submit}
+      className="flex w-full flex-col gap-4"
+      noValidate
+    >
+      <FormField
+        label="Email"
+        htmlFor="forgot-email"
+        {...(error !== undefined ? { error } : {})}
+        isRequired
+      >
+        <input
+          id="forgot-email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(e) => {
+            setEmail(e.currentTarget.value);
+          }}
+          aria-invalid={error !== undefined}
+          aria-describedby={emailField.describedBy(error !== undefined, false)}
+          className="w-full rounded-lg bg-primary px-3 py-2 text-md text-primary shadow-xs ring-1 ring-primary ring-inset focus:outline-hidden focus:ring-2 focus:ring-brand"
+          placeholder="Enter your email"
+        />
+      </FormField>
+      <Button type="submit" size="lg" isLoading={isSubmitting} isDisabled={!isLoaded}>
+        Reset password
+      </Button>
+    </form>
+  );
+}
+
+function ResetStep({
+  isLoaded,
+  isSubmitting,
+  error,
+  onSubmit,
+}: {
+  isLoaded: boolean;
+  isSubmitting: boolean;
+  error: string | undefined;
+  onSubmit: (input: { code: string; password: string; confirmPassword: string }) => void;
+}): ReactNode {
+  const [code, setCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const submit = (event: SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit({ code, password, confirmPassword });
+  };
+  return (
+    <form
+      data-testid="forgot-reset-form"
+      onSubmit={submit}
+      className="flex w-full flex-col gap-4"
+      noValidate
+    >
+      <VerificationCodeInput
+        label="Reset code"
+        digits={6}
+        value={code}
+        onChange={setCode}
+        ariaLabel="Reset code"
+        {...(error !== undefined ? { isInvalid: true } : {})}
+      />
+      <PasswordInput
+        label="New password"
+        autoComplete="new-password"
+        hint="Must be at least 8 characters."
+        value={password}
+        onChange={setPassword}
+        isRequired
+      />
+      <PasswordInput
+        label="Confirm password"
+        autoComplete="new-password"
+        value={confirmPassword}
+        onChange={setConfirmPassword}
+        isRequired
+      />
+      {error !== undefined && (
+        <p role="alert" data-testid="forgot-reset-error" className="text-sm text-error">
+          {error}
+        </p>
+      )}
+      <Button type="submit" size="lg" isLoading={isSubmitting} isDisabled={!isLoaded}>
+        Reset password
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/features/auth/forgot-password/use-forgot-password.ts
+++ b/apps/web/src/features/auth/forgot-password/use-forgot-password.ts
@@ -1,0 +1,188 @@
+// `useForgotPassword` — drives the four-step Forgot password flow
+// (#472) via Clerk's headless `useSignIn()` hook with the
+// `reset_password_email_code` strategy. The page component owns the
+// per-step UI; the hook owns the SDK orchestration + state machine.
+
+import { useSignIn } from '@clerk/clerk-react';
+import { useCallback, useReducer } from 'react';
+
+// Internal types — only the `useForgotPassword` hook is consumed
+// outside this module, so knip flags wider exports.
+type ForgotStep = 'email' | 'check-email' | 'reset' | 'success';
+
+type ForgotErrorCode =
+  | 'form_param_format_invalid'
+  | 'form_identifier_not_found'
+  | 'form_code_incorrect'
+  | 'form_code_expired'
+  | 'form_password_pwned'
+  | 'unknown';
+
+interface ForgotErrorState {
+  readonly code: ForgotErrorCode;
+  readonly message: string;
+}
+
+interface ForgotMachineState {
+  readonly step: ForgotStep;
+  readonly email: string;
+  readonly status: 'idle' | 'submitting';
+  readonly error: ForgotErrorState | null;
+}
+
+type Action =
+  | { kind: 'submitting' }
+  | { kind: 'email-sent'; email: string }
+  | { kind: 'go-to-reset' }
+  | { kind: 'reset-success' }
+  | { kind: 'error'; error: ForgotErrorState }
+  | { kind: 'back' };
+
+const initial: ForgotMachineState = {
+  step: 'email',
+  email: '',
+  status: 'idle',
+  error: null,
+};
+
+function reducer(state: ForgotMachineState, action: Action): ForgotMachineState {
+  switch (action.kind) {
+    case 'submitting':
+      return { ...state, status: 'submitting', error: null };
+    case 'email-sent':
+      return { step: 'check-email', email: action.email, status: 'idle', error: null };
+    case 'go-to-reset':
+      return { ...state, step: 'reset', status: 'idle', error: null };
+    case 'reset-success':
+      return { ...state, step: 'success', status: 'idle', error: null };
+    case 'error':
+      return { ...state, status: 'idle', error: action.error };
+    case 'back':
+      if (state.step === 'check-email') return { ...initial, email: state.email };
+      if (state.step === 'reset') return { ...state, step: 'check-email', error: null };
+      return state;
+    default:
+      return state;
+  }
+}
+
+export function useForgotPassword(): {
+  state: ForgotMachineState;
+  requestReset: (email: string) => Promise<void>;
+  resendCode: () => Promise<void>;
+  goToReset: () => void;
+  resetPassword: (input: {
+    code: string;
+    password: string;
+    confirmPassword: string;
+  }) => Promise<void>;
+  back: () => void;
+  isLoaded: boolean;
+} {
+  const { signIn, isLoaded, setActive } = useSignIn();
+  const [state, dispatch] = useReducer(reducer, initial);
+
+  const requestReset = useCallback(
+    async (email: string) => {
+      if (!isLoaded) return;
+      dispatch({ kind: 'submitting' });
+      try {
+        await signIn.create({
+          strategy: 'reset_password_email_code',
+          identifier: email,
+        });
+        dispatch({ kind: 'email-sent', email });
+      } catch (cause) {
+        dispatch({ kind: 'error', error: errorFromCause(cause) });
+      }
+    },
+    [isLoaded, signIn],
+  );
+
+  const resendCode = useCallback(async () => {
+    if (!isLoaded || state.email.length === 0) return;
+    dispatch({ kind: 'submitting' });
+    try {
+      await signIn.create({
+        strategy: 'reset_password_email_code',
+        identifier: state.email,
+      });
+      dispatch({ kind: 'email-sent', email: state.email });
+    } catch (cause) {
+      dispatch({ kind: 'error', error: errorFromCause(cause) });
+    }
+  }, [isLoaded, signIn, state.email]);
+
+  const goToReset = useCallback(() => {
+    dispatch({ kind: 'go-to-reset' });
+  }, []);
+
+  const resetPassword = useCallback(
+    async (input: { code: string; password: string; confirmPassword: string }) => {
+      if (!isLoaded) return;
+      if (input.password !== input.confirmPassword) {
+        dispatch({
+          kind: 'error',
+          error: { code: 'form_param_format_invalid', message: "Passwords don't match." },
+        });
+        return;
+      }
+      if (input.password.length < 8) {
+        dispatch({
+          kind: 'error',
+          error: {
+            code: 'form_param_format_invalid',
+            message: 'Password must be at least 8 characters.',
+          },
+        });
+        return;
+      }
+      dispatch({ kind: 'submitting' });
+      try {
+        const result = await signIn.attemptFirstFactor({
+          strategy: 'reset_password_email_code',
+          code: input.code,
+          password: input.password,
+        });
+        if (result.status === 'complete') {
+          if (result.createdSessionId !== null) {
+            await setActive({ session: result.createdSessionId });
+          }
+          dispatch({ kind: 'reset-success' });
+          return;
+        }
+        dispatch({
+          kind: 'error',
+          error: { code: 'unknown', message: 'Additional verification is required.' },
+        });
+      } catch (cause) {
+        dispatch({ kind: 'error', error: errorFromCause(cause) });
+      }
+    },
+    [isLoaded, setActive, signIn],
+  );
+
+  const back = useCallback(() => {
+    dispatch({ kind: 'back' });
+  }, []);
+
+  return { state, requestReset, resendCode, goToReset, resetPassword, back, isLoaded };
+}
+
+function errorFromCause(cause: unknown): ForgotErrorState {
+  if (typeof cause === 'object' && cause !== null && 'errors' in cause) {
+    const errors = (cause as { errors?: unknown }).errors;
+    if (Array.isArray(errors) && errors.length > 0) {
+      const first = errors[0] as { code?: unknown; longMessage?: unknown; message?: unknown };
+      const code = (typeof first.code === 'string' ? first.code : 'unknown') as ForgotErrorCode;
+      const message =
+        typeof first.longMessage === 'string'
+          ? first.longMessage
+          : typeof first.message === 'string'
+            ? first.message
+            : 'Reset failed.';
+      return { code, message };
+    }
+  }
+  return { code: 'unknown', message: 'Reset failed. Try again in a moment.' };
+}


### PR DESCRIPTION
## Summary

Adds the `/forgot-password` screen — a four-step Glaon-rendered password reset flow that drives Clerk's headless `useSignIn()` with the `reset_password_email_code` strategy. Steps follow the Figma centered-card design: **email** → **check-email** → **reset (code + new password)** → **success → /login**.

Closes #472 — refs epic #467.

> **Stacked PR:** depends on #479 (UI primitives — `<AuthLayout>`, `<PasswordInput>`, `<FormField>`, `<AuthFooter>`, `<VerificationCodeInput>`).

## Scope — In

- `apps/web/src/features/auth/forgot-password/forgot-password-page.tsx` — single route, four step components co-located. `<AuthLayout variant="centered">` with a per-step inline-SVG icon (key / mail / lock / check). Reuses `<FormField>`, `<PasswordInput>`, and `<VerificationCodeInput>`.
- `apps/web/src/features/auth/forgot-password/use-forgot-password.ts` — `useReducer` machine wraps Clerk: `signIn.create` for the email step, `signIn.attemptFirstFactor` for the reset step. Client-side guards (matching passwords, ≥8-char min) before the SDK call.
- `apps/web/src/App.tsx` — new `/forgot-password` route gated on the Clerk publishable key (graceful "unavailable" fallback for builds without the key).
- `apps/web/vitest.config.ts` — gains the `@/` and `react-native` aliases (mirrors @glaon/ui's vitest setup) so jsdom resolves transitive kit imports.
- Inline-SVG icons keep the `@untitledui/icons` package out of apps/web's dependency surface (only @glaon/ui imports the kit's icon set).

## Scope — Out

- SMS code reset (email-only).
- Captcha (Clerk env-dependent; invisible/disabled).
- Storybook page-level stories (need a mock `useSignIn` provider in `.storybook`; deferring to a follow-up).
- Dedicated unit tests for each step component (the existing repo-wide regression suite covers the basic render via App.test.tsx; per-step RTL tests are a follow-up).
- Mobile parity — follow-up.

## Test plan

- [x] `pnpm type-check` (repo-wide) green
- [x] `pnpm lint` (repo-wide) green
- [x] `pnpm --filter @glaon/web test` — 71 tests pass (no regression)
- [ ] CI green on `gh pr checks <N> --watch` after #479 merges
- [ ] Manual: `pnpm dev` → `/forgot-password` → email → mock Clerk reset email → enter code + new password → land on `/login`

## Cross-references

- ADR 0019 — Clerk identity provider.
- Figma Forgot password frame — [node 1269:1186](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1269-1186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
