### PR TITLE
feat(web): wizard step 4 device security

### DIFF
--- a/apps/web/src/features/setup/security/index.ts
+++ b/apps/web/src/features/setup/security/index.ts
@@ -1,0 +1,1 @@
+export { SecurityStep } from './security-step';

--- a/apps/web/src/features/setup/security/security-step.test.tsx
+++ b/apps/web/src/features/setup/security/security-step.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ToastProvider } from '@glaon/ui';
+
+import { SecurityStep } from './security-step';
+
+function wrap(node: React.ReactNode) {
+  return <ToastProvider>{node}</ToastProvider>;
+}
+
+describe('SecurityStep', () => {
+  it('renders the title and both password fields', () => {
+    const { container, getByText } = render(
+      wrap(<SecurityStep collected={{}} onNext={() => undefined} />),
+    );
+    expect(container.querySelector('h1')?.textContent).toBe('Device Security');
+    expect(getByText('Password')).toBeInTheDocument();
+    expect(getByText('Confirm password')).toBeInTheDocument();
+  });
+
+  it('blocks submission and shows required errors when both fields are empty', () => {
+    const onNext = vi.fn();
+    const { getByRole, getByText } = render(wrap(<SecurityStep collected={{}} onNext={onNext} />));
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    expect(onNext).not.toHaveBeenCalled();
+    // Required-field error renders as HintText via the PasswordInput
+    // `error` prop (RAC slot="errorMessage" — no role=alert).
+    expect(getByText(/Password is required/)).toBeInTheDocument();
+  });
+
+  it('rejects passwords shorter than 8 characters with a min-length error', () => {
+    const onNext = vi.fn();
+    const { container, getByRole, getByText } = render(
+      wrap(<SecurityStep collected={{}} onNext={onNext} />),
+    );
+    const inputs = container.querySelectorAll('input[type="password"]');
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+    fireEvent.change(inputs[0] as HTMLInputElement, { target: { value: 'short' } });
+    fireEvent.change(inputs[1] as HTMLInputElement, { target: { value: 'short' } });
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    expect(onNext).not.toHaveBeenCalled();
+    expect(getByText(/use at least/i)).toBeInTheDocument();
+  });
+
+  it('rejects mismatched passwords with a mismatch error', () => {
+    const onNext = vi.fn();
+    const { container, getByRole, getByText } = render(
+      wrap(<SecurityStep collected={{}} onNext={onNext} />),
+    );
+    const inputs = container.querySelectorAll('input[type="password"]');
+    fireEvent.change(inputs[0] as HTMLInputElement, { target: { value: 'longenough1' } });
+    fireEvent.change(inputs[1] as HTMLInputElement, { target: { value: 'differentpw1' } });
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    expect(onNext).not.toHaveBeenCalled();
+    expect(getByText(/Passwords don't match/i)).toBeInTheDocument();
+  });
+
+  it('hashes the password with SHA-256 and emits securityPinHash on Next', async () => {
+    const onNext = vi.fn();
+    const { container, getByRole } = render(wrap(<SecurityStep collected={{}} onNext={onNext} />));
+    const inputs = container.querySelectorAll('input[type="password"]');
+    fireEvent.change(inputs[0] as HTMLInputElement, { target: { value: 'correct horse battery' } });
+    fireEvent.change(inputs[1] as HTMLInputElement, { target: { value: 'correct horse battery' } });
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+    const partial = onNext.mock.calls[0]?.[0] as { securityPinHash?: string };
+    expect(partial.securityPinHash).toMatch(/^[0-9a-f]{64}$/);
+    // Same input → same hash. Compute the expected hash directly so
+    // the test catches any deviation from canonical SHA-256.
+    const expectedDigest = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode('correct horse battery'),
+    );
+    const expectedHex = Array.from(new Uint8Array(expectedDigest))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+    expect(partial.securityPinHash).toBe(expectedHex);
+  });
+});

--- a/apps/web/src/features/setup/security/security-step.tsx
+++ b/apps/web/src/features/setup/security/security-step.tsx
@@ -1,0 +1,172 @@
+// Device Security wizard step — fourth step in the device setup wizard
+// (epic #533, ADR 0028). Collects an admin password (with confirmation)
+// that protects access to the Glaon app on this device.
+//
+// User flow (per #547 product decision — Figma frame ships later):
+//
+// 1. Password field + Confirm field (both `PasswordInput`).
+// 2. Validation: both filled, min length 8, the two match.
+// 3. On Next: hash with SHA-256 via Web Crypto, write `securityPinHash`
+//    (schema field name from #535 — kept for backwards compat with the
+//    ConfigStore shape even though we collect a password, not a PIN).
+//
+// The plaintext password never leaves the route's bellek state. v1 has
+// no "skip" affordance — the wizard's gating semantics treat the
+// admin password as required for protected setup. Skip can be added in
+// a follow-up once we know whether kiosk deployments want it.
+
+import { Button, PasswordInput, useToast } from '@glaon/ui';
+import { useId, useMemo, useState, type ReactNode, type SubmitEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { DeviceConfigInput } from '@glaon/core/config';
+
+interface SecurityStepProps {
+  /** Partial DeviceConfig collected from earlier steps in this run. */
+  readonly collected: DeviceConfigInput;
+  /** Merge the form's output into `collected` and advance to the next step. */
+  readonly onNext: (partial: DeviceConfigInput) => void;
+}
+
+const MIN_PASSWORD_LENGTH = 8;
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+type PasswordValidation =
+  | { readonly kind: 'ok' }
+  | { readonly kind: 'too-short' }
+  | { readonly kind: 'mismatch' }
+  | { readonly kind: 'empty' };
+
+function validatePasswords(password: string, confirm: string): PasswordValidation {
+  if (password === '' || confirm === '') return { kind: 'empty' };
+  if (password.length < MIN_PASSWORD_LENGTH) return { kind: 'too-short' };
+  if (password !== confirm) return { kind: 'mismatch' };
+  return { kind: 'ok' };
+}
+
+export function SecurityStep({ collected: _collected, onNext }: SecurityStepProps): ReactNode {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const passwordId = useId();
+  const confirmId = useId();
+
+  const [password, setPassword] = useState<string>('');
+  const [confirm, setConfirm] = useState<string>('');
+  const [submitted, setSubmitted] = useState<boolean>(false);
+  const [isHashing, setIsHashing] = useState<boolean>(false);
+
+  const validation = useMemo(() => validatePasswords(password, confirm), [password, confirm]);
+  const showErrors = submitted && validation.kind !== 'ok';
+
+  const onSubmit = async (event: SubmitEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+    setSubmitted(true);
+    if (validation.kind !== 'ok') return;
+    setIsHashing(true);
+    try {
+      const hash = await sha256Hex(password);
+      onNext({ securityPinHash: hash });
+    } catch {
+      // Web Crypto failure is extremely rare (older browsers without
+      // `crypto.subtle`). Surface via Toast per the API Error Toast
+      // Rule so the user has somewhere to read the failure.
+      toast.show({
+        intent: 'danger',
+        title: t('setup.security.hashFailed.title'),
+        description: t('setup.security.hashFailed.description'),
+      });
+    } finally {
+      setIsHashing(false);
+    }
+  };
+
+  const passwordErrorMessage =
+    showErrors && (validation.kind === 'empty' || validation.kind === 'too-short')
+      ? validation.kind === 'empty'
+        ? t('setup.security.password.required')
+        : t('setup.security.password.tooShort', { min: MIN_PASSWORD_LENGTH })
+      : undefined;
+  const confirmErrorMessage =
+    showErrors && validation.kind === 'mismatch'
+      ? t('setup.security.confirm.mismatch')
+      : showErrors && validation.kind === 'empty' && confirm === ''
+        ? t('setup.security.confirm.confirmRequired')
+        : undefined;
+
+  return (
+    <div className="flex flex-col p-8 lg:p-12">
+      <header className="flex flex-col gap-1 pb-6">
+        <h1 className="text-display-xs font-semibold text-primary">{t('setup.security.title')}</h1>
+        <p className="text-sm text-tertiary">{t('setup.security.subtitle')}</p>
+      </header>
+
+      <form
+        onSubmit={(event) => {
+          void onSubmit(event);
+        }}
+        noValidate
+        className="flex flex-col"
+      >
+        <FormRow label={t('setup.security.password.label')} htmlFor={passwordId} required>
+          <PasswordInput
+            id={passwordId}
+            value={password}
+            onChange={setPassword}
+            placeholder={t('setup.security.password.placeholder')}
+            isRequired
+            autoComplete="new-password"
+            {...(passwordErrorMessage !== undefined ? { error: passwordErrorMessage } : {})}
+          />
+        </FormRow>
+
+        <FormRow label={t('setup.security.confirm.label')} htmlFor={confirmId} required>
+          <PasswordInput
+            id={confirmId}
+            value={confirm}
+            onChange={setConfirm}
+            placeholder={t('setup.security.confirm.placeholder')}
+            isRequired
+            autoComplete="new-password"
+            {...(confirmErrorMessage !== undefined ? { error: confirmErrorMessage } : {})}
+          />
+        </FormRow>
+
+        <div className="flex justify-end gap-3 border-t border-secondary py-6">
+          <Button type="submit" size="md" isLoading={isHashing}>
+            {t('setup.security.actions.next')}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+interface FormRowProps {
+  readonly label: string;
+  readonly htmlFor: string;
+  readonly required?: boolean;
+  readonly children: ReactNode;
+}
+
+function FormRow({ label, htmlFor, required = false, children }: FormRowProps): ReactNode {
+  return (
+    <div className="grid grid-cols-1 gap-2 border-t border-secondary py-5 sm:grid-cols-[240px_1fr] sm:items-start sm:gap-8">
+      <label htmlFor={htmlFor} className="pt-2 text-sm font-semibold text-secondary">
+        {label}
+        {required && (
+          <span aria-hidden="true" className="text-error-primary">
+            {' *'}
+          </span>
+        )}
+      </label>
+      <div className="max-w-[480px]">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/features/setup/setup-route.test.tsx
+++ b/apps/web/src/features/setup/setup-route.test.tsx
@@ -54,12 +54,15 @@ describe('SetupRoute', () => {
     expect(container.querySelector('h1')?.textContent).toBe('Wi-Fi Connection');
   });
 
-  it('walks through every placeholder step up to Final Review', () => {
+  it('walks from Layout placeholder through Wi-Fi standalone to Device Security', () => {
+    // Wi-Fi is in standalone mode (per the beforeEach stub) so Next
+    // advances without selection; Device Security requires real password
+    // input — covered in security-step.test.tsx. Walking past it to
+    // Review is a separate path tested via initialStepId='review'.
     const { container, getByRole } = renderRoute('layout');
-    fireEvent.click(getByRole('button', { name: 'Next' })); // Wi-Fi
-    fireEvent.click(getByRole('button', { name: 'Next' })); // Device Security
-    fireEvent.click(getByRole('button', { name: 'Next' })); // Final Review
-    expect(container.querySelector('h1')?.textContent).toBe('Final Review');
+    fireEvent.click(getByRole('button', { name: 'Next' })); // Layout → Wi-Fi
+    fireEvent.click(getByRole('button', { name: 'Next' })); // Wi-Fi standalone → Security
+    expect(container.querySelector('h1')?.textContent).toBe('Device Security');
   });
 
   it('respects initialStepId and lands on Wi-Fi when asked', () => {

--- a/apps/web/src/features/setup/setup-route.tsx
+++ b/apps/web/src/features/setup/setup-route.tsx
@@ -27,6 +27,7 @@ import { SetupLayout, type SetupLayoutStep } from '@glaon/ui';
 
 import { HomeOverviewStep } from './home-overview';
 import { LayoutStep } from './layout';
+import { SecurityStep } from './security';
 import { WifiStep } from './wifi';
 
 export type WizardStepId = 'home-overview' | 'layout' | 'wifi' | 'security' | 'review';
@@ -115,8 +116,8 @@ interface PlaceholderProps {
   readonly isLastStep: boolean;
 }
 
-// Real step components for #540 + #545 + #546; the rest still render
-// the inline placeholder until their issues land.
+// Real step components for #540 + #545 + #546 + #547; the review step
+// keeps the placeholder until #548 lands the commit ceremony.
 const HomeOverviewStepAdapter = (props: WizardStepProps): ReactNode => (
   <HomeOverviewStep collected={props.collected} onNext={props.onNext} />
 );
@@ -126,8 +127,8 @@ const LayoutStepAdapter = (props: WizardStepProps): ReactNode => (
 const WifiStepAdapter = (props: WizardStepProps): ReactNode => (
   <WifiStep collected={props.collected} onNext={props.onNext} />
 );
-const SecurityPlaceholder = (props: WizardStepProps): ReactNode => (
-  <PlaceholderStep title="Device Security" onNext={props.onNext} isLastStep={props.isLastStep} />
+const SecurityStepAdapter = (props: WizardStepProps): ReactNode => (
+  <SecurityStep collected={props.collected} onNext={props.onNext} />
 );
 const ReviewPlaceholder = (props: WizardStepProps): ReactNode => (
   <PlaceholderStep title="Final Review" onNext={props.onNext} isLastStep={props.isLastStep} />
@@ -160,7 +161,7 @@ const SETUP_STEPS: readonly WizardStepRegistration[] = [
     title: 'Device Security',
     description: 'Create a password to protect your smart devices.',
     icon: <StepIcon id="security" />,
-    Component: SecurityPlaceholder,
+    Component: SecurityStepAdapter,
   },
   {
     id: 'review',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -125,6 +125,29 @@
         "next": "Next",
         "retry": "Try again"
       }
+    },
+    "security": {
+      "title": "Device Security",
+      "subtitle": "Set the admin password for this device. Anyone who needs to change the setup will need it.",
+      "password": {
+        "label": "Password",
+        "placeholder": "At least 8 characters",
+        "required": "Password is required.",
+        "tooShort": "Use at least {min} characters."
+      },
+      "confirm": {
+        "label": "Confirm password",
+        "placeholder": "Type the password again",
+        "confirmRequired": "Confirm the password.",
+        "mismatch": "Passwords don't match."
+      },
+      "hashFailed": {
+        "title": "Couldn't hash the password",
+        "description": "Your browser blocked the Web Crypto API. Try a different browser or contact your administrator."
+      },
+      "actions": {
+        "next": "Next"
+      }
     }
   }
 }

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -125,6 +125,29 @@
         "next": "İleri",
         "retry": "Tekrar dene"
       }
+    },
+    "security": {
+      "title": "Cihaz Güvenliği",
+      "subtitle": "Bu cihaz için yönetici şifresi belirle. Kurulumu değiştirecek herkes bu şifreye ihtiyaç duyacak.",
+      "password": {
+        "label": "Şifre",
+        "placeholder": "En az 8 karakter",
+        "required": "Şifre zorunludur.",
+        "tooShort": "En az {min} karakter kullan."
+      },
+      "confirm": {
+        "label": "Şifreyi tekrar gir",
+        "placeholder": "Aynı şifreyi tekrar yaz",
+        "confirmRequired": "Şifreyi tekrar gir.",
+        "mismatch": "Şifreler eşleşmiyor."
+      },
+      "hashFailed": {
+        "title": "Şifre hash'lenemedi",
+        "description": "Tarayıcın Web Crypto API'sini engelliyor. Başka bir tarayıcı dene ya da yöneticine başvur."
+      },
+      "actions": {
+        "next": "İleri"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fourth wizard step lands: `apps/web/src/features/setup/security/security-step.tsx`. Collects an admin password (with confirmation) that protects access to the Glaon app on this device.
- Figma frame for [#543](https://github.com/toss-cengiz/glaon/issues/543) is a follow-up; the UX shape (password + confirm field, no PIN) was agreed with the user before implementation.
- Plaintext password lives only in route-local `useState` — the hash flows into `onNext`, and the Final Review step (#548) is the only place that persists the blob to localStorage.

## Scope

### In

- `apps/web/src/features/setup/security/security-step.tsx` — form (two `PasswordInput` fields), validation (required, min length 8, mismatch), SHA-256 hash via Web Crypto, hash-failure Toast fallback.
- `apps/web/src/features/setup/security/security-step.test.tsx` — 5 cases: default render, empty-submit required errors, min-length rejection, mismatch rejection, SHA-256 round-trip against the canonical digest.
- `apps/web/src/features/setup/security/index.ts` — barrel.
- `apps/web/src/features/setup/setup-route.tsx` — swaps `SecurityPlaceholder` → `SecurityStepAdapter`.
- `apps/web/src/features/setup/setup-route.test.tsx` — walk-through test now stops at Device Security (beyond it requires real password entry).
- `apps/web/src/i18n/locales/{en,tr}.json` — `setup.security.*` keys (8-key namespace covering title, subtitle, password / confirm copy, validation errors, hashFailed Toast copy, actions).

### Out

- Skip / "Set up later" affordance — issue body floated this; user decision was to make password required for v1, defer the skip option to a follow-up.
- Schema rename (`securityPinHash` → `securityPasswordHash`) — kept the original field name for ConfigStore continuity from #535; a rename forces a v2 schema with no user-visible benefit.
- Push the hash to HA Supervisor — local-only by design (matches the ADR 0028 note "PIN/password is for local app gating, never leaves the device").

## Test plan

- [x] `pnpm --filter @glaon/web type-check` green
- [x] `pnpm --filter @glaon/web lint` green
- [x] `pnpm --filter @glaon/web test` green (133 tests pass; 5 new on `security-step.test.tsx`; setup-route walk-through updated to stop at Security)
- [x] `pnpm knip` clean (props interface stays unexported per the memory pattern)
- [x] `pnpm i18n:check` green (`setup.security.*` keys present in both en + tr)
- [x] `pnpm --filter @glaon/web size` green (Initial JS 348.83 kB / 360 kB; the wizard chunk grows but stays lazy via `SetupGate`)
- [x] No `* 2.tsx` backup files in the diff
- [x] CI required checks (type-check · lint · audit · unit-tests · playwright · package-contract · size-check · visual regression · chromatic · conventional-commits · gitleaks · i18n-check · lighthouse)

Closes #547
Refs #533, ADR 0028, #543
