### PR TITLE
feat(web): apps-side ha translations bridge — install + hook (i18n-D)

### DIFF
--- a/apps/web/src/i18n/ha-resources.test.tsx
+++ b/apps/web/src/i18n/ha-resources.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react';
+import i18next, { type i18n } from 'i18next';
+import type { ReactNode } from 'react';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { installHaResources, useHaTranslation } from './ha-resources';
+
+let instance: i18n;
+
+beforeEach(async () => {
+  instance = i18next.createInstance();
+  await instance.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    ns: ['translation', 'ha'],
+    defaultNS: 'translation',
+    resources: { en: { translation: {} }, tr: { translation: {} } },
+    interpolation: { escapeValue: false },
+    returnNull: false,
+  });
+});
+
+afterEach(() => {
+  for (const lng of instance.languages) {
+    if (instance.hasResourceBundle(lng, 'ha')) {
+      instance.removeResourceBundle(lng, 'ha');
+    }
+  }
+});
+
+function wrapper({ children }: { readonly children: ReactNode }): ReactNode {
+  return <I18nextProvider i18n={instance}>{children}</I18nextProvider>;
+}
+
+describe('installHaResources', () => {
+  it('stores HA flat keys under the ha namespace verbatim', () => {
+    installHaResources(instance, 'en', { 'component.switch.state.off': 'Off' });
+    expect(instance.getResourceBundle('en', 'ha')).toEqual({
+      'component.switch.state.off': 'Off',
+    });
+  });
+
+  it('overwrites the bundle on a re-install (locale switch / reconnect)', () => {
+    installHaResources(instance, 'en', { k: 'v1' });
+    installHaResources(instance, 'en', { k: 'v2', other: 'x' });
+    expect(instance.getResourceBundle('en', 'ha')).toEqual({ k: 'v2', other: 'x' });
+  });
+
+  it('keeps locales isolated', () => {
+    installHaResources(instance, 'en', { k: 'Off' });
+    installHaResources(instance, 'tr', { k: 'Kapalı' });
+    expect(instance.getResourceBundle('en', 'ha')).toEqual({ k: 'Off' });
+    expect(instance.getResourceBundle('tr', 'ha')).toEqual({ k: 'Kapalı' });
+  });
+});
+
+describe('useHaTranslation', () => {
+  it('resolves a flat dotted key via keySeparator: false', () => {
+    installHaResources(instance, 'en', {
+      'component.switch.state.off': 'Off',
+    });
+    const { result } = renderHook(() => useHaTranslation(), { wrapper });
+    expect(result.current.t('component.switch.state.off')).toBe('Off');
+  });
+
+  it('falls back to the raw key when the bundle has no entry', () => {
+    const { result } = renderHook(() => useHaTranslation(), { wrapper });
+    expect(result.current.t('component.unknown.key')).toBe('component.unknown.key');
+  });
+});

--- a/apps/web/src/i18n/ha-resources.ts
+++ b/apps/web/src/i18n/ha-resources.ts
@@ -1,0 +1,41 @@
+// Apps-side companion to `@glaon/core/i18n/ha-bridge` (#426 / i18n-D).
+// `fetchHaTranslations` lives in core because the round-trip is pure
+// over an HaClient handle; the i18next install step lives here because
+// `@glaon/core` doesn't take a runtime dep on i18next (ADR 0004
+// platform-agnostic boundary).
+//
+// HA serves translations as **flat dotted keys** (`component.switch.state.off`
+// → 'Off'). i18next's default `keySeparator: '.'` would interpret those
+// dots as a nested traversal — `t('component.switch.state.off')` would
+// look for `component → switch → state → off`, miss, and return the
+// raw key. So `useHaTranslation` flips `keySeparator: false` per call,
+// and `installHaResources` stores the dictionary verbatim under the
+// `ha` namespace.
+
+import type { i18n } from 'i18next';
+import { useTranslation } from 'react-i18next';
+
+const HA_NAMESPACE = 'ha';
+
+export function installHaResources(
+  instance: i18n,
+  locale: string,
+  resources: Readonly<Record<string, string>>,
+): void {
+  // `deep: true, overwrite: true` — replace the existing bundle
+  // wholesale so a locale switch or a reconnect doesn't leave stale
+  // entries behind from the prior fetch.
+  instance.addResourceBundle(locale, HA_NAMESPACE, resources, true, true);
+}
+
+/**
+ * Translate an HA-owned key. The flat dotted form HA serves
+ * (`component.switch.state.off`) is preserved as-is — we don't
+ * traverse it as a nested path.
+ */
+export function useHaTranslation(): { readonly t: (key: string) => string } {
+  const { t } = useTranslation(HA_NAMESPACE);
+  return {
+    t: (key) => t(key, { keySeparator: false }),
+  };
+}


