### PR TITLE
feat(core): ha translations bridge \xe2\x80\x94 frontend/get_translations (i18n-D)

### DIFF
--- a/packages/core/src/ha/protocol/messages.ts
+++ b/packages/core/src/ha/protocol/messages.ts
@@ -109,6 +109,32 @@ export interface HaGetStatesFrame {
   readonly type: 'get_states';
 }
 
+/* ---------- frontend/get_translations (i18n-D / #426) ---------- */
+
+/**
+ * HA's localized strings RPC. Returns a flat dictionary of dotted keys
+ * (`component.switch.state.off` → `Off`/`Kapalı`) for the given
+ * `language` and `category`. Glaon merges the response into i18next
+ * under the `ha` namespace; we never re-translate HA-owned content.
+ *
+ * `category` follows HA's enum. We only ship the values Glaon actually
+ * consumes today — `state` (entity state labels) and `entity_component`
+ * (device class + service descriptions). HA's full list is broader;
+ * extending the union is a one-line change when a new category lands.
+ */
+export type HaTranslationCategory = 'state' | 'entity_component';
+
+export interface HaGetTranslationsFrame {
+  readonly id: number;
+  readonly type: 'frontend/get_translations';
+  readonly language: string;
+  readonly category: HaTranslationCategory;
+}
+
+export interface HaTranslationsResult {
+  readonly resources?: Readonly<Record<string, string>>;
+}
+
 /* ---------- Aggregates ---------- */
 
 export type HaInboundFrame =
@@ -126,4 +152,5 @@ export type HaOutboundFrame =
   | HaSubscribeEntitiesFrame
   | HaUnsubscribeEventsFrame
   | HaCallServiceFrame
-  | HaGetStatesFrame;
+  | HaGetStatesFrame
+  | HaGetTranslationsFrame;

