### PR TITLE
fix(api): wire CORS middleware so cross-origin web preflights pass

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -21,11 +21,15 @@ SESSION_JWT_SECRET=
 # clients re-mint before expiry.
 SESSION_TTL_SECONDS=3600
 
-# Comma-separated allowlist of web origins that should receive a
-# Set-Cookie header for the session JWT. Mobile clients use the
-# Authorization header instead and don't appear in this list.
+# Comma-separated allowlist of web origins. Used by both:
+#   - the CORS middleware (Access-Control-Allow-Origin on preflight
+#     and on every response from `app.use('*', cors(...))`)
+#   - the Set-Cookie path for the session JWT (cookie-mode web
+#     clients; mobile uses Authorization header instead).
+# Dev default = apps/web Vite dev server. Production gets its values
+# from the deploy pipeline (#422).
 # Example: WEB_ORIGINS=https://app.glaon.com,http://localhost:5173
-WEB_ORIGINS=
+WEB_ORIGINS=http://localhost:5173
 
 # Build metadata. The deploy pipeline injects these; locally they
 # default to placeholders.

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -97,6 +97,50 @@ describe('createServer wiring', () => {
   });
 });
 
+describe('CORS allow-list (#525)', () => {
+  function makeAppWithOrigins(webOrigins: string[]) {
+    const deps = makeDeps();
+    return createServer({ ...deps, config: { ...deps.config, webOrigins } });
+  }
+
+  it('allows the preflight when the Origin is in webOrigins', async () => {
+    const app = makeAppWithOrigins(['http://localhost:5173']);
+    const res = await app.request('/auth/ha/password-grant', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'content-type',
+      },
+    });
+    expect([200, 204]).toContain(res.status);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:5173');
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(res.headers.get('Access-Control-Allow-Methods') ?? '').toContain('POST');
+  });
+
+  it('does not echo the Origin back when it is not allow-listed', async () => {
+    const app = makeAppWithOrigins(['https://app.glaon.com']);
+    const res = await app.request('/auth/ha/password-grant', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://evil.example',
+        'Access-Control-Request-Method': 'POST',
+      },
+    });
+    // The browser refuses the preflight if Allow-Origin is absent /
+    // wrong, regardless of the response status — assert the absence.
+    expect(res.headers.get('Access-Control-Allow-Origin')).not.toBe('http://evil.example');
+  });
+
+  it('skips CORS headers entirely when the request has no Origin (same-origin)', async () => {
+    const app = makeAppWithOrigins(['http://localhost:5173']);
+    const res = await app.request('/healthz');
+    // Hono's cors middleware leaves same-origin responses alone.
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+  });
+});
+
 describe('GET /metrics', () => {
   it('returns the prometheus text format with mongo + request counters populated', async () => {
     const app = createServer(makeDeps());

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,6 +3,7 @@
 // a stub Mongo + config without spinning up a real driver.
 
 import { Hono } from 'hono';
+import { cors } from 'hono/cors';
 import type { Db } from 'mongodb';
 
 import { decodeSecret } from './auth/jwt';
@@ -33,6 +34,30 @@ export function createServer(deps: ServerDeps): Hono {
   const metrics = deps.metrics ?? new Metrics();
 
   app.use('*', observabilityMiddleware({ logger, metrics }));
+
+  // CORS allow-list (#525). `config.webOrigins` drives both the
+  // preflight `Access-Control-Allow-Origin` response and the
+  // Set-Cookie logic in routes/auth.ts — both consume the same env-
+  // configured allow-list, so a developer can't accidentally enable
+  // one path without the other. `credentials: true` is required so
+  // the session-cookie flow keeps working for cookie-mode web
+  // clients; the allow-list (not `*`) makes that safe.
+  //
+  // Empty `webOrigins` means no cross-origin client is allowed; the
+  // preflight response carries no `Access-Control-Allow-Origin` and
+  // the browser drops the call. Production deploys MUST set the env
+  // var; dev defaults live in `apps/api/.env.example`.
+  app.use(
+    '*',
+    cors({
+      origin: (incoming) => (deps.config.webOrigins.includes(incoming) ? incoming : null),
+      credentials: true,
+      allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+      allowHeaders: ['Content-Type', 'Authorization'],
+      exposeHeaders: ['X-Request-Id'],
+      maxAge: 600,
+    }),
+  );
 
   app.route(
     '/auth',

--- a/scripts/dev-bootstrap.sh
+++ b/scripts/dev-bootstrap.sh
@@ -47,6 +47,20 @@ else
   echo "· SESSION_JWT_SECRET already set — leaving it alone"
 fi
 
+# Backfill the CORS / Set-Cookie allow-list if the value is empty
+# (#525). Earlier `.env` files created before the dev default landed
+# leave `WEB_ORIGINS=` blank, which makes every cross-origin call
+# from apps/web (Vite dev server on :5173) fail the preflight.
+DEV_WEB_ORIGINS="http://localhost:5173"
+if grep -qE '^WEB_ORIGINS=\s*$' "$API_ENV"; then
+  TMP_FILE="$(mktemp)"
+  awk -v val="$DEV_WEB_ORIGINS" '/^WEB_ORIGINS=\s*$/ { print "WEB_ORIGINS=" val; next } { print }' "$API_ENV" > "$TMP_FILE"
+  mv "$TMP_FILE" "$API_ENV"
+  echo "✓ set apps/api WEB_ORIGINS to $DEV_WEB_ORIGINS (dev default)"
+else
+  echo "· WEB_ORIGINS already set — leaving it alone"
+fi
+
 echo ""
 echo "Next steps:"
 echo "  1. pnpm dev:mongo:up   # start the MongoDB container (apps/api dependency)"


### PR DESCRIPTION
## Summary

Closes #525. apps/web (Vite dev server on `:5173`) talks to apps/api (`:8080`) cross-origin. Browsers send an `OPTIONS` preflight before the real POST; apps/api had **no CORS middleware mounted**, so every preflight returned 404 and the browser dropped the call. The symptom in the bug report:

```
@glaon/api:dev: {"msg":"request","method":"OPTIONS","path":"/auth/ha/password-grant","status":404,…}
```

After this PR the same log line returns 204 with the expected `Access-Control-Allow-*` headers.

## Changes

### `apps/api/src/server.ts` — mount `hono/cors`

```ts
app.use('*', cors({
  origin: (incoming) => deps.config.webOrigins.includes(incoming) ? incoming : null,
  credentials: true,
  allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
  allowHeaders: ['Content-Type', 'Authorization'],
  exposeHeaders: ['X-Request-Id'],
  maxAge: 600,
}));
```

The allow-list reuses `config.webOrigins` — the same env-driven list that already gates the `Set-Cookie` path in `routes/auth.ts`. One env var, two enforcement points. `credentials: true` keeps cookie-mode auth working; the explicit allow-list (never `*`) makes that safe.

### `apps/api/.env.example`

```diff
- # ... Set-Cookie wording only ...
- WEB_ORIGINS=
+ # Comma-separated allowlist of web origins. Used by both:
+ #   - the CORS middleware (Access-Control-Allow-Origin on preflight
+ #     and on every response from `app.use('*', cors(...))`)
+ #   - the Set-Cookie path for the session JWT
+ WEB_ORIGINS=http://localhost:5173
```

A fresh `pnpm dev:bootstrap` lands a working dev allow-list. Production keeps reading the deploy-pipeline-injected value.

### `scripts/dev-bootstrap.sh` — backfill empty WEB_ORIGINS

Developers with a `.env` created before this PR have `WEB_ORIGINS=` empty. The bootstrap script now backfills it (idempotent — same shape as the existing SESSION_JWT_SECRET backfill). No need to delete the `.env`.

### `apps/api/src/server.test.ts` — three new CORS tests

1. Allow-listed Origin → preflight returns 204 with `Access-Control-Allow-Origin: <origin>`, `Access-Control-Allow-Credentials: true`, and `Allow-Methods` containing POST.
2. Non-allow-listed Origin → no `Allow-Origin` echoed (browser drops the preflight).
3. Same-origin request (no `Origin` header) → response has no CORS headers (Hono's middleware leaves them alone).

## Verification

- [x] `pnpm type-check` — 11/11
- [x] `pnpm lint` — 10/10
- [x] `pnpm --filter @glaon/api test` — **100/100** (97 prior + 3 new)
- [x] Bootstrap script idempotency — re-ran on a `.env` with `WEB_ORIGINS=` empty: backfilled correctly; second run says "WEB_ORIGINS already set — leaving it alone".
- [ ] Manual: `pnpm dev` after pulling; device-tab sign-in from apps/web logs `OPTIONS /auth/ha/password-grant … 204` instead of `… 404`. Real POST proceeds (succeeds or hits the Toast for auth failures, but no longer for preflight failures).

## Security notes

- Allow-list is enforced via a function predicate, never `*`. A request from `http://evil.example` has no `Access-Control-Allow-Origin` echoed back and the browser drops the response.
- `credentials: true` paired with the explicit allow-list keeps the cookie-mode session-cookie flow working without opening the door to credential-bearing cross-origin requests from arbitrary origins.
- `maxAge: 600` caches preflight for 10 minutes — within the typical browser cap.

## Out of scope

- `GET /` returns 404 (Vite dev proxy probing for `/`) — separate, low-priority issue. Not a real product surface.
- Per-route CORS granularity. All routes currently share one allow-list; revisit if a public read-only API ships.

## Refs

- ADR 0025 (apps-api stack)
- #517 (device-login Toast that surfaced this), #519 (Toast Rule), #520 (worker-src + fetch failure mapping)
- #522 / #524 (bootstrap + .env loading chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)