### PR DESCRIPTION
## Summary

Lands the apps/web companion to `@glaon/core`'s `fetchHaTranslations` (PR #487). With this PR, a future UI consumer can do the full round-trip in three lines:

```ts
const dict = await fetchHaTranslations(haClient, locale);
installHaResources(i18nInstance, locale, dict);
// in any component: const { t } = useHaTranslation(); t('component.switch.state.off');
```

Mobile gets the same wrappers when its test runner lands (apps/mobile has no vitest setup today; adding one is its own scope). The web side carries the contract for now.

## Why two functions

HA serves translations as **flat dotted keys** (`component.switch.state.off` → `'Off'`). i18next's default `keySeparator: '.'` treats dots as nested traversal, so a naive `t('component.switch.state.off')` would look for `component → switch → state → off`, miss, and return the raw key. Two options:

1. **Nest the dictionary at install time.** Loses `O(1)` access, dictates HA's runtime memory shape, makes locale-switch invalidation more fiddly.
2. **Store flat + read flat.** `installHaResources` writes the bundle verbatim with `addResourceBundle(lng, 'ha', dict, deep=true, overwrite=true)`, and `useHaTranslation()` calls `t(key, { keySeparator: false })`. Same outcome, less ceremony.

This PR takes option 2. The `keySeparator: false` flag is per-call, scoped to the `ha` namespace, so the regular Glaon-owned strings (`apps/web/src/i18n/locales/{en,tr}.json`) keep their nested keys (`modeSelect.local.title`) without any change.

## Scope (In)

- `apps/web/src/i18n/ha-resources.ts` — `installHaResources(i18n, locale, resources)` + `useHaTranslation()`. Both small wrappers; the contract is the value.
- `apps/web/src/i18n/ha-resources.test.tsx` — 5 tests:
  - install stores HA flat keys verbatim under the `ha` namespace
  - re-install overwrites (locale switch / reconnect simulation)
  - locales stay isolated
  - hook resolves a flat dotted key via `keySeparator: false`
  - hook falls back to the raw key when the bundle has no entry (matches the `frontend/get_translations` contract: missing key → use HA-side label)

## Scope (Out)

- `apps/mobile` parallel — apps/mobile has no test runner today, so the same wrappers without unit-test coverage would be a regression in our own quality bar. Lands together with the mobile vitest config (separate issue), or with the first mobile feature that consumes HA strings.
- Reconnect lifecycle wiring — the bridge already exposes `refresh: true` and `invalidateHaTranslations` via `@glaon/core` (PR #487). The actual `HaClient` reconnect listener calling them is feature-layer work that lands with the consumer.
- `useHaTranslation(entityId)` shorthand — the issue mentions a sugar variant that builds the key from an entity id. Skipping for now; the hook signature is intentionally minimal so the consumer chooses the convention.
- Sample `/locales/<lng>/ha.example.json` — the dictionary HA serves is a runtime artifact; checking a snapshot in misleads contributors. Skipped until a real consumer sets the convention.

## Test plan

- [x] `pnpm --filter @glaon/web type-check`
- [x] `pnpm --filter @glaon/web test` — 76 tests, +5 net
- [x] `pnpm --filter @glaon/web lint`
- [x] `pnpm i18n:check` — passes (no new `t()` calls in source)
- [x] `pnpm exec knip` — no new unused exports
- [ ] CI: standard verify + storybook + visual regression unaffected

Refs #426 #406