### PR TITLE
fix(web): align LoginPage with Figma Design-System reference

### DIFF
--- a/apps/web-e2e/tests/auth-login.spec.ts
+++ b/apps/web-e2e/tests/auth-login.spec.ts
@@ -30,9 +30,14 @@ test.describe('auth-login @smoke', () => {
   });
 
   test('renders the LoginPage with Device tab default + clean a11y', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto('/login');
     await expect(page.getByTestId('login-device-form')).toBeVisible();
     await expect(page.getByRole('heading', { level: 1, name: /welcome back/i })).toBeVisible();
+    // #501 Figma parity: hero image in split right column at lg+,
+    // "Remember for 30 days" checkbox is rendered on the active tab.
+    await expect(page.locator('aside img[alt=""]')).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: /remember for 30 days/i })).toBeVisible();
     await assertA11y(page);
   });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import loginHeroUrl from './assets/auth/login-hero.svg';
 import { AuthProvider, useAuth } from './auth/auth-provider';
 import { CloudAuthProvider, getClerkPublishableKey } from './auth/cloud/clerk-provider';
 import { useCloudSessionSync } from './auth/cloud/use-cloud-session';
@@ -22,6 +23,12 @@ import {
 
 const HA_BASE_URL: string = import.meta.env.VITE_HA_BASE_URL ?? 'http://homeassistant.local:8123';
 const LOGOUT_ENDPOINT = '/auth/logout';
+
+// Brand-aligned hero rendered in the LoginPage split layout's right
+// column (#501). SVG (not bitmap) to stay within the apps/web bundle
+// budget being tightened in #500 — final designer asset will replace
+// this file in-place when ready.
+const LOGIN_HERO_IMAGE = <img src={loginHeroUrl} alt="" className="h-full w-full object-cover" />;
 
 export function App(): ReactNode {
   const tokenStore = useMemo(() => new WebTokenStore({ logoutEndpoint: LOGOUT_ENDPOINT }), []);
@@ -102,6 +109,7 @@ function Router({ clerkKey }: RouterProps): ReactNode {
         defaultTab={defaultTab}
         defaultHaBaseUrl={HA_BASE_URL}
         cloudAvailable={clerkKey !== null}
+        imageSlot={LOGIN_HERO_IMAGE}
       />
     );
   }
@@ -174,6 +182,7 @@ function Router({ clerkKey }: RouterProps): ReactNode {
         defaultTab={defaultTab}
         defaultHaBaseUrl={localBaseUrl}
         cloudAvailable={clerkKey !== null}
+        imageSlot={LOGIN_HERO_IMAGE}
       />
     );
   }

--- a/apps/web/src/assets/auth/login-hero.svg
+++ b/apps/web/src/assets/auth/login-hero.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 900" preserveAspectRatio="xMidYMid slice" role="img" aria-label="Glaon">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#234860" />
+      <stop offset="60%" stop-color="#326789" />
+      <stop offset="100%" stop-color="#3d7da7" />
+    </linearGradient>
+    <radialGradient id="orb" cx="0.7" cy="0.3" r="0.55">
+      <stop offset="0%" stop-color="#ff6a3d" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#ff6a3d" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="720" height="900" fill="url(#bg)" />
+  <circle cx="540" cy="270" r="260" fill="url(#orb)" />
+  <g fill="none" stroke="rgba(255,255,255,0.12)" stroke-width="1">
+    <circle cx="200" cy="700" r="120" />
+    <circle cx="200" cy="700" r="180" />
+    <circle cx="200" cy="700" r="240" />
+  </g>
+  <rect x="80" y="640" width="60" height="180" rx="10" fill="#ff6a3d" opacity="0.9" />
+</svg>

--- a/apps/web/src/features/auth/login/login-page.test.tsx
+++ b/apps/web/src/features/auth/login/login-page.test.tsx
@@ -68,6 +68,26 @@ describe('LoginPage', () => {
     expect(screen.getByTestId('login-device-form')).toBeInTheDocument();
   });
 
