### PR TITLE
feat(web): wizard step 5 final review + commit ceremony

### DIFF
--- a/apps/web/src/features/setup/review/index.ts
+++ b/apps/web/src/features/setup/review/index.ts
@@ -1,0 +1,1 @@
+export { ReviewStep } from './review-step';

--- a/apps/web/src/features/setup/review/review-step.test.tsx
+++ b/apps/web/src/features/setup/review/review-step.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InMemoryConfigStore } from '@glaon/core/config';
+import { ToastProvider } from '@glaon/ui';
+
+import { ConfigProvider } from '../../../config/config-provider';
+import { ReviewStep } from './review-step';
+
+function wrap(node: React.ReactNode, configStore = new InMemoryConfigStore()) {
+  return (
+    <ConfigProvider configStore={configStore}>
+      <ToastProvider>{node}</ToastProvider>
+    </ConfigProvider>
+  );
+}
+
+const baseCollected = {
+  homeName: 'Olivia',
+  country: 'TR',
+  unitSystem: 'metric' as const,
+};
+
+const reloadSpy = vi.fn();
+
+beforeEach(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { reload: reloadSpy },
+  });
+  reloadSpy.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ReviewStep — summary', () => {
+  it('renders a row per collected field', () => {
+    const { container, getByText } = render(wrap(<ReviewStep collected={baseCollected} />));
+    expect(container.querySelector('h1')?.textContent).toBe('Final Review');
+    expect(getByText('Olivia')).toBeInTheDocument();
+    expect(getByText('TR')).toBeInTheDocument();
+    expect(getByText('Metric')).toBeInTheDocument();
+  });
+
+  it('shows the Wi-Fi line as secured / open and hides the password', () => {
+    const { container, queryByText } = render(
+      wrap(
+        <ReviewStep
+          collected={{
+            ...baseCollected,
+            wifi: { ssid: 'Home', passwordCipher: 'plaintext-secret' },
+          }}
+        />,
+      ),
+    );
+    // ICU rendering returns "Home (secured)" via the `{ssid}` slot;
+    // assert against the summary list's text content directly so a
+    // split across nodes doesn't trip getByText.
+    expect(container.textContent ?? '').toMatch(/Home/);
+    expect(container.textContent ?? '').toMatch(/secured/);
+    // The plaintext value never appears in the summary.
+    expect(queryByText(/plaintext-secret/)).toBeNull();
+  });
+
+  it('marks empty fields with the not-set glyph', () => {
+    const { getAllByText } = render(wrap(<ReviewStep collected={{}} />));
+    // Every row renders the "—" placeholder when its value is missing.
+    expect(getAllByText('—').length).toBeGreaterThan(0);
+  });
+});
+
+describe('ReviewStep — commit ceremony', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: true } as Response)),
+    );
+  });
+
+  it('commits without a dialog when no Wi-Fi was collected', async () => {
+    const configStore = new InMemoryConfigStore();
+    const { getByRole } = render(wrap(<ReviewStep collected={baseCollected} />, configStore));
+    fireEvent.click(getByRole('button', { name: 'Complete setup' }));
+    await waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(await configStore.isConfigured()).toBe(true);
+    const persisted = await configStore.get();
+    expect(persisted?.homeName).toBe('Olivia');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('commits straight away for an unsecured Wi-Fi network and pushes the open auth payload', async () => {
+    const configStore = new InMemoryConfigStore();
+    const collected = {
+      ...baseCollected,
+      wifi: { ssid: 'Guest', passwordCipher: '(unsecured)' },
+    };
+    const { getByRole } = render(wrap(<ReviewStep collected={collected} />, configStore));
+    fireEvent.click(getByRole('button', { name: 'Complete setup' }));
+    await waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+    const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(calls.length).toBe(1);
+    const body = JSON.parse((calls[0]?.[1] as { body: string }).body) as { wifi: { auth: string } };
+    expect(body.wifi.auth).toBe('open');
+  });
+
+  it('opens a password dialog for a secured Wi-Fi network and commits after Connect', async () => {
+    const configStore = new InMemoryConfigStore();
+    const collected = {
+      ...baseCollected,
+      wifi: { ssid: 'Home', passwordCipher: 'old-cipher' },
+    };
+    const { getByRole } = render(wrap(<ReviewStep collected={collected} />, configStore));
+    fireEvent.click(getByRole('button', { name: 'Complete setup' }));
+    // RAC Modal renders into a portal — query the document body to
+    // reach it, not the test container.
+    const connect = await waitFor(() => getByRole('button', { name: 'Connect' }));
+    expect((connect as HTMLButtonElement).disabled).toBe(true);
+    const passwordInput = document.body.querySelector('input[type="password"]');
+    expect(passwordInput).not.toBeNull();
+    fireEvent.change(passwordInput as HTMLInputElement, { target: { value: 'fresh-secret' } });
+    fireEvent.click(getByRole('button', { name: 'Connect' }));
+    await waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+    const persisted = await configStore.get();
+    // The dialog's value overwrites whatever cipher was carried in.
+    expect(persisted?.wifi?.passwordCipher).toBe('fresh-secret');
+    // Supervisor body carries the wpa-psk auth + the fresh password.
+    const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    const body = JSON.parse((calls[0]?.[1] as { body: string }).body) as {
+      wifi: { auth: string; psk: string };
+    };
+    expect(body.wifi.auth).toBe('wpa-psk');
+    expect(body.wifi.psk).toBe('fresh-secret');
+  });
+
+  it('surfaces a Toast and stays on review when the Supervisor push fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: false, status: 500 } as Response)),
+    );
+    const configStore = new InMemoryConfigStore();
+    const collected = {
+      ...baseCollected,
+      wifi: { ssid: 'Guest', passwordCipher: '(unsecured)' },
+    };
+    const { getByRole, findByRole } = render(
+      wrap(<ReviewStep collected={collected} />, configStore),
+    );
+    fireEvent.click(getByRole('button', { name: 'Complete setup' }));
+    expect(await findByRole('status')).toBeInTheDocument();
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(await configStore.isConfigured()).toBe(false);
+  });
+});

