### PR TITLE
feat(mobile): in-app language switcher (closes mobile i18n surface)

### DIFF
--- a/apps/mobile/src/features/mode-select/mode-select-screen.tsx
+++ b/apps/mobile/src/features/mode-select/mode-select-screen.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 
 import { probeLocal, type LocalProbeResult } from './local-probe';
+import { LanguageSwitcher } from '../../i18n/LanguageSwitcher';
 import { ModeSelectorCard } from './mode-selector-card';
 import {
   expoModePreferenceStore,
@@ -131,6 +132,10 @@ export function ModeSelectScreen({
           <Text style={styles.manualButtonText}>{t('modeSelect.manual.submit')}</Text>
         </Pressable>
       </View>
+
+      <View style={styles.languageSwitcherSection}>
+        <LanguageSwitcher />
+      </View>
     </View>
   );
 }
@@ -172,4 +177,5 @@ const styles = StyleSheet.create({
   },
   manualButtonDisabled: { opacity: 0.5 },
   manualButtonText: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
+  languageSwitcherSection: { marginTop: 24 },
 });

--- a/apps/mobile/src/i18n/LanguageSwitcher.tsx
+++ b/apps/mobile/src/i18n/LanguageSwitcher.tsx
@@ -1,0 +1,102 @@
+// Apps/mobile in-app language switcher (#406). Two-button segmented
+// control that flips i18next + persists via the locale-cache (#431).
+//
+// Mobile doesn't have a native `<select>` we'd want to drop in mid-page
+// — the platform pickers (iOS Picker / Android Picker) take a full
+// modal sheet, which is overkill for a closed 2-locale set. Two
+// Pressable buttons with an active-state ring give the user a
+// one-tap path and stay on-page.
+//
+// Persistence: `i18n.changeLanguage(next)` updates the active locale
+// in the i18next instance; the I18nProvider's `useLocales()` effect
+// path (`apps/mobile/src/i18n/I18nProvider.tsx`) writes through to
+// the cache on the next OS-locale tick. To make the switch
+// immediately persistent we also call `cache.write(next)` here — the
+// next cold start reads it back and beats the OS-locale fallback per
+// the negotiator precedence chain.
+
+import { type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { SUPPORTED_LOCALES, isSupportedLocale, type SupportedLocale } from '@glaon/core/i18n';
+
+import { expoLocaleCache, type LocaleCache } from './locale-cache';
+
+interface LanguageSwitcherProps {
+  /** Test seam — swap the cache backend for an in-memory fake. */
+  readonly cache?: LocaleCache;
+}
+
+export function LanguageSwitcher({ cache = expoLocaleCache }: LanguageSwitcherProps): ReactNode {
+  const { t, i18n } = useTranslation();
+  const active = (
+    isSupportedLocale(i18n.resolvedLanguage) ? i18n.resolvedLanguage : 'en'
+  ) satisfies SupportedLocale;
+
+  const pick = (next: SupportedLocale): void => {
+    if (next === active) return;
+    void i18n.changeLanguage(next);
+    void cache.write(next);
+  };
+
+  return (
+    <View testID="language-switcher" accessibilityLabel={t('languageSwitcher.ariaLabel')}>
+      <Text style={styles.label}>{t('languageSwitcher.label')}</Text>
+      <View style={styles.row}>
+        {SUPPORTED_LOCALES.map((code) => {
+          const isActive = code === active;
+          return (
+            <Pressable
+              key={code}
+              testID={`language-switcher-option-${code}`}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isActive }}
+              onPress={() => {
+                pick(code);
+              }}
+              style={[styles.option, isActive ? styles.optionActive : null]}
+            >
+              <Text style={[styles.optionText, isActive ? styles.optionTextActive : null]}>
+                {t(`languageSwitcher.options.${code}`)}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  option: {
+    minHeight: 40,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#d0d7de',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  optionActive: {
+    borderColor: '#1a73e8',
+    backgroundColor: '#e8f0fe',
+  },
+  optionText: {
+    fontSize: 14,
+    color: '#5b6770',
+  },
+  optionTextActive: {
+    color: '#1a73e8',
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -35,5 +35,13 @@
     "body": "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY is not configured for this build.",
     "pickDifferentMode": "Pick a different mode",
     "back": "Back"
+  },
+  "languageSwitcher": {
+    "label": "Language",
+    "ariaLabel": "Choose interface language",
+    "options": {
+      "en": "English",
+      "tr": "Türkçe"
+    }
   }
 }

--- a/apps/mobile/src/i18n/locales/tr.json
+++ b/apps/mobile/src/i18n/locales/tr.json
@@ -35,5 +35,13 @@
     "body": "Bu derleme için EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY ayarlanmamış.",
     "pickDifferentMode": "Başka bir mod seç",
     "back": "Geri"
+  },
+  "languageSwitcher": {
+    "label": "Dil",
+    "ariaLabel": "Arayüz dilini seç",
+    "options": {
+      "en": "English",
+      "tr": "Türkçe"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Mobile counterpart to #490. The web app got a `<select>`-based switcher mounted in mode-select; mobile gets a two-button segmented control in the same spot. Tap-to-switch flips i18next + writes through to the locale cache so a cold start lands in the user's chosen language without an English flash.

Two buttons (not a platform picker / modal sheet) because the supported set is closed at two locales — opening a full Picker modal for a binary choice is heavyweight. The segmented row stays inline with the rest of the mode-select layout.

## Scope (In)

- `apps/mobile/src/i18n/LanguageSwitcher.tsx` — `<Pressable>` per supported locale; active state highlighted (blue border + tinted background, brand-voice friendly). `onPress` calls `i18n.changeLanguage(next)` and `cache.write(next)` so persistence stays in the locale-cache layer that #431 introduced.
- `apps/mobile/src/features/mode-select/mode-select-screen.tsx` — mounts the switcher under the manual-URL section with `marginTop: 24`. Same placement convention as web.
- `apps/mobile/src/i18n/locales/{en,tr}.json` — `languageSwitcher.{label, ariaLabel, options.{en, tr}}`. Language names in their own language so a TR-default user reading EN still recognizes their option.

## Scope (Out)

- Detox / mobile E2E gate — apps/mobile has no test runner today (`pnpm --filter @glaon/mobile test` doesn't exist). The acceptance item for mobile lands when Detox is set up; the contract this PR ships is the same one #490 validates on web — i18next changeLanguage + locale-cache write-through — and the unit-tested helpers in `@glaon/core/i18n` already cover the matching logic.
- iOS/Android native Picker — overkill for a closed 2-locale set.
- apps/api `/me/preferences` write-through — blocked on missing apps/mobile session producer (same gate that's open on apps/web).

## Test plan

- [x] `pnpm --filter @glaon/mobile type-check`
- [x] `pnpm --filter @glaon/mobile lint`
- [x] `pnpm i18n:check` — passes (template-string interpolation triggers the known unused-keys *warning*, not a failure).
- [ ] CI: standard verify + Storybook + visual regression unaffected.
- [ ] Manual (Expo simulator): tap Türkçe → strings flip → reload app → strings stay Turkish.

After this lands, the open i18n acceptance items are: (a) `frontend/get_translations` cache invalidates on HA reconnect, and (b) the RTL audit (i18n-F / #428, on backlog). Both are gated on a UI feature mounting `HaClient` — that feature doesn't exist yet.

Refs #406 #431