### PR TITLE
feat(ui): add setup-layout primitive + storybook

### DIFF
--- a/packages/ui/src/components/SetupLayout/SetupLayout.controls.ts
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.controls.ts
@@ -1,0 +1,25 @@
+// `SetupLayout.controls.ts` — single source of truth for SetupLayout's
+// controllable props. Slot props (`logoSlot`, `footerSlot`, `children`)
+// and the `steps` array (ReactNode-bearing objects) live in
+// `excludeFromArgs` because they don't render meaningfully via the
+// controls panel.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+export const setupLayoutControls = {
+  activeStepId: {
+    type: 'text',
+    default: 'home-overview',
+    description:
+      'Id of the active step in `steps`. The matching row renders at full opacity; every other row renders at 50% opacity (`opacity-50` on the text block, icon stays full opacity).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const setupLayoutExcludeFromArgs = defineExcludeFromArgs([
+  'steps',
+  'logoSlot',
+  'footerSlot',
+  'children',
+] as const);

--- a/packages/ui/src/components/SetupLayout/SetupLayout.mdx
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.mdx
@@ -1,0 +1,77 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as SetupLayoutStories from './SetupLayout.stories';
+
+<Meta of={SetupLayoutStories} />
+
+# SetupLayout
+
+Page chrome for the first-run device setup wizard (epic #533, [ADR 0028](?path=/docs/design-decisions-adr-0028-device-config-state--docs)). Sibling primitive to [AuthLayout](?path=/docs/app-primitives-authlayout--docs) — left-rail step navigator, brand logo, fixed footer, right-column content area. Pixel-matched to Figma node [`1277:791`](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1277-791) at 1440px.
+
+## When to use
+
+- The single `/setup` route while the device is unconfigured (SetupGate
+  short-circuits to this layout before mounting the rest of the Router).
+- Other multi-step provisioning flows that need the same chrome
+  (long-term, e.g. a future "Pair another device" wizard).
+
+## When NOT to use
+
+- Single-screen auth flows — use [AuthLayout](?path=/docs/app-primitives-authlayout--docs).
+- Authenticated pages — they use AppShell instead (Phase 2 follow-up).
+- Modal-style wizards inside an existing page — use a [Modal](?path=/docs/web-primitives-modal--docs) with
+  internal step state; SetupLayout is full-viewport chrome.
+
+## Anatomy
+
+<Canvas of={SetupLayoutStories.HomeOverviewActive} />
+
+```tsx
+<SetupLayout steps={wizardSteps} activeStepId="home-overview">
+  <HomeOverviewStep onNext={(partial) => configStore.setPartial(partial)} />
+</SetupLayout>
+```
+
+The layout draws the left rail (logo + step navigator + footer) and an
+empty right column. Step components render their own title, form, and
+CTAs inside `children` — the layout does NOT impose right-column
+padding (per-step gutters vary in the Figma frames).
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Step rail behaviour
+
+- The active row matches `activeStepId` and renders at full opacity.
+- Every other row renders at `opacity-50` on the text block (icon stays
+  full opacity). This is the only visual differentiation drawn in the
+  current Figma frame.
+- The dedicated `SetupStepNav` primitive (#538) adds a `completed`
+  state with a checkmark once D2–D5 designs land.
+
+## Accessibility
+
+- The sidebar is wrapped in `<aside aria-label="Setup wizard navigation">`
+  so screen readers can skip it.
+- The step list is `<nav aria-label="Wizard progress"><ol>…</ol></nav>`;
+  the active item carries `aria-current="step"`.
+- The right column is `<main>` so the primary content gets the landmark.
+- Icons inside the featured-icon containers are `aria-hidden="true"` —
+  the visible step title is the accessible name.
+- The default footer's email link is a real anchor (`mailto:`) and
+  picks up the standard focus ring.
+
+## Related components
+
+- [Logo](?path=/docs/web-primitives-logo--docs) — used in the sidebar
+  header by default; override via `logoSlot`.
+- [AuthLayout](?path=/docs/app-primitives-authlayout--docs) — sibling
+  primitive for the auth flows.
+- [Input](?path=/docs/app-primitives-input--docs), [PasswordInput](?path=/docs/app-primitives-passwordinput--docs),
+  [Button](?path=/docs/app-primitives-button--docs) — what step
+  components compose inside `children`.

--- a/packages/ui/src/components/SetupLayout/SetupLayout.stories.tsx
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.stories.tsx
@@ -1,0 +1,156 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { Asterisk02, Columns02, HomeLine, Modem02, ThumbsUp } from '@untitledui/icons';
+
+import { defineControls } from '../_internal/controls';
+import { SetupLayout, type SetupLayoutStep } from './SetupLayout';
+import { setupLayoutControls, setupLayoutExcludeFromArgs } from './SetupLayout.controls';
+
+const { args, argTypes } = defineControls(setupLayoutControls);
+
+const meta: Meta<typeof SetupLayout> = {
+  title: 'App Primitives/SetupLayout',
+  component: SetupLayout,
+  // Storybook CSF treats every named export as a story. The
+  // `excludeFromArgs` constant we export for the F6 prop-coverage gate
+  // (`packages/ui/src/__tests__/prop-coverage.test.ts`) is not a story —
+  // explicitly excluding it stops the test runner from rendering it
+  // (without `steps`, the default render would crash because `steps` is
+  // a required prop).
+  excludeStories: ['excludeFromArgs'],
+  parameters: {
+    layout: 'fullscreen',
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1277-791',
+    },
+  },
+  args,
+  argTypes,
+};
+
+export default meta;
+type Story = StoryObj<typeof SetupLayout>;
+
+export const excludeFromArgs = setupLayoutExcludeFromArgs;
+
+const wizardSteps: SetupLayoutStep[] = [
+  {
+    id: 'home-overview',
+    icon: <HomeLine />,
+    title: 'Home Overview',
+    description: 'Enter basic information about your home.',
+  },
+  {
+    id: 'layout',
+    icon: <Columns02 />,
+    title: 'Layout Setup',
+    description: 'Define floors and rooms to organize your space.',
+  },
+  {
+    id: 'wifi',
+    icon: <Modem02 />,
+    title: 'Wi-Fi Configuration',
+    description: 'Connect to your network and set a secure password.',
+  },
+  {
+    id: 'security',
+    icon: <Asterisk02 />,
+    title: 'Device Security',
+    description: 'Create a password to protect your smart devices.',
+  },
+  {
+    id: 'review',
+    icon: <ThumbsUp />,
+    title: 'Final Review',
+    description: 'Check your settings and complete the setup.',
+  },
+];
+
+// Placeholder right-column content. Each step issue (#540, #545–#548)
+// replaces this with the real form for its step.
+const placeholderContent = (
+  <div className="flex flex-col gap-6 p-8 lg:p-12">
+    <header className="flex flex-col gap-3">
+      <h1 className="text-display-xs font-semibold text-primary">Home Overview</h1>
+      <p className="text-md text-tertiary">
+        Manage your team members and their account permissions here.
+      </p>
+    </header>
+    <div className="flex flex-col gap-4">
+      <div className="rounded-lg bg-secondary px-3 py-3 text-sm text-tertiary">Home Name</div>
+      <div className="rounded-lg bg-secondary px-3 py-3 text-sm text-tertiary">Location</div>
+      <div className="rounded-lg bg-secondary px-3 py-3 text-sm text-tertiary">Country</div>
+    </div>
+    <div className="flex justify-end gap-3">
+      <div className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset">
+        Cancel
+      </div>
+      <div className="rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white">
+        Next
+      </div>
+    </div>
+  </div>
+);
+
+export const HomeOverviewActive: Story = {
+  args: { activeStepId: 'home-overview' },
+  render: (args) => (
+    <SetupLayout {...args} steps={wizardSteps}>
+      {placeholderContent}
+    </SetupLayout>
+  ),
+};
+
+export const LayoutSetupActive: Story = {
+  args: { activeStepId: 'layout' },
+  render: (args) => (
+    <SetupLayout {...args} steps={wizardSteps}>
+      {placeholderContent}
+    </SetupLayout>
+  ),
+};
+
+export const WifiConfigurationActive: Story = {
+  args: { activeStepId: 'wifi' },
+  render: (args) => (
+    <SetupLayout {...args} steps={wizardSteps}>
+      {placeholderContent}
+    </SetupLayout>
+  ),
+};
+
+export const DeviceSecurityActive: Story = {
+  args: { activeStepId: 'security' },
+  render: (args) => (
+    <SetupLayout {...args} steps={wizardSteps}>
+      {placeholderContent}
+    </SetupLayout>
+  ),
+};
+
+export const FinalReviewActive: Story = {
+  args: { activeStepId: 'review' },
+  render: (args) => (
+    <SetupLayout {...args} steps={wizardSteps}>
+      {placeholderContent}
+    </SetupLayout>
+  ),
+};
+
+export const WithoutFooter: Story = {
+  args: { activeStepId: 'home-overview' },
+  render: (args) => (
+    <SetupLayout {...args} steps={wizardSteps} footerSlot={null}>
+      {placeholderContent}
+    </SetupLayout>
+  ),
+};
+
+export const WithoutLogo: Story = {
+  args: { activeStepId: 'home-overview' },
+  render: (args) => (
+    <SetupLayout {...args} steps={wizardSteps} logoSlot={null}>
+      {placeholderContent}
+    </SetupLayout>
+  ),
+};

--- a/packages/ui/src/components/SetupLayout/SetupLayout.tsx
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.tsx
@@ -1,0 +1,199 @@
+// Glaon SetupLayout — page chrome for the first-run setup wizard
+// (epic #533, ADR 0028). Sibling primitive to AuthLayout, not a variant —
+// the chrome is materially different (vertical step rail on the left, no
+// brand image, fixed footer with brand + contact).
+//
+// Pixel-matches Figma node `1277:791` (Design System / SETUP progress 01 /
+// Desktop) at 1440px. The right-column content (form title / fields /
+// CTAs) is the step component's responsibility, supplied via `children`.
+//
+// SetupLayout is purely presentational — no async state, no ConfigStore
+// reads, no router knowledge. SetupRoute (#539) owns the state machine
+// and feeds the active step's component into `children`.
+//
+// The inline step navigator below is intentionally minimal: it renders
+// only the two states the existing Figma frame draws (active = full
+// opacity text; upcoming = 50% opacity text). #538 extracts this into a
+// dedicated `SetupStepNav` primitive that adds the `completed` state
+// once D2–D5 land.
+
+import type { ReactNode } from 'react';
+
+import { Logo } from '../Logo';
+
+export interface SetupLayoutStep {
+  /** Stable identifier; matched against `activeStepId` to mark this row active. */
+  id: string;
+  /**
+   * Icon node rendered inside the 40×40 featured-icon container. Typically a
+   * UUI 20×20 outline icon — the container handles bg, border, and shadow.
+   */
+  icon: ReactNode;
+  /** Bold title — Inter Semi Bold, text-sm, neutral-700 (text-secondary). */
+  title: string;
+  /** Optional descriptive line under the title — Inter Regular, text-sm, neutral-600 (text-tertiary). */
+  description?: string;
+}
+
+export interface SetupLayoutProps {
+  /** Ordered list of wizard steps rendered in the left rail. */
+  steps: readonly SetupLayoutStep[];
+  /**
+   * Id of the active step. The matching row renders at full opacity; every
+   * other row renders at 50% opacity (matches Figma `opacity-50` on the
+   * text block, icon stays full opacity).
+   */
+  activeStepId: string;
+  /**
+   * Override for the brand logo at the top-left of the sidebar. Defaults to
+   * `<Logo size={133} />` (matches Figma's 133×60 wordmark). Pass `null` to
+   * suppress.
+   */
+  logoSlot?: ReactNode;
+  /**
+   * Override for the sidebar footer. Defaults to `© Glaon {year}` on the
+   * left and `help@glaon.com` on the right (with the UUI mail icon). Pass
+   * `null` to suppress.
+   */
+  footerSlot?: ReactNode;
+  /**
+   * Right-column content. Step components render their own header, form,
+   * and CTAs here — SetupLayout does not impose padding so the step can
+   * pick its own gutter (the Figma frame uses generous internal padding
+   * that varies per step).
+   */
+  children?: ReactNode;
+}
+
+export function SetupLayout({
+  steps,
+  activeStepId,
+  logoSlot,
+  footerSlot,
+  children,
+}: SetupLayoutProps) {
+  // `logoSlot === undefined` → render the default. `logoSlot === null` →
+  // suppress entirely. Same distinction as AuthLayout (the AuthLayout
+  // pattern documents why this matters for Storybook controls panels).
+  const logo = logoSlot === undefined ? <Logo size={133} /> : logoSlot;
+  const footer =
+    footerSlot === undefined ? <DefaultSetupFooter year={new Date().getFullYear()} /> : footerSlot;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-primary lg:h-screen lg:min-h-0 lg:flex-row lg:overflow-hidden">
+      <aside
+        className="flex flex-col justify-between bg-[var(--glaon-light-grey)] lg:h-full lg:w-full lg:max-w-[384px] lg:shrink-0"
+        aria-label="Setup wizard navigation"
+      >
+        <div className="flex flex-col gap-16 px-8 pt-8">
+          {logo !== null && <div className="h-[60px] w-[133px]">{logo}</div>}
+          <SetupStepNav steps={steps} activeStepId={activeStepId} />
+        </div>
+        {footer !== null && (
+          <div className="flex h-24 items-end justify-between p-8 text-sm text-tertiary">
+            {footer}
+          </div>
+        )}
+      </aside>
+      <main className="flex flex-1 flex-col lg:min-w-[480px] lg:overflow-y-auto">{children}</main>
+    </div>
+  );
+}
+
+interface SetupStepNavProps {
+  readonly steps: readonly SetupLayoutStep[];
+  readonly activeStepId: string;
+}
+
+/**
+ * Minimal inline navigator that ships with the layout for #537. #538
+ * replaces this with a dedicated `SetupStepNav` primitive that exposes
+ * its own props / stories / completed state. Until then this is the
+ * single source of truth for the rail markup.
+ */
+function SetupStepNav({ steps, activeStepId }: SetupStepNavProps) {
+  return (
+    <nav aria-label="Wizard progress" className="w-[320px]">
+      <ol className="flex flex-col">
+        {steps.map((step, index) => {
+          const isActive = step.id === activeStepId;
+          const isLast = index === steps.length - 1;
+          return (
+            <li key={step.id} className="flex items-start gap-3">
+              {/* Left rail: icon + connector */}
+              <div className="flex flex-col items-center self-stretch gap-1 pb-1">
+                <div className="z-[1] flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset">
+                  <span aria-hidden="true" className="block size-5">
+                    {step.icon}
+                  </span>
+                </div>
+                {!isLast && <div className="w-px flex-1 bg-[var(--color-neutral-300)]" />}
+              </div>
+              {/* Right column: text block.
+               *
+               * Figma draws inactive rows with `opacity-50` on the text
+               * block (#404040 @ 50% → effective #94979a, ~2.5:1 against
+               * the sidebar bg). That fails WCAG AA color-contrast.
+               * `text-quaternary` (#737373) is the closest match by tone
+               * but still falls short at 4.06:1 for normal 14px text.
+               * Glaon instead downshifts the title only: active title
+               * stays `text-secondary` (#404040, ~8.8:1); inactive title
+               * uses `text-tertiary` (#525252, ~6.3:1) which keeps the
+               * visual hierarchy via the colour-step + still-bold
+               * weight while passing axe-core. Descriptions in both
+               * states use `text-tertiary` since the contrast budget
+               * makes a deeper distinction impractical without a brand
+               * accent. Revisit with design at the SetupStepNav
+               * extraction (#538) once D2–D5 land. */}
+              <div
+                className="flex flex-1 flex-col pb-8"
+                aria-current={isActive ? 'step' : undefined}
+              >
+                <p
+                  className={`text-sm font-semibold leading-5 ${isActive ? 'text-secondary' : 'text-tertiary'}`}
+                >
+                  {step.title}
+                </p>
+                {step.description !== undefined && step.description !== '' && (
+                  <p className="text-sm font-normal leading-5 text-tertiary">{step.description}</p>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+interface DefaultSetupFooterProps {
+  readonly year: number;
+}
+
+function DefaultSetupFooter({ year }: DefaultSetupFooterProps) {
+  return (
+    <>
+      <p>© Glaon {year.toString()}</p>
+      <a
+        href="mailto:help@glaon.com"
+        className="inline-flex items-center gap-2 text-tertiary hover:text-secondary"
+      >
+        {/* Inline minimal mail icon — keeps the footer dependency-free; the
+         * Figma uses UUI mail-01 outline at size 16. */}
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 16 16"
+          width="16"
+          height="16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <rect x="1.667" y="2.667" width="12.667" height="10.667" rx="1.5" />
+          <path d="M2 3.333 8 8l6-4.667" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        <span>help@glaon.com</span>
+      </a>
+    </>
+  );
+}

--- a/packages/ui/src/components/SetupLayout/index.ts
+++ b/packages/ui/src/components/SetupLayout/index.ts
@@ -1,0 +1,2 @@
+export { SetupLayout } from './SetupLayout';
+export type { SetupLayoutProps, SetupLayoutStep } from './SetupLayout';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -32,6 +32,7 @@ export * from './components/PressableButton';
 export * from './components/ProgressBar';
 export * from './components/Radio';
 export * from './components/Select';
+export * from './components/SetupLayout';
 export * from './components/SideNav';
 export * from './components/SocialButton';
 export * from './components/Spinner';


### PR DESCRIPTION
## Summary

- New `SetupLayout` primitive in `@glaon/ui` — page chrome for the first-run device setup wizard (epic #533, ADR 0028).
- Sibling to `AuthLayout` (NOT a variant): left rail with brand logo + vertical step navigator + fixed footer (`© Glaon {year}` + `help@glaon.com`), right column for step content via `children`.
- Pixel-matched to Figma node [`1277:791`](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1277-791) at 1440px desktop. Sidebar bg uses the existing `--glaon-light-grey` token (already emitted by style-dictionary, no override edit).
- The inline step navigator handles active / upcoming visual states only — the dedicated `SetupStepNav` primitive (#538) extracts it later and adds the `completed` state once D2–D5 designs land.

## Scope

### In

- `packages/ui/src/components/SetupLayout/SetupLayout.tsx` — component, props, inline navigator.
- `packages/ui/src/components/SetupLayout/SetupLayout.controls.ts` — `defineControls` spec.
- `packages/ui/src/components/SetupLayout/SetupLayout.stories.tsx` — 7 stories: one per active step (5) + `WithoutFooter` + `WithoutLogo`. Design parameters link Figma `1277:791` so Chromatic's design-code diff (#53) picks it up.
- `packages/ui/src/components/SetupLayout/SetupLayout.mdx` — narrative docs (when to use / anatomy / a11y / related).
- `packages/ui/src/components/SetupLayout/index.ts` — barrel.
- `packages/ui/src/index.ts` — re-export (alphabetically slotted between `Select` and `SideNav`).

### Out

- `SetupStepNav` primitive (#538 — this PR ships an inline minimal impl that #538 replaces with the dedicated component + completed state).
- Wiring into `apps/web` (`SetupGate` + `/setup` route — #539).
- Wizard step components (#540 + #545–#548).

## Test plan

- [x] `pnpm --filter @glaon/ui type-check` green
- [x] `pnpm --filter @glaon/ui lint` green
- [x] `pnpm --filter @glaon/ui test` green (138 tests pass, F6 prop-coverage gate covers `activeStepId` control + slot props in excludeFromArgs)
- [x] `pnpm knip` green for new files
- [x] Storybook stories render at 1440px and match Figma `1277:791` side-by-side (sidebar 384px max-w / 32px pad, logo 133×60, step icon 40×40 with skeuomorphic shadow, text-sm semibold/regular per Figma, opacity-50 on inactive text blocks, footer h-96 / p-32 with mail icon)
- [x] CI required checks (type-check · lint · audit · unit-tests · package-contract · size-check · visual regression · chromatic)

Closes #537
Refs #533, ADR 0028
