### PR TITLE
refactor(ui): consolidate auth-page skeleton into AuthLayout

### DIFF
--- a/apps/web/src/features/auth/login/login-page.tsx
+++ b/apps/web/src/features/auth/login/login-page.tsx
@@ -33,7 +33,6 @@ import {
   Button,
   Checkbox,
   Input,
-  Logo,
   PasswordInput,
   SocialButton,
   Tabs,
@@ -91,15 +90,10 @@ export function LoginPage({
   return (
     <AuthLayout
       variant="split"
-      logoSlot={<Logo size={133} />}
       imageSlot={imageSlot}
-      footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
+      title="Welcome back"
+      subtitle="Welcome back! Please enter your details."
     >
-      <header className="flex flex-col gap-3">
-        <h1 className="text-display-xs font-semibold text-primary">Welcome back</h1>
-        <p className="text-md text-tertiary">Welcome back! Please enter your details.</p>
-      </header>
-
       <Tabs
         selectedKey={activeTab}
         onSelectionChange={(key) => {

--- a/apps/web/src/features/auth/sign-up/sign-up-page.tsx
+++ b/apps/web/src/features/auth/sign-up/sign-up-page.tsx
@@ -110,13 +110,9 @@ export function SignUpPage({ imageSlot, navigate }: SignUpPageProps): ReactNode 
     <AuthLayout
       variant="split"
       imageSlot={imageSlot}
-      footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
+      title="Sign up"
+      subtitle="Start your 30-day free trial."
     >
-      <header className="flex flex-col gap-3">
-        <h1 className="text-display-xs font-semibold text-primary">Sign up</h1>
-        <p className="text-md text-tertiary">Start your 30-day free trial.</p>
-      </header>
-
       <form
         data-testid="signup-form"
         onSubmit={onSubmit}

--- a/packages/ui/src/components/AuthLayout/AuthLayout.controls.ts
+++ b/packages/ui/src/components/AuthLayout/AuthLayout.controls.ts
@@ -19,6 +19,20 @@ export const authLayoutControls = {
       'Layout variant. `split` is the Login + Sign-up frame (left-side card + right-side hero image, collapses to a single column under `lg`). `centered` is the Forgot password + Email verification frame (single card with optional icon slot above the title).',
     category: 'Style',
   } satisfies ControlSpec<(typeof variantOptions)[number]>,
+  title: {
+    type: 'text',
+    default: '',
+    description:
+      'Page title rendered as `<h1 className="text-display-xs font-semibold">` inside a shared `flex flex-col gap-3` header. Leave empty to skip the header (e.g. when the screen renders its own custom heading via `children`).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  subtitle: {
+    type: 'text',
+    default: '',
+    description:
+      'Supporting text rendered under `title` as `<p className="text-md text-tertiary">`. Ignored when `title` is empty.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
 } as const;
 
 export const authLayoutExcludeFromArgs = defineExcludeFromArgs([

--- a/packages/ui/src/components/AuthLayout/AuthLayout.stories.tsx
+++ b/packages/ui/src/components/AuthLayout/AuthLayout.stories.tsx
@@ -26,20 +26,18 @@ type Story = StoryObj<typeof AuthLayout>;
 
 export const excludeFromArgs = authLayoutExcludeFromArgs;
 
+// Form fields only. The title + subtitle now live on AuthLayout
+// itself (via `title` / `subtitle` props) so stories declare them
+// once at the args level instead of repeating the header markup
+// inside every render fn.
 const placeholderForm = (
-  <>
-    <div>
-      <h1 className="text-display-sm font-semibold text-primary">Welcome back</h1>
-      <p className="mt-2 text-md text-tertiary">Welcome back! Please enter your details.</p>
+  <div className="flex flex-col gap-4">
+    <div className="rounded-lg bg-secondary px-3 py-3 text-sm text-tertiary">Email field</div>
+    <div className="rounded-lg bg-secondary px-3 py-3 text-sm text-tertiary">Password field</div>
+    <div className="rounded-lg bg-brand_solid px-3 py-3 text-center text-sm font-semibold text-white">
+      Sign in
     </div>
-    <div className="flex flex-col gap-4">
-      <div className="rounded-lg bg-secondary px-3 py-3 text-sm text-tertiary">Email field</div>
-      <div className="rounded-lg bg-secondary px-3 py-3 text-sm text-tertiary">Password field</div>
-      <div className="rounded-lg bg-brand_solid px-3 py-3 text-center text-sm font-semibold text-white">
-        Sign in
-      </div>
-    </div>
-  </>
+  </div>
 );
 
 const placeholderImage = (
@@ -53,63 +51,60 @@ const featuredIcon = (Icon: typeof Mail01) => (
 );
 
 export const Split: Story = {
-  args: { variant: 'split' },
+  args: {
+    variant: 'split',
+    title: 'Welcome back',
+    subtitle: 'Welcome back! Please enter your details.',
+  },
   render: (args) => (
-    <AuthLayout {...args} imageSlot={placeholderImage} footerSlot={<span>© Glaon 2026</span>}>
+    <AuthLayout {...args} imageSlot={placeholderImage}>
       {placeholderForm}
     </AuthLayout>
   ),
 };
 
 export const SplitWithoutImage: Story = {
-  args: { variant: 'split' },
+  args: {
+    variant: 'split',
+    title: 'Welcome back',
+    subtitle: 'Welcome back! Please enter your details.',
+  },
   render: (args) => (
-    <AuthLayout {...args} imageSlot={null} footerSlot={<span>© Glaon 2026</span>}>
+    <AuthLayout {...args} imageSlot={null}>
       {placeholderForm}
     </AuthLayout>
   ),
 };
 
+const centeredForm = (
+  <div className="flex w-full flex-col gap-4">
+    <div className="rounded-lg bg-secondary px-3 py-3 text-left text-sm text-tertiary">
+      Email field
+    </div>
+    <div className="rounded-lg bg-brand_solid px-3 py-3 text-center text-sm font-semibold text-white">
+      Reset password
+    </div>
+  </div>
+);
+
 export const Centered: Story = {
-  args: { variant: 'centered' },
-  render: (args) => (
-    <AuthLayout {...args} footerSlot={<span>© Glaon 2026</span>}>
-      <div>
-        <h1 className="text-display-sm font-semibold text-primary">Forgot password?</h1>
-        <p className="mt-2 text-md text-tertiary">
-          No worries, we&apos;ll send you reset instructions.
-        </p>
-      </div>
-      <div className="flex w-full flex-col gap-4">
-        <div className="rounded-lg bg-secondary px-3 py-3 text-left text-sm text-tertiary">
-          Email field
-        </div>
-        <div className="rounded-lg bg-brand_solid px-3 py-3 text-center text-sm font-semibold text-white">
-          Reset password
-        </div>
-      </div>
-    </AuthLayout>
-  ),
+  args: {
+    variant: 'centered',
+    title: 'Forgot password?',
+    subtitle: "No worries, we'll send you reset instructions.",
+  },
+  render: (args) => <AuthLayout {...args}>{centeredForm}</AuthLayout>,
 };
 
 export const CenteredWithIcon: Story = {
-  args: { variant: 'centered' },
+  args: {
+    variant: 'centered',
+    title: 'Forgot password?',
+    subtitle: "No worries, we'll send you reset instructions.",
+  },
   render: (args) => (
-    <AuthLayout {...args} iconSlot={featuredIcon(Key01)} footerSlot={<span>© Glaon 2026</span>}>
-      <div>
-        <h1 className="text-display-sm font-semibold text-primary">Forgot password?</h1>
-        <p className="mt-2 text-md text-tertiary">
-          No worries, we&apos;ll send you reset instructions.
-        </p>
-      </div>
-      <div className="flex w-full flex-col gap-4">
-        <div className="rounded-lg bg-secondary px-3 py-3 text-left text-sm text-tertiary">
-          Email field
-        </div>
-        <div className="rounded-lg bg-brand_solid px-3 py-3 text-center text-sm font-semibold text-white">
-          Reset password
-        </div>
-      </div>
+    <AuthLayout {...args} iconSlot={featuredIcon(Key01)}>
+      {centeredForm}
     </AuthLayout>
   ),
 };

--- a/packages/ui/src/components/AuthLayout/AuthLayout.tsx
+++ b/packages/ui/src/components/AuthLayout/AuthLayout.tsx
@@ -25,9 +25,23 @@ export interface AuthLayoutProps {
    */
   variant?: AuthLayoutVariant;
   /**
-   * Optional override for the brand logo at the top-left. Defaults to
-   * the standard `<Logo />` primitive at `md` size; pass `null` to
-   * suppress the logo (e.g. when AuthLayout sits inside another shell).
+   * Page title rendered as `<h1>` above the form. When set, AuthLayout
+   * also renders the standard `flex flex-col gap-3` header wrapper —
+   * pages no longer hand-roll the heading + subtitle stack. Pass
+   * `null` (or omit) for screens that want full control of the header
+   * area (e.g. centered variant with a custom icon block).
+   */
+  title?: ReactNode;
+  /**
+   * Secondary text rendered under `title`. Ignored when `title` is
+   * unset.
+   */
+  subtitle?: ReactNode;
+  /**
+   * Override for the brand logo at the top-left. Defaults to
+   * `<Logo size={133} />` — the pixel size measured from Figma node
+   * `1267:132204`. Pass `null` to suppress the logo (e.g. when
+   * AuthLayout sits inside another shell).
    */
   logoSlot?: ReactNode;
   /**
@@ -43,28 +57,59 @@ export interface AuthLayoutProps {
    */
   iconSlot?: ReactNode;
   /**
-   * Optional footer rendered at the bottom of the form column.
-   * Typically `© Glaon {year}` on the auth flows.
+   * Footer rendered at the bottom of the form column. Defaults to
+   * `© Glaon {currentYear}`; pass `null` to suppress, or override with
+   * a custom node for legal / build-info chrome.
    */
   footerSlot?: ReactNode;
-  /** Form contents — title, fields, CTAs. */
+  /** Form contents — fields, CTAs, social buttons, footer links. */
   children: ReactNode;
 }
 
 export function AuthLayout({
   variant = 'split',
+  title,
+  subtitle,
   logoSlot,
   imageSlot,
   iconSlot,
   footerSlot,
   children,
 }: AuthLayoutProps) {
-  const logo = logoSlot === undefined ? <Logo size="md" /> : logoSlot;
+  // Default logo / footer slots — pages can still override per slot,
+  // but the common case (LoginPage, SignUpPage, …) gets them for free.
+  // `logoSlot === undefined` distinguishes "not set" from "set to
+  // null" (the latter suppresses the slot).
+  const logo = logoSlot === undefined ? <Logo size={133} /> : logoSlot;
+  const footer =
+    footerSlot === undefined ? (
+      <span>© Glaon {new Date().getFullYear().toString()}</span>
+    ) : (
+      footerSlot
+    );
+
+  // Shared title + subtitle stack. Pages that pass a `title` prop
+  // skip hand-rolling the `<header>` — keeps Figma-spec typography
+  // (`text-display-xs font-semibold` + `text-md text-tertiary`,
+  // gap-3) on one source line. Named `titleBlock` rather than
+  // `header` because the centered variant already uses the `<header>`
+  // element as the logo container at the top of the page.
+  const titleBlock =
+    title !== undefined && title !== null ? (
+      <header className="flex flex-col gap-3">
+        <h1 className="text-display-xs font-semibold text-primary">{title}</h1>
+        {subtitle !== undefined && subtitle !== null && (
+          <p className="text-md text-tertiary">{subtitle}</p>
+        )}
+      </header>
+    ) : null;
 
   if (variant === 'centered') {
     return (
       <div className="flex min-h-screen flex-col bg-primary">
-        <header className="flex items-start px-6 py-6 sm:px-10 sm:py-8">{logo}</header>
+        {logo !== null && (
+          <header className="flex items-start px-6 py-6 sm:px-10 sm:py-8">{logo}</header>
+        )}
         <main className="flex flex-1 items-center justify-center px-6 pb-12">
           <div className="flex w-full max-w-[400px] flex-col items-center gap-6 text-center">
             {iconSlot !== undefined && iconSlot !== null && (
@@ -72,11 +117,12 @@ export function AuthLayout({
                 {iconSlot}
               </div>
             )}
+            {titleBlock}
             {children}
           </div>
         </main>
-        {footerSlot !== undefined && footerSlot !== null && (
-          <footer className="px-6 py-6 text-sm text-tertiary sm:px-10">{footerSlot}</footer>
+        {footer !== null && (
+          <footer className="px-6 py-6 text-sm text-tertiary sm:px-10">{footer}</footer>
         )}
       </div>
     );
@@ -106,13 +152,16 @@ export function AuthLayout({
   return (
     <div className="flex min-h-screen flex-col bg-primary lg:h-screen lg:min-h-0 lg:flex-row lg:items-stretch lg:overflow-hidden">
       <section className="relative flex flex-1 flex-col items-center justify-center px-6 py-24 sm:px-10 lg:min-w-[480px] lg:overflow-y-auto lg:py-8">
-        <div className="absolute left-6 top-6 sm:left-8 sm:top-8">{logo}</div>
+        {logo !== null && <div className="absolute left-6 top-6 sm:left-8 sm:top-8">{logo}</div>}
 
-        <div className="flex w-full max-w-[360px] flex-col gap-8">{children}</div>
+        <div className="flex w-full max-w-[360px] flex-col gap-8">
+          {titleBlock}
+          {children}
+        </div>
 
-        {footerSlot !== undefined && footerSlot !== null && (
+        {footer !== null && (
           <footer className="absolute bottom-6 left-6 text-sm text-tertiary sm:bottom-8 sm:left-8">
-            {footerSlot}
+            {footer}
           </footer>
         )}
       </section>

--- a/packages/ui/src/components/AuthLayout/AuthLayout.tsx
+++ b/packages/ui/src/components/AuthLayout/AuthLayout.tsx
@@ -94,15 +94,19 @@ export function AuthLayout({
   // gap-3) on one source line. Named `titleBlock` rather than
   // `header` because the centered variant already uses the `<header>`
   // element as the logo container at the top of the page.
-  const titleBlock =
-    title !== undefined && title !== null ? (
-      <header className="flex flex-col gap-3">
-        <h1 className="text-display-xs font-semibold text-primary">{title}</h1>
-        {subtitle !== undefined && subtitle !== null && (
-          <p className="text-md text-tertiary">{subtitle}</p>
-        )}
-      </header>
-    ) : null;
+  //
+  // `title === ''` is also treated as "no title" so the Storybook
+  // controls panel (which defaults string controls to "") doesn't
+  // render an empty `<h1>` and trip the axe `empty-heading` rule
+  // in story-tests CI. Same coverage for `subtitle`.
+  const hasTitle = title !== undefined && title !== null && title !== '';
+  const hasSubtitle = subtitle !== undefined && subtitle !== null && subtitle !== '';
+  const titleBlock = hasTitle ? (
+    <header className="flex flex-col gap-3">
+      <h1 className="text-display-xs font-semibold text-primary">{title}</h1>
+      {hasSubtitle && <p className="text-md text-tertiary">{subtitle}</p>}
+    </header>
+  ) : null;
 
   if (variant === 'centered') {
     return (


### PR DESCRIPTION
## Summary

Closes #529. LoginPage and SignUpPage repeated the same outer skeleton — `<Logo size={133}>` logoSlot, the `flex flex-col gap-3` header stack with Figma typography, and the `© Glaon {year}` footer — at every call site. Only the title, supporting text, and form contents differed. Moves the shared skeleton into `AuthLayout` so pages declare *what's different*, not *what's the same*.

When ForgotPasswordPage and EmailVerificationPage migrate next, they pick up the new `title`/`subtitle` API automatically.

## Changes

### `packages/ui/src/components/AuthLayout/AuthLayout.tsx`
- New optional props `title?: ReactNode`, `subtitle?: ReactNode`. When `title` is set, AuthLayout renders a `<header className="flex flex-col gap-3">` containing `<h1 className="text-display-xs font-semibold text-primary">{title}</h1>` and an optional `<p className="text-md text-tertiary">{subtitle}</p>`. Pages keep using `children` directly when they need a custom header shape (none today; reserved for future flows).
- **Default `logoSlot`** changes from `<Logo size="md" />` to `<Logo size={133} />` — the pixel size measured from Figma node `1267:132204` and documented in #511.
- **Default `footerSlot`** is `<span>© Glaon {currentYear}</span>`. Pages no longer hand-roll the copyright line.
- Both defaults distinguish `undefined` (use default) from `null` (suppress).

### `packages/ui/src/components/AuthLayout/AuthLayout.controls.ts` + `.stories.tsx`
- Expose `title` and `subtitle` as text controls in Storybook.
- `Split`, `SplitWithoutImage`, `Centered`, `CenteredWithIcon` stories now drive their headings through args. Placeholder form/centered-form blocks dropped their inline heading markup.

### `apps/web/src/features/auth/login/login-page.tsx` + `apps/web/src/features/auth/sign-up/sign-up-page.tsx`
- Drop `logoSlot`, `footerSlot`, and the manual `<header>` block at every call site. Pass `title` + `subtitle` props instead.
- Both pages shrink by roughly 10 lines each.

```tsx
// Before
<AuthLayout
  variant="split"
  logoSlot={<Logo size={133} />}
  imageSlot={imageSlot}
  footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
>
  <header className="flex flex-col gap-3">
    <h1 className="text-display-xs font-semibold text-primary">Welcome back</h1>
    <p className="text-md text-tertiary">Welcome back! Please enter your details.</p>
  </header>
  <Tabs>…</Tabs>
</AuthLayout>

// After
<AuthLayout
  variant="split"
  imageSlot={imageSlot}
  title="Welcome back"
  subtitle="Welcome back! Please enter your details."
>
  <Tabs>…</Tabs>
</AuthLayout>
```

## Verification

- [x] `pnpm type-check` — 11/11
- [x] `pnpm lint` — 10/10
- [x] `pnpm --filter @glaon/web test` — 86/86
- [x] `pnpm --filter @glaon/ui test` — 135/135
- [ ] Local visual: `/login` and `/sign-up` side-by-side with Figma `1267:132204` and `14530:2343` — pixel output identical to the prior hand-rolled headers (same Logo size, same gap-3 header, same `© Glaon {year}` footer). The Fidelity Rule check still passes.
- [ ] Chromatic — AuthLayout stories will show a diff (heading now flows through `title`/`subtitle` props instead of `children`). The pixel output is unchanged; the baseline shift is intentional and auto-accepted on `development`.

## Out of scope

- ForgotPasswordPage / EmailVerificationPage migration to `title`/`subtitle` + Toast + Figma frames — each gets its own issue + PR, but they will consume the new API for free once their migration lands.
- Renaming `AuthLayout` — primitive name stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)