### PR TITLE
fix(web): centralize API errors via Toast + drop inline form errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,38 @@ Operational requirements:
 
 A PR that violates this rule and gets caught after merge is reverted, not patched forward. The "shipped now, fix later" PR (#508) and its three follow-ups (#510, #511, …) is the cautionary tale this section was written to prevent repeating.
 
+## API Error Toast Rule (MANDATORY)
+
+API failures (network down, auth invalid, server 5xx, backend-validation rejections) are global, page-level signals — not field-level validation. They MUST be reported through the central `<ToastProvider>` using `useToast().show({ intent: 'danger', title, description })`. Hand-rolled inline error blocks under forms (`<p className="text-error">Sign-in failed</p>`) are forbidden for API failures.
+
+This rule exists because inline "Something went wrong" copy is the single largest UX dead-end in Glaon today: the user can't tell whether their input was wrong, the network is down, or the server is failing — and the same hand-rolled pattern leaks into every new form. Centralizing through Toast forces a copy mapping (error code → human-readable description), surfaces the failure consistently across screens, and is screen-reader-correct out of the box (`role="status"`, `aria-live="polite"`).
+
+What goes through Toast:
+
+- Fetch/SDK rejection (network error, CORS, DNS).
+- HTTP 4xx other than 422 field-validation (401/403 auth, 404 not-found, 429 rate-limit).
+- HTTP 5xx server errors.
+- Backend-side flow errors that don't map to a single field ("Pairing code expired", "Account locked").
+
+What stays inline (allowed):
+
+- Per-field validation the user can resolve locally (`<Input error="Email is required">`).
+- HTTP 422 field-validation responses, mapped back to the specific `<FormField error>` prop.
+
+Forbidden patterns:
+
+- `<p role="alert" className="text-error">{error.message}</p>` rendered under the submit button.
+- Catching a fetch rejection and rendering its raw `.message` inline.
+- Generic "Something went wrong" copy anywhere — every error has a code; the code maps to specific copy in a per-feature dictionary (see `apps/web/src/features/auth/login/login-page.tsx` for the reference shape).
+
+Operational requirements:
+
+- `ToastProvider` mounts once near the app root (`apps/web/src/main.tsx` or `apps/web/src/App.tsx`). Every feature consumes `useToast()` rather than rendering its own Toast component or inventing a parallel queue.
+- Every error code that reaches the UI has a copy entry (`title` + optional `description`). If a new error code lands, the same PR adds the copy — generic fallbacks are reserved for `code === 'unknown'`.
+- E2E tests assert the Toast via `page.getByRole('status')` (or `findByRole('alert')` in RTL for the danger intent), not inline `data-testid="...-error"` selectors. PRs that rely on inline error testids are sent back.
+
+This rule was added after the LoginPage device-tab error UX shipped as a hand-rolled inline block. The Toast Rule is the door closing on that pattern — no auth, no settings, no integration screen ships an inline API error block from now on.
+
 ## UUI Source Rule (MANDATORY)
 
 - Every base primitive in `@glaon/ui` (web side) **must wrap an Untitled UI source pulled via `npx untitledui add`**. Hand-rolling a primitive's structural HTML/CSS or rolling your own variant matrix from scratch is forbidden — Glaon's contribution is the wrap layer (token override, `<ThemeProvider>` integration, prop API consistency, Figma `parameters.design` mapping), not the kit's source itself.

--- a/apps/web-e2e/tests/auth-login.spec.ts
+++ b/apps/web-e2e/tests/auth-login.spec.ts
@@ -9,8 +9,8 @@
 //     submits cleanly.
 //   - Tab toggle → both tabs share the same page so a click flips the
 //     active panel without a navigation.
-//   - Device 401 → mocked `invalid-credentials` reply renders an
-//     inline error region.
+//   - Device 401 → mocked `invalid-credentials` reply surfaces the
+//     failure via the central Toast (#516).
 //
 // The legacy `local-mode.spec.ts` (HA OAuth redirect flow) is now a
 // no-op stub kept only for the auth-callback error scenario, which
@@ -96,7 +96,11 @@ test.describe('auth-login @smoke', () => {
     expect(body.password).toBe('correct-horse');
   });
 
-  test('Device tab surfaces the inline error on invalid credentials', async ({ page }) => {
+  test('Device tab surfaces invalid-credentials via the central Toast', async ({ page }) => {
+    // #516 — API errors flow through `useToast()` (intent: 'danger'),
+    // not a hand-rolled inline error block under the form. The toast
+    // primitive renders with `role="status"` per a11y notes in
+    // `Toast.tsx`.
     await page.context().route(PASSWORD_GRANT_PATH, async (route) => {
       await route.fulfill({
         status: 401,
@@ -111,9 +115,7 @@ test.describe('auth-login @smoke', () => {
     await page.locator('[data-testid="login-device-form"] input[type="password"]').fill('wrong');
     await page.getByRole('button', { name: /^sign in$/i }).click();
 
-    await expect(page.getByTestId('login-device-error')).toBeVisible();
-    await expect(page.getByTestId('login-device-error')).toContainText(
-      /wrong username or password/i,
-    );
+    const toast = page.getByRole('status').filter({ hasText: /wrong username or password/i });
+    await expect(toast).toBeVisible();
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { ToastProvider } from '@glaon/ui';
+
 import loginHeroUrl from './assets/auth/login-hero.jpg';
 import { AuthProvider, useAuth } from './auth/auth-provider';
 import { CloudAuthProvider, getClerkPublishableKey } from './auth/cloud/clerk-provider';
@@ -40,10 +42,17 @@ export function App(): ReactNode {
   // Clerk SDK throws on import-time when given an empty key, so local-mode
   // builds without VITE_CLERK_PUBLISHABLE_KEY skip the provider entirely
   // (mode-detect #353 will narrow the scope further once it lands).
+  //
+  // ToastProvider lives at the app root so every feature can call
+  // `useToast()` for API-error notifications — see the API Error Toast
+  // Rule in CLAUDE.md. The provider portals into <body>, so its
+  // position in the tree only matters for context resolution.
   const inner = (
     <AuthProvider tokenStore={tokenStore}>
-      {clerkKey !== null ? <CloudSessionBridge /> : null}
-      <Router clerkKey={clerkKey} />
+      <ToastProvider>
+        {clerkKey !== null ? <CloudSessionBridge /> : null}
+        <Router clerkKey={clerkKey} />
+      </ToastProvider>
     </AuthProvider>
   );
 

--- a/apps/web/src/features/auth/login/login-page.test.tsx
+++ b/apps/web/src/features/auth/login/login-page.test.tsx
@@ -7,6 +7,7 @@
 //   - Clerk's `useSignIn` is replaced through the global vi.mock so
 //     the Cloud tab reads a deterministic `signIn.create`.
 
+import { ToastProvider } from '@glaon/ui';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactNode } from 'react';
@@ -17,18 +18,28 @@ import { LoginPage } from './login-page';
 
 const HA_DEFAULT_URL = 'http://homeassistant.local:8123';
 
+// Mirrors the apps/web App.tsx provider chain. LoginPage's tabs call
+// `useToast()` for API-error reporting (#516), so the ToastProvider
+// must be in the tree for tests to render without throwing.
+function withProviders(ui: ReactNode, tokenStore: WebTokenStore): ReactNode {
+  return (
+    <AuthProvider tokenStore={tokenStore}>
+      <ToastProvider>{ui}</ToastProvider>
+    </AuthProvider>
+  );
+}
+
 function renderPage(props: { cloudAvailable?: boolean; navigate?: (url: string) => void } = {}) {
   const tokenStore = new WebTokenStore({ logoutEndpoint: '/auth/logout' });
   const navigate = props.navigate ?? vi.fn();
-  const ui: ReactNode = (
-    <AuthProvider tokenStore={tokenStore}>
-      <LoginPage
-        defaultHaBaseUrl={HA_DEFAULT_URL}
-        cloudAvailable={props.cloudAvailable ?? true}
-        imageSlot={null}
-        navigate={navigate}
-      />
-    </AuthProvider>
+  const ui = withProviders(
+    <LoginPage
+      defaultHaBaseUrl={HA_DEFAULT_URL}
+      cloudAvailable={props.cloudAvailable ?? true}
+      imageSlot={null}
+      navigate={navigate}
+    />,
+    tokenStore,
   );
   return { tokenStore, navigate, ...render(ui) };
 }
@@ -71,13 +82,14 @@ describe('LoginPage', () => {
   it('renders Figma reference surface — tabs, checkbox, and hero (#501)', () => {
     const tokenStore = new WebTokenStore({ logoutEndpoint: '/auth/logout' });
     render(
-      <AuthProvider tokenStore={tokenStore}>
+      withProviders(
         <LoginPage
           defaultHaBaseUrl={HA_DEFAULT_URL}
           cloudAvailable
           imageSlot={<div data-testid="hero-slot" />}
-        />
-      </AuthProvider>,
+        />,
+        tokenStore,
+      ),
     );
     // Tabs render with button-brand pill triggers (role=tab).
     expect(screen.getByRole('tab', { name: /device/i })).toBeInTheDocument();
@@ -91,14 +103,15 @@ describe('LoginPage', () => {
   it('renders the Cloud tab when ?tab=cloud equivalent is passed via prop', () => {
     const tokenStore = new WebTokenStore({ logoutEndpoint: '/auth/logout' });
     render(
-      <AuthProvider tokenStore={tokenStore}>
+      withProviders(
         <LoginPage
           defaultTab="cloud"
           defaultHaBaseUrl={HA_DEFAULT_URL}
           cloudAvailable
           imageSlot={null}
-        />
-      </AuthProvider>,
+        />,
+        tokenStore,
+      ),
     );
     expect(screen.getByTestId('login-cloud-form')).toBeInTheDocument();
   });

--- a/apps/web/src/features/auth/login/login-page.tsx
+++ b/apps/web/src/features/auth/login/login-page.tsx
@@ -37,6 +37,7 @@ import {
   PasswordInput,
   SocialButton,
   Tabs,
+  useToast,
 } from '@glaon/ui';
 
 import { useAuth } from '../../../auth/auth-provider';
@@ -133,6 +134,46 @@ interface DeviceTabProps {
   readonly navigate?: ((url: string) => void) | undefined;
 }
 
+// Per the API Error Toast Rule (CLAUDE.md), every error code that
+// reaches the UI maps to specific copy here — generic fallback is
+// reserved for `unknown` only. Mirrors `DeviceSignInErrorCode` from
+// `use-device-sign-in.ts`. The fallback constant stays separate so the
+// `?? UNKNOWN` lookup is type-safe under `noUncheckedIndexedAccess`.
+interface ToastCopy {
+  readonly title: string;
+  readonly description?: string;
+}
+
+const DEVICE_UNKNOWN_COPY: ToastCopy = {
+  title: 'Sign-in failed',
+  description: 'Something went wrong. Try again, or check the browser console for details.',
+};
+
+const DEVICE_ERROR_COPY: Record<string, ToastCopy> = {
+  'invalid-url': {
+    title: 'Invalid Home Assistant URL',
+    description: 'Enter the full URL of your install (e.g. http://homeassistant.local:8123).',
+  },
+  'invalid-credentials': {
+    title: 'Wrong username or password',
+    description: 'Double-check your Home Assistant credentials and try again.',
+  },
+  'mfa-required': {
+    title: 'Multi-factor authentication required',
+    description:
+      'Two-factor sign-in via Glaon is not supported yet. Sign in directly through Home Assistant for now.',
+  },
+  unreachable: {
+    title: 'Couldn’t reach the Glaon addon',
+    description: 'Make sure the Glaon addon is running and reachable, then try again.',
+  },
+  'flow-error': {
+    title: 'Home Assistant rejected the sign-in',
+    description: 'Home Assistant returned an unexpected response. Try again in a moment.',
+  },
+  unknown: DEVICE_UNKNOWN_COPY,
+};
+
 function DeviceTab({ defaultHaBaseUrl, navigate }: DeviceTabProps): ReactNode {
   const [haBaseUrl, setHaBaseUrl] = useState<string>(defaultHaBaseUrl);
   const [username, setUsername] = useState<string>('');
@@ -142,6 +183,7 @@ function DeviceTab({ defaultHaBaseUrl, navigate }: DeviceTabProps): ReactNode {
   // refresh window today. Wire-through is tracked as a follow-up.
   const [rememberMe, setRememberMe] = useState<boolean>(false);
   const { state, submit } = useDeviceSignIn();
+  const toast = useToast();
 
   useEffect(() => {
     if (state.status === 'success') {
@@ -152,7 +194,11 @@ function DeviceTab({ defaultHaBaseUrl, navigate }: DeviceTabProps): ReactNode {
         });
       go('/');
     }
-  }, [navigate, state]);
+    if (state.status === 'error') {
+      const copy = DEVICE_ERROR_COPY[state.error.code] ?? DEVICE_UNKNOWN_COPY;
+      toast.show({ intent: 'danger', ...copy });
+    }
+  }, [navigate, state, toast]);
 
   const onSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -166,7 +212,6 @@ function DeviceTab({ defaultHaBaseUrl, navigate }: DeviceTabProps): ReactNode {
   };
 
   const isSubmitting = state.status === 'submitting';
-  const error = state.status === 'error' ? state.error : null;
 
   return (
     <form
@@ -212,12 +257,6 @@ function DeviceTab({ defaultHaBaseUrl, navigate }: DeviceTabProps): ReactNode {
         size="sm"
       />
 
-      {error !== null && (
-        <p role="alert" data-testid="login-device-error" className="text-sm text-error">
-          {error.message}
-        </p>
-      )}
-
       <Button type="submit" size="lg" isLoading={isSubmitting}>
         Sign in
       </Button>
@@ -229,6 +268,34 @@ interface CloudTabProps {
   readonly navigate?: ((url: string) => void) | undefined;
 }
 
+// Mirrors `CloudSignInErrorCode` from `use-cloud-sign-in.ts`. Clerk
+// error codes use snake_case; copy stays user-facing English. Same
+// type-safe fallback pattern as the device copy table above.
+const CLOUD_UNKNOWN_COPY: ToastCopy = {
+  title: 'Sign-in failed',
+  description: 'Something went wrong with Glaon Cloud. Try again in a moment.',
+};
+
+const CLOUD_ERROR_COPY: Record<string, ToastCopy> = {
+  form_param_format_invalid: {
+    title: 'Check your email address',
+    description: 'That doesn’t look like a valid email — try again.',
+  },
+  form_password_incorrect: {
+    title: 'Wrong password',
+    description: 'Double-check your password and try again, or use Forgot password.',
+  },
+  form_identifier_not_found: {
+    title: 'No account with that email',
+    description: 'Make sure you signed up with this address, or create a new account.',
+  },
+  session_exists: {
+    title: 'Already signed in',
+    description: 'A Glaon Cloud session is already active. Refresh to continue.',
+  },
+  unknown: CLOUD_UNKNOWN_COPY,
+};
+
 function CloudTab({ navigate }: CloudTabProps): ReactNode {
   const [identifier, setIdentifier] = useState<string>('');
   const [password, setPassword] = useState<string>('');
@@ -238,6 +305,7 @@ function CloudTab({ navigate }: CloudTabProps): ReactNode {
   const [cloudRememberMe, setCloudRememberMe] = useState<boolean>(false);
   const { state, submit, signInWithSocial, isLoaded } = useCloudSignIn();
   const { mode } = useAuth();
+  const toast = useToast();
 
   useEffect(() => {
     if (state.status === 'success' || (state.status === 'idle' && mode?.kind === 'cloud')) {
@@ -248,7 +316,11 @@ function CloudTab({ navigate }: CloudTabProps): ReactNode {
         });
       go('/');
     }
-  }, [mode, navigate, state]);
+    if (state.status === 'error') {
+      const copy = CLOUD_ERROR_COPY[state.error.code] ?? CLOUD_UNKNOWN_COPY;
+      toast.show({ intent: 'danger', ...copy });
+    }
+  }, [mode, navigate, state, toast]);
 
   const onSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -257,7 +329,6 @@ function CloudTab({ navigate }: CloudTabProps): ReactNode {
   };
 
   const isSubmitting = state.status === 'submitting';
-  const error = state.status === 'error' ? state.error : null;
 
   return (
     <form
@@ -299,12 +370,6 @@ function CloudTab({ navigate }: CloudTabProps): ReactNode {
           Forgot password
         </a>
       </div>
-
-      {error !== null && (
-        <p role="alert" data-testid="login-cloud-error" className="text-sm text-error">
-          {error.message}
-        </p>
-      )}
 
       <Button type="submit" size="lg" isLoading={isSubmitting} isDisabled={!isLoaded}>
         Sign in


### PR DESCRIPTION
## Summary

Closes #516. Replaces #518 (closed for a commitlint header-max-length violation — original subject was 73 chars; this one is 67).

Two coupled changes:

1. **`CLAUDE.md` — API Error Toast Rule (MANDATORY)**. API failures (network, auth, server, backend flow) MUST report through `useToast({ intent: 'danger' })`. Hand-rolled inline `<p className=\"text-error\">` blocks under forms are forbidden for API failures. Inline error UI stays reserved for per-field validation only.
2. **LoginPage device + cloud tabs migrated to the new pattern**. First feature on the rule.

SignUpPage / ForgotPasswordPage / EmailVerificationPage still use the inline pattern; tracked in a follow-up. The rule is in place; migrations are incremental.

## Changes

### `CLAUDE.md`
- New MANDATORY section after the Design-System Fidelity Rule: what goes through Toast, what stays inline, forbidden patterns (with examples), operational requirements (one ToastProvider mount, per-feature copy dictionary, `page.getByRole('status')` e2e convention).

### `apps/web/src/App.tsx`
- Mounts `<ToastProvider>` inside `<AuthProvider>` so every consumer downstream can call `useToast()` without local provider wrapping.

### `apps/web/src/features/auth/login/login-page.tsx`
- Drops the `<p role=\"alert\" data-testid=\"login-device-error\">` and `login-cloud-error` blocks.
- Adds `DEVICE_ERROR_COPY` (6 codes: invalid-url, invalid-credentials, mfa-required, unreachable, flow-error, unknown) and `CLOUD_ERROR_COPY` (5 codes from `useCloudSignIn`).
- Each `unknown` fallback in a separate constant (`DEVICE_UNKNOWN_COPY`, `CLOUD_UNKNOWN_COPY`) so `Record<string, ToastCopy>` lookup with `??` stays type-safe under `noUncheckedIndexedAccess`.
- `useEffect` watches `state.status === 'error'` and dispatches `toast.show({ intent: 'danger', ...copy })` once per transition.

### Tests
- `login-page.test.tsx`: every `render()` goes through a `withProviders(ui, tokenStore)` helper that wraps in `<AuthProvider>` + `<ToastProvider>`. Without the provider, `useToast()` throws on mount.
- `auth-login.spec.ts`: the invalid-credentials e2e now asserts `page.getByRole('status').filter({ hasText: /wrong username/i })`.

## Verification

- [x] `pnpm type-check` — 11/11.
- [x] `pnpm lint` — 10/10.
- [x] `pnpm --filter @glaon/web test` — 85/85.
- [x] `pnpm --filter @glaon/ui test` — 135/135.
- [ ] Local manual: trigger invalid-credentials submit on device tab. Expected: Toast in top-right with \"Wrong username or password\". With addon API down: Toast \"Couldn't reach the Glaon addon\". No inline error block under Sign in.
- [ ] Playwright `@smoke` passes with toast-based assertion.

## Out of scope

- **#517** — device login backend connectivity (CSP `worker-src blob:`, descriptive network errors). Lands on top so its new error codes flow through the Toast mapping table added here.
- SignUpPage / ForgotPasswordPage / EmailVerificationPage migration — follow-up issue. Rule prevents new inline-error code; this PR doesn't backfill existing screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)