### PR TITLE
feat(web): wizard step 2 layout setup (placeholder)

### DIFF
--- a/apps/web/src/features/setup/layout/index.ts
+++ b/apps/web/src/features/setup/layout/index.ts
@@ -1,0 +1,1 @@
+export { LayoutStep } from './layout-step';

--- a/apps/web/src/features/setup/layout/layout-step.test.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LayoutStep } from './layout-step';
+
+describe('LayoutStep', () => {
+  it('renders the title and the optional layout field', () => {
+    const { container, getByText } = render(<LayoutStep collected={{}} onNext={() => undefined} />);
+    expect(container.querySelector('h1')?.textContent).toBe('Layout Setup');
+    expect(getByText(/Home structure/)).toBeInTheDocument();
+  });
+
+  it('submits an empty partial when the field is left blank (no required validation)', () => {
+    const onNext = vi.fn();
+    const { getByRole } = render(<LayoutStep collected={{}} onNext={onNext} />);
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onNext.mock.calls[0]?.[0]).toEqual({});
+  });
+
+  it('passes the trimmed layout string through onNext when filled', () => {
+    const onNext = vi.fn();
+    const { container, getByRole } = render(<LayoutStep collected={{}} onNext={onNext} />);
+    const input = container.querySelector('input[type="text"]');
+    expect(input).not.toBeNull();
+    if (input === null) return;
+    fireEvent.change(input, { target: { value: '  2 floors, 5 rooms  ' } });
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    const partial = onNext.mock.calls[0]?.[0] as { layout?: string };
+    expect(partial.layout).toBe('2 floors, 5 rooms');
+  });
+
+  it('hydrates layout from collected partial', () => {
+    const { container } = render(
+      <LayoutStep collected={{ layout: 'open-plan' }} onNext={() => undefined} />,
+    );
+    const input = container.querySelector('input[type="text"]');
+    expect((input as HTMLInputElement | null)?.value).toBe('open-plan');
+  });
+});

