### PR TITLE
feat(web): wizard step 3 wifi configuration

### DIFF
--- a/apps/web/.size-limit.json
+++ b/apps/web/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "Initial JS (gzipped)",
     "path": "dist/assets/index-*.js",
-    "limit": "350 kB",
+    "limit": "360 kB",
     "gzip": true
   },
   {

--- a/apps/web/src/features/setup/setup-route.test.tsx
+++ b/apps/web/src/features/setup/setup-route.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { InMemoryConfigStore } from '@glaon/core/config';
+import { ToastProvider } from '@glaon/ui';
 
 import { ConfigProvider } from '../../config/config-provider';
 import { SetupRoute, type WizardStepId } from './setup-route';
@@ -9,10 +10,32 @@ import { SetupRoute, type WizardStepId } from './setup-route';
 function renderRoute(initialStepId?: WizardStepId) {
   return render(
     <ConfigProvider configStore={new InMemoryConfigStore()}>
-      {initialStepId === undefined ? <SetupRoute /> : <SetupRoute initialStepId={initialStepId} />}
+      <ToastProvider>
+        {initialStepId === undefined ? (
+          <SetupRoute />
+        ) : (
+          <SetupRoute initialStepId={initialStepId} />
+        )}
+      </ToastProvider>
     </ConfigProvider>,
   );
 }
+
+// WifiStep (#546) calls /api/hassio/network/info on mount unless the
+// build is `standalone`. Stub fetch + VITE_APP_MODE so the placeholder
+// walk-through tests don't hit a real network — actual Wi-Fi behaviour
+// is covered in `wifi/wifi-step.test.tsx`.
+beforeEach(() => {
+  vi.stubEnv('VITE_APP_MODE', 'standalone');
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.reject(new TypeError('network'))),
+  );
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
 
 describe('SetupRoute', () => {
   it('starts at the Home Overview step by default', () => {
@@ -28,7 +51,7 @@ describe('SetupRoute', () => {
     const { container, getByRole } = renderRoute('layout');
     const next = getByRole('button', { name: 'Next' });
     fireEvent.click(next);
-    expect(container.querySelector('h1')?.textContent).toBe('Wi-Fi Configuration');
+    expect(container.querySelector('h1')?.textContent).toBe('Wi-Fi Connection');
   });
 
   it('walks through every placeholder step up to Final Review', () => {
@@ -41,7 +64,7 @@ describe('SetupRoute', () => {
 
   it('respects initialStepId and lands on Wi-Fi when asked', () => {
     const { container } = renderRoute('wifi');
-    expect(container.querySelector('h1')?.textContent).toBe('Wi-Fi Configuration');
+    expect(container.querySelector('h1')?.textContent).toBe('Wi-Fi Connection');
   });
 
   it('disables Next on the last step (commit ceremony lands in #548)', () => {
@@ -53,6 +76,9 @@ describe('SetupRoute', () => {
   it('marks the active step with aria-current=step in the rail', () => {
     const { container } = renderRoute('wifi');
     const activeRail = container.querySelector('nav [aria-current="step"]');
+    // The rail label is the hardcoded SETUP_STEPS title ("Wi-Fi
+    // Configuration"); the body title is the i18n one ("Wi-Fi
+    // Connection") rendered by WifiStep. The test asserts on the rail.
     expect(activeRail?.textContent).toContain('Wi-Fi Configuration');
   });
 });

--- a/apps/web/src/features/setup/setup-route.tsx
+++ b/apps/web/src/features/setup/setup-route.tsx
@@ -27,6 +27,7 @@ import { SetupLayout, type SetupLayoutStep } from '@glaon/ui';
 
 import { HomeOverviewStep } from './home-overview';
 import { LayoutStep } from './layout';
+import { WifiStep } from './wifi';
 
 export type WizardStepId = 'home-overview' | 'layout' | 'wifi' | 'security' | 'review';
 
@@ -114,20 +115,16 @@ interface PlaceholderProps {
   readonly isLastStep: boolean;
 }
 
-// Real step components for #540 + #545; the rest still render the
-// inline placeholder until their issues land.
+// Real step components for #540 + #545 + #546; the rest still render
+// the inline placeholder until their issues land.
 const HomeOverviewStepAdapter = (props: WizardStepProps): ReactNode => (
   <HomeOverviewStep collected={props.collected} onNext={props.onNext} />
 );
 const LayoutStepAdapter = (props: WizardStepProps): ReactNode => (
   <LayoutStep collected={props.collected} onNext={props.onNext} />
 );
-const WifiPlaceholder = (props: WizardStepProps): ReactNode => (
-  <PlaceholderStep
-    title="Wi-Fi Configuration"
-    onNext={props.onNext}
-    isLastStep={props.isLastStep}
-  />
+const WifiStepAdapter = (props: WizardStepProps): ReactNode => (
+  <WifiStep collected={props.collected} onNext={props.onNext} />
 );
 const SecurityPlaceholder = (props: WizardStepProps): ReactNode => (
   <PlaceholderStep title="Device Security" onNext={props.onNext} isLastStep={props.isLastStep} />
@@ -156,7 +153,7 @@ const SETUP_STEPS: readonly WizardStepRegistration[] = [
     title: 'Wi-Fi Configuration',
     description: 'Connect to your network and set a secure password.',
     icon: <StepIcon id="wifi" />,
-    Component: WifiPlaceholder,
+    Component: WifiStepAdapter,
   },
   {
     id: 'security',

--- a/apps/web/src/features/setup/wifi/index.ts
+++ b/apps/web/src/features/setup/wifi/index.ts
@@ -1,0 +1,1 @@
+export { WifiStep } from './wifi-step';

--- a/apps/web/src/features/setup/wifi/wifi-step.test.tsx
+++ b/apps/web/src/features/setup/wifi/wifi-step.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ToastProvider } from '@glaon/ui';
+
+import { WifiStep } from './wifi-step';
+
+interface MockResponseInit {
+  readonly ok?: boolean;
+  readonly status?: number;
+  readonly json?: unknown;
+}
+
+function mockFetchResponse({ ok = true, status = 200, json }: MockResponseInit): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(json),
+  } as unknown as Response;
+}
+
+function wrap(node: React.ReactNode) {
+  return <ToastProvider>{node}</ToastProvider>;
+}
+
+const sampleSupervisorPayload = {
+  data: {
+    interfaces: [
+      {
+        accesspoints: [
+          { ssid: 'HomeWifi', auth: 'wpa-psk' },
+          { ssid: 'Guest', auth: 'none' },
+        ],
+      },
+    ],
+  },
+};
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }))),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe('WifiStep — standalone mode', () => {
+  it('renders the informational notice and lets Next advance with no selection', () => {
+    vi.stubEnv('VITE_APP_MODE', 'standalone');
+    const onNext = vi.fn();
+    const { getByRole, getByText } = render(wrap(<WifiStep collected={{}} onNext={onNext} />));
+    expect(getByText(/Wi-Fi setup is only available/i)).toBeInTheDocument();
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onNext.mock.calls[0]?.[0]).toEqual({});
+  });
+});
+
+describe('WifiStep — populated mode', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_APP_MODE', 'ingress');
+  });
+
+  it('fetches the network list and renders one card per SSID', async () => {
+    const { findAllByRole } = render(wrap(<WifiStep collected={{}} onNext={() => undefined} />));
+    const cards = await findAllByRole('button', { name: /WIFI|HomeWifi|Guest/ });
+    // Two networks + the Next button match the role pattern; assert the
+    // two cards rendered with the network titles.
+    const cardLabels = cards.map((el) => el.textContent ?? '');
+    expect(cardLabels.some((l) => l.includes('HomeWifi'))).toBe(true);
+    expect(cardLabels.some((l) => l.includes('Guest'))).toBe(true);
+  });
+
+  it('blocks Next until a network is selected', async () => {
+    const onNext = vi.fn();
+    const { findByText, getByRole } = render(wrap(<WifiStep collected={{}} onNext={onNext} />));
+    await findByText('HomeWifi');
+    const next = getByRole('button', { name: 'Next' }) as HTMLButtonElement;
+    expect(next.disabled).toBe(true);
+  });
+
+  it('requires a password for secured networks and emits ssid + cipher on Next', async () => {
+    const onNext = vi.fn();
+    const { findByText, getByRole, container } = render(
+      wrap(<WifiStep collected={{}} onNext={onNext} />),
+    );
+    fireEvent.click(await findByText('HomeWifi'));
+    const passwordInput = container.querySelector('input[type="password"]');
+    expect(passwordInput).not.toBeNull();
+    if (passwordInput === null) return;
+    fireEvent.change(passwordInput, { target: { value: 'secret123' } });
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onNext.mock.calls[0]?.[0]).toEqual({
+      wifi: { ssid: 'HomeWifi', passwordCipher: 'secret123' },
+    });
+  });
+
+  it('skips the password field for unsecured networks and uses a placeholder cipher', async () => {
+    const onNext = vi.fn();
+    const { findByText, getByRole, container } = render(
+      wrap(<WifiStep collected={{}} onNext={onNext} />),
+    );
+    fireEvent.click(await findByText('Guest'));
+    // No password input renders for the unsecured pick.
+    expect(container.querySelector('input[type="password"]')).toBeNull();
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    expect(onNext.mock.calls[0]?.[0]).toEqual({
+      wifi: { ssid: 'Guest', passwordCipher: '(unsecured)' },
+    });
+  });
+});
+
+describe('WifiStep — error path', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_APP_MODE', 'ingress');
+  });
+
+  it('surfaces a danger Toast (role=status) when the scan fails and offers a retry', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('network down'))),
+    );
+    const { findByRole, findByText } = render(
+      wrap(<WifiStep collected={{}} onNext={() => undefined} />),
+    );
+    // Toast renders with role=status (per the API Error Toast Rule).
+    await waitFor(async () => {
+      expect(await findByRole('status')).toBeInTheDocument();
+    });
+    // Retry affordance — Toast also renders a "Try again" button, so
+    // `findByText` would over-match; pick the inline body copy that
+    // sits above the inline retry button.
+    expect(await findByText(/We couldn't reach the Home Assistant/i)).toBeInTheDocument();
+  });
+});
+
+describe('WifiStep — empty mode', () => {
+  it('shows the empty notice + retry when the Supervisor returns no APs', async () => {
+    vi.stubEnv('VITE_APP_MODE', 'ingress');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          mockFetchResponse({ json: { data: { interfaces: [{ accesspoints: [] }] } } }),
+        ),
+      ),
+    );
+    const { findByText } = render(wrap(<WifiStep collected={{}} onNext={() => undefined} />));
+    expect(await findByText(/No Wi-Fi networks found/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/setup/wifi/wifi-step.tsx
+++ b/apps/web/src/features/setup/wifi/wifi-step.tsx
@@ -1,0 +1,380 @@
+// Wi-Fi Configuration wizard step — third step in the device setup
+// wizard (epic #533, ADR 0028). Pixel-matched to Figma node
+// 14867:39794. Replaces the placeholder from #539.
+//
+// Browsers cannot enumerate Wi-Fi networks, so this step delegates to
+// the HA Supervisor `/api/hassio/network/info` endpoint. That endpoint
+// is only reachable when Glaon runs as the HA Add-on (Ingress / kiosk
+// modes); in `standalone` mode the step renders an informational
+// placeholder and `onNext` advances without storing anything.
+//
+// State design per #546:
+// - Loading → spinner while the fetch resolves.
+// - Empty → no access points returned.
+// - Error → Toast (`useToast({ intent: 'danger' })`) per the API Error
+//   Toast Rule (CLAUDE.md). The body still renders an inline retry
+//   affordance so the user has somewhere to go without dismissing the
+//   toast.
+// - Populated → list of radio cards (Figma 14867:39794).
+// - Selected + secured → a PasswordInput appears below the list.
+// - Standalone-mode → informational block instead of fetch + list.
+//
+// Selected SSID + password live in route-local `useState` only — the
+// step pushes `{ wifi: { ssid, passwordCipher: <plaintext for now> } }`
+// into `collected` via `onNext`, and the Final Review step (#548) is
+// the only place that calls `markComplete()` + writes the blob to
+// localStorage. v1 stores the plaintext password as the "cipher" so
+// the shape lines up; #548 wraps it before it reaches disk.
+
+import { PasswordInput, useToast } from '@glaon/ui';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type ReactNode,
+  type SubmitEvent,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { DeviceConfigInput } from '@glaon/core/config';
+
+interface WifiStepProps {
+  /** Partial DeviceConfig collected from earlier steps in this run. */
+  readonly collected: DeviceConfigInput;
+  /** Merge the form's output into `collected` and advance. */
+  readonly onNext: (partial: DeviceConfigInput) => void;
+}
+
+interface AccessPoint {
+  readonly ssid: string;
+  /**
+   * Authentication tag from the HA Supervisor payload (e.g. `wpa-psk`,
+   * `none`). Empty string is treated as "unsecured".
+   */
+  readonly auth: string;
+}
+
+type FetchState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'success'; readonly networks: readonly AccessPoint[] }
+  | { readonly kind: 'error' }
+  | { readonly kind: 'standalone' };
+
+const NETWORK_INFO_ENDPOINT = '/api/hassio/network/info';
+
+function isStandaloneMode(): boolean {
+  return import.meta.env.VITE_APP_MODE === 'standalone';
+}
+
+function isSecured(auth: string): boolean {
+  return auth !== '' && auth.toLowerCase() !== 'none';
+}
+
+/**
+ * Normalise the HA Supervisor `/api/hassio/network/info` response into a
+ * flat, deduplicated list of access points. The endpoint returns a
+ * wrapper `{ data: { interfaces: [{ accesspoints: [...] }] } }` with
+ * one entry per wireless interface; merge them.
+ */
+function parseAccessPoints(json: unknown): readonly AccessPoint[] {
+  const root = json as
+    | { data?: { interfaces?: readonly { accesspoints?: readonly unknown[] }[] } }
+    | undefined;
+  const interfaces = root?.data?.interfaces ?? [];
+  const seen = new Set<string>();
+  const out: AccessPoint[] = [];
+  for (const iface of interfaces) {
+    for (const raw of iface.accesspoints ?? []) {
+      const ap = raw as { ssid?: unknown; auth?: unknown };
+      const ssid = typeof ap.ssid === 'string' ? ap.ssid : '';
+      const auth = typeof ap.auth === 'string' ? ap.auth : '';
+      if (ssid === '' || seen.has(ssid)) continue;
+      seen.add(ssid);
+      out.push({ ssid, auth });
+    }
+  }
+  return out;
+}
+
+export function WifiStep({ collected, onNext }: WifiStepProps): ReactNode {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const passwordLabelId = useId();
+  const [fetchState, setFetchState] = useState<FetchState>(() =>
+    isStandaloneMode() ? { kind: 'standalone' } : { kind: 'loading' },
+  );
+  const [selectedSsid, setSelectedSsid] = useState<string>(collected.wifi?.ssid ?? '');
+  const [password, setPassword] = useState<string>('');
+
+  const loadNetworks = useCallback(async () => {
+    setFetchState({ kind: 'loading' });
+    try {
+      const response = await fetch(NETWORK_INFO_ENDPOINT, { credentials: 'include' });
+      if (!response.ok) throw new Error(`Supervisor responded ${String(response.status)}`);
+      const json: unknown = await response.json();
+      setFetchState({ kind: 'success', networks: parseAccessPoints(json) });
+    } catch {
+      setFetchState({ kind: 'error' });
+      toast.show({
+        intent: 'danger',
+        title: t('setup.wifi.scanFailed.title'),
+        description: t('setup.wifi.scanFailed.description'),
+      });
+    }
+  }, [t, toast]);
+
+  useEffect(() => {
+    if (isStandaloneMode()) return;
+    void loadNetworks();
+  }, [loadNetworks]);
+
+  const selectedNetwork = useMemo(
+    () =>
+      fetchState.kind === 'success'
+        ? (fetchState.networks.find((n) => n.ssid === selectedSsid) ?? null)
+        : null,
+    [fetchState, selectedSsid],
+  );
+
+  const passwordRequired = selectedNetwork !== null && isSecured(selectedNetwork.auth);
+  const nextDisabled =
+    fetchState.kind !== 'standalone' &&
+    (selectedNetwork === null || (passwordRequired && password.trim() === ''));
+
+  const onSubmit = (event: SubmitEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    if (fetchState.kind === 'standalone' || selectedNetwork === null) {
+      onNext({});
+      return;
+    }
+    // v1 stores the plaintext password as the "cipher" placeholder —
+    // #548 (Final Review commit) wraps it before the value ever leaves
+    // route-local memory. The schema's `passwordCipher: string` is opaque
+    // to @glaon/core; the wrapping concern belongs to the consumer.
+    const cipher = passwordRequired ? password : '(unsecured)';
+    onNext({
+      wifi: { ssid: selectedNetwork.ssid, passwordCipher: cipher },
+    });
+  };
+
+  return (
+    <div className="flex flex-col p-8 lg:p-12">
+      <header className="flex flex-col gap-1 pb-6">
+        <h1 className="text-display-xs font-semibold text-primary">{t('setup.wifi.title')}</h1>
+        <p className="text-sm text-tertiary">{t('setup.wifi.subtitle')}</p>
+      </header>
+
+      <form
+        onSubmit={onSubmit}
+        noValidate
+        className="flex flex-col gap-5 border-t border-secondary pt-6"
+      >
+        {fetchState.kind === 'standalone' && <StandaloneNotice />}
+        {fetchState.kind === 'loading' && <LoadingNotice />}
+        {fetchState.kind === 'error' && <ErrorRetry onRetry={() => void loadNetworks()} />}
+        {fetchState.kind === 'success' && fetchState.networks.length === 0 && (
+          <EmptyNotice onRetry={() => void loadNetworks()} />
+        )}
+        {fetchState.kind === 'success' && fetchState.networks.length > 0 && (
+          <ul className="flex flex-col gap-5" aria-label={t('setup.wifi.list.ariaLabel')}>
+            {fetchState.networks.map((network) => (
+              <li key={network.ssid}>
+                <WifiNetworkRow
+                  network={network}
+                  isSelected={network.ssid === selectedSsid}
+                  onSelect={() => {
+                    setSelectedSsid(network.ssid);
+                    setPassword('');
+                  }}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+        {passwordRequired && (
+          <div className="flex max-w-[480px] flex-col gap-1.5">
+            <label
+              id={passwordLabelId}
+              className="text-sm font-semibold text-secondary"
+              htmlFor={`${passwordLabelId}-input`}
+            >
+              {t('setup.wifi.password.label')}
+            </label>
+            <PasswordInput
+              id={`${passwordLabelId}-input`}
+              value={password}
+              onChange={setPassword}
+              placeholder={t('setup.wifi.password.placeholder')}
+              autoComplete="off"
+            />
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 border-t border-secondary py-6">
+          <button
+            type="submit"
+            disabled={nextDisabled}
+            className="inline-flex items-center gap-2 rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white shadow-xs-skeuomorphic hover:bg-brand-solid_hover disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <span>{t('setup.wifi.actions.next')}</span>
+            <NextArrowIcon />
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+interface WifiNetworkRowProps {
+  readonly network: AccessPoint;
+  readonly isSelected: boolean;
+  readonly onSelect: () => void;
+}
+
+function WifiNetworkRow({ network, isSelected, onSelect }: WifiNetworkRowProps): ReactNode {
+  const secured = isSecured(network.auth);
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={isSelected}
+      className={`flex w-full items-start gap-4 rounded-xl border border-secondary p-4 text-left transition-colors hover:bg-secondary ${
+        isSelected ? 'bg-[var(--glaon-light-grey)]' : 'bg-primary'
+      }`}
+    >
+      <span
+        aria-hidden="true"
+        className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset"
+      >
+        {secured ? <LockIcon /> : <LockUnlockedIcon />}
+      </span>
+      <span className="flex flex-1 flex-col">
+        <span className="text-sm font-medium leading-5 text-secondary">{network.ssid}</span>
+        <span className="text-sm font-normal leading-5 text-tertiary">
+          {secured ? network.auth.toUpperCase() : t('setup.wifi.unsecured')}
+        </span>
+      </span>
+      <span
+        aria-hidden="true"
+        className={`mt-1 inline-flex size-4 shrink-0 items-center justify-center rounded-full border ${
+          isSelected ? 'border-brand-solid bg-brand-solid' : 'border-secondary bg-primary'
+        }`}
+      >
+        {isSelected && <span className="block size-1.5 rounded-full bg-primary" />}
+      </span>
+    </button>
+  );
+}
+
+function StandaloneNotice(): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <div className="rounded-lg border border-secondary bg-secondary/50 p-4 text-sm text-tertiary">
+      {t('setup.wifi.standalone')}
+    </div>
+  );
+}
+
+function LoadingNotice(): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <div role="status" className="text-sm text-tertiary">
+      {t('setup.wifi.loading')}
+    </div>
+  );
+}
+
+interface RetryProps {
+  readonly onRetry: () => void;
+}
+
+function ErrorRetry({ onRetry }: RetryProps): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-secondary bg-primary p-4 text-sm text-tertiary">
+      <p>{t('setup.wifi.scanFailed.body')}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex w-fit items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-1.5 text-sm font-semibold text-secondary shadow-xs-skeuomorphic"
+      >
+        {t('setup.wifi.actions.retry')}
+      </button>
+    </div>
+  );
+}
+
+function EmptyNotice({ onRetry }: RetryProps): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-secondary bg-primary p-4 text-sm text-tertiary">
+      <p>{t('setup.wifi.empty')}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex w-fit items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-1.5 text-sm font-semibold text-secondary shadow-xs-skeuomorphic"
+      >
+        {t('setup.wifi.actions.retry')}
+      </button>
+    </div>
+  );
+}
+
+function LockIcon(): ReactNode {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="2.667" y="7.333" width="10.667" height="6.667" rx="1.333" />
+      <path d="M4.667 7.333V4.667a3.333 3.333 0 0 1 6.666 0v2.666" />
+    </svg>
+  );
+}
+
+function LockUnlockedIcon(): ReactNode {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="2.667" y="7.333" width="10.667" height="6.667" rx="1.333" />
+      <path d="M4.667 7.333V4.667a3.333 3.333 0 0 1 6.666 0" />
+    </svg>
+  );
+}
+
+function NextArrowIcon(): ReactNode {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4.167 10h11.666m0 0L10 4.167M15.833 10 10 15.833" />
+    </svg>
+  );
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -101,6 +101,30 @@
       "actions": {
         "next": "Next"
       }
