### PR TITLE
fix(web): migrate forgot-password + email-verify to AuthLayout + Toast

### DIFF
--- a/apps/web/src/features/auth/email-verification/email-verification-page.tsx
+++ b/apps/web/src/features/auth/email-verification/email-verification-page.tsx
@@ -92,13 +92,9 @@ export function EmailVerificationPage({ email, navigate }: EmailVerificationPage
       <AuthLayout
         variant="centered"
         iconSlot={<FeaturedIcon path={CHECK_ICON_PATH} />}
-        footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
-      >
-        <div>
-          <h1 className="text-display-sm font-semibold text-primary">Email verified</h1>
-          <p className="mt-2 text-md text-tertiary">Welcome to Glaon — taking you in now.</p>
-        </div>
-      </AuthLayout>
+        title="Email verified"
+        subtitle="Welcome to Glaon — taking you in now."
+      />
     );
   }
 
@@ -111,13 +107,9 @@ export function EmailVerificationPage({ email, navigate }: EmailVerificationPage
     <AuthLayout
       variant="centered"
       iconSlot={<FeaturedIcon path={MAIL_ICON_PATH} />}
-      footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
+      title="Check your email"
+      subtitle={subtitle}
     >
-      <div>
-        <h1 className="text-display-sm font-semibold text-primary">Check your email</h1>
-        <p className="mt-2 text-md text-tertiary">{subtitle}</p>
-      </div>
-
       <form
         data-testid="verify-email-form"
         onSubmit={(event) => {

--- a/apps/web/src/features/auth/forgot-password/forgot-password-page.tsx
+++ b/apps/web/src/features/auth/forgot-password/forgot-password-page.tsx
@@ -1,7 +1,7 @@
 // ForgotPasswordPage — 4-step Glaon-rendered password reset flow
-// (#472). Drives Clerk's `reset_password_email_code` strategy via
-// `useForgotPassword`. Renders the Figma centered-card layout with
-// per-step icon slot:
+// (#472, #531). Drives Clerk's `reset_password_email_code` strategy
+// via `useForgotPassword`. Renders the centered AuthLayout with a
+// per-step icon, title, and subtitle.
 //
 //   step 1 (email)        — `Key01` icon, "Forgot password?"
 //   step 2 (check-email)  — `Mail01` icon, "Check your email"
@@ -10,6 +10,12 @@
 //
 // On success the page navigates to `/login` after a 2s delay (or the
 // user can click "Sign in" immediately).
+//
+// Errors route through the central Toast (#519) for the `unknown`
+// fallback only. Field-level errors (`form_code_incorrect`,
+// `form_param_format_invalid` etc.) render inline on the matching
+// `<Input>` / `<VerificationCodeInput>` / `<PasswordInput>` per the
+// Toast Rule's per-field validation exception.
 
 import { useEffect, useState, type ReactNode, type SyntheticEvent } from 'react';
 
@@ -17,10 +23,10 @@ import {
   AuthFooter,
   AuthLayout,
   Button,
-  FormField,
+  Input,
   PasswordInput,
   VerificationCodeInput,
-  useFormFieldDescriptors,
+  useToast,
 } from '@glaon/ui';
 
 import { useForgotPassword } from './use-forgot-password';
@@ -30,6 +36,25 @@ const SUCCESS_AUTOREDIRECT_MS = 2000;
 interface ForgotPasswordPageProps {
   navigate?: ((url: string) => void) | undefined;
 }
+
+interface ForgotErrorState {
+  readonly code: string;
+  readonly message: string;
+}
+
+interface ToastCopy {
+  readonly title: string;
+  readonly description?: string;
+}
+
+// Toast copy only fires for the `unknown` code — every other code is
+// owned by a specific field below and renders inline. Per the Toast
+// Rule (CLAUDE.md), the generic-fallback constant is reserved for
+// `unknown`.
+const FORGOT_UNKNOWN_COPY: ToastCopy = {
+  title: 'Password reset failed',
+  description: 'Something went wrong with Glaon Cloud. Try again in a moment.',
+};
 
 // Inline SVG icons keyed off the step. Using inline SVG avoids the
 // `@untitledui/icons` dependency leaking into apps/web (only @glaon/ui
@@ -63,6 +88,7 @@ function FeaturedIcon({ name }: { name: keyof typeof ICON_PATHS }): ReactNode {
 export function ForgotPasswordPage({ navigate }: ForgotPasswordPageProps): ReactNode {
   const { state, requestReset, resendCode, goToReset, resetPassword, isLoaded } =
     useForgotPassword();
+  const toast = useToast();
 
   useEffect(() => {
     if (state.step !== 'success') return;
@@ -79,6 +105,15 @@ export function ForgotPasswordPage({ navigate }: ForgotPasswordPageProps): React
     };
   }, [navigate, state.step]);
 
+  // Surface the `unknown`-code fallback through Toast. Field-level
+  // errors (every other code) render inline on the owning input and
+  // never reach the toast.
+  useEffect(() => {
+    if (state.error !== null && state.error.code === 'unknown') {
+      toast.show({ intent: 'danger', ...FORGOT_UNKNOWN_COPY });
+    }
+  }, [state.error, toast]);
+
   const goToLogin = () => {
     const go =
       navigate ??
@@ -90,31 +125,33 @@ export function ForgotPasswordPage({ navigate }: ForgotPasswordPageProps): React
 
   if (state.step === 'email') {
     return (
-      <ForgotPasswordLayout icon={<FeaturedIcon name="key" />}>
-        <Heading
-          title="Forgot password?"
-          subtitle="No worries, we'll send you reset instructions."
-        />
+      <AuthLayout
+        variant="centered"
+        iconSlot={<FeaturedIcon name="key" />}
+        title="Forgot password?"
+        subtitle="No worries, we'll send you reset instructions."
+      >
         <EmailStep
           isLoaded={isLoaded}
           isSubmitting={state.status === 'submitting'}
-          error={state.error?.message}
+          error={state.error}
           onSubmit={(email) => {
             void requestReset(email);
           }}
         />
         <AuthFooter linkText="Back to log in" linkHref="/login" iconLeading="arrow-left" />
-      </ForgotPasswordLayout>
+      </AuthLayout>
     );
   }
 
   if (state.step === 'check-email') {
     return (
-      <ForgotPasswordLayout icon={<FeaturedIcon name="mail" />}>
-        <Heading
-          title="Check your email"
-          subtitle={`We sent a password reset link to ${state.email}.`}
-        />
+      <AuthLayout
+        variant="centered"
+        iconSlot={<FeaturedIcon name="mail" />}
+        title="Check your email"
+        subtitle={`We sent a password reset link to ${state.email}.`}
+      >
         <div className="flex w-full flex-col gap-3">
           <Button size="lg" onClick={goToReset}>
             Enter reset code
@@ -131,67 +168,50 @@ export function ForgotPasswordPage({ navigate }: ForgotPasswordPageProps): React
           </Button>
         </div>
         <AuthFooter linkText="Back to log in" linkHref="/login" iconLeading="arrow-left" />
-      </ForgotPasswordLayout>
+      </AuthLayout>
     );
   }
 
   if (state.step === 'reset') {
     return (
-      <ForgotPasswordLayout icon={<FeaturedIcon name="lock" />}>
-        <Heading title="Set new password" subtitle={`Enter the code we sent to ${state.email}.`} />
+      <AuthLayout
+        variant="centered"
+        iconSlot={<FeaturedIcon name="lock" />}
+        title="Set new password"
+        subtitle={`Enter the code we sent to ${state.email}.`}
+      >
         <ResetStep
           isLoaded={isLoaded}
           isSubmitting={state.status === 'submitting'}
-          error={state.error?.message}
+          error={state.error}
           onSubmit={(input) => {
             void resetPassword(input);
           }}
         />
         <AuthFooter linkText="Back to log in" linkHref="/login" iconLeading="arrow-left" />
-      </ForgotPasswordLayout>
+      </AuthLayout>
     );
   }
 
   // success
   return (
-    <ForgotPasswordLayout icon={<FeaturedIcon name="check" />}>
-      <Heading
-        title="Password reset"
-        subtitle="Your password has been updated. Sign in to continue."
-      />
+    <AuthLayout
+      variant="centered"
+      iconSlot={<FeaturedIcon name="check" />}
+      title="Password reset"
+      subtitle="Your password has been updated. Sign in to continue."
+    >
       <Button size="lg" onClick={goToLogin}>
         Sign in
       </Button>
-    </ForgotPasswordLayout>
-  );
-}
-
-function ForgotPasswordLayout({
-  icon,
-  children,
-}: {
-  icon: ReactNode;
-  children: ReactNode;
-}): ReactNode {
-  return (
-    <AuthLayout
-      variant="centered"
-      iconSlot={icon}
-      footerSlot={<span>© Glaon {new Date().getFullYear().toString()}</span>}
-    >
-      {children}
     </AuthLayout>
   );
 }
 
-function Heading({ title, subtitle }: { title: string; subtitle: string }): ReactNode {
-  return (
-    <div>
-      <h1 className="text-display-sm font-semibold text-primary">{title}</h1>
-      <p className="mt-2 text-md text-tertiary">{subtitle}</p>
-    </div>
-  );
-}
+// Codes that belong to the email field; anything else here is either
+// a field error owned by ResetStep or the `unknown` fallback that
+// fires through Toast at the parent level.
+const EMAIL_FIELD_CODES = new Set(['form_param_format_invalid', 'form_identifier_not_found']);
 
 function EmailStep({
   isLoaded,
@@ -201,11 +221,12 @@ function EmailStep({
 }: {
   isLoaded: boolean;
   isSubmitting: boolean;
-  error: string | undefined;
+  error: ForgotErrorState | null;
   onSubmit: (email: string) => void;
 }): ReactNode {
   const [email, setEmail] = useState('');
-  const emailField = useFormFieldDescriptors('forgot-email');
+  const emailError =
+    error !== null && EMAIL_FIELD_CODES.has(error.code) ? error.message : undefined;
   const submit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
     onSubmit(email);
@@ -217,34 +238,31 @@ function EmailStep({
       className="flex w-full flex-col gap-4"
       noValidate
     >
-      <FormField
+      <Input
         label="Email"
-        htmlFor="forgot-email"
-        {...(error !== undefined ? { error } : {})}
+        name="email"
+        type="email"
+        autoComplete="email"
         isRequired
-      >
-        <input
-          id="forgot-email"
-          name="email"
-          type="email"
-          autoComplete="email"
-          required
-          value={email}
-          onChange={(e) => {
-            setEmail(e.currentTarget.value);
-          }}
-          aria-invalid={error !== undefined}
-          aria-describedby={emailField.describedBy(error !== undefined, false)}
-          className="w-full rounded-lg bg-primary px-3 py-2 text-md text-primary shadow-xs ring-1 ring-primary ring-inset focus:outline-hidden focus:ring-2 focus:ring-brand"
-          placeholder="Enter your email"
-        />
-      </FormField>
+        value={email}
+        onChange={setEmail}
+        placeholder="Enter your email"
+        isInvalid={emailError !== undefined}
+        {...(emailError !== undefined ? { hint: emailError } : {})}
+      />
       <Button type="submit" size="lg" isLoading={isSubmitting} isDisabled={!isLoaded}>
         Reset password
       </Button>
     </form>
   );
 }
+
+// Code-field codes — VerificationCodeInput owns them.
+const CODE_FIELD_CODES = new Set(['form_code_incorrect', 'form_code_expired']);
+// Password-field codes — the new-password `<PasswordInput>` owns them.
+// `form_param_format_invalid` here is the hook's "passwords don't
+// match" / "too short" client-side validation in `resetPassword`.
+const PASSWORD_FIELD_CODES = new Set(['form_param_format_invalid', 'form_password_pwned']);
 
 function ResetStep({
   isLoaded,
@@ -254,12 +272,15 @@ function ResetStep({
 }: {
   isLoaded: boolean;
   isSubmitting: boolean;
-  error: string | undefined;
+  error: ForgotErrorState | null;
   onSubmit: (input: { code: string; password: string; confirmPassword: string }) => void;
 }): ReactNode {
   const [code, setCode] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const codeError = error !== null && CODE_FIELD_CODES.has(error.code) ? error.message : undefined;
+  const passwordError =
+    error !== null && PASSWORD_FIELD_CODES.has(error.code) ? error.message : undefined;
   const submit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
     onSubmit({ code, password, confirmPassword });
@@ -277,12 +298,13 @@ function ResetStep({
         value={code}
         onChange={setCode}
         ariaLabel="Reset code"
-        {...(error !== undefined ? { isInvalid: true } : {})}
+        {...(codeError !== undefined ? { isInvalid: true, hint: codeError } : {})}
       />
       <PasswordInput
         label="New password"
         autoComplete="new-password"
-        hint="Must be at least 8 characters."
+        hint={passwordError ?? 'Must be at least 8 characters.'}
+        {...(passwordError !== undefined ? { error: passwordError } : {})}
         value={password}
         onChange={setPassword}
         isRequired
@@ -294,11 +316,6 @@ function ResetStep({
         onChange={setConfirmPassword}
         isRequired
       />
-      {error !== undefined && (
-        <p role="alert" data-testid="forgot-reset-error" className="text-sm text-error">
-          {error}
-        </p>
-      )}
       <Button type="submit" size="lg" isLoading={isSubmitting} isDisabled={!isLoaded}>
         Reset password
       </Button>

--- a/packages/ui/src/components/AuthLayout/AuthLayout.tsx
+++ b/packages/ui/src/components/AuthLayout/AuthLayout.tsx
@@ -62,8 +62,13 @@ export interface AuthLayoutProps {
    * a custom node for legal / build-info chrome.
    */
   footerSlot?: ReactNode;
-  /** Form contents — fields, CTAs, social buttons, footer links. */
-  children: ReactNode;
+  /**
+   * Form contents — fields, CTAs, social buttons, footer links.
+   * Optional so success / acknowledgment screens (e.g.
+   * `<AuthLayout title="Email verified" subtitle="…" />`) can render
+   * without a form body.
+   */
+  children?: ReactNode;
 }
 
 export function AuthLayout({


### PR DESCRIPTION
## Summary

Closes #531. Migrates the last two auth screens — `ForgotPasswordPage` and `EmailVerificationPage` — to the AuthLayout `title`/`subtitle` API (#530) and routes the `unknown`-fallback API errors through the central Toast (#519). Field-level errors stay inline per the Toast Rule's per-field-validation exception.

After this PR the four auth screens (Login, SignUp, ForgotPassword, EmailVerify) all share the same layout primitive and the same error-routing rules.

## Changes

### `apps/web/src/features/auth/forgot-password/forgot-password-page.tsx`
- Drop the local `Heading` and `ForgotPasswordLayout` wrapper components — every step now inlines `<AuthLayout variant="centered" iconSlot title subtitle>` with its own copy.
- `EmailStep`: raw `<input>` + `<FormField>` → `<Input>` primitive. Codes `form_param_format_invalid` + `form_identifier_not_found` render inline on the email field via `isInvalid` + `hint`.
- `ResetStep`: drop the inline `<p role="alert" data-testid="forgot-reset-error">{error}</p>` block. Codes route by field:
  - `form_code_incorrect` / `form_code_expired` → `<VerificationCodeInput hint>`
  - `form_param_format_invalid` / `form_password_pwned` → new-password `<PasswordInput error>`
  - `unknown` → Toast via parent-level `useEffect` with `FORGOT_UNKNOWN_COPY`
- `text-display-sm` → `text-display-xs` (via AuthLayout `title` default), aligning with the Fidelity Rule typography.

### `apps/web/src/features/auth/email-verification/email-verification-page.tsx`
- Drop the manual `<h1 className="text-display-sm">` + `mt-2` para blocks; pass `title` + `subtitle` props to `<AuthLayout>`.
- Drop the `footerSlot={<span>© Glaon …</span>}` overrides — AuthLayout default kicks in.
- The verification-code error path (`hint={errorMessage}`) and the `isLocked` "Too many attempts" copy stay inline on `<VerificationCodeInput>`: both are field-level.
- Success step renders as `<AuthLayout title subtitle />` (no children) — needs the AuthLayout `children` prop to be optional (small API touch).

### `packages/ui/src/components/AuthLayout/AuthLayout.tsx`
- `children?: ReactNode` (was required). Acknowledgment screens like Email-verified can now render with just `title` + `subtitle` + `iconSlot`. No behavioural change for existing consumers — they all pass children.

## Verification

- [x] `pnpm type-check` — 11/11
- [x] `pnpm lint` — 10/10
- [x] `pnpm --filter @glaon/web test` — 86/86
- [x] `pnpm --filter @glaon/ui test` — 135/135 (unchanged set; only an API addition)
- [ ] Local visual: `/forgot-password` and `/verify-email` next to their Figma frames (TBD). Heading drops to 24px; footerSlot now shows the auto-rendered `© Glaon {year}`; `<Input>` surface on the email step.
- [ ] Toast smoke: simulate `unknown` Clerk error on `requestReset` / `resetPassword` → toast in top-right with "Password reset failed". Field-level errors (bad code, weak password) stay inline.

## Out of scope

- Figma pixel-perfect pass per frame node IDs — no Figma references linked yet for either page. This PR is the API migration + Toast wiring; the visual fidelity check happens once the Figma reference is documented.
- Tests for ForgotPasswordPage / EmailVerificationPage — none existed in this scope and adding them is its own issue.

## Refs

- ADR 0013 (Tailwind v4 + UUI theme.css)
- #511 (Design-System Fidelity Rule), #519 (API Error Toast Rule)
- #529 / #530 (AuthLayout `title`/`subtitle` API)
- #512, #528 (LoginPage + SignUpPage migrations consuming the same API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)