### PR TITLE
fix(web): allow Clerk frontend domains in CSP for cloud sign-in

### DIFF
--- a/apps/web-e2e/tests/smoke.spec.ts
+++ b/apps/web-e2e/tests/smoke.spec.ts
@@ -25,6 +25,14 @@ test.describe('web app @smoke', () => {
     expect(csp).toBeTruthy();
     expect(csp).toContain("default-src 'self'");
     expect(csp).not.toContain('unsafe-eval');
+    // #506: Clerk frontend domains must be in script-src so the Cloud
+    // sign-in path can load the SDK bundle. A revert that drops them
+    // breaks Cloud auth silently in production — guard it here.
+    expect(csp).toContain('https://*.clerk.accounts.dev');
+    expect(csp).toContain('https://*.clerk.com');
+    // script-src itself must not regress to permissive primitives.
+    expect(csp).not.toMatch(/script-src[^;]*'unsafe-inline'/);
+    expect(csp).not.toMatch(/script-src[^;]*'unsafe-eval'/);
   });
 
   test('loads the Tailwind v4 + UUI CSS pipeline', async ({ page }) => {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,9 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
+    <!--
+      script-src includes Clerk's frontend domains so the SDK can fetch its
+      runtime bundle on demand. `*.clerk.accounts.dev` covers Clerk dev
+      instances (publishable key prefix `pk_test_…`); `*.clerk.com` covers
+      production instances and Clerk-hosted CDN. No `unsafe-eval` or
+      `unsafe-inline` on script-src — Clerk's SDK ships ES-module
+      compatible bundles. Tracked in #506.
+    -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' ws: wss: https:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none';"
+      content="default-src 'self'; connect-src 'self' ws: wss: https:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com; frame-ancestors 'none';"
     />
     <title>Glaon</title>
   </head>


### PR DESCRIPTION
## Summary

\`apps/web/index.html\`'s meta CSP limits \`script-src\` to \`'self'\` only, so the Clerk SDK can't fetch its runtime bundle from \`<instance>.clerk.accounts.dev/npm/@clerk/clerk-js@5/dist/clerk.browser.js\`. Every Cloud-sign-in attempt fails with:

\`\`\`
Refused to load https://<instance>.clerk.accounts.dev/...
  because it does not appear in the script-src directive of the Content Security Policy.
Unhandled Promise Rejection: Error: Clerk: Failed to load Clerk
\`\`\`

Surfaced in local dev after #505 finally let the page render. Affects every environment consuming the meta CSP.

## Scope

**In**
- \`apps/web/index.html\` — add \`https://*.clerk.accounts.dev\` and \`https://*.clerk.com\` to \`script-src\`. Comment block above the meta documents the trust relationship.
- \`apps/web-e2e/tests/smoke.spec.ts\` — positive CSP assertions on the Clerk domains + guards that \`script-src\` never regresses to \`'unsafe-inline'\` or \`'unsafe-eval'\`.

**Out**
- HTTP-header CSP (meta CSP has known limitations — \`frame-ancestors\` is already ignored; tracked separately).
- Production custom-domain support — add the domain explicitly when a Clerk-hosted custom domain is provisioned.
- Narrowing \`connect-src\` to Clerk + HA hosts — broader hardening, separate enumeration work.

## Security invariants preserved

- \`default-src 'self'\` unchanged.
- No \`unsafe-eval\` added anywhere.
- No \`unsafe-inline\` added to \`script-src\` (only \`style-src\` retains it, pre-existing for Vite HMR).
- \`frame-ancestors 'none'\` unchanged.
- Wildcards scope new permissions to **Clerk-owned domains only** — \`*.clerk.accounts.dev\` and \`*.clerk.com\` are both Clerk-controlled apexes.
- Ran the \`security-review\` skill per CLAUDE.md (auth/CSP changes require it). **No findings.**

## Test plan

- [x] Local dev: \`VITE_CLERK_PUBLISHABLE_KEY=<dev-key> pnpm --filter @glaon/web dev\` → no CSP errors in console, Clerk SDK loads.
- [x] \`pnpm --filter @glaon/web type-check\` / lint — clean (config + HTML untouched by TS).
- [ ] CI — full pipeline; the extended smoke test should pass and guard against future regressions.

## Refs

- #501 — LoginPage Figma alignment umbrella (Cloud tab works now)
- #505 — apps/web Vite alias fix (unblocked rendering that surfaced this)

Closes #506.
Refs #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)