### PR TITLE
feat(web): add web-config-store + config-provider

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import { CloudAuthProvider, getClerkPublishableKey } from './auth/cloud/clerk-pr
 import { useCloudSessionSync } from './auth/cloud/use-cloud-session';
 import { deriveClientIdFromOrigin } from './auth/local-auth-flow';
 import { WebTokenStore } from './auth/web-token-store';
+import { ConfigProvider, WebConfigStore } from './config';
 import { AuthCallbackRoute } from './features/auth/local/auth-callback-route';
 import { EmailVerificationPage } from './features/auth/email-verification/email-verification-page';
 import { ForgotPasswordPage } from './features/auth/forgot-password/forgot-password-page';
@@ -36,6 +37,11 @@ const AUTH_HERO_IMAGE = (
 
 export function App(): ReactNode {
   const tokenStore = useMemo(() => new WebTokenStore({ logoutEndpoint: LOGOUT_ENDPOINT }), []);
+  const configStore = useMemo(() => new WebConfigStore(), []);
+  // Synchronous hydration so SetupGate (#539) decides between wizard and
+  // Router on the first render without a flash. peekSync reads localStorage
+  // directly; ConfigProvider's mutators handle every subsequent write.
+  const initialConfig = useMemo(() => configStore.peekSync(), [configStore]);
   const clerkKey = getClerkPublishableKey();
 
   // CloudAuthProvider only mounts when a publishable key is configured. The
@@ -47,13 +53,19 @@ export function App(): ReactNode {
   // `useToast()` for API-error notifications — see the API Error Toast
   // Rule in CLAUDE.md. The provider portals into <body>, so its
   // position in the tree only matters for context resolution.
+  //
+  // ConfigProvider sits outermost: SetupGate (#539) reads it before
+  // AuthProvider hydration runs, and a future factory-reset call needs to
+  // wipe both ConfigStore + TokenStore together.
   const inner = (
-    <AuthProvider tokenStore={tokenStore}>
-      <ToastProvider>
-        {clerkKey !== null ? <CloudSessionBridge /> : null}
-        <Router clerkKey={clerkKey} />
-      </ToastProvider>
-    </AuthProvider>
+    <ConfigProvider configStore={configStore} initialConfig={initialConfig}>
+      <AuthProvider tokenStore={tokenStore}>
+        <ToastProvider>
+          {clerkKey !== null ? <CloudSessionBridge /> : null}
+          <Router clerkKey={clerkKey} />
+        </ToastProvider>
+      </AuthProvider>
+    </ConfigProvider>
   );
 
   if (clerkKey === null) return inner;

--- a/apps/web/src/config/config-provider.test.tsx
+++ b/apps/web/src/config/config-provider.test.tsx
@@ -1,0 +1,103 @@
+import { act, render, renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEVICE_CONFIG_SCHEMA_VERSION,
+  type DeviceConfig,
+  InMemoryConfigStore,
+} from '@glaon/core/config';
+
+import { ConfigProvider, useDeviceConfig } from './config-provider';
+
+function wrap(store: InMemoryConfigStore, initialConfig?: DeviceConfig | null) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return initialConfig === undefined ? (
+      <ConfigProvider configStore={store}>{children}</ConfigProvider>
+    ) : (
+      <ConfigProvider configStore={store} initialConfig={initialConfig}>
+        {children}
+      </ConfigProvider>
+    );
+  };
+}
+
+describe('useDeviceConfig', () => {
+  it('throws a clear error when used outside the provider', () => {
+    expect(() => renderHook(() => useDeviceConfig())).toThrow(
+      /useDeviceConfig must be used inside <ConfigProvider>/,
+    );
+  });
+
+  it('starts with null config and isConfigured=false when no initialConfig is supplied', () => {
+    const store = new InMemoryConfigStore();
+    const { result } = renderHook(() => useDeviceConfig(), { wrapper: wrap(store) });
+    expect(result.current.config).toBeNull();
+    expect(result.current.isConfigured).toBe(false);
+  });
+
+  it('hydrates from initialConfig synchronously on first render', () => {
+    const store = new InMemoryConfigStore();
+    const { result } = renderHook(() => useDeviceConfig(), {
+      wrapper: wrap(store, {
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        homeName: 'Olivia',
+        completedAt: '2026-05-17T00:00:00.000Z',
+      }),
+    });
+    expect(result.current.config?.homeName).toBe('Olivia');
+    expect(result.current.isConfigured).toBe(true);
+  });
+
+  it('setPartial writes through the store and updates the hook value', async () => {
+    const store = new InMemoryConfigStore();
+    const { result } = renderHook(() => useDeviceConfig(), { wrapper: wrap(store) });
+
+    await act(async () => {
+      await result.current.setPartial({ homeName: 'Olivia' });
+    });
+
+    expect(result.current.config?.homeName).toBe('Olivia');
+    expect(result.current.isConfigured).toBe(false);
+    expect((await store.get())?.homeName).toBe('Olivia');
+  });
+
+  it('markComplete flips isConfigured to true and propagates through the hook', async () => {
+    const store = new InMemoryConfigStore();
+    const { result } = renderHook(() => useDeviceConfig(), { wrapper: wrap(store) });
+
+    await act(async () => {
+      await result.current.setPartial({ homeName: 'Olivia' });
+      await result.current.markComplete();
+    });
+
+    expect(result.current.isConfigured).toBe(true);
+    expect(result.current.config?.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(await store.isConfigured()).toBe(true);
+  });
+
+  it('clear empties the store and resets the hook to null', async () => {
+    const store = new InMemoryConfigStore();
+    const { result } = renderHook(() => useDeviceConfig(), { wrapper: wrap(store) });
+
+    await act(async () => {
+      await result.current.setPartial({ homeName: 'Olivia' });
+      await result.current.markComplete();
+      await result.current.clear();
+    });
+
+    expect(result.current.config).toBeNull();
+    expect(result.current.isConfigured).toBe(false);
+    expect(await store.get()).toBeNull();
+  });
+
+  it('renders children unchanged when no consumers are present', () => {
+    const store = new InMemoryConfigStore();
+    const { getByText } = render(
+      <ConfigProvider configStore={store}>
+        <p>passthrough</p>
+      </ConfigProvider>,
+    );
+    expect(getByText('passthrough')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/config/config-provider.tsx
+++ b/apps/web/src/config/config-provider.tsx
@@ -1,0 +1,72 @@
+// ConfigProvider — exposes the device-config blob to the React tree, plus
+// async mutators that re-read the store after each write. See ADR 0028 and
+// #533.
+//
+// Pattern mirrors AuthProvider: a single source of truth (the store) sits
+// outside React; the provider mirrors its current value into state so
+// renders are sync. SetupGate (#539) reads `isConfigured` and short-circuits
+// before the Router is even mounted.
+
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
+
+import type { ConfigStore, DeviceConfig, DeviceConfigInput } from '@glaon/core/config';
+
+interface ConfigContextValue {
+  readonly config: DeviceConfig | null;
+  readonly isConfigured: boolean;
+  readonly setPartial: (partial: DeviceConfigInput) => Promise<void>;
+  readonly markComplete: () => Promise<void>;
+  readonly clear: () => Promise<void>;
+}
+
+const ConfigContext = createContext<ConfigContextValue | null>(null);
+
+interface ConfigProviderProps {
+  readonly configStore: ConfigStore;
+  /**
+   * Synchronous initial value. App.tsx supplies `WebConfigStore.peekSync()`
+   * so SetupGate decides between wizard and Router on the first render
+   * without a hydration flash. Tests pass `null` (or a fixture blob) and
+   * let the store hydrate via mutator calls.
+   */
+  readonly initialConfig?: DeviceConfig | null;
+  readonly children: ReactNode;
+}
+
+export function ConfigProvider({
+  configStore,
+  initialConfig = null,
+  children,
+}: ConfigProviderProps): ReactNode {
+  const [config, setConfig] = useState<DeviceConfig | null>(initialConfig);
+
+  const value = useMemo<ConfigContextValue>(
+    () => ({
+      config,
+      isConfigured: Boolean(config?.completedAt),
+      setPartial: async (partial) => {
+        await configStore.setPartial(partial);
+        setConfig(await configStore.get());
+      },
+      markComplete: async () => {
+        await configStore.markComplete();
+        setConfig(await configStore.get());
+      },
+      clear: async () => {
+        await configStore.clear();
+        setConfig(null);
+      },
+    }),
+    [config, configStore],
+  );
+
+  return <ConfigContext.Provider value={value}>{children}</ConfigContext.Provider>;
+}
+
+export function useDeviceConfig(): ConfigContextValue {
+  const ctx = useContext(ConfigContext);
+  if (ctx === null) {
+    throw new Error('useDeviceConfig must be used inside <ConfigProvider>');
+  }
+  return ctx;
+}

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -1,0 +1,2 @@
+export { LocalStorageBackend, WebConfigStore } from './web-config-store';
+export { ConfigProvider, useDeviceConfig } from './config-provider';

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -1,2 +1,6 @@
-export { LocalStorageBackend, WebConfigStore } from './web-config-store';
-export { ConfigProvider, useDeviceConfig } from './config-provider';
+// LocalStorageBackend + useDeviceConfig are exported from their source
+// modules but kept out of this barrel until a consumer needs them; knip
+// blocks unused barrel exports. SetupGate (#539) will re-export
+// useDeviceConfig from here once it imports it.
+export { WebConfigStore } from './web-config-store';
+export { ConfigProvider } from './config-provider';

--- a/apps/web/src/config/web-config-store.test.ts
+++ b/apps/web/src/config/web-config-store.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEVICE_CONFIG_SCHEMA_VERSION, DEVICE_CONFIG_STORAGE_KEY } from '@glaon/core/config';
+
+import { LocalStorageBackend, WebConfigStore } from './web-config-store';
+
+describe('LocalStorageBackend', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('round-trips a value through window.localStorage', async () => {
+    const backend = new LocalStorageBackend();
+    await backend.set('key', 'value');
+    expect(await backend.get('key')).toBe('value');
+  });
+
+  it('returns null for an absent key', async () => {
+    const backend = new LocalStorageBackend();
+    expect(await backend.get('missing')).toBeNull();
+  });
+
+  it('delete() removes the key', async () => {
+    const backend = new LocalStorageBackend();
+    await backend.set('key', 'value');
+    await backend.delete('key');
+    expect(await backend.get('key')).toBeNull();
+  });
+});
+
+describe('WebConfigStore (async path through KeyValueConfigStore)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists setPartial output to localStorage under the device-config key', async () => {
+    const store = new WebConfigStore();
+    await store.setPartial({ homeName: 'Olivia', country: 'TR' });
+    const raw = window.localStorage.getItem(DEVICE_CONFIG_STORAGE_KEY);
+    expect(raw).toBeDefined();
+    expect(JSON.parse(raw ?? '{}')).toEqual({
+      schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+      homeName: 'Olivia',
+      country: 'TR',
+    });
+  });
+
+  it('round-trips through a fresh store instance (cross-reload simulation)', async () => {
+    const writer = new WebConfigStore();
+    await writer.setPartial({ homeName: 'Olivia' });
+    await writer.markComplete();
+
+    const reader = new WebConfigStore();
+    const blob = await reader.get();
+    expect(blob?.homeName).toBe('Olivia');
+    expect(await reader.isConfigured()).toBe(true);
+  });
+
+  it('clear() removes the device-config key', async () => {
+    const store = new WebConfigStore();
+    await store.setPartial({ homeName: 'Olivia' });
+    await store.clear();
+    expect(window.localStorage.getItem(DEVICE_CONFIG_STORAGE_KEY)).toBeNull();
+  });
+
+  it('async get() clears a corrupt JSON blob and returns null', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    window.localStorage.setItem(DEVICE_CONFIG_STORAGE_KEY, 'not-json{');
+    const store = new WebConfigStore();
+    expect(await store.get()).toBeNull();
+    expect(window.localStorage.getItem(DEVICE_CONFIG_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('WebConfigStore.peekSync', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns null when the key is absent', () => {
+    const store = new WebConfigStore();
+    expect(store.peekSync()).toBeNull();
+  });
+
+  it('returns the parsed blob when valid', async () => {
+    const writer = new WebConfigStore();
+    await writer.setPartial({ homeName: 'Olivia', country: 'TR' });
+    await writer.markComplete();
+
+    const reader = new WebConfigStore();
+    const blob = reader.peekSync();
+    expect(blob?.homeName).toBe('Olivia');
+    expect(blob?.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('returns null on invalid JSON without clearing the key', () => {
+    window.localStorage.setItem(DEVICE_CONFIG_STORAGE_KEY, 'not-json{');
+    const store = new WebConfigStore();
+    expect(store.peekSync()).toBeNull();
+    expect(window.localStorage.getItem(DEVICE_CONFIG_STORAGE_KEY)).toBe('not-json{');
+  });
+
+  it('returns null on schema mismatch without clearing the key', () => {
+    window.localStorage.setItem(
+      DEVICE_CONFIG_STORAGE_KEY,
+      JSON.stringify({ schemaVersion: 99, mystery: true }),
+    );
+    const store = new WebConfigStore();
+    expect(store.peekSync()).toBeNull();
+    expect(window.localStorage.getItem(DEVICE_CONFIG_STORAGE_KEY)).toBeTruthy();
+  });
+});

--- a/apps/web/src/config/web-config-store.ts
+++ b/apps/web/src/config/web-config-store.ts
@@ -1,0 +1,70 @@
+// Web ConfigStore implementation — see ADR 0028 and #533.
+//
+// The cross-platform `KeyValueConfigStore` does all the heavy lifting (JSON
+// codec, schema-validation-on-read, corrupt-blob recovery). Web's only
+// responsibility is binding it to `window.localStorage` and exposing a
+// synchronous `peekSync()` boot helper so `SetupGate` (#539) does not flash
+// the login screen while the async `get()` resolves.
+
+import {
+  DEVICE_CONFIG_STORAGE_KEY,
+  DeviceConfigSchema,
+  KeyValueConfigStore,
+  type DeviceConfig,
+} from '@glaon/core/config';
+import type { KeyValueBackend } from '@glaon/core/auth';
+
+export class LocalStorageBackend implements KeyValueBackend {
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(window.localStorage.getItem(key));
+  }
+  set(key: string, value: string): Promise<void> {
+    window.localStorage.setItem(key, value);
+    return Promise.resolve();
+  }
+  delete(key: string): Promise<void> {
+    window.localStorage.removeItem(key);
+    return Promise.resolve();
+  }
+}
+
+interface WebConfigStoreOptions {
+  /** Backend override; tests inject an in-memory map. Production passes nothing. */
+  readonly backend?: KeyValueBackend;
+}
+
+export class WebConfigStore extends KeyValueConfigStore {
+  constructor(options: WebConfigStoreOptions = {}) {
+    super(options.backend ?? new LocalStorageBackend());
+  }
+
+  /**
+   * Synchronous best-effort read of the persisted blob. Used by App.tsx /
+   * ConfigProvider to hydrate React state on the same tick as the first
+   * render — avoids the wizard-vs-login flash that an async hydrate causes.
+   *
+   * Returns `null` when the key is missing, the JSON is invalid, or the
+   * schema mismatches. Does NOT clear the key on failure (the async `get()`
+   * path on the next interaction takes care of recovery so this stays
+   * side-effect-free for boot).
+   */
+  peekSync(): DeviceConfig | null {
+    let raw: string | null;
+    try {
+      raw = window.localStorage.getItem(DEVICE_CONFIG_STORAGE_KEY);
+    } catch {
+      return null;
+    }
+    if (raw == null) return null;
+
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+
+    const validated = DeviceConfigSchema.safeParse(parsedJson);
+    return validated.success ? validated.data : null;
+  }
+}


### PR DESCRIPTION
## Summary

- New `apps/web/src/config/` module: `LocalStorageBackend` (`KeyValueBackend` impl), `WebConfigStore` (extends `KeyValueConfigStore` with a sync `peekSync()` boot helper), `ConfigProvider` + `useDeviceConfig()` hook.
- `App.tsx` hydrates `WebConfigStore.peekSync()` into the provider's `initialConfig` so `SetupGate` (#539) decides between wizard and Router on the first render without a flash.
- ConfigProvider is mounted as the **outermost** provider (above `AuthProvider`) so factory-reset can wipe both stores together later.

## Scope

### In

- `apps/web/src/config/web-config-store.ts` — `LocalStorageBackend`, `WebConfigStore`, `peekSync()`.
- `apps/web/src/config/config-provider.tsx` — `ConfigProvider`, `useDeviceConfig()`, `ConfigContextValue` shape.
- `apps/web/src/config/index.ts` — barrel.
- `apps/web/src/App.tsx` — mounts `ConfigProvider` above `AuthProvider`; hydrates `initialConfig` via `peekSync`.
- 15 new vitest cases (`web-config-store.test.ts`, `config-provider.test.tsx`) covering localStorage round-trips, corrupt-blob recovery (async path), `peekSync` happy / invalid-JSON / schema-mismatch, hook mutators + error.

### Out

- SetupGate routing + `/setup` route shell (#539, blocks on this PR).
- Wizard step components (#540, #545–#548).
- Mobile parity (`ExpoConfigStore` follow-up).
- Factory-reset UI (follow-up; this PR completes the contract it consumes).

## Test plan

- [x] `pnpm --filter @glaon/web type-check` green
- [x] `pnpm --filter @glaon/web lint` green
- [x] `pnpm --filter @glaon/web test` green (104 tests pass, +15 new)
- [x] Manual smoke: `localStorage.clear()` → reload → `useDeviceConfig().config === null`; `useDeviceConfig().isConfigured === false`. Set a stale blob in DevTools → reload → `peekSync()` returns it (or null on schema mismatch) without flicker.
- [x] CI required checks (type-check · lint · audit · unit-tests · playwright · visual regression · gitleaks · commitlint · package-contract · size-check)

Closes #536
Refs #533, ADR 0028
