### PR TITLE
fix(web): pixel-perfect SignUp to Figma 14530:2343 + Toast errors

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -26,11 +26,11 @@ import {
 const HA_BASE_URL: string = import.meta.env.VITE_HA_BASE_URL ?? 'http://homeassistant.local:8123';
 const LOGOUT_ENDPOINT = '/auth/logout';
 
-// Lifestyle hero shipped from Figma node 1267:132204 (#514, closes
-// #513). JPEG at quality ~80 — 290KB — stays within the apps/web
-// bundle budget #500 is tightening. The image is purely decorative
-// (the AuthLayout marks its own `<aside>` aria-hidden), so alt="".
-const LOGIN_HERO_IMAGE = (
+// Lifestyle hero shipped from Figma node 1267:132204 / 14530:2343
+// (#514 + #527). Same JPEG (~290KB) drives both the LoginPage right
+// column and the SignUpPage right column; AuthLayout treats it as
+// purely decorative (aria-hidden aside), so alt="".
+const AUTH_HERO_IMAGE = (
   <img src={loginHeroUrl} alt="" className="absolute inset-0 h-full w-full object-cover" />
 );
 
@@ -120,7 +120,7 @@ function Router({ clerkKey }: RouterProps): ReactNode {
         defaultTab={defaultTab}
         defaultHaBaseUrl={HA_BASE_URL}
         cloudAvailable={clerkKey !== null}
-        imageSlot={LOGIN_HERO_IMAGE}
+        imageSlot={AUTH_HERO_IMAGE}
       />
     );
   }
@@ -133,7 +133,7 @@ function Router({ clerkKey }: RouterProps): ReactNode {
         </main>
       );
     }
