### PR TITLE
fix(web): map fetch failures to unreachable + allow blob worker-src

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,10 +11,18 @@
       production instances and Clerk-hosted CDN. No `unsafe-eval` or
       `unsafe-inline` on script-src — Clerk's SDK ships ES-module
       compatible bundles. Tracked in #506.
+
+      worker-src 'self' blob: — Clerk's headless SDK spawns Web Workers
+      from `blob:` URLs for session refresh and OAuth state coordination.
+      Without an explicit `worker-src`, browsers fall back to
+      `script-src`, which does not allow `blob:` and produces a
+      `Refused to load blob:…` CSP violation in the console (#517).
+      Keeping `blob:` scoped to `worker-src` instead of widening
+      `script-src` so non-worker blob scripts stay blocked.
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' ws: wss: https:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com; frame-ancestors 'none';"
+      content="default-src 'self'; connect-src 'self' ws: wss: https:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com; worker-src 'self' blob:; frame-ancestors 'none';"
     />
     <title>Glaon</title>
   </head>

--- a/apps/web/src/features/auth/login/login-page.test.tsx
+++ b/apps/web/src/features/auth/login/login-page.test.tsx
@@ -162,4 +162,29 @@ describe('LoginPage', () => {
       expect(navigate).toHaveBeenCalledWith('/');
     });
   });
+
+  it('surfaces the unreachable toast when the addon API is offline (#517)', async () => {
+    // `fetch` rejects with TypeError when the addon API is unreachable
+    // (DNS failure, CORS preflight refusal, server offline). The hook
+    // previously fell through to the generic `unknown` code; #517's
+    // fix maps TypeError → `unreachable` so the user sees actionable
+    // copy via the central Toast.
+    haPasswordGrantSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    renderPage();
+    const deviceFormEl = screen.getByTestId('login-device-form');
+    const deviceForm = within(deviceFormEl);
+    fireEvent.change(deviceForm.getByLabelText(/username/i), { target: { value: 'olivia' } });
+    const passwordInput = deviceFormEl.querySelector<HTMLInputElement>('input[type="password"]');
+    expect(passwordInput).not.toBeNull();
+    if (passwordInput !== null) {
+      fireEvent.change(passwordInput, { target: { value: 'pw' } });
+    }
+    fireEvent.click(deviceForm.getByRole('button', { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(haPasswordGrantSpy).toHaveBeenCalledTimes(1);
+    });
+    // Toast surfaces the unreachable copy from DEVICE_ERROR_COPY.
+    expect(await screen.findByText(/couldn.?t reach the glaon addon/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/auth/login/use-device-sign-in.ts
+++ b/apps/web/src/features/auth/login/use-device-sign-in.ts
@@ -112,6 +112,21 @@ function errorFromCause(cause: unknown): DeviceSignInErrorState {
       return { code, message: messageForCode(code) };
     }
   }
+  // Network failures (addon API offline, DNS error, CORS preflight
+  // refused) bubble up here as a `TypeError` (`fetch` rejection) or a
+  // generic `Error` with a "failed to fetch" / "network request
+  // failed" message. Map them to the `unreachable` code so the user
+  // sees actionable copy via the central Toast (#516, #517) instead
+  // of the generic `unknown` blanket the original report showed.
+  if (cause instanceof TypeError) {
+    return { code: 'unreachable', message: messageForCode('unreachable') };
+  }
+  if (
+    cause instanceof Error &&
+    /failed to fetch|networkerror|network request failed/i.test(cause.message)
+  ) {
+    return { code: 'unreachable', message: messageForCode('unreachable') };
+  }
   return { code: 'unknown', message: messageForCode('unknown') };
 }
 


### PR DESCRIPTION
## Summary

Closes #517. Two coupled fixes for device-tab login when the Glaon addon API is offline — the symptom that produced the "Something went wrong while signing in" toast plus a `Refused to load blob:…` CSP violation in the console.

## Changes

### `apps/web/src/features/auth/login/use-device-sign-in.ts`
- `errorFromCause` previously parsed only the `body.error` field of a structured `ApiError`. Any `fetch` rejection (DNS failure, CORS preflight refused, server offline) fell through to the `unknown` code, surfacing a generic toast.
- Now: `cause instanceof TypeError` → `unreachable`; `cause instanceof Error && /failed to fetch|networkerror|network request failed/i` → `unreachable`.
- The `unreachable` entry in the LoginPage `DEVICE_ERROR_COPY` table added in #519 already reads "Couldn't reach the Glaon addon — make sure it's running and reachable", so the user now sees actionable copy through the central Toast (per the API Error Toast Rule).

### `apps/web/index.html`
- Adds `worker-src 'self' blob:` to the CSP. Without it, browsers fall back to `script-src` which doesn't allow `blob:`, producing the `Refused to load blob:…` violations Clerk's session-refresh worker generates.
- `blob:` is scoped to `worker-src` only, so non-worker `blob:` scripts stay blocked. An inline note in the CSP comment explains the choice.

### `apps/web/src/features/auth/login/login-page.test.tsx`
- New test (`surfaces the unreachable toast when the addon API is offline (#517)`) rejects the mocked `haPasswordGrant` with `new TypeError('Failed to fetch')` and asserts the toast text matches `/couldn.?t reach the glaon addon/i`. Locks in the behaviour the original report was missing.

## Verification

- [x] `pnpm type-check` — 11/11
- [x] `pnpm lint` — 10/10
- [x] `pnpm --filter @glaon/web test login-page` — **6/6** (5 prior + new unreachable assertion)
- [ ] Local manual: with addon API offline, submit device tab. Expected: Toast "Couldn't reach the Glaon addon — make sure it's running and reachable", no `Refused to load blob:…` violations in the browser console.
- [ ] Playwright `@smoke` continues to pass.
- [ ] `security-review` skill run — touches CSP. Reviewer: confirm scoping `blob:` to `worker-src` (not `script-src`) keeps the threat model intact.

## Notes for reviewers (security)

- `blob:` workers are first-party only because Clerk's SDK is served from `script-src 'self' https://*.clerk.accounts.dev https://*.clerk.com`. The worker source URL is constructed via `URL.createObjectURL(new Blob(...))` from JS that's already loaded — same-origin script integrity is enforced by `script-src`.
- We do NOT widen `script-src` to include `blob:`. That would allow arbitrary blob-loaded scripts (e.g. injected via XSS into an `eval`-equivalent). The narrower `worker-src 'self' blob:` says: "scripts running in a worker context started from a blob URL are fine, but the page itself still can't execute blob scripts directly."
- The CSP comment was updated to record this rationale so future readers don't lift `blob:` to `script-src` for convenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)