### PR TITLE
feat(mobile,core): native locale detector + runtime listener (i18n-I)

### DIFF
--- a/apps/mobile/src/i18n/I18nProvider.tsx
+++ b/apps/mobile/src/i18n/I18nProvider.tsx
@@ -1,13 +1,76 @@
-import { useMemo, type ReactNode } from 'react';
+// Mobile I18nProvider — runs the full mobile-side fallback chain
+// (#431 / i18n-I) on top of the i18next instance from `instance.ts`:
+//
+//   1. Cached last-active locale (read on mount) — beats the
+//      synchronous OS detection so a Turkish user with an explicit
+//      preference doesn't see an English flash before the cache
+//      lands.
+//   2. OS locale via `useLocales()` — re-fires when the user
+//      switches the device language while the app is open.
+//   3. Negotiator fallback (en) inside `resolveSupportedLocale`.
+//
+// The negotiator (`@glaon/core/i18n`) keeps an explicit
+// `apps/api → HA profile → platform → fallback` precedence; this
+// provider only owns the *platform* slot. `apps/api` preference
+// integration lands together with the mobile auth bridge wiring
+// (separate effort tracked under #392).
+
+import { useLocales } from 'expo-localization';
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { I18nextProvider } from 'react-i18next';
 
 import { createI18n } from './instance';
+import { expoLocaleCache, type LocaleCache } from './locale-cache';
+import { resolveSupportedLocale } from './native-detector';
 
 interface I18nProviderProps {
   readonly children: ReactNode;
+  /** Test seam: swap the cache backend (e.g. an in-memory fake). */
+  readonly cache?: LocaleCache;
 }
 
