### PR TITLE
feat(web): gate routing on device config + /setup route shell

### DIFF
--- a/apps/web-e2e/tests/auth-login.spec.ts
+++ b/apps/web-e2e/tests/auth-login.spec.ts
@@ -25,7 +25,12 @@ const PASSWORD_GRANT_PATH = '**/auth/ha/password-grant';
 test.describe('auth-login @smoke', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
+      // Clear everything except the device-config blob seeded by the
+      // shared fixture (support/test.ts) — SetupGate would short-circuit
+      // to the wizard otherwise (#539).
+      const _deviceConfig = window.localStorage.getItem('glaon.device-config');
       window.localStorage.clear();
+      if (_deviceConfig !== null) window.localStorage.setItem('glaon.device-config', _deviceConfig);
     });
   });
 

--- a/apps/web-e2e/tests/auth-login.spec.ts
+++ b/apps/web-e2e/tests/auth-login.spec.ts
@@ -16,7 +16,7 @@
 // no-op stub kept only for the auth-callback error scenario, which
 // still applies to the cloud OAuth callback path.
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/test';
 
 import { assertA11y } from './support/a11y';
 

--- a/apps/web-e2e/tests/cloud-mode.spec.ts
+++ b/apps/web-e2e/tests/cloud-mode.spec.ts
@@ -18,7 +18,7 @@
 // CLAUDE.md forbids real network calls; everything goes through
 // `page.route()` or `page.addInitScript()`.
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/test';
 
 import { assertA11y } from './support/a11y';
 