-    return <SignUpPage />;
+    return <SignUpPage imageSlot={AUTH_HERO_IMAGE} />;
   }
   if (path === '/forgot-password') {
     if (clerkKey === null) {
@@ -193,7 +193,7 @@ function Router({ clerkKey }: RouterProps): ReactNode {
         defaultTab={defaultTab}
         defaultHaBaseUrl={localBaseUrl}
         cloudAvailable={clerkKey !== null}
-        imageSlot={LOGIN_HERO_IMAGE}
+        imageSlot={AUTH_HERO_IMAGE}
       />
     );
   }

--- a/apps/web/src/features/auth/sign-up/sign-up-page.test.tsx
+++ b/apps/web/src/features/auth/sign-up/sign-up-page.test.tsx
@@ -3,6 +3,7 @@
 // `/verify-email?after=signup`) is exercised end-to-end without
 // touching Clerk's network.
 
+import { ToastProvider } from '@glaon/ui';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -26,9 +27,13 @@ vi.mock('@clerk/clerk-react', () => ({
 
 function renderPage(navigate?: (url: string) => void) {
   const tokenStore = new WebTokenStore({ logoutEndpoint: '/auth/logout' });
+  // ToastProvider mirrors apps/web App.tsx; SignUpPage calls
+  // `useToast()` for general API errors (#527).
   const ui = (
     <AuthProvider tokenStore={tokenStore}>
-      <SignUpPage imageSlot={null} {...(navigate !== undefined ? { navigate } : {})} />
+      <ToastProvider>
+        <SignUpPage imageSlot={null} {...(navigate !== undefined ? { navigate } : {})} />
+      </ToastProvider>
     </AuthProvider>
   );
   return render(ui);

--- a/apps/web/src/features/auth/sign-up/sign-up-page.tsx
+++ b/apps/web/src/features/auth/sign-up/sign-up-page.tsx
@@ -2,9 +2,16 @@
 // Replaces the legacy `<SignUpRoute>` (Clerk hosted view) with the
 // split-screen Figma design and wires the SDK via `useCloudSignUp`.
 //
-// On success the form navigates to `/verify-email?after=signup`
-// (handled by #473 / F). Until F merges, the route renders a
-// placeholder; this PR's scope ends at the redirect.
+// On success the form navigates to `/verify-email?after=signup`.
+//
+// Figma reference: Design-System / Sign up / node 14530:2343
+// (Desktop + Mobile). #527 brings the page in line with the
+// Design-System Fidelity Rule and the API Error Toast Rule —
+// `<Input>` primitive instead of raw `<input>`, no marketing
+// checkbox (the Figma frame doesn't show one), and general API
+// failures route through `useToast()` instead of an inline block.
+// Field-level Clerk errors stay inline on the `<Input>` itself
+// (Toast Rule explicitly allows per-field validation copy).
 
 import { useEffect, useState, type ReactNode, type SyntheticEvent } from 'react';
 
@@ -12,11 +19,10 @@ import {
   AuthFooter,
   AuthLayout,
   Button,
-  Checkbox,
-  FormField,
+  Input,
   PasswordInput,
   SocialButton,
-  useFormFieldDescriptors,
+  useToast,
 } from '@glaon/ui';
 
 import { useCloudSignUp } from './use-cloud-sign-up';
@@ -28,15 +34,49 @@ interface SignUpPageProps {
   navigate?: ((url: string) => void) | undefined;
 }
 
+interface ToastCopy {
+  readonly title: string;
+  readonly description?: string;
+}
+
+// Per the API Error Toast Rule (CLAUDE.md), every error code that
+// reaches the UI maps to specific copy here — generic fallback is
+// reserved for `unknown` only. Mirrors `CloudSignUpErrorCode` from
+// `use-cloud-sign-up.ts`. Field-level errors (`fieldKey !== undefined`)
+// never hit this table because they render inline on `<Input>`.
+const SIGNUP_UNKNOWN_COPY: ToastCopy = {
+  title: 'Sign-up failed',
+  description: 'Something went wrong with Glaon Cloud. Try again in a moment.',
+};
+
+const SIGNUP_ERROR_COPY: Record<string, ToastCopy> = {
+  form_param_format_invalid: {
+    title: 'Check your details',
+    description: 'One of the fields you entered isn’t in the right format. Try again.',
+  },
+  form_password_pwned: {
+    title: 'That password isn’t safe',
+    description:
+      'This password appears in known data breaches. Pick a different one to keep your account secure.',
+  },
+  form_password_length_too_short: {
+    title: 'Password too short',
+    description: 'Use at least 8 characters for your account password.',
+  },
+  form_identifier_exists: {
+    title: 'You already have an account',
+    description: 'That email is already in use. Sign in instead, or use a different address.',
+  },
+  unknown: SIGNUP_UNKNOWN_COPY,
+};
+
 export function SignUpPage({ imageSlot, navigate }: SignUpPageProps): ReactNode {
   const [name, setName] = useState<string>('');
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [confirmPassword, setConfirmPassword] = useState<string>('');
-  const [marketingOptIn, setMarketingOptIn] = useState<boolean>(false);
   const { state, submit, signUpWithSocial, isLoaded } = useCloudSignUp();
-  const nameField = useFormFieldDescriptors('signup-name');
-  const emailField = useFormFieldDescriptors('signup-email');
+  const toast = useToast();
 
   useEffect(() => {
     if (state.status === 'awaiting_verification') {
@@ -47,7 +87,13 @@ export function SignUpPage({ imageSlot, navigate }: SignUpPageProps): ReactNode 
         });
       go('/verify-email?after=signup');
     }
-  }, [navigate, state]);
+    // Non-field (general) errors flow through Toast; field errors
+    // render inline on the matching <Input>/<PasswordInput>.
+    if (state.status === 'error' && state.error.fieldKey === undefined) {
+      const copy = SIGNUP_ERROR_COPY[state.error.code] ?? SIGNUP_UNKNOWN_COPY;
+      toast.show({ intent: 'danger', ...copy });
+    }
+  }, [navigate, state, toast]);
 
   const onSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -59,7 +105,6 @@ export function SignUpPage({ imageSlot, navigate }: SignUpPageProps): ReactNode 
   const fieldError = (
     field: 'name' | 'email' | 'password' | 'confirmPassword',
   ): string | undefined => (error?.fieldKey === field ? error.message : undefined);
-  const generalError = error !== null && error.fieldKey === undefined ? error.message : undefined;
 
   return (
     <AuthLayout
@@ -67,62 +112,42 @@ export function SignUpPage({ imageSlot, navigate }: SignUpPageProps): ReactNode 
       imageSlot={imageSlot}
       footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
     >
-      <header className="flex flex-col gap-2">
-        <h1 className="text-display-sm font-semibold text-primary">Sign up</h1>
+      <header className="flex flex-col gap-3">
+        <h1 className="text-display-xs font-semibold text-primary">Sign up</h1>
         <p className="text-md text-tertiary">Start your 30-day free trial.</p>
       </header>
 
       <form
         data-testid="signup-form"
         onSubmit={onSubmit}
-        className="flex flex-col gap-4"
+        className="flex flex-col gap-5"
         noValidate
       >
-        <FormField
+        <Input
           label="Name"
-          htmlFor="signup-name"
-          {...(fieldError('name') !== undefined ? { error: fieldError('name') } : {})}
+          name="name"
+          type="text"
+          autoComplete="name"
           isRequired
-        >
-          <input
-            id="signup-name"
-            name="name"
-            type="text"
-            autoComplete="name"
-            required
-            value={name}
-            onChange={(e) => {
-              setName(e.currentTarget.value);
-            }}
-            aria-invalid={fieldError('name') !== undefined}
-            aria-describedby={nameField.describedBy(fieldError('name') !== undefined, false)}
-            className="w-full rounded-lg bg-primary px-3 py-2 text-md text-primary shadow-xs ring-1 ring-primary ring-inset focus:outline-hidden focus:ring-2 focus:ring-brand"
-            placeholder="Enter your name"
-          />
-        </FormField>
+          value={name}
+          onChange={setName}
+          placeholder="Enter your name"
+          isInvalid={fieldError('name') !== undefined}
+          {...(fieldError('name') !== undefined ? { hint: fieldError('name') } : {})}
+        />
 
-        <FormField
+        <Input
           label="Email"
-          htmlFor="signup-email"
-          {...(fieldError('email') !== undefined ? { error: fieldError('email') } : {})}
+          name="email"
+          type="email"
+          autoComplete="email"
           isRequired
-        >
-          <input
-            id="signup-email"
-            name="email"
-            type="email"
-            autoComplete="email"
-            required
-            value={email}
-            onChange={(e) => {
-              setEmail(e.currentTarget.value);
-            }}
-            aria-invalid={fieldError('email') !== undefined}
-            aria-describedby={emailField.describedBy(fieldError('email') !== undefined, false)}
-            className="w-full rounded-lg bg-primary px-3 py-2 text-md text-primary shadow-xs ring-1 ring-primary ring-inset focus:outline-hidden focus:ring-2 focus:ring-brand"
-            placeholder="Enter your email"
-          />
-        </FormField>
+          value={email}
+          onChange={setEmail}
+          placeholder="Enter your email"
+          isInvalid={fieldError('email') !== undefined}
+          {...(fieldError('email') !== undefined ? { hint: fieldError('email') } : {})}
+        />
 
         <PasswordInput
           label="Password"
@@ -145,18 +170,6 @@ export function SignUpPage({ imageSlot, navigate }: SignUpPageProps): ReactNode 
           onChange={setConfirmPassword}
           isRequired
         />
-
-        <Checkbox
-          isSelected={marketingOptIn}
-          onChange={setMarketingOptIn}
-          label="Send me product updates and announcements (optional)."
-        />
-
-        {generalError !== undefined && (
-          <p role="alert" data-testid="signup-error" className="text-sm text-error">
-            {generalError}
-          </p>
-        )}
 
         <Button type="submit" size="lg" isLoading={isSubmitting} isDisabled={!isLoaded}>
           Get started


### PR DESCRIPTION
## Summary

Closes #527. Applies both the Design-System Fidelity Rule (#511) and the API Error Toast Rule (#519) to `SignUpPage` — the first of the remaining auth screens to migrate. The page now matches Figma node `14530:2343` (Desktop) and routes general API failures through the central Toast.

**Figma reference**: https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=14530-2343

## Changes

### `apps/web/src/features/auth/sign-up/sign-up-page.tsx`
- **Header typography**: `text-display-sm` (30px) → `text-display-xs` (24px); header `gap-2` → `gap-3` (matching Figma's 12px stack gap between title and supporting text).
- **Name + Email fields**: swapped from raw `<input>` + `<FormField>` to the `<Input>` primitive. Same pattern shipped on LoginPage (#519). Field-level Clerk errors now render inline via `isInvalid` + `hint`.
- **Marketing opt-in checkbox removed**. The Figma frame doesn't show one, and the Fidelity Rule explicitly forbids shipping UI that isn't in the reference frame.
- **General API failures route through Toast**. Added `SIGNUP_ERROR_COPY` + `SIGNUP_UNKNOWN_COPY` keyed off `CloudSignUpErrorCode` (`form_param_format_invalid`, `form_password_pwned`, `form_password_length_too_short`, `form_identifier_exists`, `unknown`). `useEffect` watches `state.status === 'error' && error.fieldKey === undefined` and dispatches `toast.show({ intent: 'danger', ...copy })`. Field-level errors stay inline on `<Input>`/`<PasswordInput>` per the Toast Rule's per-field-validation exception.
- Dropped the inline `<p role="alert" data-testid="signup-error">` block.

### `apps/web/src/App.tsx`
- Passes the shared hero image to `<SignUpPage>` so the split layout's right column renders at `lg+`. Renamed `LOGIN_HERO_IMAGE` → `AUTH_HERO_IMAGE` (one asset, two pages — same Figma JPEG).

### `apps/web/src/features/auth/sign-up/sign-up-page.test.tsx`
- Wrap renders in `<ToastProvider>` alongside `<AuthProvider>` so `useToast()` resolves. Selectors unchanged; the existing tests don't assert against the (now removed) inline error block.

## Verification

- [x] `pnpm type-check` — 11/11
- [x] `pnpm lint` — 10/10
- [x] `pnpm --filter @glaon/web test sign-up` — 4/4
- [ ] Local visual: open `/sign-up` at viewport ≥1280×720 next to Figma `14530:2343`. Expected pixel-for-pixel match: logo absolute top-left, form column `max-w-[360px]` centered, hero photo full-bleed on the right with `rounded-tl-[80px] rounded-bl-[80px]`, no marketing checkbox.
- [ ] Trigger `form_identifier_exists` (already-registered email) → Toast in top-right reads "You already have an account · That email is already in use…". Field-level errors stay on the matching `<Input>`/`<PasswordInput>`.
- [ ] Chromatic — no `packages/ui` stories changed; the `AuthLayout` shape is unaffected. Apps/web doesn't ship Storybook, so no SignUpPage story baseline.

## Out of scope (follow-up issues)

- ForgotPasswordPage and EmailVerificationPage have the same pre-rules pattern. Each gets its own issue + Figma frame review per the Fidelity Rule.
- Mobile breakpoint Figma frame for SignUp (separate variant) — this PR targets the Desktop variant explicitly.

## Refs

- ADR 0013 (Tailwind v4 + UUI theme.css)
- #511 / PR #512 (Design-System Fidelity Rule)
- #519 / PR #519 squashed equivalent (API Error Toast Rule)
- #515 / PR #515 (Figma hero photo shipped as `apps/web/src/assets/auth/login-hero.jpg` — reused here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)