--- a/apps/web/src/features/setup/review/review-step.tsx
+++ b/apps/web/src/features/setup/review/review-step.tsx
@@ -1,0 +1,237 @@
+// Final Review wizard step — fifth and last step in the device setup
+// wizard (epic #533, ADR 0028). Shows the user a summary of what they
+// entered, then commits the blob and reloads.
+//
+// User flow (per #548 product decision — Figma frame ships later):
+//
+// 1. Render a read-only summary of every field the wizard collected.
+//    Wi-Fi shows the SSID + auth tag but NOT the password — that
+//    field is asked again in a modal at submit time so the user
+//    always confirms the credential explicitly.
+// 2. On "Complete setup":
+//    a. If a secured Wi-Fi network was picked, open a modal asking
+//       for the password. Connect / Cancel.
+//    b. Otherwise commit straight away (open network or no Wi-Fi).
+// 3. Commit ceremony:
+//    a. If Wi-Fi: POST the selection + password to the HA Supervisor
+//       network update endpoint. Toast danger on failure — stay on
+//       review so the user can retry.
+//    b. configStore.setPartial(<final blob>) + markComplete().
+//    c. window.location.reload() — the gate sees the completed blob
+//       on the next mount and drops the user on /login.
+//
+// Per the API Error Toast Rule (CLAUDE.md), commit failures surface
+// through useToast; inline error blocks would mask the cross-step
+// nature of the failure.
+
+import { Button, Modal, PasswordInput, useToast } from '@glaon/ui';
+import { useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { DeviceConfigInput } from '@glaon/core/config';
+
+import { useDeviceConfig } from '../../../config/config-provider';
+
+interface ReviewStepProps {
+  /** Final accumulated partial from prior steps. */
+  readonly collected: DeviceConfigInput;
+  /** Hint from the wizard route that this is the last step (unused in v1 — the step owns its CTA copy). */
+  readonly onNext?: (partial: DeviceConfigInput) => void;
+}
+
+const SUPERVISOR_NETWORK_INTERFACE = 'wlan0';
+const SUPERVISOR_NETWORK_UPDATE = `/api/hassio/network/${SUPERVISOR_NETWORK_INTERFACE}/update`;
+
+function isSecuredCipher(cipher: string | undefined): boolean {
+  return cipher !== undefined && cipher !== '' && cipher !== '(unsecured)';
+}
+
+interface PushWifiArgs {
+  readonly ssid: string;
+  readonly password: string;
+  readonly secured: boolean;
+}
+
+async function pushWifiToSupervisor({ ssid, password, secured }: PushWifiArgs): Promise<void> {
+  const body = secured
+    ? { wifi: { mode: 'infrastructure', auth: 'wpa-psk', ssid, psk: password } }
+    : { wifi: { mode: 'infrastructure', auth: 'open', ssid } };
+  const response = await fetch(SUPERVISOR_NETWORK_UPDATE, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`Supervisor responded ${String(response.status)}`);
+  }
+}
+
+export function ReviewStep({ collected }: ReviewStepProps): ReactNode {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const { setPartial, markComplete } = useDeviceConfig();
+
+  const wifi = collected.wifi;
+  const isWifiSecured = wifi !== undefined && isSecuredCipher(wifi.passwordCipher);
+
+  const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState<boolean>(false);
+  const [dialogPassword, setDialogPassword] = useState<string>('');
+  const [isCommitting, setIsCommitting] = useState<boolean>(false);
+
+  const onCompleteClick = (): void => {
+    if (isWifiSecured) {
+      setDialogPassword('');
+      setIsPasswordDialogOpen(true);
+      return;
+    }
+    void runCommit();
+  };
+
+  const onDialogConfirm = (): void => {
+    if (dialogPassword.trim() === '') return;
+    setIsPasswordDialogOpen(false);
+    void runCommit(dialogPassword);
+  };
+
+  async function runCommit(secureWifiPassword?: string): Promise<void> {
+    setIsCommitting(true);
+    try {
+      if (wifi !== undefined) {
+        const secured = isSecuredCipher(wifi.passwordCipher);
+        const password = secured ? (secureWifiPassword ?? '') : '';
+        if (secured && password === '') {
+          // Shouldn't reach here — the dialog gates this — but guard
+          // so a future caller can't bypass.
+          throw new Error('missing wifi password');
+        }
+        await pushWifiToSupervisor({ ssid: wifi.ssid, password, secured });
+        // Update the collected wifi block with the cipher the user
+        // confirmed in the dialog (overwrites whatever #546 stored).
+        const persistedWifi = {
+          ssid: wifi.ssid,
+          passwordCipher: secured ? password : '(unsecured)',
+        };
+        await setPartial({ ...collected, wifi: persistedWifi });
+      } else {
+        await setPartial(collected);
+      }
+      await markComplete();
+      window.location.reload();
+    } catch {
+      toast.show({
+        intent: 'danger',
+        title: t('setup.review.commitFailed.title'),
+        description: t('setup.review.commitFailed.description'),
+      });
+    } finally {
+      setIsCommitting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col p-8 lg:p-12">
+      <header className="flex flex-col gap-1 pb-6">
+        <h1 className="text-display-xs font-semibold text-primary">{t('setup.review.title')}</h1>
+        <p className="text-sm text-tertiary">{t('setup.review.subtitle')}</p>
+      </header>
+
+      <dl className="flex flex-col">
+        <SummaryRow label={t('setup.homeOverview.homeName.label')} value={collected.homeName} />
+        <SummaryRow label={t('setup.homeOverview.location.label')} value={collected.location} />
+        <SummaryRow label={t('setup.homeOverview.country.label')} value={collected.country} />
+        <SummaryRow label={t('setup.homeOverview.timezone.label')} value={collected.timezone} />
+        <SummaryRow label={t('setup.homeOverview.language.label')} value={collected.locale} />
+        <SummaryRow
+          label={t('setup.homeOverview.unitSystem.label')}
+          value={
+            collected.unitSystem !== undefined
+              ? t(`setup.homeOverview.unitSystem.${collected.unitSystem}.label`)
+              : undefined
+          }
+        />
+        <SummaryRow label={t('setup.layoutSetup.layout.label')} value={collected.layout} />
+        <SummaryRow
+          label={t('setup.review.summary.wifi')}
+          value={
+            wifi !== undefined
+              ? isSecuredCipher(wifi.passwordCipher)
+                ? t('setup.review.summary.wifiSecured', { ssid: wifi.ssid })
+                : t('setup.review.summary.wifiUnsecured', { ssid: wifi.ssid })
+              : undefined
+          }
+        />
+        <SummaryRow
+          label={t('setup.review.summary.adminPassword')}
+          value={
+            collected.securityPinHash !== undefined
+              ? t('setup.review.summary.passwordSet')
+              : undefined
+          }
+        />
+      </dl>
+
+      <div className="flex justify-end gap-3 border-t border-secondary py-6">
+        <Button size="md" color="primary" onClick={onCompleteClick} isLoading={isCommitting}>
+          {t('setup.review.actions.complete')}
+        </Button>
+      </div>
+
+      <Modal isOpen={isPasswordDialogOpen} onOpenChange={setIsPasswordDialogOpen}>
+        <Modal.Content size="md">
+          <Modal.Header>
+            <Modal.Title>
+              {t('setup.review.passwordDialog.title', { ssid: wifi?.ssid ?? '' })}
+            </Modal.Title>
+            <Modal.Description>{t('setup.review.passwordDialog.description')}</Modal.Description>
+          </Modal.Header>
+          <Modal.Body>
+            <PasswordInput
+              value={dialogPassword}
+              onChange={setDialogPassword}
+              placeholder={t('setup.review.passwordDialog.placeholder')}
+              autoComplete="off"
+              isRequired
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              size="md"
+              color="secondary"
+              onClick={() => {
+                setIsPasswordDialogOpen(false);
+              }}
+            >
+              {t('setup.review.passwordDialog.cancel')}
+            </Button>
+            <Button
+              size="md"
+              color="primary"
+              onClick={onDialogConfirm}
+              isDisabled={dialogPassword.trim() === ''}
+            >
+              {t('setup.review.passwordDialog.connect')}
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+    </div>
+  );
+}
+
+interface SummaryRowProps {
+  readonly label: string;
+  readonly value: string | undefined;
+}
+
+function SummaryRow({ label, value }: SummaryRowProps): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <div className="grid grid-cols-1 gap-2 border-t border-secondary py-4 sm:grid-cols-[240px_1fr] sm:items-baseline sm:gap-8">
+      <dt className="text-sm font-semibold text-secondary">{label}</dt>
+      <dd className="text-sm text-tertiary">
+        {value !== undefined && value !== '' ? value : t('setup.review.summary.notSet')}
+      </dd>
+    </div>
+  );
+}

