### PR TITLE
docs(addon): document apps/api delivery story per ADR 0026 (#392)

### DIFF
--- a/addon/README.md
+++ b/addon/README.md
@@ -67,6 +67,18 @@ Log akışı:
 ha su addons logs local_glaon -f
 ```
 
+## `apps/api` ile ilişki
+
+Add-on yalnızca `apps/web` static bundle'ını servis eder. **`apps/api` add-on içinde paketlenmez** — [ADR 0026](../docs/adr/0026-apps-api-delivery-hosted.md) `apps/api`'ı Glaon-managed hosted service olarak konumlandırdı. Mongo Atlas + container hosting Glaon ekibi tarafından işletilir; add-on kullanıcısı sadece HA Ingress üzerinden web'i açar, web ise cross-origin HTTPS ile `https://api.glaon.app` (deploy pipeline kararına göre) endpoint'ine bağlanır.
+
+Sonuç:
+
+- Add-on Dockerfile'ı **sadece** nginx + dist içerir; `node`, `mongo`, `apps/api` artefaktı yoktur.
+- Add-on güncellendiğinde Mongo şeması ya da apps/api endpoint contract'ı zorunluluk değil — ikisi bağımsız deploy döngülerine sahip.
+- Self-host (sidecar) modeli **şimdilik kapsam dışı**; Phase 5'te ayrı ADR ile yeniden değerlendirilir.
+
+Detaylar: [docs/api.md](../docs/api.md).
+
 ## Güvenlik kontrolleri
 
 - `ingress: true` — harici port açmaz; erişim sadece HA Ingress üzerinden.


### PR DESCRIPTION
## Summary

Closes the last open acceptance item on epic #392 — *\"Add-on packaging story documented (sidecar or hosted) in `addon/README.md`\"*. ADR 0026 already locked the decision (`apps/api` runs as a Glaon-managed hosted service, not as an add-on sidecar). This PR surfaces that decision in `addon/README.md` so a contributor reading the add-on docs cold understands what's NOT in the image and why.

## Scope (In)

- New `## apps/api ile ilişki` section in `addon/README.md` (Turkish, per the language policy):
  - States the add-on packages only `apps/web` static bundle.
  - Cross-references ADR 0026 and `docs/api.md`.
  - Notes: no Node / Mongo / apps/api artefacts in the Dockerfile; add-on and apps/api have independent deploy cycles; self-host (sidecar) is out-of-scope until Phase 5 reopens it via a new ADR.

## Scope (Out)

- Sidecar runtime support — explicitly deferred per ADR 0026.
- `docs/api.md` rewrite — apps/api docs already live there; this PR only adds the cross-reference.

## Test plan

- [x] Manual proofread of the new section.
- [ ] CI: docs-only PR; only the standard verify gates run.

After this lands, epic #392 should be closeable — every checkbox (ADRs P2-A/P2-B, scaffold + healthcheck, auth bridge integration test, P2-F end-to-end, packaging story, no Phase 1 regression) maps to a merged PR.

Refs #392