### PR TITLE
feat(ui): extract setup-step-nav into its own primitive

### DIFF
--- a/packages/ui/src/components/SetupLayout/SetupLayout.controls.ts
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.controls.ts
@@ -19,6 +19,8 @@ export const setupLayoutControls = {
 
 export const setupLayoutExcludeFromArgs = defineExcludeFromArgs([
   'steps',
+  'completedStepIds',
+  'onSelectStep',
   'logoSlot',
   'footerSlot',
   'children',

--- a/packages/ui/src/components/SetupLayout/SetupLayout.tsx
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.tsx
@@ -11,48 +11,50 @@
 // reads, no router knowledge. SetupRoute (#539) owns the state machine
 // and feeds the active step's component into `children`.
 //
-// The inline step navigator below is intentionally minimal: it renders
-// only the two states the existing Figma frame draws (active = full
-// opacity text; upcoming = 50% opacity text). #538 extracts this into a
-// dedicated `SetupStepNav` primitive that adds the `completed` state
-// once D2–D5 land.
+// The step rail is rendered by the dedicated `SetupStepNav` primitive
+// (#538). SetupLayout supplies the surrounding chrome and passes through
+// the `steps` / `activeStepId` / `completedStepIds` / `onSelectStep`
+// props.
 
 import type { ReactNode } from 'react';
 
 import { Logo } from '../Logo';
+import { SetupStepNav, type SetupStepNavStep } from '../SetupStepNav';
 
-export interface SetupLayoutStep {
-  /** Stable identifier; matched against `activeStepId` to mark this row active. */
-  id: string;
-  /**
-   * Icon node rendered inside the 40×40 featured-icon container. Typically a
-   * UUI 20×20 outline icon — the container handles bg, border, and shadow.
-   */
-  icon: ReactNode;
-  /** Bold title — Inter Semi Bold, text-sm, neutral-700 (text-secondary). */
-  title: string;
-  /** Optional descriptive line under the title — Inter Regular, text-sm, neutral-600 (text-tertiary). */
-  description?: string;
-}
+/**
+ * Step shape consumed by SetupLayout. Re-exported as the SetupStepNav
+ * primitive's `SetupStepNavStep` so callers that only depend on
+ * SetupLayout do not need a second import.
+ */
+export type SetupLayoutStep = SetupStepNavStep;
 
 export interface SetupLayoutProps {
   /** Ordered list of wizard steps rendered in the left rail. */
   steps: readonly SetupLayoutStep[];
-  /**
-   * Id of the active step. The matching row renders at full opacity; every
-   * other row renders at 50% opacity (matches Figma `opacity-50` on the
-   * text block, icon stays full opacity).
-   */
+  /** Id of the active step. Forwarded to SetupStepNav. */
   activeStepId: string;
   /**
-   * Override for the brand logo at the top-left of the sidebar. Defaults to
-   * `<Logo size={133} />` (matches Figma's 133×60 wordmark). Pass `null` to
-   * suppress.
+   * Optional override for which steps are considered completed. Forwarded
+   * to SetupStepNav. When omitted, SetupStepNav defaults to "every step
+   * before `activeStepId` in `steps` order". The v1 first-run wizard
+   * accepts the default; callers that allow skipping pass an explicit list.
+   */
+  completedStepIds?: readonly string[];
+  /**
+   * Optional click handler. Forwarded to SetupStepNav. When provided the
+   * rail rows become click-to-jump buttons. The v1 first-run wizard does
+   * not pass this (the order is locked).
+   */
+  onSelectStep?: (id: string) => void;
+  /**
+   * Override for the brand logo at the top-left of the sidebar. Defaults
+   * to `<Logo size={133} />` (matches Figma's 133×60 wordmark). Pass
+   * `null` to suppress.
    */
   logoSlot?: ReactNode;
   /**
    * Override for the sidebar footer. Defaults to `© Glaon {year}` on the
-   * left and `help@glaon.com` on the right (with the UUI mail icon). Pass
+   * left and `help@glaon.com` on the right (with a Glaon mail icon). Pass
    * `null` to suppress.
    */
   footerSlot?: ReactNode;
@@ -68,6 +70,8 @@ export interface SetupLayoutProps {
 export function SetupLayout({
   steps,
   activeStepId,
+  completedStepIds,
+  onSelectStep,
   logoSlot,
   footerSlot,
   children,
@@ -87,7 +91,12 @@ export function SetupLayout({
       >
         <div className="flex flex-col gap-16 px-8 pt-8">
           {logo !== null && <div className="h-[60px] w-[133px]">{logo}</div>}
-          <SetupStepNav steps={steps} activeStepId={activeStepId} />
+          <SetupStepNav
+            steps={steps}
+            activeStepId={activeStepId}
+            {...(completedStepIds === undefined ? {} : { completedStepIds })}
+            {...(onSelectStep === undefined ? {} : { onSelect: onSelectStep })}
+          />
         </div>
         {footer !== null && (
           <div className="flex h-24 items-end justify-between p-8 text-sm text-tertiary">
@@ -97,72 +106,6 @@ export function SetupLayout({
       </aside>
       <main className="flex flex-1 flex-col lg:min-w-[480px] lg:overflow-y-auto">{children}</main>
     </div>
-  );
-}
-
-interface SetupStepNavProps {
-  readonly steps: readonly SetupLayoutStep[];
-  readonly activeStepId: string;
-}
-
-/**
- * Minimal inline navigator that ships with the layout for #537. #538
- * replaces this with a dedicated `SetupStepNav` primitive that exposes
- * its own props / stories / completed state. Until then this is the
- * single source of truth for the rail markup.
- */
-function SetupStepNav({ steps, activeStepId }: SetupStepNavProps) {
-  return (
-    <nav aria-label="Wizard progress" className="w-[320px]">
-      <ol className="flex flex-col">
-        {steps.map((step, index) => {
-          const isActive = step.id === activeStepId;
-          const isLast = index === steps.length - 1;
-          return (
-            <li key={step.id} className="flex items-start gap-3">
-              {/* Left rail: icon + connector */}
-              <div className="flex flex-col items-center self-stretch gap-1 pb-1">
-                <div className="z-[1] flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset">
-                  <span aria-hidden="true" className="block size-5">
-                    {step.icon}
-                  </span>
-                </div>
-                {!isLast && <div className="w-px flex-1 bg-[var(--color-neutral-300)]" />}
-              </div>
-              {/* Right column: text block.
-               *
-               * Figma draws inactive rows with `opacity-50` on the text
-               * block (#404040 @ 50% → effective #94979a, ~2.5:1 against
-               * the sidebar bg). That fails WCAG AA color-contrast.
-               * `text-quaternary` (#737373) is the closest match by tone
-               * but still falls short at 4.06:1 for normal 14px text.
-               * Glaon instead downshifts the title only: active title
-               * stays `text-secondary` (#404040, ~8.8:1); inactive title
-               * uses `text-tertiary` (#525252, ~6.3:1) which keeps the
-               * visual hierarchy via the colour-step + still-bold
-               * weight while passing axe-core. Descriptions in both
-               * states use `text-tertiary` since the contrast budget
-               * makes a deeper distinction impractical without a brand
-               * accent. Revisit with design at the SetupStepNav
-               * extraction (#538) once D2–D5 land. */}
-              <div
-                className="flex flex-1 flex-col pb-8"
-                aria-current={isActive ? 'step' : undefined}
-              >
-                <p
-                  className={`text-sm font-semibold leading-5 ${isActive ? 'text-secondary' : 'text-tertiary'}`}
-                >
-                  {step.title}
-                </p>
-                {step.description !== undefined && step.description !== '' && (
-                  <p className="text-sm font-normal leading-5 text-tertiary">{step.description}</p>
-                )}
-              </div>
-            </li>
-          );
-        })}
-      </ol>
-    </nav>
   );
 }
 

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.controls.ts
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.controls.ts
@@ -1,0 +1,24 @@
+// `SetupStepNav.controls.ts` — Storybook control spec for SetupStepNav.
+// `steps`, `completedStepIds`, `onSelect`, `className` live in
+// `excludeFromArgs` because they carry ReactNode / callable / array
+// values that don't render through the controls panel.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+export const setupStepNavControls = {
+  activeStepId: {
+    type: 'text',
+    default: 'home-overview',
+    description:
+      'Id of the active step in `steps`. The matching row uses the active visual state; rows before it in `steps` order get the completed state by default; rows after it get the upcoming state.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+} as const;
+
+export const setupStepNavExcludeFromArgs = defineExcludeFromArgs([
+  'steps',
+  'completedStepIds',
+  'onSelect',
+  'className',
+] as const);

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.mdx
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.mdx
@@ -1,0 +1,66 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as SetupStepNavStories from './SetupStepNav.stories';
+
+<Meta of={SetupStepNavStories} />
+
+# SetupStepNav
+
+Vertical step navigator that ships inside [SetupLayout](?path=/docs/app-primitives-setuplayout--docs). Extracted into its own primitive so the three visual states (active / completed / upcoming) are exercised independently in Storybook + Chromatic. Pixel-matched to Figma node [`1277:791`](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1277-791) at 1440px.
+
+## When to use
+
+- Inside SetupLayout — the only consumer in epic #533.
+- Other vertical wizards that need the same icon + title + description
+  rail (post-launch onboarding flows, settings wizards).
+
+## Visual states
+
+- **active** — title in `text-secondary` (#404040), icon as supplied.
+  The single row that matches `activeStepId`.
+- **completed** — title in `text-tertiary` (#525252), icon replaced by
+  a Check glyph so the user can scan past finished steps.
+- **upcoming** — title in `text-tertiary` (#525252), icon as supplied.
+
+Color tokens are chosen so every state passes WCAG AA (≥ 4.5:1) on the
+`--glaon-light-grey` sidebar background that SetupLayout draws. Figma
+uses `opacity-50` on inactive rows; that drops effective contrast below
+threshold, so this primitive uses a token-based downshift instead.
+
+## Anatomy
+
+<Canvas of={SetupStepNavStories.Default} />
+
+```tsx
+<SetupStepNav
+  steps={wizardSteps}
+  activeStepId="wifi"
+  // optional — every step before activeStepId is completed by default
+  completedStepIds={['home-overview', 'layout']}
+  // optional — interactive click-to-jump variant; v1 wizard omits it
+  onSelect={(id) => router.jumpTo(id)}
+/>
+```
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- The outer wrapper is `<nav aria-label="Wizard progress">` so screen
+  readers announce the section.
+- The active row's text block carries `aria-current="step"`.
+- Icons inside the featured-icon containers are `aria-hidden="true"`;
+  the visible step title is the accessible name.
+- When `onSelect` is provided each row renders as a `<button>` with a
+  visible focus ring; keyboard users get the standard tab order.
+
+## Related components
+
+- [SetupLayout](?path=/docs/app-primitives-setuplayout--docs) — embeds
+  this navigator in the sidebar by default.

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.stories.tsx
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+import { Asterisk02, Columns02, HomeLine, Modem02, ThumbsUp } from '@untitledui/icons';
+import { expect, fn, within } from 'storybook/test';
+
+import { defineControls } from '../_internal/controls';
+import { SetupStepNav, type SetupStepNavStep } from './SetupStepNav';
+import { setupStepNavControls, setupStepNavExcludeFromArgs } from './SetupStepNav.controls';
+
+const { args, argTypes } = defineControls(setupStepNavControls);
+
+const meta: Meta<typeof SetupStepNav> = {
+  title: 'App Primitives/SetupStepNav',
+  component: SetupStepNav,
+  // The prop-coverage gate's named export is data, not a story — see
+  // the matching note on SetupLayout.stories.tsx for the rationale.
+  excludeStories: ['excludeFromArgs'],
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'glaon-light-grey',
+      values: [{ name: 'glaon-light-grey', value: '#e9eef4' }],
+    },
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=1277-791',
+    },
+  },
+  args,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div className="bg-[var(--glaon-light-grey)] p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SetupStepNav>;
+
+export const excludeFromArgs = setupStepNavExcludeFromArgs;
+
+const wizardSteps: SetupStepNavStep[] = [
+  {
+    id: 'home-overview',
+    icon: <HomeLine />,
+    title: 'Home Overview',
+    description: 'Enter basic information about your home.',
+  },
+  {
+    id: 'layout',
+    icon: <Columns02 />,
+    title: 'Layout Setup',
+    description: 'Define floors and rooms to organize your space.',
+  },
+  {
+    id: 'wifi',
+    icon: <Modem02 />,
+    title: 'Wi-Fi Configuration',
+    description: 'Connect to your network and set a secure password.',
+  },
+  {
+    id: 'security',
+    icon: <Asterisk02 />,
+    title: 'Device Security',
+    description: 'Create a password to protect your smart devices.',
+  },
+  {
+    id: 'review',
+    icon: <ThumbsUp />,
+    title: 'Final Review',
+    description: 'Check your settings and complete the setup.',
+  },
+];
+
+export const Default: Story = {
+  args: { activeStepId: 'home-overview' },
+  render: (args) => <SetupStepNav {...args} steps={wizardSteps} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const active = canvas.getByText('Home Overview').closest('[aria-current="step"]');
+    await expect(active).not.toBeNull();
+  },
+};
+
+export const MidWizardActive: Story = {
+  args: { activeStepId: 'wifi' },
+  render: (args) => <SetupStepNav {...args} steps={wizardSteps} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Active row has aria-current=step; only one in the doc.
+    const activeRows = canvasElement.querySelectorAll('[aria-current="step"]');
+    await expect(activeRows.length).toBe(1);
+    await expect(
+      canvas.getByText('Wi-Fi Configuration').closest('[aria-current="step"]'),
+    ).not.toBeNull();
+  },
+};
+
+export const AllCompleted: Story = {
+  args: { activeStepId: 'review' },
+  render: (args) => (
+    // Explicitly mark every step (including the active one) as completed
+    // so every row renders the Check glyph. Useful for the post-wizard
+    // success preview and for visual-regression coverage of the
+    // completed icon swap.
+    <SetupStepNav
+      {...args}
+      steps={wizardSteps}
+      completedStepIds={wizardSteps.map((step) => step.id)}
+    />
+  ),
+};
+
+export const WithOnSelect: Story = {
+  args: { activeStepId: 'wifi' },
+  render: (args) => <SetupStepNav {...args} steps={wizardSteps} onSelect={fn()} />,
+  play: async ({ canvasElement }) => {
+    const buttons = canvasElement.querySelectorAll('button');
+    await expect(buttons.length).toBe(wizardSteps.length);
+  },
+};
+
+const singleStepFixture: SetupStepNavStep[] = [
+  {
+    id: 'home-overview',
+    icon: <HomeLine />,
+    title: 'Home Overview',
+    description: 'Enter basic information about your home.',
+  },
+];
+
+export const SingleStep: Story = {
+  args: { activeStepId: 'home-overview' },
+  render: (args) => <SetupStepNav {...args} steps={singleStepFixture} />,
+};

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.tsx
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.tsx
@@ -1,0 +1,176 @@
+// Glaon SetupStepNav — vertical step navigator for the first-run setup
+// wizard (epic #533, ADR 0028). Extracted from SetupLayout's inline impl
+// (#537) into its own primitive so the visual states are exercised
+// independently in Storybook + Chromatic.
+//
+// Three visual states:
+//   - active     — title in `text-secondary` (#404040), icon container
+//                  unchanged. The single row that matches `activeStepId`.
+//   - completed  — title in `text-tertiary` (#525252), icon replaced by
+//                  a Check glyph so the user can scan past finished steps.
+//   - upcoming   — title in `text-tertiary` (#525252), icon as supplied.
+//
+// Color tokens are chosen so every state passes WCAG AA on the
+// `--glaon-light-grey` sidebar background that SetupLayout draws — see
+// the SetupLayout fidelity note for the contrast rationale.
+//
+// When `onSelect` is provided each row renders as a `<button>`, so the
+// nav doubles as a click-to-jump control (settings wizards, post-launch
+// flows). The v1 first-run wizard omits `onSelect` and the nav renders
+// as a non-interactive `<ol>`.
+
+import { Check } from '@untitledui/icons';
+import type { ReactNode } from 'react';
+
+export interface SetupStepNavStep {
+  /** Stable identifier — matched against `activeStepId` / `completedStepIds`. */
+  id: string;
+  /**
+   * Icon node for the 40×40 featured-icon container. Replaced by a
+   * Check glyph when the step is marked completed.
+   */
+  icon: ReactNode;
+  /** Bold title — Inter Semi Bold, text-sm. */
+  title: string;
+  /** Optional descriptive line under the title. */
+  description?: string;
+}
+
+export interface SetupStepNavProps {
+  /** Ordered list of wizard steps. */
+  steps: readonly SetupStepNavStep[];
+  /** The id of the currently-active step. */
+  activeStepId: string;
+  /**
+   * Step ids to render as completed (Check glyph + muted title). When
+   * omitted, every step before `activeStepId` in `steps` order is
+   * considered completed. Pass `[]` to disable the default (e.g. if
+   * the wizard allows arbitrary skipping).
+   */
+  completedStepIds?: readonly string[];
+  /**
+   * Optional click handler. When provided each row becomes a
+   * `<button>` so the nav is interactive (click-to-jump). When
+   * undefined, rows render as non-interactive `<li>` content — the v1
+   * first-run wizard locks the order, so SetupLayout passes no
+   * handler.
+   */
+  onSelect?: (id: string) => void;
+  /** Optional class hook for the outer `<nav>`. */
+  className?: string;
+}
+
+type StepState = 'active' | 'completed' | 'upcoming';
+
+function resolveStepState(
+  stepId: string,
+  activeStepId: string,
+  completed: ReadonlySet<string>,
+): StepState {
+  if (stepId === activeStepId) return 'active';
+  if (completed.has(stepId)) return 'completed';
+  return 'upcoming';
+}
+
+function defaultCompletedIds(
+  steps: readonly SetupStepNavStep[],
+  activeStepId: string,
+): readonly string[] {
+  const ids: string[] = [];
+  for (const step of steps) {
+    if (step.id === activeStepId) break;
+    ids.push(step.id);
+  }
+  return ids;
+}
+
+export function SetupStepNav({
+  steps,
+  activeStepId,
+  completedStepIds,
+  onSelect,
+  className,
+}: SetupStepNavProps) {
+  const completedSet = new Set(completedStepIds ?? defaultCompletedIds(steps, activeStepId));
+  return (
+    <nav aria-label="Wizard progress" className={className ?? 'w-[320px]'}>
+      <ol className="flex flex-col">
+        {steps.map((step, index) => {
+          const state = resolveStepState(step.id, activeStepId, completedSet);
+          const isLast = index === steps.length - 1;
+          return onSelect === undefined ? (
+            <SetupStepNavItem key={step.id} step={step} state={state} isLast={isLast} />
+          ) : (
+            <SetupStepNavItem
+              key={step.id}
+              step={step}
+              state={state}
+              isLast={isLast}
+              onSelect={onSelect}
+            />
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+interface SetupStepNavItemProps {
+  readonly step: SetupStepNavStep;
+  readonly state: StepState;
+  readonly isLast: boolean;
+  readonly onSelect?: (id: string) => void;
+}
+
+function SetupStepNavItem({ step, state, isLast, onSelect }: SetupStepNavItemProps) {
+  const isActive = state === 'active';
+  const isCompleted = state === 'completed';
+  // Title colour: active gets full strength; completed + upcoming both
+  // downshift to text-tertiary — see component-level comment for why
+  // text-quaternary is not used here (4.06:1 fails WCAG AA on the
+  // Glaon light-grey sidebar).
+  const titleClass = `text-sm font-semibold leading-5 ${isActive ? 'text-secondary' : 'text-tertiary'}`;
+  const descriptionClass = 'text-sm font-normal leading-5 text-tertiary';
+  // Completed rows swap the supplied icon for a Check glyph so the user
+  // can scan past finished steps. The icon container styling stays the
+  // same across states until design ships a richer "completed" frame
+  // (D2–D5 follow-ups for steps 2–5).
+  const iconNode = isCompleted ? <Check aria-hidden="true" /> : step.icon;
+  const textBlock = (
+    <div
+      className="flex flex-1 flex-col pb-8 text-left"
+      aria-current={isActive ? 'step' : undefined}
+    >
+      <p className={titleClass}>{step.title}</p>
+      {step.description !== undefined && step.description !== '' && (
+        <p className={descriptionClass}>{step.description}</p>
+      )}
+    </div>
+  );
+
+  return (
+    <li className="flex items-start gap-3">
+      <div className="flex flex-col items-center gap-1 self-stretch pb-1">
+        <div className="z-[1] flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset">
+          <span aria-hidden="true" className="block size-5">
+            {iconNode}
+          </span>
+        </div>
+        {!isLast && <div className="w-px flex-1 bg-[var(--color-neutral-300)]" />}
+      </div>
+      {onSelect === undefined ? (
+        textBlock
+      ) : (
+        <button
+          type="button"
+          onClick={() => {
+            onSelect(step.id);
+          }}
+          className="flex flex-1 cursor-pointer rounded-md outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2"
+        >
+          {textBlock}
+        </button>
+      )}
+    </li>
+  );
+}

--- a/packages/ui/src/components/SetupStepNav/index.ts
+++ b/packages/ui/src/components/SetupStepNav/index.ts
@@ -1,0 +1,2 @@
+export { SetupStepNav } from './SetupStepNav';
+export type { SetupStepNavProps, SetupStepNavStep } from './SetupStepNav';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -33,6 +33,7 @@ export * from './components/ProgressBar';
 export * from './components/Radio';
 export * from './components/Select';
 export * from './components/SetupLayout';
+export * from './components/SetupStepNav';
 export * from './components/SideNav';
 export * from './components/SocialButton';
 export * from './components/Spinner';


### PR DESCRIPTION
## Summary

- New `SetupStepNav` primitive in `@glaon/ui` — vertical step navigator with active / completed / upcoming visual states. Extracts the inline impl that SetupLayout (#537) shipped with.
- Completed rows replace the supplied icon with a UUI `Check` glyph so the user can scan past finished steps. Active row keeps `text-secondary` (#404040) title; completed + upcoming both use `text-tertiary` (#525252) — every state lands ≥ 4.5:1 WCAG AA on the Glaon light-grey sidebar.
- Optional `onSelect` flips each row to a `<button>` with a focus ring so the primitive doubles as a click-to-jump nav for post-launch flows. The v1 first-run wizard locks the order; SetupLayout's new `onSelectStep` pass-through is undefined there.
- SetupLayout consumes the primitive and gains `completedStepIds` + `onSelectStep` forwarders; `SetupLayoutStep` is now an alias of `SetupStepNavStep` so callers that only depend on SetupLayout keep their imports.

## Scope

### In

- `packages/ui/src/components/SetupStepNav/SetupStepNav.tsx` — component, props, state resolver.
- `packages/ui/src/components/SetupStepNav/SetupStepNav.controls.ts` — `defineControls` spec.
- `packages/ui/src/components/SetupStepNav/SetupStepNav.stories.tsx` — 5 stories: Default (step 1 active), MidWizardActive (step 3 active), AllCompleted (every step completed), WithOnSelect (interactive variant), SingleStep. `aria-current="step"` asserted in `play`. `meta.excludeStories: ['excludeFromArgs']` so the prop-coverage gate's data export doesn't crash the runner.
- `packages/ui/src/components/SetupStepNav/SetupStepNav.mdx` — narrative docs (when to use / states / a11y / related).
- `packages/ui/src/components/SetupStepNav/index.ts` — barrel.
- `packages/ui/src/components/SetupLayout/SetupLayout.tsx` — switches the inline rail for `<SetupStepNav>`; adds `completedStepIds` + `onSelectStep` props; re-exports `SetupLayoutStep` as a type alias of `SetupStepNavStep`.
- `packages/ui/src/components/SetupLayout/SetupLayout.controls.ts` — adds the two new props to `excludeFromArgs`.
- `packages/ui/src/index.ts` — exports `./components/SetupStepNav`.

### Out

- D2–D5 design frames for the wider wizard step content (separate issues #541–#544).
- SetupGate routing + `/setup` route shell (#539, depends on this).
- Wizard step components (#540 + #545–#548).

## Test plan

- [x] `pnpm --filter @glaon/ui type-check` green
- [x] `pnpm --filter @glaon/ui lint` green
- [x] `pnpm --filter @glaon/ui test` green (141 tests pass; F6 prop-coverage gate now covers SetupStepNav + SetupLayout)
- [x] `pnpm knip` no new violations
- [x] Storybook stories render with the documented visual states; `aria-current="step"` set on exactly one row per nav; `WithOnSelect` renders `<button>` per step
- [x] SetupLayout still pixel-matches Figma `1277:791` (chrome + step rail unchanged for the default case; the primitive renders identical DOM)
- [x] CI required checks (type-check · lint · audit · unit-tests · story-tests · package-contract · size-check · visual regression · chromatic)

Closes #538
Refs #533, ADR 0028, #537
