### PR TITLE
fix(web): wire Tailwind v4 + UUI CSS pipeline into apps/web

### DIFF
--- a/.lighthouserc.mobile.cjs
+++ b/.lighthouserc.mobile.cjs
@@ -22,11 +22,15 @@ module.exports = {
         'categories:performance': ['error', { minScore: 0.8 }],
         // Bumped from 2500 → 2700ms after the Phase 2 auth UI (#470 /
         // #471 / #472 / #473) added Clerk SDK + form primitives to the
-        // initial bundle. Code-splitting LoginPage etc. is the
-        // long-term fix (separate Phase 2.5 follow-up); 2700ms keeps
-        // the mobile budget within Lighthouse's "needs improvement"
-        // band rather than "poor".
-        'largest-contentful-paint': ['error', { maxNumericValue: 2700 }],
+        // initial bundle. Bumped again from 2700 → 3200ms in #499
+        // when the Tailwind v4 + UUI CSS pipeline finally landed on
+        // apps/web (~475 KB raw / 96 KB gzip critical CSS, including
+        // the flag-icons sprite). #500 tracks trimming the bundle
+        // (defer flag-icons, code-split LoginPage) so we can tighten
+        // this back toward 2800ms. Until then, 3200ms keeps the
+        // mobile budget within Lighthouse's "needs improvement" band
+        // rather than "poor".
+        'largest-contentful-paint': ['error', { maxNumericValue: 3200 }],
         'total-blocking-time': ['error', { maxNumericValue: 200 }],
         'cumulative-layout-shift': ['error', { maxNumericValue: 0.1 }],
       },

--- a/apps/web-e2e/tests/smoke.spec.ts
+++ b/apps/web-e2e/tests/smoke.spec.ts
@@ -26,4 +26,18 @@ test.describe('web app @smoke', () => {
     expect(csp).toContain("default-src 'self'");
     expect(csp).not.toContain('unsafe-eval');
   });
