### PR TITLE
fix(api): load .env in dev via tsx --env-file-if-exists

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc -b && esbuild src/index.ts --bundle --platform=node --target=node22 --format=cjs --outfile=dist/index.cjs",
     "clean": "rm -rf dist .turbo coverage",
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file-if-exists=.env src/index.ts",
     "lint": "eslint .",
     "test": "vitest run --exclude=**/*.integration.test.ts",
     "test:integration": "vitest run --config vitest.integration.config.ts",


### PR DESCRIPTION
## Summary

Closes #523. Follow-up to #522 — re-applies a fix that was prepared on PR #522's branch but pushed after the squash merge, so it never made it into `development`.

## Symptom

After #522 merged, even with `apps/api/.env` correctly created by `pnpm dev:bootstrap`, `pnpm dev` keeps printing the Zod missing-config banner. `process.env.MONGODB_URI` and `SESSION_JWT_SECRET` are never set.

## Root cause

`apps/api/package.json`'s dev script is `tsx watch src/index.ts`. `tsx` (like node) does NOT auto-load `.env` files — without an explicit `--env-file` / `--env-file-if-exists` flag, the spawned process gets only the parent shell's environment, which doesn't have the bootstrap-generated values.

The squash commit (`d9683fa`) for #522 contained README + dev-bootstrap.sh + apps/api/src/index.ts banner + root package.json scripts, but never touched `apps/api/package.json`. The dev script stayed untouched.

## Fix

```diff
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file-if-exists=.env src/index.ts",
```

- `-if-exists` so a missing file stays silent (the #522 banner still triggers and instructs the user to run bootstrap).
- Production path unaffected — production runs `node dist/index.cjs` with env vars injected by the deploy pipeline.

## Verification

- [x] `pnpm type-check` — 11/11
- [x] `pnpm lint` — 10/10
- [x] `pnpm --filter @glaon/api test` — 97/97
- [x] `tsx --env-file-if-exists=apps/api/.env -e "..."` — exposes MONGODB_URI + 64-hex SESSION_JWT_SECRET on `process.env`
- [ ] After merge, `pnpm dev:bootstrap && pnpm dev:mongo:up && pnpm dev` boots apps/api (no Zod banner; reaches `apps-api-listening` log).

## Refs

- #521 (original bootstrap issue)
- #522 (the PR that landed bootstrap + banner but missed the dev-script wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)