### PR TITLE
fix(web): wire kit '@/' alias into apps/web Vite config

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -65,6 +65,17 @@ export default defineConfig(({ command, mode }) => {
     resolve: {
       alias: {
         'react-native': 'react-native-web',
+        // The Untitled UI kit source pulled via `npx untitledui add` uses
+        // `@/` prefixed imports for cross-cutting utilities and components
+        // (e.g. `@/utils/cx`, `@/components/base/buttons/button`). The
+        // convention expects `@` to resolve to `packages/ui/src`.
+        // Storybook wires this in `packages/ui/.storybook/main.ts`; apps/web
+        // needs the same alias or the dev server throws hard import-analysis
+        // errors as soon as the graph walks into a kit file like `tooltip.tsx`.
+        // Production Rolldown builds happened to tolerate the missing alias,
+        // which is why CI stayed green — dev mode is the canonical reproducer.
+        // apps/web's own source uses relative imports, so there's no collision.
+        '@': fileURLToPath(new URL('../../packages/ui/src/', import.meta.url)),
         ...(e2eAuthStub
           ? {
               '@clerk/clerk-react': fileURLToPath(


### PR DESCRIPTION
## Summary

Vite dev server on apps/web throws hard import-resolution errors as soon as the dependency graph walks into a kit file:

```
[plugin:vite:import-analysis] Failed to resolve import "@/utils/cx" from
  "../../packages/ui/src/components/base/tooltip/tooltip.tsx"
```

The kit source (pulled via `npx untitledui add`) uses `@/`-prefixed imports for cross-cutting utilities and components. Storybook wires this alias in `.storybook/main.ts:42`; apps/web does not, so dev mode is silently broken. Production Rolldown builds tolerated the missing alias on a different code path, which is why CI stayed green — the gap only surfaced when the LoginPage graph was fully walked in dev mode (and #503 unmasked it during visual evaluation).

The optimizeDeps `Failed to run dependency scan` warning at every cold dev start was the early signal nobody acted on; this PR addresses the root cause.

## Scope

**In**
- `apps/web/vite.config.ts` — register `'@': fileURLToPath(new URL('../../packages/ui/src/', import.meta.url))` in `resolve.alias`

**Out**
- Removing the `@/` convention from kit source (forking kit, divergence from `untitledui upgrade`)
- apps/mobile (kit isn't consumed from a web bundle there)

## Test plan

- [x] `pnpm --filter @glaon/web type-check` — clean
- [x] `pnpm --filter @glaon/web lint` — clean
- [x] Local repro: `cd apps/web && pnpm exec vite --port 5175 --strictPort=false` — server starts, `curl /@fs/<path>/packages/ui/src/components/base/tooltip/tooltip.tsx` returns transformed JS with `@/utils/cx` rewritten (count of `@/utils` in output: 0)
- [x] `--brand-500` token resolution from #503 still lands on the document via `curl /src/styles.css`
- [ ] CI — full pipeline (type-check, lint, knip, build, unit, story-tests, playwright, Chromatic, Lighthouse)

## Refs

- #501 — LoginPage Figma alignment umbrella (this unblocks visual evaluation)
- #503 — F2 token wiring (whose CSS works only when the JS dep graph isn't crashing)

Closes #504.
Refs #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)