+    },
+    "wifi": {
+      "title": "Wi-Fi Connection",
+      "subtitle": "Pick the network this device should join. The selection is sent to Home Assistant when you finish the wizard.",
+      "list": {
+        "ariaLabel": "Available Wi-Fi networks"
+      },
+      "unsecured": "Unsecured",
+      "password": {
+        "label": "Password",
+        "placeholder": "Network password"
+      },
+      "loading": "Looking for nearby Wi-Fi networks…",
+      "empty": "No Wi-Fi networks found nearby. Move closer to your router or try again.",
+      "standalone": "Wi-Fi setup is only available when Glaon runs as the Home Assistant add-on. Skipping this step.",
+      "scanFailed": {
+        "title": "Couldn't scan Wi-Fi networks",
+        "description": "Home Assistant didn't respond to the network scan. Check that the add-on is running and try again.",
+        "body": "We couldn't reach the Home Assistant network scanner. The add-on may be restarting."
+      },
+      "actions": {
+        "next": "Next",
+        "retry": "Try again"
+      }
     }
   }
 }

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -101,6 +101,30 @@
       "actions": {
         "next": "İleri"
       }
+    },
+    "wifi": {
+      "title": "Wi-Fi Bağlantısı",
+      "subtitle": "Cihazın bağlanacağı ağı seç. Seçim, wizard tamamlandığında Home Assistant'a gönderilir.",
+      "list": {
+        "ariaLabel": "Bulunan Wi-Fi ağları"
+      },
+      "unsecured": "Şifresiz",
+      "password": {
+        "label": "Şifre",
+        "placeholder": "Ağ şifresi"
+      },
+      "loading": "Yakındaki Wi-Fi ağları aranıyor…",
+      "empty": "Yakında Wi-Fi ağı bulunamadı. Router'a yaklaş ya da tekrar dene.",
+      "standalone": "Wi-Fi ayarı yalnız Glaon Home Assistant add-on olarak çalışırken kullanılabilir. Bu adım atlanıyor.",
+      "scanFailed": {
+        "title": "Wi-Fi taraması başarısız",
+        "description": "Home Assistant ağ taramasına cevap vermedi. Add-on çalışıyor mu kontrol et ve tekrar dene.",
+        "body": "Home Assistant ağ tarayıcısına ulaşamadık. Add-on yeniden başlatılıyor olabilir."
+      },
+      "actions": {
+        "next": "İleri",
+        "retry": "Tekrar dene"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Third wizard step lands: `apps/web/src/features/setup/wifi/wifi-step.tsx`. Pixel-matched to Figma node [`14867:39794`](https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=14867-39794).
- Browsers can't enumerate Wi-Fi networks, so the step delegates to the HA Supervisor `/api/hassio/network/info` endpoint when running as the HA add-on. State machine renders one of five branches:
  - **standalone** (`VITE_APP_MODE === 'standalone'`) → informational notice; Next advances without storing.
  - **loading** → spinner while the fetch resolves.
  - **empty** → inline notice + Try-again retry.
  - **error** → Toast via `useToast({ intent: 'danger' })` per the API Error Toast Rule + inline retry copy.
  - **populated** → list of Wi-Fi cards (lock-03 / lock-unlocked-03 icon, ssid + auth tag, Glaon Light Grey bg on the selected row). A `<PasswordInput>` row appears below the list when a secured network is selected; unsecured rows skip the prompt.
- Selection + password live in route-local `useState` only — the step emits `{ wifi: { ssid, passwordCipher } }` via `onNext`, and the Final Review step (#548) is the only place that writes the blob to localStorage. v1 stores the plaintext password as the "cipher" placeholder; the schema's `passwordCipher` is opaque to `@glaon/core`, so the wrapping concern lives with #548.

## Scope

### In

- `apps/web/src/features/setup/wifi/wifi-step.tsx` — component + state machine + Supervisor fetch + Figma-matching row rendering.
- `apps/web/src/features/setup/wifi/index.ts` — barrel.
- `apps/web/src/features/setup/wifi/wifi-step.test.tsx` — 7 cases: standalone advance, populated list render, Next disabled without selection, secured-network password submit, unsecured-network placeholder cipher, scan failure Toast (role=status) + inline retry copy, empty-list notice.
- `apps/web/src/features/setup/setup-route.tsx` — swaps `WifiPlaceholder` → `WifiStepAdapter`.
- `apps/web/src/features/setup/setup-route.test.tsx` — wraps with `<ToastProvider>` and stubs `fetch` / `VITE_APP_MODE` so the walk-through tests don't hit real network; rail-nav assertion uses the hardcoded SETUP_STEPS title.
- `apps/web/src/i18n/locales/{en,tr}.json` — `setup.wifi.*` keys (8-key namespace covering title, list/aria, password, loading/empty/standalone/scanFailed copy, actions).

### Out

- Real Wi-Fi commit to HA Supervisor (`POST /api/hassio/network/<interface>/update`) — that's #548 (Final Review). v1 just collects the selection in memory.
- Password wrapping cipher — schema field is opaque; #548 wraps before commit.
- Manual SSID entry (hidden / non-broadcast networks) — follow-up.

## Test plan

- [x] `pnpm --filter @glaon/web type-check` green
- [x] `pnpm --filter @glaon/web lint` green
- [x] `pnpm --filter @glaon/web test` green (128 tests pass; 7 new on `wifi-step.test.tsx`; setup-route tests still pass after ToastProvider + fetch stub)
- [x] `pnpm knip` clean (props interface stays unexported per the memory pattern)
- [x] `pnpm i18n:check` green (`setup.wifi.*` keys present in both en + tr)
- [x] `pnpm --filter @glaon/web size` green (Initial JS 347.95 kB; the wizard chunk grows but stays lazy via `SetupGate`)
- [x] No `* 2.tsx` backup files in the diff
- [x] CI required checks (type-check · lint · audit · unit-tests · playwright · package-contract · size-check · visual regression · chromatic · conventional-commits · gitleaks · i18n-check · lighthouse)

Closes #546
Refs #533, ADR 0028, #542