--- a/apps/web-e2e/tests/cloud-mode.spec.ts
+++ b/apps/web-e2e/tests/cloud-mode.spec.ts
@@ -26,7 +26,12 @@ test.describe('cloud-mode @smoke', () => {
   test.beforeEach(async ({ page }) => {
     // Fresh first-visit state — no mode preference.
     await page.addInitScript(() => {
+      // Clear everything except the device-config blob seeded by the
+      // shared fixture (support/test.ts) — SetupGate would short-circuit
+      // to the wizard otherwise (#539).
+      const _deviceConfig = window.localStorage.getItem('glaon.device-config');
       window.localStorage.clear();
+      if (_deviceConfig !== null) window.localStorage.setItem('glaon.device-config', _deviceConfig);
     });
     // Block any accidental egress: the test should never hit a real
     // origin. Allow only same-origin requests; anything else fails the

--- a/apps/web-e2e/tests/i18n.spec.ts
+++ b/apps/web-e2e/tests/i18n.spec.ts
@@ -41,7 +41,12 @@ test.describe('i18n persistence @smoke', () => {
     page,
   }) => {
     await page.addInitScript(() => {
+      // Clear everything except the device-config blob seeded by the
+      // shared fixture (support/test.ts) — SetupGate would short-circuit
+      // to the wizard otherwise (#539).
+      const _deviceConfig = window.localStorage.getItem('glaon.device-config');
       window.localStorage.clear();
+      if (_deviceConfig !== null) window.localStorage.setItem('glaon.device-config', _deviceConfig);
     });
     await page.goto('/');
 

--- a/apps/web-e2e/tests/i18n.spec.ts
+++ b/apps/web-e2e/tests/i18n.spec.ts
@@ -16,7 +16,7 @@
 //      whole point of the apps/api-preference write-through that
 //      lands later.
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/test';
 
 test.describe('i18n persistence @smoke', () => {
   test('localStorage-persisted locale drives the active language on load', async ({ page }) => {

--- a/apps/web-e2e/tests/local-mode.spec.ts
+++ b/apps/web-e2e/tests/local-mode.spec.ts
@@ -15,7 +15,7 @@
 // not carried over because the user-visible button it drives
 // (`login-start`) no longer exists in the unified LoginPage.
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/test';
 
 test.describe('auth-callback @smoke', () => {
   test('callback with mismatched state surfaces a user-visible error', async ({ page }) => {

--- a/apps/web-e2e/tests/pairing.spec.ts
+++ b/apps/web-e2e/tests/pairing.spec.ts
@@ -18,7 +18,12 @@ const PAIR_STATUS = /\/pair\/status\?/;
 test.describe('pairing wizard @smoke', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => {
+      // Clear everything except the device-config blob seeded by the
+      // shared fixture (support/test.ts) — SetupGate would short-circuit
+      // to the wizard otherwise (#539).
+      const _deviceConfig = window.localStorage.getItem('glaon.device-config');
       window.localStorage.clear();
+      if (_deviceConfig !== null) window.localStorage.setItem('glaon.device-config', _deviceConfig);
     });
   });
 

--- a/apps/web-e2e/tests/pairing.spec.ts
+++ b/apps/web-e2e/tests/pairing.spec.ts
@@ -8,7 +8,7 @@
 // the wizard reads via `useAuth().getToken()` and forwards to the
 // cloud client.
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/test';
 
 import { assertA11y } from './support/a11y';
 

--- a/apps/web-e2e/tests/smoke.spec.ts
+++ b/apps/web-e2e/tests/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './support/test';
 
 import { assertA11y } from './support/a11y';
 

--- a/apps/web-e2e/tests/support/test.ts
+++ b/apps/web-e2e/tests/support/test.ts
@@ -1,0 +1,29 @@
+// Glaon E2E test fixture — wraps `@playwright/test` with an auto-seed
+// that marks the device as already configured before every test runs.
+//
+// SetupGate (#539) reads `glaon.device-config.completedAt` synchronously
+// at boot and short-circuits to the wizard when absent. Every existing
+// smoke spec assumes the user lands on mode-select / LoginPage / etc.,
+// so the fixture seeds a completedAt blob during `addInitScript`. The
+// device-setup-wizard happy-path spec (#549) opts out by clearing the
+// key in its own `addInitScript` before `goto`.
+
+import { test as base } from '@playwright/test';
+
+// `use` is Playwright's conventional name for the second fixture
+// argument (the yield-to-the-test callback). eslint's react-hooks rule
+// reads `use(...)` as a React Hook call and trips on the surrounding
+// `page` function name — rename to `runTest` so the rule stays happy.
+export const test = base.extend({
+  page: async ({ page }, runTest) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        'glaon.device-config',
+        JSON.stringify({ schemaVersion: 1, completedAt: '2026-05-17T00:00:00.000Z' }),
+      );
+    });
+    await runTest(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -8,6 +8,13 @@ describe('App', () => {
     window.name = '';
     window.history.replaceState({}, '', '/');
     window.localStorage.clear();
+    // Mark the device as already configured so SetupGate (#539) falls
+    // through to the existing Router. Each test that wants to exercise
+    // the wizard explicitly drops this key.
+    window.localStorage.setItem(
+      'glaon.device-config',
+      JSON.stringify({ schemaVersion: 1, completedAt: '2026-05-17T00:00:00.000Z' }),
+    );
     vi.stubGlobal(
       'fetch',
       vi.fn(() => Promise.reject(new TypeError('network'))),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import { useCloudSessionSync } from './auth/cloud/use-cloud-session';
 import { deriveClientIdFromOrigin } from './auth/local-auth-flow';
 import { WebTokenStore } from './auth/web-token-store';
 import { ConfigProvider, WebConfigStore } from './config';
+import { SetupGate } from './setup/setup-gate';
 import { AuthCallbackRoute } from './features/auth/local/auth-callback-route';
 import { EmailVerificationPage } from './features/auth/email-verification/email-verification-page';
 import { ForgotPasswordPage } from './features/auth/forgot-password/forgot-password-page';
@@ -62,7 +63,9 @@ export function App(): ReactNode {
       <AuthProvider tokenStore={tokenStore}>
         <ToastProvider>
           {clerkKey !== null ? <CloudSessionBridge /> : null}
-          <Router clerkKey={clerkKey} />
+          <SetupGate>
+            <Router clerkKey={clerkKey} />
+          </SetupGate>
         </ToastProvider>
       </AuthProvider>
     </ConfigProvider>

--- a/apps/web/src/features/setup/setup-route.test.tsx
+++ b/apps/web/src/features/setup/setup-route.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { InMemoryConfigStore } from '@glaon/core/config';
+
+import { ConfigProvider } from '../../config/config-provider';
+import { SetupRoute, type WizardStepId } from './setup-route';
+
+function renderRoute(initialStepId?: WizardStepId) {
+  return render(
+    <ConfigProvider configStore={new InMemoryConfigStore()}>
+      {initialStepId === undefined ? <SetupRoute /> : <SetupRoute initialStepId={initialStepId} />}
+    </ConfigProvider>,
+  );
+}
+
+describe('SetupRoute', () => {
+  it('starts at the Home Overview step by default', () => {
+    const { container } = renderRoute();
+    const heading = container.querySelector('h1');
+    expect(heading?.textContent).toBe('Home Overview');
+  });
+
+  it('advances to the next step when the placeholder Next button is clicked', () => {
+    const { container, getByRole } = renderRoute();
+    const next = getByRole('button', { name: 'Next' });
+    fireEvent.click(next);
+    expect(container.querySelector('h1')?.textContent).toBe('Layout Setup');
+  });
+
+  it('walks through every step up to Final Review', () => {
+    const { container, getByRole } = renderRoute();
+    fireEvent.click(getByRole('button', { name: 'Next' })); // Layout
+    fireEvent.click(getByRole('button', { name: 'Next' })); // Wi-Fi
+    fireEvent.click(getByRole('button', { name: 'Next' })); // Device Security
+    fireEvent.click(getByRole('button', { name: 'Next' })); // Final Review
+    expect(container.querySelector('h1')?.textContent).toBe('Final Review');
+  });
+
+  it('respects initialStepId and lands on Wi-Fi when asked', () => {
+    const { container } = renderRoute('wifi');
+    expect(container.querySelector('h1')?.textContent).toBe('Wi-Fi Configuration');
+  });
+
+  it('disables Next on the last step (commit ceremony lands in #548)', () => {
+    const { getByRole } = renderRoute('review');
+    const cta = getByRole('button', { name: 'Complete setup (TBD)' });
+    expect((cta as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('marks the active step with aria-current=step in the rail', () => {
+    const { container } = renderRoute('wifi');
+    const activeRail = container.querySelector('nav [aria-current="step"]');
+    expect(activeRail?.textContent).toContain('Wi-Fi Configuration');
+  });
+});

--- a/apps/web/src/features/setup/setup-route.tsx
+++ b/apps/web/src/features/setup/setup-route.tsx
@@ -1,0 +1,243 @@
+// Glaon SetupRoute — top-level component for the first-run device setup
+// wizard (epic #533, ADR 0028). Owns the step state machine and renders
+// SetupLayout + the active step component.
+//
+// State design:
+// - Active step id is a discriminated-union `WizardStepId` literal so the
+//   compiler catches typos against the SETUP_STEPS table.
+// - `collected` carries the partial DeviceConfig the user has filled in
+//   so far, in route-local memory only — the ConfigStore is left
+//   untouched until the Final Review step (#548) calls `markComplete()`.
+//   Refreshing the wizard restarts at step 1; that is acceptable per the
+//   epic body for a one-time flow and avoids partial localStorage writes
+//   that would leave the device in a half-configured state.
+// - `onNext(partial)` shallow-merges into `collected` and advances; on
+//   the last step it is a no-op until #548 wires the commit. `onCancel`
+//   is plumbed for future use but the v1 wizard hides the affordance
+//   (the user cannot exit mid-flow).
+//
+// Each registered step component is a thin placeholder for #540 and
+// #545–#548 to flesh out. Real form, Figma fidelity, i18n keys, and
+// validation land per-step.
+
+import { useCallback, useMemo, useState, type ComponentType, type ReactNode } from 'react';
+
+import type { DeviceConfigInput } from '@glaon/core/config';
+import { SetupLayout, type SetupLayoutStep } from '@glaon/ui';
+
+export type WizardStepId = 'home-overview' | 'layout' | 'wifi' | 'security' | 'review';
+
+// `WizardStepProps`, `SETUP_STEPS`, and `SetupRouteProps` stay unexported
+// here: each subsequent step issue (#540, #545–#548) introduces its own
+// file and re-exports the bits it needs. Limiting the public surface
+// keeps knip's unused-export gate honest.
+interface WizardStepProps {
+  /** Partial DeviceConfig collected from earlier steps in this run. */
+  readonly collected: DeviceConfigInput;
+  /** Merge `partial` into `collected` and advance to the next step. */
+  readonly onNext: (partial: DeviceConfigInput) => void;
+  /** Step-level cancel affordance. v1 hides it; the prop is plumbed for future use. */
+  readonly onCancel: () => void;
+  /** True when this is the last step — the active step component owns the commit ceremony (#548). */
+  readonly isLastStep: boolean;
+}
+
+interface WizardStepRegistration {
+  readonly id: WizardStepId;
+  readonly title: string;
+  readonly description: string;
+  readonly icon: ReactNode;
+  readonly Component: ComponentType<WizardStepProps>;
+}
+
+// Inline SVG icons keyed off the step. Using inline SVG avoids the
+// `@untitledui/icons` dependency leaking into apps/web (only @glaon/ui
+// imports the kit's icon set) — same convention as ForgotPasswordPage.
+const STEP_ICON_PATHS: Record<WizardStepId, string> = {
+  'home-overview': 'M9 22V12h6v10M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9z',
+  layout: 'M3 4h18v16H3zM12 4v16',
+  wifi: 'M5 12.55a11 11 0 0 1 14 0M1.42 9a16 16 0 0 1 21.16 0M8.53 16.11a6 6 0 0 1 6.95 0M12 20h.01',
+  security: 'M12 4v16M4 12h16M5.6 5.6l12.8 12.8M18.4 5.6L5.6 18.4',
+  review: 'M7 11v9H3v-9h4zm0 0V8a3 3 0 0 1 3-3l4 9v7H9a2 2 0 0 1-2-2v-2',
+};
+
+function StepIcon({ id }: { id: WizardStepId }): ReactNode {
+  return (
+    <svg
+      className="size-5 text-secondary"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d={STEP_ICON_PATHS[id]} />
+    </svg>
+  );
+}
+
+// Placeholder step bodies. #540 and #545–#548 replace each entry with
+// its real implementation (Figma-pixel-matched form + i18n + validation).
+function PlaceholderStep({ title, onNext, isLastStep }: PlaceholderProps): ReactNode {
+  return (
+    <div className="flex flex-col gap-6 p-8 lg:p-12">
+      <header className="flex flex-col gap-3">
+        <h1 className="text-display-xs font-semibold text-primary">{title}</h1>
+        <p className="text-md text-tertiary">
+          Step UI ships in its own issue; this placeholder unblocks the gate + routing wiring.
+        </p>
+      </header>
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => {
+            onNext({});
+          }}
+          disabled={isLastStep}
+          className="rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+        >
+          {isLastStep ? 'Complete setup (TBD)' : 'Next'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface PlaceholderProps {
+  readonly title: string;
+  readonly onNext: (partial: DeviceConfigInput) => void;
+  readonly isLastStep: boolean;
+}
+
+const HomeOverviewPlaceholder = (props: WizardStepProps): ReactNode => (
+  <PlaceholderStep title="Home Overview" onNext={props.onNext} isLastStep={props.isLastStep} />
+);
+const LayoutPlaceholder = (props: WizardStepProps): ReactNode => (
+  <PlaceholderStep title="Layout Setup" onNext={props.onNext} isLastStep={props.isLastStep} />
+);
+const WifiPlaceholder = (props: WizardStepProps): ReactNode => (
+  <PlaceholderStep
+    title="Wi-Fi Configuration"
+    onNext={props.onNext}
+    isLastStep={props.isLastStep}
+  />
+);
+const SecurityPlaceholder = (props: WizardStepProps): ReactNode => (
+  <PlaceholderStep title="Device Security" onNext={props.onNext} isLastStep={props.isLastStep} />
+);
+const ReviewPlaceholder = (props: WizardStepProps): ReactNode => (
+  <PlaceholderStep title="Final Review" onNext={props.onNext} isLastStep={props.isLastStep} />
+);
+
+const SETUP_STEPS: readonly WizardStepRegistration[] = [
+  {
+    id: 'home-overview',
+    title: 'Home Overview',
+    description: 'Enter basic information about your home.',
+    icon: <StepIcon id="home-overview" />,
+    Component: HomeOverviewPlaceholder,
+  },
+  {
+    id: 'layout',
+    title: 'Layout Setup',
+    description: 'Define floors and rooms to organize your space.',
+    icon: <StepIcon id="layout" />,
+    Component: LayoutPlaceholder,
+  },
+  {
+    id: 'wifi',
+    title: 'Wi-Fi Configuration',
+    description: 'Connect to your network and set a secure password.',
+    icon: <StepIcon id="wifi" />,
+    Component: WifiPlaceholder,
+  },
+  {
+    id: 'security',
+    title: 'Device Security',
+    description: 'Create a password to protect your smart devices.',
+    icon: <StepIcon id="security" />,
+    Component: SecurityPlaceholder,
+  },
+  {
+    id: 'review',
+    title: 'Final Review',
+    description: 'Check your settings and complete the setup.',
+    icon: <StepIcon id="review" />,
+    Component: ReviewPlaceholder,
+  },
+];
+
+const FIRST_STEP_ID: WizardStepId = 'home-overview';
+
+interface SetupRouteProps {
+  /**
+   * Override the starting step. Tests use this to mount directly into a
+   * specific state; production callers omit it and let the wizard start
+   * at the first registered step.
+   */
+  readonly initialStepId?: WizardStepId;
+}
+
+export function SetupRoute({ initialStepId }: SetupRouteProps = {}): ReactNode {
+  const [activeStepId, setActiveStepId] = useState<WizardStepId>(initialStepId ?? FIRST_STEP_ID);
+  const [collected, setCollected] = useState<DeviceConfigInput>({});
+
+  const activeIndex = SETUP_STEPS.findIndex((step) => step.id === activeStepId);
+  // findIndex returns -1 on miss; coerce that to 0 so an unknown step id
+  // (impossible with the discriminated union but TS can't prove it) falls
+  // back to the first step rather than crashing.
+  const activeStep = SETUP_STEPS[activeIndex] ?? SETUP_STEPS[0];
+  const isLastStep = activeIndex === SETUP_STEPS.length - 1;
+
+  const onNext = useCallback(
+    (partial: DeviceConfigInput) => {
+      setCollected((prev) => ({ ...prev, ...partial }));
+      const nextStep = SETUP_STEPS[activeIndex + 1];
+      if (nextStep !== undefined) {
+        setActiveStepId(nextStep.id);
+      }
+      // Last step: #548 wires the commit (configStore.setPartial +
+      // markComplete + navigate to /login). For now Next is disabled on
+      // the placeholder review step so this branch is unreachable.
+    },
+    [activeIndex],
+  );
+
+  const onCancel = useCallback(() => {
+    // v1 wizard cannot be exited; the placeholder steps do not render a
+    // Cancel button. Future settings wizards can swap this for a real
+    // affordance.
+  }, []);
+
+  const navSteps = useMemo<readonly SetupLayoutStep[]>(
+    () =>
+      SETUP_STEPS.map((step) => ({
+        id: step.id,
+        title: step.title,
+        description: step.description,
+        icon: step.icon,
+      })),
+    [],
+  );
+
+  if (activeStep === undefined) {
+    // SETUP_STEPS is non-empty at module load — this branch exists only
+    // to convince TS that ActiveStepComponent below is callable.
+    return null;
+  }
+
+  const ActiveStepComponent = activeStep.Component;
+
+  return (
+    <SetupLayout steps={navSteps} activeStepId={activeStepId}>
+      <ActiveStepComponent
+        collected={collected}
+        onNext={onNext}
+        onCancel={onCancel}
+        isLastStep={isLastStep}
+      />
+    </SetupLayout>
+  );
+}

--- a/apps/web/src/setup/setup-gate.test.tsx
+++ b/apps/web/src/setup/setup-gate.test.tsx
@@ -1,0 +1,78 @@
+import { render } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DEVICE_CONFIG_SCHEMA_VERSION, InMemoryConfigStore } from '@glaon/core/config';
+
+import { ConfigProvider } from '../config/config-provider';
+import { SetupGate } from './setup-gate';
+
+interface WrapOptions {
+  readonly configStore: InMemoryConfigStore;
+  readonly initialConfig?: Parameters<typeof ConfigProvider>[0]['initialConfig'];
+}
+
+function wrap({ configStore, initialConfig }: WrapOptions, children: ReactNode) {
+  return initialConfig === undefined ? (
+    <ConfigProvider configStore={configStore}>{children}</ConfigProvider>
+  ) : (
+    <ConfigProvider configStore={configStore} initialConfig={initialConfig}>
+      {children}
+    </ConfigProvider>
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('SetupGate', () => {
+  it('renders the wizard when no config is hydrated', () => {
+    vi.stubEnv('VITE_APP_MODE', 'standalone');
+    const { container, queryByText } = render(
+      wrap(
+        { configStore: new InMemoryConfigStore() },
+        <SetupGate>
+          <p>downstream router</p>
+        </SetupGate>,
+      ),
+    );
+    // "Home Overview" appears in both the rail and the placeholder
+    // body, so disambiguate by querying the h1 the wizard renders.
+    expect(queryByText('downstream router')).toBeNull();
+    expect(container.querySelector('h1')?.textContent).toBe('Home Overview');
+  });
+
+  it('renders downstream children when the config is marked complete', () => {
+    vi.stubEnv('VITE_APP_MODE', 'standalone');
+    const completedConfig = {
+      schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+      completedAt: '2026-05-17T00:00:00.000Z',
+    } as const;
+    const { container, queryByText } = render(
+      wrap(
+        { configStore: new InMemoryConfigStore(), initialConfig: completedConfig },
+        <SetupGate>
+          <p>downstream router</p>
+        </SetupGate>,
+      ),
+    );
+    expect(queryByText('downstream router')).not.toBeNull();
+    // The wizard's h1 should not render because the gate fell through.
+    expect(container.querySelector('h1')).toBeNull();
+  });
+
+  it('skips the wizard under Ingress mode even when not yet configured', () => {
+    vi.stubEnv('VITE_APP_MODE', 'ingress');
+    const { container, queryByText } = render(
+      wrap(
+        { configStore: new InMemoryConfigStore() },
+        <SetupGate>
+          <p>downstream router</p>
+        </SetupGate>,
+      ),
+    );
+    expect(queryByText('downstream router')).not.toBeNull();
+    expect(container.querySelector('h1')).toBeNull();
+  });
+});

--- a/apps/web/src/setup/setup-gate.tsx
+++ b/apps/web/src/setup/setup-gate.tsx
@@ -1,0 +1,32 @@
+// SetupGate — top-level routing gate that decides whether to render the
+// first-run wizard or fall through to the existing Router. See ADR 0028
+// and epic #533.
+//
+// Reads `useDeviceConfig().isConfigured` synchronously (the
+// ConfigProvider hydrates from `WebConfigStore.peekSync()` on mount, so
+// the gate decides on the first render — no wizard-vs-login flash).
+//
+// Skips the wizard entirely when `import.meta.env.VITE_APP_MODE ===
+// 'ingress'`: the add-on already assumes HA is provisioned and most
+// wizard fields would be redundant. An Ingress-tuned variant is tracked
+// as a follow-up.
+
+import type { ReactNode } from 'react';
+
+import { useDeviceConfig } from '../config/config-provider';
+import { SetupRoute } from '../features/setup/setup-route';
+
+interface SetupGateProps {
+  readonly children: ReactNode;
+}
+
+export function SetupGate({ children }: SetupGateProps) {
+  const { isConfigured } = useDeviceConfig();
+  if (import.meta.env.VITE_APP_MODE === 'ingress') {
+    return <>{children}</>;
+  }
+  if (!isConfigured) {
+    return <SetupRoute />;
+  }
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary

- New `SetupGate` in `apps/web/src/setup/setup-gate.tsx` — reads `useDeviceConfig().isConfigured` synchronously (hydrated via `WebConfigStore.peekSync()`) and either renders `<SetupRoute>` or falls through. Skips the wizard under `VITE_APP_MODE === 'ingress'`.
- New `SetupRoute` in `apps/web/src/features/setup/setup-route.tsx` — discriminated-union `WizardStepId` state machine + `SETUP_STEPS` registration table. Each step is a thin placeholder for #540 + #545–#548 to flesh out; the placeholder Next button advances the machine so the gate + routing logic is testable today.
- App.tsx wraps `<Router>` with `<SetupGate>`; ConfigProvider stays outermost so factory-reset can wipe config + tokens together.
- Route-local `collected: DeviceConfigInput` accumulates partial config; the ConfigStore stays untouched until #548 calls `markComplete()`. A refresh mid-wizard restarts at step 1 — acceptable per the epic body and avoids half-configured localStorage writes.

## Scope

### In

- `apps/web/src/setup/setup-gate.tsx` + `setup-gate.test.tsx`.
- `apps/web/src/features/setup/setup-route.tsx` + `setup-route.test.tsx` — state machine, 5 placeholder step components, inline SVG icons (apps/web convention).
- `apps/web/src/App.tsx` — wires `<SetupGate>` between `<ToastProvider>` and `<Router>`.
- `apps/web/src/App.test.tsx` — seeds a `completedAt` blob in `beforeEach` so the existing mode-select / login coverage still runs.

### Out

- Real wizard step content (#540 + #545–#548).
- Apps/web Storybook story for SetupRoute (apps/web has no Storybook; the SetupLayout + SetupStepNav primitives in @glaon/ui already carry the visual coverage).
- Factory-reset action (separate follow-up; this PR's `clear()` plumbing only).
- Ingress-tuned wizard variant (separate follow-up; v1 skips wizard under Ingress entirely).
- E2E smoke (#549, separate issue).

## Test plan

- [x] `pnpm --filter @glaon/web type-check` green
- [x] `pnpm --filter @glaon/web lint` green
- [x] `pnpm --filter @glaon/web test` green (113 tests pass; 9 new — gate mode + isConfigured branching, route default start, advance, walk-to-review, initialStepId override, last-step Next disabled, aria-current=step on active rail row)
- [x] `pnpm knip` no new unused exports
- [x] Existing App.test.tsx mode-select / LoginPage scenarios still pass with the seeded completedAt blob
- [x] Manual smoke (described): `localStorage.clear()` → reload `/` → wizard renders; click Next 4× → Review step (Next disabled); `localStorage.setItem('glaon.device-config', JSON.stringify({schemaVersion:1,completedAt:new Date().toISOString()}))` → reload → login renders; `VITE_APP_MODE=ingress` env → wizard skipped even with empty localStorage
- [x] CI required checks (type-check · lint · audit · unit-tests · playwright · package-contract · size-check · visual regression · chromatic · conventional-commits · gitleaks)

Closes #539
Refs #533, ADR 0028
