### PR TITLE
feat(core): add config-store interface + device-config schema

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     ".": "./src/index.ts",
     "./api-client": "./src/api-client/index.ts",
     "./auth": "./src/auth/index.ts",
+    "./config": "./src/config/index.ts",
     "./ha": "./src/ha/index.ts",
     "./i18n": "./src/i18n/index.ts",
     "./observability": "./src/observability/index.ts",

--- a/packages/core/src/config/config-store.test.ts
+++ b/packages/core/src/config/config-store.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+
+import type { KeyValueBackend } from '../auth/token-store';
+
+import {
+  DEVICE_CONFIG_STORAGE_KEY,
+  InMemoryConfigStore,
+  KeyValueConfigStore,
+} from './config-store';
+import { DEVICE_CONFIG_SCHEMA_VERSION } from './types';
+
+function makeMockBackend(): KeyValueBackend & { state: Map<string, string> } {
+  const state = new Map<string, string>();
+  return {
+    state,
+    get(key) {
+      return Promise.resolve(state.get(key) ?? null);
+    },
+    set(key, value) {
+      state.set(key, value);
+      return Promise.resolve();
+    },
+    delete(key) {
+      state.delete(key);
+      return Promise.resolve();
+    },
+  };
+}
+
+describe('InMemoryConfigStore', () => {
+  it('returns null and isConfigured=false before any write', async () => {
+    const store = new InMemoryConfigStore();
+    expect(await store.get()).toBeNull();
+    expect(await store.isConfigured()).toBe(false);
+  });
+
+  it('round-trips a partial write and stamps schemaVersion', async () => {
+    const store = new InMemoryConfigStore();
+    await store.setPartial({ homeName: 'Olivia', country: 'TR' });
+    const blob = await store.get();
+    expect(blob).toEqual({
+      schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+      homeName: 'Olivia',
+      country: 'TR',
+    });
+  });
+
+  it('shallow-merges successive setPartial calls', async () => {
+    const store = new InMemoryConfigStore();
+    await store.setPartial({ homeName: 'Olivia' });
+    await store.setPartial({ country: 'TR', timezone: 'Europe/Istanbul' });
+    expect(await store.get()).toEqual({
+      schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+      homeName: 'Olivia',
+      country: 'TR',
+      timezone: 'Europe/Istanbul',
+    });
+  });
+
+  it('markComplete stamps an ISO timestamp and flips isConfigured', async () => {
+    const store = new InMemoryConfigStore();
+    await store.setPartial({ homeName: 'Olivia' });
+    expect(await store.isConfigured()).toBe(false);
+
+    await store.markComplete();
+    expect(await store.isConfigured()).toBe(true);
+    const blob = await store.get();
+    expect(blob?.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('markComplete works from a fully empty state (only schemaVersion + completedAt)', async () => {
+    const store = new InMemoryConfigStore();
+    await store.markComplete();
+    expect(await store.isConfigured()).toBe(true);
+    const blob = await store.get();
+    expect(Object.keys(blob ?? {}).sort()).toEqual(['completedAt', 'schemaVersion']);
+  });
+
+  it('markComplete is idempotent and refreshes the timestamp', async () => {
+    const store = new InMemoryConfigStore();
+    await store.markComplete();
+    const first = (await store.get())?.completedAt;
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+    await store.markComplete();
+    const second = (await store.get())?.completedAt;
+
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(second).not.toBe(first);
+  });
+
+  it('clear() drops the blob to null and isConfigured back to false', async () => {
+    const store = new InMemoryConfigStore();
+    await store.setPartial({ homeName: 'Olivia' });
+    await store.markComplete();
+    await store.clear();
+    expect(await store.get()).toBeNull();
+    expect(await store.isConfigured()).toBe(false);
+  });
+
+  it('clear() is idempotent when nothing is stored', async () => {
+    const store = new InMemoryConfigStore();
+    await store.clear();
+    expect(await store.get()).toBeNull();
+  });
+
+  it('setPartial rejects values that fail schema validation', async () => {
+    const store = new InMemoryConfigStore();
+    // `country` is typed as string at compile time, but the schema regex
+    // rejects lowercase / non-2-letter codes at runtime.
+    await expect(store.setPartial({ country: 'lowercase' })).rejects.toThrow();
+  });
+});
+
+describe('KeyValueConfigStore', () => {
+  let warnSpy: MockInstance<typeof console.warn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('persists under the device-config key as JSON', async () => {
+    const backend = makeMockBackend();
+    const store = new KeyValueConfigStore(backend);
+    await store.setPartial({ homeName: 'Olivia' });
+    const raw = backend.state.get(DEVICE_CONFIG_STORAGE_KEY);
+    expect(raw).toBeDefined();
+    expect(JSON.parse(raw ?? '{}')).toEqual({
+      schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+      homeName: 'Olivia',
+    });
+  });
+
+  it('round-trips through the backend', async () => {
+    const backend = makeMockBackend();
+    const store = new KeyValueConfigStore(backend);
+    await store.setPartial({ homeName: 'Olivia', country: 'TR' });
+    await store.markComplete();
+
+    const fresh = new KeyValueConfigStore(backend);
+    const blob = await fresh.get();
+    expect(blob?.homeName).toBe('Olivia');
+    expect(blob?.country).toBe('TR');
+    expect(blob?.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(await fresh.isConfigured()).toBe(true);
+  });
+
+  it('returns null and isConfigured=false on a fresh backend', async () => {
+    const store = new KeyValueConfigStore(makeMockBackend());
+    expect(await store.get()).toBeNull();
+    expect(await store.isConfigured()).toBe(false);
+  });
+
+  it('clears the key and returns null when the JSON is invalid', async () => {
+    const backend = makeMockBackend();
+    backend.state.set(DEVICE_CONFIG_STORAGE_KEY, 'not-json{');
+    const store = new KeyValueConfigStore(backend);
+    expect(await store.get()).toBeNull();
+    expect(backend.state.has(DEVICE_CONFIG_STORAGE_KEY)).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('invalid JSON'),
+      expect.anything(),
+    );
+  });
+
+  it('clears the key and returns null when the schema mismatches', async () => {
+    const backend = makeMockBackend();
+    backend.state.set(
+      DEVICE_CONFIG_STORAGE_KEY,
+      JSON.stringify({ schemaVersion: 99, unknownField: true }),
+    );
+    const store = new KeyValueConfigStore(backend);
+    expect(await store.get()).toBeNull();
+    expect(backend.state.has(DEVICE_CONFIG_STORAGE_KEY)).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('schema mismatch'),
+      expect.anything(),
+    );
+  });
+
+  it('setPartial recovers from a corrupt blob and writes a fresh shape', async () => {
+    const backend = makeMockBackend();
+    backend.state.set(DEVICE_CONFIG_STORAGE_KEY, 'not-json{');
+    const store = new KeyValueConfigStore(backend);
+    await store.setPartial({ homeName: 'Olivia' });
+    const blob = await store.get();
+    expect(blob).toEqual({
+      schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+      homeName: 'Olivia',
+    });
+  });
+
+  it('clear() deletes the backend key and is idempotent', async () => {
+    const backend = makeMockBackend();
+    const store = new KeyValueConfigStore(backend);
+    await store.setPartial({ homeName: 'Olivia' });
+    await store.clear();
+    expect(backend.state.has(DEVICE_CONFIG_STORAGE_KEY)).toBe(false);
+    await store.clear();
+    expect(backend.state.has(DEVICE_CONFIG_STORAGE_KEY)).toBe(false);
+  });
+});

--- a/packages/core/src/config/config-store.ts
+++ b/packages/core/src/config/config-store.ts
@@ -1,0 +1,151 @@
+// Cross-platform device-config storage contract — see ADR 0028. One blob
+// per device under `glaon.device-config`; platform adapters bind the
+// interface to localStorage (web) or expo-secure-store (mobile).
+//
+// `isConfigured()` reads the `completedAt` timestamp, not field doluluk —
+// adding optional fields to the schema does not retro-configure devices.
+//
+// Reading a corrupt blob (invalid JSON, schema mismatch) returns null and
+// silently clears the key; the caller behaves as first-run. This is the
+// downgrade / schema-migration recovery path documented in ADR 0028.
+
+import type { KeyValueBackend } from '../auth/token-store';
+
+import {
+  DEVICE_CONFIG_SCHEMA_VERSION,
+  DeviceConfigSchema,
+  type DeviceConfig,
+  type DeviceConfigInput,
+} from './types';
+
+export const DEVICE_CONFIG_STORAGE_KEY = 'glaon.device-config';
+
+export interface ConfigStore {
+  /**
+   * Fetch the persisted device config, or `null` when first-run (key absent,
+   * invalid JSON, or schema mismatch). On corruption the store silently
+   * clears the key so the next call also returns `null` cheaply.
+   */
+  get(): Promise<DeviceConfig | null>;
+
+  /**
+   * Shallow-merge `partial` into the existing blob and persist the result.
+   * Validates the merged shape — invalid input throws. `schemaVersion` is
+   * set automatically; `completedAt` is reserved for `markComplete()`.
+   */
+  setPartial(partial: DeviceConfigInput): Promise<void>;
+
+  /**
+   * Stamp `completedAt: new Date().toISOString()` onto the blob. Idempotent —
+   * a second call refreshes the timestamp. The wizard's final step is the
+   * only legitimate caller.
+   */
+  markComplete(): Promise<void>;
+
+  /**
+   * Has the wizard ever finished on this device? Reads `completedAt`. Cheap
+   * to call from a routing gate at boot.
+   */
+  isConfigured(): Promise<boolean>;
+
+  /**
+   * Erase the persisted blob. Safe to call when no blob exists. The future
+   * factory-reset action's only entry point into this store.
+   */
+  clear(): Promise<void>;
+}
+
+/**
+ * Reference implementation that holds the blob in a single variable.
+ * Test fixture; also fine as a transient in-memory store when persistence
+ * is intentionally not wanted (e.g. demo / kiosk preview mode).
+ */
+/* eslint-disable @typescript-eslint/require-await */
+export class InMemoryConfigStore implements ConfigStore {
+  private blob: DeviceConfig | null = null;
+
+  async get(): Promise<DeviceConfig | null> {
+    return this.blob;
+  }
+
+  async setPartial(partial: DeviceConfigInput): Promise<void> {
+    const base = this.blob ?? { schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION };
+    this.blob = DeviceConfigSchema.parse({ ...base, ...partial });
+  }
+
+  async markComplete(): Promise<void> {
+    const base = this.blob ?? { schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION };
+    this.blob = DeviceConfigSchema.parse({
+      ...base,
+      completedAt: new Date().toISOString(),
+    });
+  }
+
+  async isConfigured(): Promise<boolean> {
+    return Boolean(this.blob?.completedAt);
+  }
+
+  async clear(): Promise<void> {
+    this.blob = null;
+  }
+}
+/* eslint-enable @typescript-eslint/require-await */
+
+/**
+ * ConfigStore backed by a key-value primitive. Persists as JSON under
+ * `DEVICE_CONFIG_STORAGE_KEY`. Web pairs this with a `localStorage` adapter
+ * (#536); mobile with an `expo-secure-store` adapter (follow-up).
+ *
+ * Web does not strictly need an async wrapper — localStorage is synchronous —
+ * but the `Promise.resolve()` cost is negligible and keeping the contract
+ * uniform across platforms makes the SetupGate boot path identical too.
+ */
+export class KeyValueConfigStore implements ConfigStore {
+  constructor(private readonly backend: KeyValueBackend) {}
+
+  async get(): Promise<DeviceConfig | null> {
+    const raw = await this.backend.get(DEVICE_CONFIG_STORAGE_KEY);
+    if (raw == null) return null;
+
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(raw);
+    } catch (error) {
+      console.warn('[ConfigStore] invalid JSON in device-config; clearing', error);
+      await this.backend.delete(DEVICE_CONFIG_STORAGE_KEY);
+      return null;
+    }
+
+    const validated = DeviceConfigSchema.safeParse(parsedJson);
+    if (!validated.success) {
+      console.warn('[ConfigStore] device-config schema mismatch; clearing', validated.error);
+      await this.backend.delete(DEVICE_CONFIG_STORAGE_KEY);
+      return null;
+    }
+    return validated.data;
+  }
+
+  async setPartial(partial: DeviceConfigInput): Promise<void> {
+    const current = (await this.get()) ?? { schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION };
+    const next = DeviceConfigSchema.parse({ ...current, ...partial });
+    await this.backend.set(DEVICE_CONFIG_STORAGE_KEY, JSON.stringify(next));
+  }
+
+  async markComplete(): Promise<void> {
+    const current = (await this.get()) ?? { schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION };
+    const next = DeviceConfigSchema.parse({
+      ...current,
+      completedAt: new Date().toISOString(),
+    });
+    await this.backend.set(DEVICE_CONFIG_STORAGE_KEY, JSON.stringify(next));
+  }
+
+  async isConfigured(): Promise<boolean> {
+    const current = await this.get();
+    return Boolean(current?.completedAt);
+  }
+
+  async clear(): Promise<void> {
+    await this.backend.delete(DEVICE_CONFIG_STORAGE_KEY);
+  }
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './config-store';

--- a/packages/core/src/config/types.test.ts
+++ b/packages/core/src/config/types.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEVICE_CONFIG_SCHEMA_VERSION,
+  DeviceConfigSchema,
+  UnitSystemSchema,
+  WifiConfigSchema,
+} from './types';
+
+describe('DeviceConfigSchema', () => {
+  it('accepts a bare blob with only schemaVersion', () => {
+    const parsed = DeviceConfigSchema.parse({ schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION });
+    expect(parsed).toEqual({ schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION });
+  });
+
+  it('accepts a full blob with every field populated', () => {
+    const blob = {
+      schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+      homeName: 'Olivia',
+      location: 'Istanbul, TR',
+      country: 'TR',
+      timezone: 'Europe/Istanbul',
+      locale: 'tr-TR',
+      unitSystem: 'metric',
+      layout: 'open-plan, 2 katlı',
+      wifi: { ssid: 'home', passwordCipher: 'AES-GCM:abc123' },
+      securityPinHash: 'a'.repeat(64),
+      completedAt: '2026-05-17T18:30:00.000Z',
+    } as const;
+    expect(DeviceConfigSchema.parse(blob)).toEqual(blob);
+  });
+
+  it('rejects an unrecognised schemaVersion', () => {
+    expect(() => DeviceConfigSchema.parse({ schemaVersion: 2 })).toThrow();
+  });
+
+  it('rejects unknown fields (strict mode)', () => {
+    expect(() =>
+      DeviceConfigSchema.parse({
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        someFutureField: true,
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a lowercase country code', () => {
+    expect(() =>
+      DeviceConfigSchema.parse({ schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION, country: 'tr' }),
+    ).toThrow(/ISO 3166-1/);
+  });
+
+  it('rejects a non-2-letter country code', () => {
+    expect(() =>
+      DeviceConfigSchema.parse({ schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION, country: 'USA' }),
+    ).toThrow();
+  });
+
+  it('rejects a securityPinHash that is not 64 lowercase hex chars', () => {
+    expect(() =>
+      DeviceConfigSchema.parse({
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        securityPinHash: 'too short',
+      }),
+    ).toThrow(/SHA-256 hex/);
+    expect(() =>
+      DeviceConfigSchema.parse({
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        securityPinHash: 'A'.repeat(64),
+      }),
+    ).toThrow(/SHA-256 hex/);
+  });
+
+  it('rejects an invalid completedAt timestamp', () => {
+    expect(() =>
+      DeviceConfigSchema.parse({
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        completedAt: 'not-a-date',
+      }),
+    ).toThrow();
+  });
+
+  it('rejects wifi with an empty ssid or empty passwordCipher', () => {
+    expect(() =>
+      DeviceConfigSchema.parse({
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        wifi: { ssid: '', passwordCipher: 'x' },
+      }),
+    ).toThrow();
+    expect(() =>
+      DeviceConfigSchema.parse({
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        wifi: { ssid: 'home', passwordCipher: '' },
+      }),
+    ).toThrow();
+  });
+});
+
+describe('UnitSystemSchema', () => {
+  it('accepts metric and imperial', () => {
+    expect(UnitSystemSchema.parse('metric')).toBe('metric');
+    expect(UnitSystemSchema.parse('imperial')).toBe('imperial');
+  });
+
+  it('rejects anything else', () => {
+    expect(() => UnitSystemSchema.parse('si')).toThrow();
+  });
+});
+
+describe('WifiConfigSchema', () => {
+  it('round-trips a populated wifi entry', () => {
+    expect(WifiConfigSchema.parse({ ssid: 'home', passwordCipher: 'x' })).toEqual({
+      ssid: 'home',
+      passwordCipher: 'x',
+    });
+  });
+});

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,0 +1,66 @@
+// Device-config schema — see ADR 0028. The wizard (epic #533) fills this blob
+// progressively; `completedAt` is the bit that flips `isConfigured()` to true.
+//
+// Strict-mode parsing means an older Glaon's blob can survive only if every
+// field it wrote is still on the schema. Bumping `schemaVersion` is the
+// migration hook for the day that stops being true (see ADR 0028 — "Tekrar
+// değerlendirme tetikleyicileri").
+
+import { z } from 'zod';
+
+/** Bumped when the persisted shape changes in a way old readers can't handle. */
+export const DEVICE_CONFIG_SCHEMA_VERSION = 1 as const;
+
+export const UnitSystemSchema = z.union([z.literal('metric'), z.literal('imperial')]);
+export type UnitSystem = z.infer<typeof UnitSystemSchema>;
+
+export const WifiConfigSchema = z.object({
+  ssid: z.string().min(1),
+  /**
+   * Opaque to @glaon/core — the consumer decides what wrapping cipher to use
+   * (Web Crypto AES-GCM on web, separate strategy on mobile). The schema only
+   * enforces "non-empty string"; never plaintext.
+   */
+  passwordCipher: z.string().min(1),
+});
+export type WifiConfig = z.infer<typeof WifiConfigSchema>;
+
+export const DeviceConfigSchema = z
+  .object({
+    schemaVersion: z.literal(DEVICE_CONFIG_SCHEMA_VERSION),
+    homeName: z.string().optional(),
+    location: z.string().optional(),
+    /** ISO 3166-1 alpha-2 (e.g. "TR", "US"). Uppercase. */
+    country: z
+      .string()
+      .regex(/^[A-Z]{2}$/, 'country must be ISO 3166-1 alpha-2 uppercase')
+      .optional(),
+    /** IANA TZ name (e.g. "Europe/Istanbul"). */
+    timezone: z.string().optional(),
+    /** BCP-47 locale tag. SUPPORTED_LOCALES validation is the consumer's job. */
+    locale: z.string().optional(),
+    unitSystem: UnitSystemSchema.optional(),
+    /** v1 free-text placeholder; real floor/room editor is a follow-up epic. */
+    layout: z.string().optional(),
+    wifi: WifiConfigSchema.optional(),
+    /** SHA-256 hex (64 lowercase hex chars). Plaintext PIN never leaves the device. */
+    securityPinHash: z
+      .string()
+      .regex(/^[0-9a-f]{64}$/, 'securityPinHash must be SHA-256 hex (64 lowercase chars)')
+      .optional(),
+    /**
+     * Presence drives `ConfigStore.isConfigured()`. Set exactly once at the
+     * end of the wizard via `markComplete()`. Empty schema (only this field)
+     * is a valid "configured" state — fields can stay optional forever.
+     */
+    completedAt: z.string().datetime().optional(),
+  })
+  .strict();
+
+export type DeviceConfig = z.infer<typeof DeviceConfigSchema>;
+
+/**
+ * What `setPartial` accepts. `schemaVersion` is store-internal, `completedAt`
+ * is set by `markComplete()` — neither belongs in user-facing form output.
+ */
+export type DeviceConfigInput = Partial<Omit<DeviceConfig, 'schemaVersion' | 'completedAt'>>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * as auth from './auth';
+export * as config from './config';
 export * as ha from './ha';
 export * as observability from './observability';
 export * as state from './state';


### PR DESCRIPTION
## Summary

- New `packages/core/src/config/` module: `DeviceConfig` zod schema + `ConfigStore` interface + `InMemoryConfigStore` (test fixture) + `KeyValueConfigStore` (reuses the existing `KeyValueBackend` from `auth/token-store.ts`).
- Stamps `schemaVersion: 1` on every blob; `isConfigured()` reads `completedAt: ISOString` so optional-field churn never retro-configures existing devices (per ADR 0028).
- Strict-mode parse; corrupt blob (invalid JSON / schema mismatch) returns `null` and silently clears the key so the next caller behaves as first-run.
- Re-exported from `@glaon/core` via the new `./config` subpath. `apps/web` (#536) and `apps/mobile` (follow-up) bind their own backend (localStorage / SecureStore).

## Scope

### In

- `packages/core/src/config/types.ts` — `DeviceConfigSchema`, `WifiConfigSchema`, `UnitSystemSchema`, `DEVICE_CONFIG_SCHEMA_VERSION`, `DeviceConfig`, `DeviceConfigInput` types.
- `packages/core/src/config/config-store.ts` — `ConfigStore` interface, `InMemoryConfigStore`, `KeyValueConfigStore`, `DEVICE_CONFIG_STORAGE_KEY` constant.
- `packages/core/src/config/index.ts` — barrel.
- `packages/core/src/index.ts` — re-export under `config` namespace.
- `packages/core/package.json` — `./config` exports entry.
- 23 new vitest cases (`types.test.ts`, `config-store.test.ts`) covering schema validation + every store method on both implementations.

### Out

- `WebConfigStore` localStorage adapter + `ConfigProvider` React context (#536, blocked on this PR).
- Mobile parity (`ExpoConfigStore` adapter, follow-up).
- SetupGate / wizard route (#539+).
- Factory-reset UI (follow-up; this PR designs the `clear()` shape it consumes).

## Test plan

- [x] `pnpm --filter @glaon/core type-check` green
- [x] `pnpm --filter @glaon/core lint` green
- [x] `pnpm --filter @glaon/core test` green (154 tests pass, +23 new)
- [x] `pnpm --filter @glaon/core package-contract` green (`./config` entry resolves as ESM)
- [x] CI: type-check · lint · audit · gitleaks · commitlint · visual regression · unit-tests · playwright

Closes #535
Refs #533, ADR 0028