--- a/packages/core/src/i18n/ha-bridge.test.ts
+++ b/packages/core/src/i18n/ha-bridge.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { HaClient } from '../ha/client';
+import {
+  clearHaTranslationsCache,
+  fetchHaTranslations,
+  invalidateHaTranslations,
+  type HaTranslationsCache,
+} from './ha-bridge';
+
+function inMemoryCache(): HaTranslationsCache {
+  const store = new Map<string, Readonly<Record<string, string>>>();
+  return {
+    get: (k) => store.get(k),
+    set: (k, v) => {
+      store.set(k, v);
+    },
+    delete: (k) => {
+      store.delete(k);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+}
+
+function fakeClient(resources: Record<string, string>): { client: HaClient; calls: number } {
+  let calls = 0;
+  const client = {
+    request: vi.fn(async () => {
+      calls += 1;
+      return Promise.resolve({ resources });
+    }),
+  } as unknown as HaClient;
+  return {
+    client,
+    get calls() {
+      return calls;
+    },
+  };
+}
+
+describe('fetchHaTranslations', () => {
+  it('returns the flat dictionary HA serves on frontend/get_translations', async () => {
+    const cache = inMemoryCache();
+    const { client } = fakeClient({ 'component.switch.state.off': 'Off' });
+    expect(await fetchHaTranslations(client, 'en', { cache })).toEqual({
+      'component.switch.state.off': 'Off',
+    });
+  });
+
+  it('caches by locale + category — second call hits the cache', async () => {
+    const cache = inMemoryCache();
+    const fc = fakeClient({ k: 'v' });
+    await fetchHaTranslations(fc.client, 'en', { cache });
+    await fetchHaTranslations(fc.client, 'en', { cache });
+    expect(fc.calls).toBe(1);
+  });
+
+  it('refresh: true bypasses the cache and overwrites the entry', async () => {
+    const cache = inMemoryCache();
+    const fc = fakeClient({ k: 'v1' });
+    await fetchHaTranslations(fc.client, 'en', { cache });
+    await fetchHaTranslations(fc.client, 'en', { cache, refresh: true });
+    expect(fc.calls).toBe(2);
+  });
+
+  it('different locales are isolated in the cache', async () => {
+    const cache = inMemoryCache();
+    const fc = fakeClient({ k: 'v' });
+    await fetchHaTranslations(fc.client, 'en', { cache });
+    await fetchHaTranslations(fc.client, 'tr', { cache });
+    expect(fc.calls).toBe(2);
+  });
+
+  it('different categories are isolated in the cache', async () => {
+    const cache = inMemoryCache();
+    const fc = fakeClient({ k: 'v' });
+    await fetchHaTranslations(fc.client, 'en', { cache, category: 'state' });
+    await fetchHaTranslations(fc.client, 'en', { cache, category: 'entity_component' });
+    expect(fc.calls).toBe(2);
+  });
+
+  it('tolerates an HA response missing the resources field', async () => {
+    const cache = inMemoryCache();
+    const client = {
+      request: vi.fn(async () => Promise.resolve({})),
+    } as unknown as HaClient;
+    expect(await fetchHaTranslations(client, 'en', { cache })).toEqual({});
+  });
+});
+
+describe('invalidateHaTranslations', () => {
+  it('drops a single locale/category pair', async () => {
+    const cache = inMemoryCache();
+    const fc = fakeClient({ k: 'v' });
+    await fetchHaTranslations(fc.client, 'en', { cache });
+    invalidateHaTranslations('en', { cache });
+    await fetchHaTranslations(fc.client, 'en', { cache });
+    expect(fc.calls).toBe(2);
+  });
+
+  it('does not affect other locales / categories', async () => {
+    const cache = inMemoryCache();
+    const fc = fakeClient({ k: 'v' });
+    await fetchHaTranslations(fc.client, 'en', { cache });
+    await fetchHaTranslations(fc.client, 'tr', { cache });
+    invalidateHaTranslations('en', { cache });
+    await fetchHaTranslations(fc.client, 'tr', { cache });
+    expect(fc.calls).toBe(2);
+  });
+});
+
+describe('clearHaTranslationsCache', () => {
+  it('drops every entry', async () => {
+    const cache = inMemoryCache();
+    const fc = fakeClient({ k: 'v' });
+    await fetchHaTranslations(fc.client, 'en', { cache });
+    await fetchHaTranslations(fc.client, 'tr', { cache });
+    clearHaTranslationsCache(cache);
+    await fetchHaTranslations(fc.client, 'en', { cache });
+    await fetchHaTranslations(fc.client, 'tr', { cache });
+    expect(fc.calls).toBe(4);
+  });
+});

--- a/packages/core/src/i18n/ha-bridge.ts
+++ b/packages/core/src/i18n/ha-bridge.ts
@@ -1,0 +1,117 @@
+// HA translations bridge (i18n-D / #426). Glaon never re-translates
+// HA-owned content (device class labels, state names, area names,
+// service descriptions); we ask HA for them in the active locale via
+// `frontend/get_translations` and merge the result into i18next under
+// the `ha` namespace. The bridge itself is a pure function over the
+// HaClient handshake — the i18next install step lives in the apps so
+// this file stays inside `@glaon/core`'s platform-agnostic boundary.
+//
+// Cache: the bridge keeps an in-memory cache keyed by `${locale}/${category}`.
+// Callers wire reconnect-driven invalidation (#10's reconnect lifecycle)
+// by passing `{ refresh: true }` — that bypasses the cache and overwrites
+// the entry. The cache lifetime is process-bound on purpose: a long-lived
+// HA session with a static locale should fetch once, but a TR-EN switch
+// or a reconnect should re-fetch.
+
+import type { HaClient } from '../ha/client';
+import type {
+  HaGetTranslationsFrame,
+  HaTranslationCategory,
+  HaTranslationsResult,
+} from '../ha/protocol/messages';
+
+export interface FetchHaTranslationsOptions {
+  /** HA's translation category. Defaults to `'state'`. */
+  readonly category?: HaTranslationCategory;
+  /** Bypass + overwrite the cached entry. */
+  readonly refresh?: boolean;
+  /**
+   * Override the cache backend (test seam). The default is a per-bridge
+   * Map; pass a fake when reasoning about cache hits in unit tests.
+   */
+  readonly cache?: HaTranslationsCache;
+}
+
+export interface HaTranslationsCache {
+  get(key: string): Readonly<Record<string, string>> | undefined;
+  set(key: string, value: Readonly<Record<string, string>>): void;
+  delete(key: string): void;
+  clear(): void;
+}
+
+const defaultCache: HaTranslationsCache = (() => {
+  const store = new Map<string, Readonly<Record<string, string>>>();
+  return {
+    get: (key) => store.get(key),
+    set: (key, value) => {
+      store.set(key, value);
+    },
+    delete: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  };
+})();
+
+function cacheKey(locale: string, category: HaTranslationCategory): string {
+  return `${locale}/${category}`;
+}
+
+/**
+ * Fetch HA-owned translations for `locale` from a connected HaClient.
+ *
+ * Returns the flat dotted-key dictionary HA serves on `frontend/get_translations`
+ * (e.g. `component.switch.state.off → 'Off'` in English). Caches the result
+ * keyed by `${locale}/${category}` so a render path that needs the same
+ * pair pays the WS round-trip once. Pass `{ refresh: true }` to force a
+ * fresh fetch — the typical caller is the HaClient reconnect listener.
+ */
+export async function fetchHaTranslations(
+  client: HaClient,
+  locale: string,
+  options: FetchHaTranslationsOptions = {},
+): Promise<Readonly<Record<string, string>>> {
+  const category: HaTranslationCategory = options.category ?? 'state';
+  const cache = options.cache ?? defaultCache;
+  const key = cacheKey(locale, category);
+  if (options.refresh !== true) {
+    const cached = cache.get(key);
+    if (cached !== undefined) return cached;
+  }
+  const frame: Omit<HaGetTranslationsFrame, 'id'> = {
+    type: 'frontend/get_translations',
+    language: locale,
+    category,
+  };
+  const result = await client.request<HaTranslationsResult>(frame);
+  // HA wraps the dictionary in `{ resources: {...} }`. Glaon keeps the
+  // flat shape downstream so the i18next install side never has to
+  // unwrap.
+  const resources = result.resources ?? {};
+  cache.set(key, resources);
+  return resources;
+}
+
+/**
+ * Drop a single locale/category pair from the cache. Wire this into
+ * the HaClient reconnect listener (or call directly when the user
+ * switches language) so the next fetch hits HA.
+ */
+export function invalidateHaTranslations(
+  locale: string,
+  options: { category?: HaTranslationCategory; cache?: HaTranslationsCache } = {},
+): void {
+  const category: HaTranslationCategory = options.category ?? 'state';
+  const cache = options.cache ?? defaultCache;
+  cache.delete(cacheKey(locale, category));
+}
+
+/**
+ * Drop every cached locale/category pair. Useful on app-wide auth
+ * resets or test isolation.
+ */
+export function clearHaTranslationsCache(cache: HaTranslationsCache = defaultCache): void {
+  cache.clear();
+}

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -13,3 +13,10 @@ export {
   type SupportedLocale,
 } from './locale-negotiator';
 export type { I18nNamespaces, I18nResource, I18nResources, LocaleChoice } from './types';
+export {
+  clearHaTranslationsCache,
+  fetchHaTranslations,
+  invalidateHaTranslations,
+  type FetchHaTranslationsOptions,
+  type HaTranslationsCache,
+} from './ha-bridge';


### PR DESCRIPTION
## Summary

Lands the @glaon/core slice of i18n-D — the bridge that lets Glaon consume HA-owned translations (device class labels, state names, area names, service descriptions) without ever maintaining them ourselves. The runtime/UI parts (i18next `addResourceBundle` install, `useHaTranslation` hook, reconnect-driven invalidation, language-on-subscribe envelope) stay deferred to the consumer wiring — those need a UI feature mounting `HaClient`, which doesn't exist yet. This PR establishes the contract those callers will plug into.

## Scope (In)

- `packages/core/src/ha/protocol/messages.ts`:
  - New `HaGetTranslationsFrame` (`{ type: 'frontend/get_translations', language, category }`) added to the outbound union so `HaClient.request()` accepts it.
  - `HaTranslationsResult` (the inbound `{ resources?: Record<string, string> }`).
  - `HaTranslationCategory` closed enum (`'state' | 'entity_component'`) — only the values Glaon consumes today; widening is a one-line change.
- `packages/core/src/i18n/ha-bridge.ts`:
  - `fetchHaTranslations(client, locale, options?)` — sends the WS request and returns the flat dotted-key dictionary HA serves.
  - In-memory cache keyed by `${locale}/${category}`. Default cache is module-scoped; `options.cache` is the test seam (the test suite uses fresh `Map`-backed caches per test for isolation).
  - `options.refresh: true` — bypass + overwrite (HA reconnect listener will use this).
  - `invalidateHaTranslations(locale, options?)` — drop a single (locale, category) pair from the cache.
  - `clearHaTranslationsCache(cache?)` — drop everything.
- `packages/core/src/i18n/index.ts` — re-exports `fetchHaTranslations`, `invalidateHaTranslations`, `clearHaTranslationsCache`, `FetchHaTranslationsOptions`, `HaTranslationsCache`.
- `packages/core/src/i18n/ha-bridge.test.ts` — 9 tests: round-trip, cache hit, refresh-bypass, locale isolation, category isolation, defensive fallback when HA omits `resources`, plus invalidate / clear behaviour.

## Scope (Out)

- `installHaResources(i18next, locale, translations)` — i18next is a runtime concern in the apps; the helper would be 1 line of `i18n.addResourceBundle(...)` and doesn't earn its place in `@glaon/core` (which respects ADR 0004's platform-agnostic boundary).
- `useHaTranslation(entityId)` hook — apps-side, lands when a UI feature consumes HA translations.
- HA WebSocket subscribe envelope `language` field — that's a small `subscribe_events` / `subscribe_entities` extension. Layering it onto `HaClient` correctly needs a real consumer to validate the lifecycle (e.g. what happens if `language` changes mid-subscription); deferred.
- Reconnect lifecycle wiring — same as above. The bridge already exposes the right primitive (`refresh: true`) for the listener to call.
- Sample `/locales/<lng>/ha.example.json` — the dictionary HA serves is a runtime artifact; checking a snapshot in misleads contributors. Skipped until a real consumer sets the convention.

## Test plan

- [x] `pnpm --filter @glaon/core test` — 126 tests, +9 net.
- [x] `pnpm --filter @glaon/core type-check`.
- [x] `pnpm --filter @glaon/core lint`.
- [x] `pnpm --filter @glaon/core package-contract` — `@glaon/core/i18n` subpath green.
- [x] `pnpm exec knip` — no new unused exports.
- [ ] CI: standard verify + storybook + visual regression unaffected.

## Acceptance mapping (from #426)

- [x] `fetchHaTranslations(client, locale)` calls `frontend/get_translations` and returns the flat dictionary.
- [x] Cache result per locale (in-memory).
- [x] Cache invalidation primitive (`refresh: true` + `invalidateHaTranslations`) — wiring the reconnect listener to call it lands with the consumer.
- [ ] HA WebSocket subscribe envelope `language` extension — deferred (see Scope Out).
- [ ] `installHaResources(i18next, locale, translations)` — deferred (apps side).
- [ ] Sample `/locales/<lng>/ha.example.json` — deferred (runtime artifact).
- [ ] `useHaTranslation(entityId)` hook — deferred (consumer wiring).

Refs #426 #406 #424