--- a/apps/web/src/features/setup/layout/layout-step.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.tsx
@@ -1,0 +1,96 @@
+// Layout Setup wizard step — second step in the device setup wizard
+// (epic #533, ADR 0028). v1 placeholder per the epic body and #545:
+// single optional `<Input>` ("Home structure description") + Next,
+// no floor/room domain. The real floor/room editor is its own epic.
+//
+// Same horizontal-form layout primitives as #540 — a label column on
+// the left, the control on the right, divider above the row. Below
+// `sm` the rows stack.
+//
+// The placeholder field writes into the string `layout?: string` slot
+// already defined on DeviceConfig (#535); when the real editor lands
+// it will replace this step without touching the schema's surface.
+
+import { InputBase, TextField } from '@glaon/ui';
+import { useId, useState, type ReactNode, type SubmitEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { DeviceConfigInput } from '@glaon/core/config';
+
+export interface LayoutStepProps {
+  /** Partial DeviceConfig collected from earlier steps in this run. */
+  readonly collected: DeviceConfigInput;
+  /** Merge the form's output into `collected` and advance to the next step. */
+  readonly onNext: (partial: DeviceConfigInput) => void;
+}
+
+export function LayoutStep({ collected, onNext }: LayoutStepProps): ReactNode {
+  const { t } = useTranslation();
+  const layoutLabelId = useId();
+  const [layout, setLayout] = useState<string>(collected.layout ?? '');
+
+  const onSubmit = (event: SubmitEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    const trimmed = layout.trim();
+    const partial: DeviceConfigInput = {};
+    if (trimmed !== '') partial.layout = trimmed;
+    onNext(partial);
+  };
+
+  return (
+    <div className="flex flex-col p-8 lg:p-12">
+      <header className="flex flex-col gap-1 pb-6">
+        <h1 className="text-display-xs font-semibold text-primary">
+          {t('setup.layoutSetup.title')}
+        </h1>
+        <p className="text-sm text-tertiary">{t('setup.layoutSetup.subtitle')}</p>
+      </header>
+
+      <form onSubmit={onSubmit} noValidate className="flex flex-col">
+        <div className="grid grid-cols-1 gap-2 border-t border-secondary py-5 sm:grid-cols-[240px_1fr] sm:items-start sm:gap-8">
+          <p id={layoutLabelId} className="pt-2 text-sm font-semibold text-secondary">
+            {t('setup.layoutSetup.layout.label')}
+          </p>
+          <div className="flex max-w-[480px] flex-col gap-1.5">
+            <TextField value={layout} onChange={setLayout} aria-labelledby={layoutLabelId}>
+              <InputBase
+                type="text"
+                placeholder={t('setup.layoutSetup.layout.placeholder')}
+                autoComplete="off"
+              />
+            </TextField>
+            <p className="text-sm text-tertiary">{t('setup.layoutSetup.layout.hint')}</p>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-3 border-t border-secondary py-6">
+          <button
+            type="submit"
+            className="inline-flex items-center gap-2 rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white shadow-xs-skeuomorphic hover:bg-brand-solid_hover"
+          >
+            <span>{t('setup.layoutSetup.actions.next')}</span>
+            <NextArrowIcon />
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function NextArrowIcon(): ReactNode {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4.167 10h11.666m0 0L10 4.167M15.833 10 10 15.833" />
+    </svg>
+  );
+}

--- a/apps/web/src/features/setup/layout/layout-step.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.tsx
@@ -17,7 +17,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { DeviceConfigInput } from '@glaon/core/config';
 
-export interface LayoutStepProps {
+interface LayoutStepProps {
   /** Partial DeviceConfig collected from earlier steps in this run. */
   readonly collected: DeviceConfigInput;
   /** Merge the form's output into `collected` and advance to the next step. */

--- a/apps/web/src/features/setup/setup-route.tsx
+++ b/apps/web/src/features/setup/setup-route.tsx
@@ -26,6 +26,7 @@ import type { DeviceConfigInput } from '@glaon/core/config';
 import { SetupLayout, type SetupLayoutStep } from '@glaon/ui';
 
 import { HomeOverviewStep } from './home-overview';
+import { LayoutStep } from './layout';
 
 export type WizardStepId = 'home-overview' | 'layout' | 'wifi' | 'security' | 'review';
 
@@ -113,13 +114,13 @@ interface PlaceholderProps {
   readonly isLastStep: boolean;
 }
 
-// Real step component for #540; the rest of the wizard's steps still
-// render the inline placeholder until their issues land.
+// Real step components for #540 + #545; the rest still render the
+// inline placeholder until their issues land.
 const HomeOverviewStepAdapter = (props: WizardStepProps): ReactNode => (
   <HomeOverviewStep collected={props.collected} onNext={props.onNext} />
 );
-const LayoutPlaceholder = (props: WizardStepProps): ReactNode => (
-  <PlaceholderStep title="Layout Setup" onNext={props.onNext} isLastStep={props.isLastStep} />
+const LayoutStepAdapter = (props: WizardStepProps): ReactNode => (
+  <LayoutStep collected={props.collected} onNext={props.onNext} />
 );
 const WifiPlaceholder = (props: WizardStepProps): ReactNode => (
   <PlaceholderStep
@@ -148,7 +149,7 @@ const SETUP_STEPS: readonly WizardStepRegistration[] = [
     title: 'Layout Setup',
     description: 'Define floors and rooms to organize your space.',
     icon: <StepIcon id="layout" />,
-    Component: LayoutPlaceholder,
+    Component: LayoutStepAdapter,
   },
   {
     id: 'wifi',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -89,6 +89,18 @@
     "locales": {
       "en": "English",
       "tr": "Türkçe"
+    },
+    "layoutSetup": {
+      "title": "Layout Setup",
+      "subtitle": "Describe how your home is organized. The full floor + room editor lands in a later release.",
+      "layout": {
+        "label": "Home structure",
+        "placeholder": "e.g. 2 floors, 5 rooms — kitchen, living, two bedrooms, bathroom",
+        "hint": "Optional. Free-text for now; we'll replace this with a real layout editor in a follow-up."
+      },
+      "actions": {
+        "next": "Next"
+      }
     }
   }
 }

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -89,6 +89,18 @@
     "locales": {
       "en": "English",
       "tr": "Türkçe"
+    },
+    "layoutSetup": {
+      "title": "Yerleşim Kurulumu",
+      "subtitle": "Evinin nasıl organize olduğunu kısaca anlat. Tam kat + oda editörü ileri bir sürümde geliyor.",
+      "layout": {
+        "label": "Ev yapısı",
+        "placeholder": "örn. 2 kat, 5 oda — mutfak, salon, iki yatak odası, banyo",
+        "hint": "Opsiyonel. Şimdilik serbest metin; ileride gerçek bir yerleşim editörü ile değiştireceğiz."
+      },
+      "actions": {
+        "next": "İleri"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Second wizard step lands: `apps/web/src/features/setup/layout/layout-step.tsx`. v1 minimal placeholder per epic #533's "no floor/room domain yet" decision — single optional free-text input + Next.
- Writes into the existing `layout?: string` slot on `DeviceConfig` (#535), so the real floor/room editor (separate epic) can replace this step without a schema migration.
- Replaces the inline `LayoutPlaceholder` in `setup-route.tsx` via a thin adapter.

## Scope

### In

- `apps/web/src/features/setup/layout/layout-step.tsx` — form component (Home structure free-text input + Next).
- `apps/web/src/features/setup/layout/index.ts` — barrel.
- `apps/web/src/features/setup/layout/layout-step.test.tsx` — 4 cases: default render, empty-submit produces empty partial, trimmed string flows through `onNext`, hydration from `collected`.
- `apps/web/src/features/setup/setup-route.tsx` — swaps `LayoutPlaceholder` → `LayoutStepAdapter`.
- `apps/web/src/i18n/locales/{en,tr}.json` — `setup.layoutSetup.*` keys (Turkish + English).

### Out

- Real floor/room editor (separate epic). The free-text field is intentionally a stepping-stone.
- Pixel-perfect Figma-fidelity validation — the design frame for [#541](https://github.com/toss-cengiz/glaon/issues/541) (Figma node [`14530:18666`](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=14530-18666)) currently shows Home Overview content as a copy-paste template. v1 ships the minimal placeholder per the epic body; when the design owner updates the frame with the real Layout Setup content, the code's chrome already matches.

## Test plan

- [x] `pnpm --filter @glaon/web type-check` green
- [x] `pnpm --filter @glaon/web lint` green
- [x] `pnpm --filter @glaon/web test` green (121 tests pass; 4 new on `layout-step.test.tsx`; setup-route placeholder tests still green because the LayoutStep has no required fields)
- [x] `pnpm i18n:check` green (`setup.layoutSetup.*` keys present in both en + tr)
- [x] `pnpm --filter @glaon/web size` green (Initial JS 347.95 kB / 350 kB; the new step lives in the lazy `setup-route` chunk)
- [x] No `* 2.tsx` backup files in the diff (per the memory note from #540's hiccup)
- [x] CI required checks (type-check · lint · audit · unit-tests · playwright · package-contract · size-check · visual regression · chromatic · conventional-commits · gitleaks · i18n-check · lighthouse)

Closes #545
Refs #533, ADR 0028, #541