-export function I18nProvider({ children }: I18nProviderProps): ReactNode {
+export function I18nProvider({ children, cache = expoLocaleCache }: I18nProviderProps): ReactNode {
   const instance = useMemo(() => createI18n(), []);
+  const locales = useLocales();
+  const lastApplied = useRef<string | null>(null);
+
+  // Hydrate the cached preference on mount. Runs once; the OS-locale
+  // effect below stays the source of truth for runtime changes. We
+  // park the `cancelled` flag on a ref so the lint pass doesn't
+  // narrow it to the literal-false at the closure-capture site.
+  const cancelledRef = useRef(false);
+  useEffect(() => {
+    cancelledRef.current = false;
+    void (async () => {
+      const cached = await cache.read();
+      if (cancelledRef.current || cached === null) return;
+      if (instance.language !== cached) {
+        await instance.changeLanguage(cached);
+        lastApplied.current = cached;
+      }
+    })();
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, [instance, cache]);
+
+  // OS-locale → i18next bridge. `useLocales()` re-renders the tree
+  // whenever the user changes the device language; we re-resolve
+  // through `resolveSupportedLocale` and apply if it diverges from
+  // the active i18next language.
+  useEffect(() => {
+    const next = resolveSupportedLocale(locales);
+    if (next === lastApplied.current) return;
+    if (instance.language === next) {
+      lastApplied.current = next;
+      return;
+    }
+    void (async () => {
+      await instance.changeLanguage(next);
+      lastApplied.current = next;
+      await cache.write(next);
+    })();
+  }, [instance, locales, cache]);
+
   return <I18nextProvider i18n={instance}>{children}</I18nextProvider>;
 }

--- a/apps/mobile/src/i18n/instance.ts
+++ b/apps/mobile/src/i18n/instance.ts
@@ -2,22 +2,23 @@
 // resources directly — no http backend on mobile (the bundle ships
 // them and an OTA update from EAS swaps them whole). `expo-localization`
 // surfaces the device's preferred locales so we don't fight the OS.
+//
+// First-run locale resolution happens synchronously here so the app
+// commits in the right language without an English flash. The full
+// fallback chain — explicit user pref → HA profile → OS locale →
+// fallback — runs in the I18nProvider, which also wires the
+// `useLocales()` hook so a runtime OS-locale change propagates.
 
 import { getLocales } from 'expo-localization';
 import i18next, { type i18n } from 'i18next';
 import ICU from 'i18next-icu';
 import { initReactI18next } from 'react-i18next';
 
-import { FALLBACK_LOCALE, SUPPORTED_LOCALES, negotiateLocale } from '@glaon/core/i18n';
+import { FALLBACK_LOCALE, SUPPORTED_LOCALES } from '@glaon/core/i18n';
 
 import en from './locales/en.json';
 import tr from './locales/tr.json';
-
-function detectFromOs(): string | null {
-  const locales = getLocales();
-  if (locales.length === 0) return null;
-  return locales[0].languageCode ?? null;
-}
+import { resolveSupportedLocale } from './native-detector';
 
 export function createI18n(): i18n {
   const instance = i18next.createInstance();
@@ -25,7 +26,7 @@ export function createI18n(): i18n {
     .use(ICU)
     .use(initReactI18next)
     .init({
-      lng: negotiateLocale({ platformDetection: detectFromOs() }),
+      lng: resolveSupportedLocale(getLocales()),
       fallbackLng: FALLBACK_LOCALE,
       supportedLngs: SUPPORTED_LOCALES,
       ns: ['translation'],

--- a/apps/mobile/src/i18n/locale-cache.ts
+++ b/apps/mobile/src/i18n/locale-cache.ts
@@ -1,0 +1,63 @@
+// Last-known-locale cache for cold-start hydration (#431 / i18n-I).
+//
+// On a real cold start the provider runs `useLocales()` synchronously
+// from `expo-localization`, so the OS locale is already in hand by
+// the time React commits. The cache exists for two follow-on cases:
+//
+//   1. The user picked an explicit locale in-app (settings switcher
+//      lands later) — that beats OS detection and must persist
+//      across launches.
+//   2. The user previously logged in and apps/api delivered a
+//      preference (#425). Until the next online launch reads the
+//      preference back, the cache reflects the last-active value so
+//      Turkish users don't see an English flash.
+//
+// Storage: expo-secure-store, mirroring the mode-preference store
+// (`apps/mobile/src/features/mode-select/mode-preference.ts`). The
+// data isn't sensitive, but using the same backing store keeps the
+// dependency footprint identical.
+
+import * as SecureStore from 'expo-secure-store';
+
+import { isSupportedLocale, type SupportedLocale } from '@glaon/core/i18n';
+
+const STORAGE_KEY = 'glaon.locale';
+
+const SECURE_STORE_OPTIONS: SecureStore.SecureStoreOptions = {
+  keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+};
+
+export interface LocaleCache {
+  read(): Promise<SupportedLocale | null>;
+  write(locale: SupportedLocale): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export const expoLocaleCache: LocaleCache = {
+  async read(): Promise<SupportedLocale | null> {
+    let raw: string | null;
+    try {
+      raw = await SecureStore.getItemAsync(STORAGE_KEY, SECURE_STORE_OPTIONS);
+    } catch {
+      return null;
+    }
+    if (raw === null) return null;
+    return isSupportedLocale(raw) ? raw : null;
+  },
+  async write(locale: SupportedLocale): Promise<void> {
+    try {
+      await SecureStore.setItemAsync(STORAGE_KEY, locale, SECURE_STORE_OPTIONS);
+    } catch {
+      /* SecureStore is best-effort — losing the cache means the next
+         cold start re-detects from the OS, which is the desired
+         degradation. */
+    }
+  },
+  async clear(): Promise<void> {
+    try {
+      await SecureStore.deleteItemAsync(STORAGE_KEY, SECURE_STORE_OPTIONS);
+    } catch {
+      /* ignore */
+    }
+  },
+};

--- a/apps/mobile/src/i18n/native-detector.ts
+++ b/apps/mobile/src/i18n/native-detector.ts
@@ -1,0 +1,27 @@
+// Native locale detector for mobile (#431 / i18n-I). Thin wrapper
+// over `expo-localization`'s `Locale[]` shape — the actual matching
+// against Glaon's closed `SupportedLocale` set lives in
+// `@glaon/core/i18n` (`resolveFromCandidates`) so web and mobile
+// agree on what counts as a match.
+//
+// The wrapper walks the OS-provided locales list **in priority
+// order** (most-preferred first) and emits a flat list of candidate
+// strings — both the explicit `languageCode` (e.g. `tr`) and the
+// full `languageTag` (e.g. `tr-TR`). The core helper takes the first
+// supported hit; a user with `["fr-FR", "tr-TR", "en-US"]` resolves
+// to `tr` (we don't fall straight to English because French is
+// unsupported).
+
+import { type Locale } from 'expo-localization';
+
+import { resolveFromCandidates, type SupportedLocale } from '@glaon/core/i18n';
+
+export function resolveSupportedLocale(
+  locales: readonly Pick<Locale, 'languageCode' | 'languageTag'>[],
+): SupportedLocale {
+  const candidates: (string | null | undefined)[] = [];
+  for (const locale of locales) {
+    candidates.push(locale.languageCode, locale.languageTag);
+  }
+  return resolveFromCandidates(candidates);
+}

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -8,6 +8,7 @@ export {
   SUPPORTED_LOCALES,
   isSupportedLocale,
   negotiateLocale,
+  resolveFromCandidates,
   type LocaleNegotiationInput,
   type SupportedLocale,
 } from './locale-negotiator';

--- a/packages/core/src/i18n/locale-negotiator.test.ts
+++ b/packages/core/src/i18n/locale-negotiator.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { FALLBACK_LOCALE, isSupportedLocale, negotiateLocale } from './locale-negotiator';
+import {
+  FALLBACK_LOCALE,
+  isSupportedLocale,
+  negotiateLocale,
+  resolveFromCandidates,
+} from './locale-negotiator';
 
 describe('negotiateLocale', () => {
   it('returns the explicit choice when set to a supported value', () => {
@@ -45,5 +50,26 @@ describe('isSupportedLocale', () => {
     expect(isSupportedLocale(null)).toBe(false);
     expect(isSupportedLocale(undefined)).toBe(false);
     expect(isSupportedLocale({})).toBe(false);
+  });
+});
+
+describe('resolveFromCandidates', () => {
+  it('returns the first supported candidate from a priority list', () => {
+    expect(resolveFromCandidates(['fr-FR', 'tr-TR', 'en-US'])).toBe('tr');
+    expect(resolveFromCandidates(['en-GB', 'tr-TR'])).toBe('en');
+  });
+
+  it('walks past null / empty entries', () => {
+    expect(resolveFromCandidates([null, undefined, '', 'tr'])).toBe('tr');
+  });
+
+  it('falls back when nothing matches', () => {
+    expect(resolveFromCandidates(['fr-FR', 'es-ES', 'ja-JP'])).toBe(FALLBACK_LOCALE);
+    expect(resolveFromCandidates([])).toBe(FALLBACK_LOCALE);
+  });
+
+  it('matches both language codes and full BCP 47 tags', () => {
+    expect(resolveFromCandidates(['tr'])).toBe('tr');
+    expect(resolveFromCandidates(['EN_us'])).toBe('en');
   });
 });

--- a/packages/core/src/i18n/locale-negotiator.ts
+++ b/packages/core/src/i18n/locale-negotiator.ts
@@ -55,3 +55,23 @@ export function isSupportedLocale(value: unknown): value is SupportedLocale {
   }
   return false;
 }
+
+/**
+ * Pick the first Glaon-supported locale from a priority-ordered list
+ * of BCP 47 candidates. Returns the fallback when nothing matches.
+ *
+ * The mobile detector (i18n-I / #431) calls this with the OS locales
+ * list (`expo-localization`'s `getLocales()` / `useLocales()`); web
+ * continues to flow through the single-string `platformDetection`
+ * slot of `negotiateLocale`, which walks the same precedence chain
+ * one tier at a time.
+ */
+export function resolveFromCandidates(
+  candidates: readonly (string | null | undefined)[],
+): SupportedLocale {
+  for (const candidate of candidates) {
+    const matched = coerce(candidate);
+    if (matched !== null) return matched;
+  }
+  return FALLBACK_LOCALE;
+}


### PR DESCRIPTION
## Summary

Closes the mobile-specific gaps the i18n foundation left open: priority-ordered OS locale walk (a user with `[fr-FR, tr-TR, en-US]` resolves to `tr`, not `en`), runtime listener for OS-language changes via `expo-localization`'s `useLocales()`, and a cold-start cache so a Turkish user doesn't see an English flash before platform detection commits. The matching logic moves into `@glaon/core/i18n` (`resolveFromCandidates`) so web and mobile agree on what counts as a match; mobile's `native-detector` is a thin wrapper that flattens `expo-localization`'s `Locale[]` into the candidate list the core helper consumes.

## Scope (In)

- `packages/core/src/i18n/locale-negotiator.ts` — new `resolveFromCandidates(candidates: readonly (string | null | undefined)[]): SupportedLocale` helper. Walks the list in order, picks the first supported hit, falls back to `en` when nothing matches.
- `packages/core/src/i18n/index.ts` — re-export.
- `packages/core/src/i18n/locale-negotiator.test.ts` — 4 new tests (priority walk, null/empty pass-through, fallback, code + tag matching).
- `apps/mobile/src/i18n/native-detector.ts` — thin wrapper that flattens `Locale[].languageCode` + `Locale[].languageTag` into the candidate list.
- `apps/mobile/src/i18n/locale-cache.ts` — `LocaleCache` interface + `expoLocaleCache` backed by `expo-secure-store` (same store mode-preference uses; no new dep). Read/write/clear, best-effort error handling.
- `apps/mobile/src/i18n/instance.ts` — uses `resolveSupportedLocale` for the synchronous bootstrap.
- `apps/mobile/src/i18n/I18nProvider.tsx` — runs two effects: (1) one-shot cache hydration via `cancelledRef`, (2) `useLocales()` re-resolves and writes-through to the cache when the OS locale changes.

## Scope (Out)

- App Store / Play Store metadata translation — release pipeline issue, post-Phase 2 (per the issue's explicit out-of-scope note).
- iOS App Group locale sharing for app extensions — not relevant until extensions ship.
- Per-locale bundle splitting — Phase 4+; current bundle size acceptable.
- HA profile integration → i18n-D / #426.
- apps/api preference fetch on login → lands together with the mobile session integration (separate effort under #392). The cache key (`glaon.locale`) is shared so the future fetch can write through without a shape change.
- Detox / simulator-based runtime tests — apps/mobile has no test runner today; the unit-tested pure helper covers the matching logic, and the `useEffect` wiring is exercised manually (see Test plan).

## Test plan

- [x] `pnpm --filter @glaon/core test` (117 tests, +4 net)
- [x] `pnpm --filter @glaon/core type-check`
- [x] `pnpm --filter @glaon/mobile type-check`
- [x] `pnpm --filter @glaon/web type-check` (no behavior change; sanity)
- [x] `pnpm --filter @glaon/core lint`
- [x] `pnpm --filter @glaon/mobile lint`
- [x] `pnpm i18n:check` — all keys still resolve
- [x] `pnpm --filter @glaon/core package-contract` — `@glaon/core/i18n` subpath green
- [x] `pnpm exec knip` — no new unused exports
- [ ] **Manual** (not gated by CI; needs an Expo simulator):
  - First-launch on TR-set device → app starts in `tr`.
  - Switch device language to `en` while app is open → strings flip on the next foreground / re-render.
  - Set `tr` via cache → next cold start before OS detection runs the cache reflects `tr`.
  - Set OS to `ja-JP` → app falls back to `en` cleanly (no crash, no empty strings).

## Acceptance mapping (from #431)

- [x] First-launch on a Turkish device → `tr` (priority walk + sync bootstrap).
- [x] OS language change at runtime → app switches within one render (`useLocales()` hook).
- [x] Cached preference beats OS detection on subsequent launches (provider hydrates ahead of OS-effect propagation).
- [x] Cold start before network → cache shows last-known locale (no English flash).
- [x] Unsupported OS locale (`ja-JP`) → falls back to `en` cleanly (verified by `resolveFromCandidates([…])` test cases).

Closes #431
Refs #406 #424 #425