+  it('renders Figma reference surface — tabs, checkbox, and hero (#501)', () => {
+    const tokenStore = new WebTokenStore({ logoutEndpoint: '/auth/logout' });
+    render(
+      <AuthProvider tokenStore={tokenStore}>
+        <LoginPage
+          defaultHaBaseUrl={HA_DEFAULT_URL}
+          cloudAvailable
+          imageSlot={<div data-testid="hero-slot" />}
+        />
+      </AuthProvider>,
+    );
+    // Tabs render with button-brand pill triggers (role=tab).
+    expect(screen.getByRole('tab', { name: /device/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /cloud/i })).toBeInTheDocument();
+    // "Remember for 30 days" is present on the active (Device) tab.
+    expect(screen.getByRole('checkbox', { name: /remember for 30 days/i })).toBeInTheDocument();
+    // imageSlot reaches the DOM via AuthLayout (split variant).
+    expect(screen.getByTestId('hero-slot')).toBeInTheDocument();
+  });
+
   it('renders the Cloud tab when ?tab=cloud equivalent is passed via prop', () => {
     const tokenStore = new WebTokenStore({ logoutEndpoint: '/auth/logout' });
     render(

--- a/apps/web/src/features/auth/login/login-page.tsx
+++ b/apps/web/src/features/auth/login/login-page.tsx
@@ -17,6 +17,13 @@
 // step for 2FA users. We surface the dedicated `mfa-required` message
 // so the user knows to fall back to HA's own UI for now (Phase 2.5
 // will add MFA support — see issue body for the follow-up).
+//
+// Figma reference: Design-System / Log in / node 1267:132397
+// (Desktop/Mobile × Cloud/Device variants). Fidelity gaps tracked
+// in #501 — three raw `<input>` call sites swapped to `<Input>`,
+// "Remember for 30 days" Checkbox added on both tabs, explicit
+// `<Logo size="lg">` so the brand-mark accent reads at the layout's
+// `lg:max-w-[720px]` form column.
 
 import { useEffect, useState, type ReactNode, type SyntheticEvent } from 'react';
 
@@ -24,11 +31,12 @@ import {
   AuthFooter,
   AuthLayout,
   Button,
-  FormField,
+  Checkbox,
+  Input,
+  Logo,
   PasswordInput,
   SocialButton,
   Tabs,
-  useFormFieldDescriptors,
 } from '@glaon/ui';
 
 import { useAuth } from '../../../auth/auth-provider';
@@ -82,6 +90,7 @@ export function LoginPage({
   return (
     <AuthLayout
       variant="split"
+      logoSlot={<Logo size="lg" />}
       imageSlot={imageSlot}
       footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
     >
@@ -96,7 +105,7 @@ export function LoginPage({
           setActiveTab(key as LoginTab);
         }}
       >
-        <Tabs.List aria-label="Sign-in mode">
+        <Tabs.List aria-label="Sign-in mode" type="button-brand" fullWidth>
           <Tabs.Trigger id="device" label="Device" />
           <Tabs.Trigger id="cloud" label="Cloud" />
         </Tabs.List>
@@ -128,8 +137,11 @@ function DeviceTab({ defaultHaBaseUrl, navigate }: DeviceTabProps): ReactNode {
   const [haBaseUrl, setHaBaseUrl] = useState<string>(defaultHaBaseUrl);
   const [username, setUsername] = useState<string>('');
   const [password, setPassword] = useState<string>('');
+  // `rememberMe` is captured for Figma parity (#501) but does not yet
+  // flow to the backend — the HA password-grant proxy uses a fixed
+  // refresh window today. Wire-through is tracked as a follow-up.
+  const [rememberMe, setRememberMe] = useState<boolean>(false);
   const { state, submit } = useDeviceSignIn();
-  const haUrlField = useFormFieldDescriptors('login-ha-url');
 
   useEffect(() => {
     if (state.status === 'success') {
@@ -144,6 +156,7 @@ function DeviceTab({ defaultHaBaseUrl, navigate }: DeviceTabProps): ReactNode {
 
   const onSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
+    void rememberMe; // UI-only this PR; see comment above.
     void submit({
       haBaseUrl,
       username,
@@ -162,42 +175,27 @@ function DeviceTab({ defaultHaBaseUrl, navigate }: DeviceTabProps): ReactNode {
       className="flex flex-col gap-4 pt-4"
       noValidate
     >
-      <FormField
+      <Input
         label="Home Assistant URL"
-        htmlFor="login-ha-url"
         hint="Enter the URL of your Home Assistant install."
+        name="haBaseUrl"
+        type="url"
         isRequired
-      >
-        <input
-          id="login-ha-url"
-          name="haBaseUrl"
-          type="url"
-          required
-          value={haBaseUrl}
-          onChange={(e) => {
-            setHaBaseUrl(e.currentTarget.value);
-          }}
-          aria-describedby={haUrlField.describedBy(false, true)}
-          className="w-full rounded-lg bg-primary px-3 py-2 text-md text-primary shadow-xs ring-1 ring-primary ring-inset focus:outline-hidden focus:ring-2 focus:ring-brand"
-          placeholder="http://homeassistant.local:8123"
-        />
-      </FormField>
+        value={haBaseUrl}
+        onChange={setHaBaseUrl}
+        placeholder="http://homeassistant.local:8123"
+      />
 
-      <FormField label="Username" htmlFor="login-device-username" isRequired>
-        <input
-          id="login-device-username"
-          name="username"
-          type="text"
-          autoComplete="username"
-          required
-          value={username}
-          onChange={(e) => {
-            setUsername(e.currentTarget.value);
-          }}
-          className="w-full rounded-lg bg-primary px-3 py-2 text-md text-primary shadow-xs ring-1 ring-primary ring-inset focus:outline-hidden focus:ring-2 focus:ring-brand"
-          placeholder="Username"
-        />
-      </FormField>
+      <Input
+        label="Username"
+        name="username"
+        type="text"
+        autoComplete="username"
+        isRequired
+        value={username}
+        onChange={setUsername}
+        placeholder="Username"
+      />
 
       <PasswordInput
         label="Password"
@@ -205,6 +203,13 @@ function DeviceTab({ defaultHaBaseUrl, navigate }: DeviceTabProps): ReactNode {
         value={password}
         onChange={setPassword}
         isRequired
+      />
+
+      <Checkbox
+        label="Remember for 30 days"
+        isSelected={rememberMe}
+        onChange={setRememberMe}
+        size="sm"
       />
 
       {error !== null && (
@@ -227,6 +232,10 @@ interface CloudTabProps {
 function CloudTab({ navigate }: CloudTabProps): ReactNode {
   const [identifier, setIdentifier] = useState<string>('');
   const [password, setPassword] = useState<string>('');
+  // `rememberMe` is captured for Figma parity (#501) but does not yet
+  // flow to Clerk — `signIn.create` doesn't surface a session-lifetime
+  // knob in the headless API today.
+  const [cloudRememberMe, setCloudRememberMe] = useState<boolean>(false);
   const { state, submit, signInWithSocial, isLoaded } = useCloudSignIn();
   const { mode } = useAuth();
 
@@ -243,6 +252,7 @@ function CloudTab({ navigate }: CloudTabProps): ReactNode {
 
   const onSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
+    void cloudRememberMe; // UI-only this PR; see comment above.
     void submit({ identifier, password });
   };
 
@@ -256,21 +266,16 @@ function CloudTab({ navigate }: CloudTabProps): ReactNode {
       className="flex flex-col gap-4 pt-4"
       noValidate
     >
-      <FormField label="Email" htmlFor="login-cloud-email" isRequired>
-        <input
-          id="login-cloud-email"
-          name="email"
-          type="email"
-          autoComplete="email"
-          required
-          value={identifier}
-          onChange={(e) => {
-            setIdentifier(e.currentTarget.value);
-          }}
-          className="w-full rounded-lg bg-primary px-3 py-2 text-md text-primary shadow-xs ring-1 ring-primary ring-inset focus:outline-hidden focus:ring-2 focus:ring-brand"
-          placeholder="Enter your email"
-        />
-      </FormField>
+      <Input
+        label="Email"
+        name="email"
+        type="email"
+        autoComplete="email"
+        isRequired
+        value={identifier}
+        onChange={setIdentifier}
+        placeholder="Enter your email"
+      />
 
       <PasswordInput
         label="Password"
@@ -280,7 +285,13 @@ function CloudTab({ navigate }: CloudTabProps): ReactNode {
         isRequired
       />
 
-      <div className="flex items-center justify-end">
+      <div className="flex items-center justify-between">
+        <Checkbox
+          label="Remember for 30 days"
+          isSelected={cloudRememberMe}
+          onChange={setCloudRememberMe}
+          size="sm"
+        />
         <a
           href="/forgot-password"
           className="text-sm font-semibold text-brand_secondary hover:text-brand"

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -5,3 +5,13 @@
    reach `apps/web/src`. The explicit `@source` keeps web utility classes
    in the JIT scan set. */
 @source "./**/*.{ts,tsx}";
+
+/* Tailwind v4 does not follow `@import` across workspace package
+   boundaries when discovering content. Kit components in
+   `packages/ui/src/components/**` reference utility classes
+   (`bg-brand-solid`, `bg-brand-primary_alt`, `text-brand-secondary`, …)
+   that must be emitted into apps/web's CSS bundle for primitives to
+   render correctly. Without this scan path, the kit's submit button
+   renders as an empty outlined box and the `<Tabs.List type="button-brand">`
+   triggers look unstyled (#501). */
+@source "../../../packages/ui/src/**/*.{ts,tsx}";

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -103,6 +103,16 @@ export interface InputProps {
   value?: string;
   defaultValue?: string;
   name?: string;
+  /**
+   * Standard HTML `autocomplete` token forwarded to the underlying
+   * `<input>` so password managers and browser autofill resolve
+   * fields correctly (e.g. `'username'`, `'email'`, `'current-password'`).
+   * The kit `Input` accepts arbitrary input attributes via pass-through
+   * on the `default` variant; non-default variants that need a fixed
+   * autocomplete token (e.g. `payment` → `cc-number`) set it via
+   * `inputOverrides` internally.
+   */
+  autoComplete?: string;
   onChange?: (value: string) => void;
   onBlur?: FocusEventHandler;
   onFocus?: FocusEventHandler;


### PR DESCRIPTION
## Summary

Closes #501. After #499 wired the Tailwind v4 + UUI CSS pipeline into `apps/web`, the LoginPage rendered but diverged from Figma node `1267:132397` (Desktop/Mobile × Cloud/Device) in seven specific ways. Most of these existed before #499; the CSS pipeline just stopped masking them.

This PR fixes wiring + token scope and uses existing primitives only — **no kit redesign**.

## Scope

**In:**
- `apps/web/src/styles.css` — add a second `@source` pointing at `packages/ui/src/**`. Tailwind v4 doesn't follow `@import` across workspace boundaries when discovering content, so kit utility classes (`bg-brand-solid`, `bg-brand-primary_alt`, `text-brand-secondary`, …) were missing from `apps/web`'s CSS bundle. **Verified post-build: `bg-brand-solid` is now present in `dist/assets/index-*.css`.**
- `apps/web/src/features/auth/login/login-page.tsx`:
  - Swap three raw `<input>` + `<FormField>` blocks (HA URL, Username, Cloud Email) for the `<Input>` primitive; drop the redundant wrapper.
  - Pass an explicit `<Logo size="lg">` `logoSlot` so the brand-mark accent reads at the layout's `lg:max-w-[720px]` form column.
  - Add a `Checkbox label="Remember for 30 days"` on both tabs (UI-only this PR; comment explains follow-up).
  - Make `<Tabs.List type="button-brand" fullWidth>` explicit for survivable intent.
- `apps/web/src/App.tsx` — import a brand-aligned hero SVG and pass via `imageSlot` on **both** `<LoginPage>` call sites (path-based + mode-preference branches).
- `apps/web/src/assets/auth/login-hero.svg` — new ~1 KB SVG hero (gradient + abstract geometry, pinned brand hex values). Inlines as a `data:image/svg+xml` URI in the bundle — well within #500's budget.
- `packages/ui/src/components/Input/Input.tsx` — add `autoComplete?: string` to the `<Input>` wrapper. The default variant's pass-through forwards it to the underlying kit `Input`; password managers / browser autofill resolve `username` and `email` fields correctly. No kit source edit.

**Out (deferred):**
- SignUpPage / ForgotPasswordPage have the same raw-input pattern — separate fix issue.
- Wire `rememberMe` through to the HA password-grant payload (addon-side refresh-window knob is its own issue).
- Final designer-supplied hero bitmap to replace the SVG placeholder.
- `apps/mobile` LoginScreen parity.

## Test plan

- [x] `pnpm type-check` — 11/11 packages green
- [x] `pnpm lint` — 10/10 packages green
- [x] `pnpm --filter @glaon/web test` — 85/85 passed (new assertion for tabs + checkbox + hero slot)
- [x] `pnpm --filter @glaon/ui test` — 135/135 passed (`<Input>` regression coverage)
- [x] `vite build --mode development` — succeeds; `bg-brand-solid` present in emitted CSS; hero SVG inlined as data URI in JS bundle
- [ ] `pnpm --filter @glaon/web-e2e e2e -- --grep auth-login` — extended `@smoke` happy-path with 1280-wide viewport check that `aside img[alt=""]` is visible and the `Remember for 30 days` checkbox is rendered. **Runs in CI.**
- [ ] Local dev visual check: submit button fills with brand-600; tabs render as branded pills; HA URL/Username/Email render with kit surface (no browser autofill key icon); hero visible at `lg`; logo accent visible.
- [ ] Chromatic build clean (no `packages/ui` stories changed; the `<Input>` prop addition is type-only and shouldn't shift any rendered snapshot).

## Notes

- The hero SVG references brand hex values inline (not `var(--brand-*)`) so the file previews correctly outside the app — Storybook, GitHub asset diff, Figma round-trip.
- `rememberMe` state is captured in both tabs but doesn't yet flow to the backend; comments in the code mark intent. The HA password-grant proxy uses a fixed refresh window today.
- Logo accent visibility is fixed via wiring (`size="lg"` on the AuthLayout `logoSlot`), not by changing the Logo source — the red rect (`var(--red-500)`) is fixed 30×90 in the viewBox and scales proportionally with the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)