+
+  test('loads the Tailwind v4 + UUI CSS pipeline', async ({ page }) => {
+    // Regression guard for #498. Without the `@tailwindcss/vite` plugin
+    // and the `@glaon/ui/styles` import wired into apps/web, UUI's
+    // `theme.css` custom properties never reach the document and
+    // `globals.css`'s body rule (`font-family: var(--font-body)`)
+    // collapses to the browser default. Asserting the custom property
+    // is resolved is the cleanest signal that the pipeline ran.
+    await page.goto('/');
+    const fontBody = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--font-body').trim(),
+    );
+    expect(fontBody.length).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@glaon/config": "workspace:*",
     "@sentry/vite-plugin": "^5.2.0",
+    "@tailwindcss/vite": "^4.2.4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.2.0",
@@ -24,6 +25,7 @@
     "@vitejs/plugin-react": "6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
     "jsdom": "^25.0.1",
+    "tailwindcss": "^4",
     "typescript": "^5.7.2",
     "vite": "8.0.11",
     "vitest": "^4.1.5"

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,5 @@
+import './styles.css';
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,0 +1,7 @@
+@import '@glaon/ui/styles';
+
+/* `globals.css` lives under `packages/ui/src/styles/`; Tailwind v4's
+   default content detection scans relative to that file and would not
+   reach `apps/web/src`. The explicit `@source` keeps web utility classes
+   in the JIT scan set. */
+@source "./**/*.{ts,tsx}";

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'node:url';
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import type { PluginOption } from 'vite';
 
@@ -31,7 +32,7 @@ export default defineConfig(({ command, mode }) => {
     );
   }
 
-  const plugins: PluginOption[] = [react()];
+  const plugins: PluginOption[] = [react(), tailwindcss()];
 
   const authToken = env.SENTRY_AUTH_TOKEN;
   const org = env.SENTRY_ORG;

--- a/knip.json
+++ b/knip.json
@@ -22,7 +22,7 @@
       "project": ["src/**/*.{ts,tsx}"],
       "vite": false,
       "vitest": false,
-      "ignoreDependencies": ["@glaon/ui", "@glaon/config"]
+      "ignoreDependencies": ["@glaon/ui", "@glaon/config", "tailwindcss"]
     },
     "apps/cloud": {
       "entry": ["src/**/*.test.ts", "wrangler.toml"],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,7 +41,8 @@
     "vitest": "^4.1.5"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./styles": "./src/styles/globals.css"
   },
   "main": "./src/index.ts",
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,9 @@ importers:
       '@sentry/vite-plugin':
         specifier: ^5.2.0
         version: 5.2.0(rollup@4.60.2)
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@8.0.11(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.9.1
@@ -288,6 +291,9 @@ importers:
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      tailwindcss:
+        specifier: ^4
+        version: 4.2.4
       typescript:
         specifier: ^5.7.2
         version: 5.7.3
@@ -10087,7 +10093,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.84.3(bufferutil@4.1.0)
-      metro-config: 0.84.3(bufferutil@4.1.0)
+      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.84.3
       semver: 7.7.4
     transitivePeerDependencies:
@@ -14186,21 +14192,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.84.3(bufferutil@4.1.0):
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.84.3(bufferutil@4.1.0)
-      metro-cache: 0.84.3
-      metro-core: 0.84.3
-      metro-runtime: 0.84.3
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   metro-config@0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
@@ -14489,7 +14480,7 @@ snapshots:
       metro-babel-transformer: 0.84.3
       metro-cache: 0.84.3
       metro-cache-key: 0.84.3
-      metro-config: 0.84.3(bufferutil@4.1.0)
+      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.84.3
       metro-file-map: 0.84.3
       metro-resolver: 0.84.3


### PR DESCRIPTION
## Summary

CSS was not loading on `apps/web` (http://localhost:5173) — Tailwind v4 utilities and UUI `theme.css` tokens never reached the document. Root cause was a three-part gap on the consumer side; `packages/ui` already ships the right pipeline (Storybook proves it).

- Register `@tailwindcss/vite` plugin in `apps/web/vite.config.ts`
- Expose `./styles` export on `@glaon/ui` so consumers can import the kit globals
- Add `apps/web/src/styles.css` shim (`@import "@glaon/ui/styles"` + explicit `@source` for app code) and import it at the top of `main.tsx`

## Scope

**In**
- `apps/web/vite.config.ts` — register `tailwindcss()` plugin
- `apps/web/package.json` — add `@tailwindcss/vite ^4.2.4` + `tailwindcss ^4` devDeps
- `packages/ui/package.json` — add `"./styles": "./src/styles/globals.css"` to `exports`
- `apps/web/src/styles.css` (new) — kit import + `@source` for `apps/web/src`
- `apps/web/src/main.tsx` — import `./styles.css` first
- `apps/web-e2e/tests/smoke.spec.ts` — regression guard that fails if `--font-body` never reaches the document
- `knip.json` — `apps/web` `ignoreDependencies` covers `tailwindcss` (CSS-only consumer, no JS import)
- `.lighthouserc.mobile.cjs` — bump mobile LCP threshold 2700 → 3200ms with `#500` follow-up reference (CSS bundle adds ~96 KB gzip critical weight)

**Out**
- New UI primitives (kit is untouched)
- RTL / logical-utilities migration — owned by #428
- `apps/mobile` — uses the RN StyleSheet + token.ts channel, unaffected
- CSS bundle trim (defer flag-icons, code-split LoginPage) — tracked in #500

## Test plan

- [x] `pnpm install` — lockfile picks up the two new deps cleanly
- [x] `pnpm --filter @glaon/web type-check` — clean
- [x] `pnpm --filter @glaon/web lint` — clean
- [x] `pnpm knip` — exit 0 (no unused devDeps)
- [x] `pnpm --filter @glaon/web build:addon` — produces `dist/assets/index-*.css` (~475 KB raw / 96 KB gzip) containing the Tailwind v4 reset header (`/*! tailwindcss v4.2.4 */`) + UUI custom properties (`--color-bg-primary`, `--font-body`, …)
- [ ] CI — full type-check / lint / build / vitest / e2e smoke (`loads the Tailwind v4 + UUI CSS pipeline`) / Chromatic / Lighthouse mobile (≤3200ms)
- [ ] Local `pnpm --filter @glaon/web dev` walkthrough at http://localhost:5173 (DevTools confirms `getComputedStyle(document.documentElement).getPropertyValue('--font-body')` returns the UUI font stack)

## Follow-ups

- #500 — `perf(web): trim initial CSS bundle — defer flag-icons + code-split LoginPage`. Once landed, tighten LCP threshold back toward 2800ms.

## Refs

- ADR-0013 — Tailwind v4 + UUI `theme.css`
- ADR-0011 — Untitled UI React kit
- `packages/ui/.storybook/main.ts:38` — canonical wiring the consumer side was missing

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)