--- a/apps/web/src/features/setup/setup-route.test.tsx
+++ b/apps/web/src/features/setup/setup-route.test.tsx
@@ -70,10 +70,11 @@ describe('SetupRoute', () => {
     expect(container.querySelector('h1')?.textContent).toBe('Wi-Fi Connection');
   });
 
-  it('disables Next on the last step (commit ceremony lands in #548)', () => {
+  it('renders the Final Review step with the Complete setup CTA', () => {
     const { getByRole } = renderRoute('review');
-    const cta = getByRole('button', { name: 'Complete setup (TBD)' });
-    expect((cta as HTMLButtonElement).disabled).toBe(true);
+    // #548 wires the real commit ceremony; the CTA is enabled by
+    // default (the dialog gates the actual submit for secured Wi-Fi).
+    expect(getByRole('button', { name: 'Complete setup' })).toBeInTheDocument();
   });
 
   it('marks the active step with aria-current=step in the rail', () => {

--- a/apps/web/src/features/setup/setup-route.tsx
+++ b/apps/web/src/features/setup/setup-route.tsx
@@ -27,6 +27,7 @@ import { SetupLayout, type SetupLayoutStep } from '@glaon/ui';
 
 import { HomeOverviewStep } from './home-overview';
 import { LayoutStep } from './layout';
+import { ReviewStep } from './review';
 import { SecurityStep } from './security';
 import { WifiStep } from './wifi';
 
@@ -83,41 +84,9 @@ function StepIcon({ id }: { id: WizardStepId }): ReactNode {
   );
 }
 
-// Placeholder step bodies. #540 and #545–#548 replace each entry with
-// its real implementation (Figma-pixel-matched form + i18n + validation).
-function PlaceholderStep({ title, onNext, isLastStep }: PlaceholderProps): ReactNode {
-  return (
-    <div className="flex flex-col gap-6 p-8 lg:p-12">
-      <header className="flex flex-col gap-3">
-        <h1 className="text-display-xs font-semibold text-primary">{title}</h1>
-        <p className="text-md text-tertiary">
-          Step UI ships in its own issue; this placeholder unblocks the gate + routing wiring.
-        </p>
-      </header>
-      <div className="flex justify-end">
-        <button
-          type="button"
-          onClick={() => {
-            onNext({});
-          }}
-          disabled={isLastStep}
-          className="rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
-        >
-          {isLastStep ? 'Complete setup (TBD)' : 'Next'}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-interface PlaceholderProps {
-  readonly title: string;
-  readonly onNext: (partial: DeviceConfigInput) => void;
-  readonly isLastStep: boolean;
-}
-
-// Real step components for #540 + #545 + #546 + #547; the review step
-// keeps the placeholder until #548 lands the commit ceremony.
+// All 5 wizard steps now ship their real implementations (#540, #545,
+// #546, #547, #548). Adapters bridge the shared `WizardStepProps`
+// contract to each step's own (smaller) props surface.
 const HomeOverviewStepAdapter = (props: WizardStepProps): ReactNode => (
   <HomeOverviewStep collected={props.collected} onNext={props.onNext} />
 );
@@ -130,8 +99,8 @@ const WifiStepAdapter = (props: WizardStepProps): ReactNode => (
 const SecurityStepAdapter = (props: WizardStepProps): ReactNode => (
   <SecurityStep collected={props.collected} onNext={props.onNext} />
 );
-const ReviewPlaceholder = (props: WizardStepProps): ReactNode => (
-  <PlaceholderStep title="Final Review" onNext={props.onNext} isLastStep={props.isLastStep} />
+const ReviewStepAdapter = (props: WizardStepProps): ReactNode => (
+  <ReviewStep collected={props.collected} onNext={props.onNext} />
 );
 
 const SETUP_STEPS: readonly WizardStepRegistration[] = [
@@ -168,7 +137,7 @@ const SETUP_STEPS: readonly WizardStepRegistration[] = [
     title: 'Final Review',
     description: 'Check your settings and complete the setup.',
     icon: <StepIcon id="review" />,
-    Component: ReviewPlaceholder,
+    Component: ReviewStepAdapter,
   },
 ];
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -148,6 +148,32 @@
       "actions": {
         "next": "Next"
       }
+    },
+    "review": {
+      "title": "Final Review",
+      "subtitle": "Double-check what Glaon will save. We'll reload once setup is complete.",
+      "summary": {
+        "wifi": "Wi-Fi",
+        "wifiSecured": "{ssid} (secured)",
+        "wifiUnsecured": "{ssid} (open)",
+        "adminPassword": "Admin password",
+        "passwordSet": "Set",
+        "notSet": "—"
+      },
+      "passwordDialog": {
+        "title": "Connect to {ssid}",
+        "description": "Enter the Wi-Fi password so Glaon can save the connection to Home Assistant.",
+        "placeholder": "Wi-Fi password",
+        "cancel": "Cancel",
+        "connect": "Connect"
+      },
+      "commitFailed": {
+        "title": "Couldn't complete setup",
+        "description": "Home Assistant didn't accept the configuration. Check the connection and try again."
+      },
+      "actions": {
+        "complete": "Complete setup"
+      }
     }
   }
 }

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -148,6 +148,32 @@
       "actions": {
         "next": "İleri"
       }
+    },
+    "review": {
+      "title": "Son Kontrol",
+      "subtitle": "Glaon'un kaydedeceği bilgileri kontrol et. Kurulum tamamlandığında sayfa yeniden yüklenir.",
+      "summary": {
+        "wifi": "Wi-Fi",
+        "wifiSecured": "{ssid} (şifreli)",
+        "wifiUnsecured": "{ssid} (açık)",
+        "adminPassword": "Yönetici şifresi",
+        "passwordSet": "Ayarlandı",
+        "notSet": "—"
+      },
+      "passwordDialog": {
+        "title": "{ssid} ağına bağlan",
+        "description": "Glaon bağlantıyı Home Assistant'a kaydedebilsin diye Wi-Fi şifresini gir.",
+        "placeholder": "Wi-Fi şifresi",
+        "cancel": "İptal",
+        "connect": "Bağlan"
+      },
+      "commitFailed": {
+        "title": "Kurulum tamamlanamadı",
+        "description": "Home Assistant ayarları kabul etmedi. Bağlantıyı kontrol edip tekrar dene."
+      },
+      "actions": {
+        "complete": "Kurulumu tamamla"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fifth (last) wizard step lands: `apps/web/src/features/setup/review/review-step.tsx`. Closes the loop on epic #533 — collected data summary, Wi-Fi password dialog at commit time, HA Supervisor push, ConfigStore commit, reload.
- All 5 wizard step adapters in `setup-route.tsx` now wrap real components; the `PlaceholderStep` body is gone.

## Flow

1. Summary list with every collected field (homeName, location, country, timezone, locale, unit system, layout, Wi-Fi SSID + auth tag, admin password set/not). **The Wi-Fi password is never rendered.**
2. **Complete setup** → if `collected.wifi` is secured, open a `<Modal>` asking for the password (Connect / Cancel). The dialog's value always overwrites whatever cipher #546 stored — per product intent the user re-confirms the credential at commit time. Unsecured or absent Wi-Fi commits straight away.
3. Commit ceremony:
   - `POST /api/hassio/network/wlan0/update` with the `wpa-psk` (or `open`) payload.
   - `configStore.setPartial(<final blob>)` + `markComplete()`.
   - `window.location.reload()` — `SetupGate` sees `completedAt` on the next mount and falls through to the existing Router, dropping the user on `/login`.
4. Commit failure (Supervisor 5xx, network error) → Toast danger via `useToast({ intent: 'danger' })` per the API Error Toast Rule; user stays on review and can retry.

## Scope

### In

- `apps/web/src/features/setup/review/review-step.tsx` — summary list + Modal dialog + commit ceremony.
- `apps/web/src/features/setup/review/review-step.test.tsx` — 6 cases: summary render, Wi-Fi line shows SSID + auth tag (not password), not-set glyph for missing fields, commit without dialog when no Wi-Fi, unsecured Wi-Fi `auth: 'open'` payload, secured Wi-Fi dialog → Connect → commit with `wpa-psk`, commit failure Toast + stays.
- `apps/web/src/features/setup/review/index.ts` — barrel.
- `apps/web/src/features/setup/setup-route.tsx` — drops `PlaceholderStep` + `ReviewPlaceholder`; adds `ReviewStepAdapter`. The header comment now reads "All 5 wizard steps now ship their real implementations".
- `apps/web/src/features/setup/setup-route.test.tsx` — the placeholder `Complete setup (TBD)` assertion becomes "renders the Final Review step with the Complete setup CTA".
- `apps/web/src/i18n/locales/{en,tr}.json` — `setup.review.*` keys (title/subtitle/summary tokens, passwordDialog copy, commitFailed Toast copy, actions).

### Out (follow-up)

- `#546` still collects the Wi-Fi password inline (the Wi-Fi step's PasswordInput). The new dialog makes that redundant; a small cleanup PR can drop it once this lands. Tracked inline in the commit footer.
- Hardcoded `wlan0` interface — works for the common single-radio kiosk case. A real-world deployment with multiple interfaces should query `/api/hassio/network/info` for the wireless one; tracked as a refinement.
- E2E smoke (#549) — depends on all 5 steps landing; will be opened next.

## Test plan

- [x] `pnpm --filter @glaon/web type-check` green
- [x] `pnpm --filter @glaon/web lint` green
- [x] `pnpm --filter @glaon/web test` green (140 tests pass; 6 new on `review-step.test.tsx`; setup-route walk-through updated)
- [x] `pnpm knip` clean (props interface stays unexported per the memory pattern)
- [x] `pnpm i18n:check` green (`setup.review.*` keys present in both en + tr)
- [x] `pnpm --filter @glaon/web size` green (Initial JS 348.83 kB / 360 kB)
- [x] No `* 2.tsx` backup files
- [x] CI required checks (type-check · lint · audit · unit-tests · playwright · package-contract · size-check · visual regression · chromatic · conventional-commits · gitleaks · i18n-check · lighthouse)

Closes #548
Refs #533, ADR 0028, #544, #546
