### PR TITLE
test(web-e2e): setup wizard happy path @smoke

### DIFF
--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -24,22 +24,18 @@
 //
 // Tagged `@smoke` so the CI matrix runs it on every PR.
 
-import type { Page } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
-import { expect, test } from './support/test';
+// Bypass the shared `support/test.ts` fixture deliberately: the fixture
+// runs an init script on every navigation that seeds
+// `glaon.device-config.completedAt`. After this spec's wizard
+// completes and reloads, that init script would overwrite the blob
+// the user just persisted — so SetupGate would still see "configured"
+// thanks to the seed but the test couldn't observe the wizard's own
+// write. Using the raw `@playwright/test` import keeps localStorage
+// untouched between navigations, matching real first-run behaviour.
 
 const DEVICE_CONFIG_KEY = 'glaon.device-config';
-
-async function clearDeviceConfig(page: Page): Promise<void> {
-  // Runs AFTER the shared fixture's seed init-script, so the wizard
-  // sees an empty store on the first render.
-  await page.addInitScript(
-    ({ key }) => {
-      window.localStorage.removeItem(key);
-    },
-    { key: DEVICE_CONFIG_KEY },
-  );
-}
 
 async function mockSupervisorNetworkScan(page: Page): Promise<void> {
   await page.route('**/api/hassio/network/info', async (route) => {
@@ -60,7 +56,6 @@ async function mockSupervisorNetworkScan(page: Page): Promise<void> {
 
 test.describe('setup wizard @smoke', () => {
   test.beforeEach(async ({ page }) => {
-    await clearDeviceConfig(page);
     await mockSupervisorNetworkScan(page);
   });
 

--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -4,20 +4,23 @@
 //   1. clear `glaon.device-config` so SetupGate routes to the wizard
 //      (the shared fixture in `support/test.ts` seeds a completedAt
 //      blob by default — we have to opt out).
-//   2. walk all 5 steps filling the minimum required fields:
+//   2. mock the HA Supervisor network endpoints. The preview build
+//      isn't started with `VITE_APP_MODE=standalone`, so WifiStep
+//      takes the populated branch and tries to scan; mocked fetch
+//      lets the test pick an unsecured `PreviewGuest` AP and the
+//      commit POST round-trips cleanly.
+//   3. walk all 5 steps filling the minimum required fields:
 //        - Home Overview → set the home name + advance
-//        - Layout Setup  → advance (placeholder, no required field)
-//        - Wi-Fi         → standalone branch (the test build doesn't
-//          run the HA Supervisor); Next advances without selection
+//        - Layout Setup → advance (placeholder, no required field)
+//        - Wi-Fi → pick the mocked unsecured AP + advance
 //        - Device Security → password + confirm + advance
-//        - Final Review  → assert summary contains the typed home name,
-//          click Complete setup, assert no dialog opens (no Wi-Fi was
-//          collected), assert the wizard ConfigStore commit fires and
-//          `window.location.reload()` lands the user on /login
-//   3. forced commit failure path: same walk but a 5xx on the
-//      Supervisor push (or the absence of `wifi` collected at all
-//      means we cannot trigger the supervisor — instead verify the
-//      mode-select / login is the next render).
+//        - Final Review → assert summary contains the typed home
+//          name + click Complete setup. No password dialog opens
+//          (the AP is unsecured) so the commit fires immediately;
+//          `window.location.reload()` lands the user on mode-select
+//          or login (either is post-wizard surface).
+//   4. second test confirms the reload-after-completion path: a
+//      second visit never re-renders the wizard.
 //
 // Tagged `@smoke` so the CI matrix runs it on every PR.
 
@@ -38,49 +41,62 @@ async function clearDeviceConfig(page: Page): Promise<void> {
   );
 }
 
+async function mockSupervisorNetworkScan(page: Page): Promise<void> {
+  await page.route('**/api/hassio/network/info', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: {
+          interfaces: [{ accesspoints: [{ ssid: 'PreviewGuest', auth: 'none' }] }],
+        },
+      }),
+    });
+  });
+  await page.route('**/api/hassio/network/wlan0/update', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{"result":"ok"}' });
+  });
+}
+
 test.describe('setup wizard @smoke', () => {
   test.beforeEach(async ({ page }) => {
     await clearDeviceConfig(page);
+    await mockSupervisorNetworkScan(page);
   });
 
   test('walks all 5 steps and lands on the login screen after commit', async ({ page }) => {
     await page.goto('/');
 
-    // Step 1: Home Overview. The h1 from setup.homeOverview.title is
-    // "Home Overview" (en). Fill the required home name then Next.
+    // Step 1: Home Overview.
     await expect(page.getByRole('heading', { level: 1, name: 'Home Overview' })).toBeVisible();
     await page.getByLabel('Home Name').fill('Olivia');
     await page.getByRole('button', { name: 'Next' }).click();
 
-    // Step 2: Layout Setup (placeholder; no required fields).
+    // Step 2: Layout Setup (placeholder; no required field).
     await expect(page.getByRole('heading', { level: 1, name: 'Layout Setup' })).toBeVisible();
     await page.getByRole('button', { name: 'Next' }).click();
 
-    // Step 3: Wi-Fi Configuration. The preview build runs without an
-    // HA Supervisor, so VITE_APP_MODE is whatever the build picked —
-    // the spec uses the standalone informational branch where Next
-    // advances unconditionally.
+    // Step 3: Wi-Fi Configuration. Pick the mocked unsecured AP.
     await expect(page.getByRole('heading', { level: 1, name: 'Wi-Fi Connection' })).toBeVisible();
+    await page.getByRole('button', { name: /PreviewGuest/i }).click();
     await page.getByRole('button', { name: 'Next' }).click();
 
-    // Step 4: Device Security. Type a password + confirm.
+    // Step 4: Device Security.
     await expect(page.getByRole('heading', { level: 1, name: 'Device Security' })).toBeVisible();
-    await page.getByLabel('Password', { exact: true }).fill('correct-horse');
-    await page.getByLabel('Confirm password', { exact: true }).fill('correct-horse');
+    // SecurityStep labels render as "Password *" / "Confirm password *"
+    // (the asterisk lives inside the <label>), so getByLabel with
+    // exact:true misses. Use the placeholder text — unique per field.
+    await page.getByPlaceholder('At least 8 characters').fill('correct-horse');
+    await page.getByPlaceholder('Type the password again').fill('correct-horse');
     await page.getByRole('button', { name: 'Next' }).click();
 
-    // Step 5: Final Review. Summary contains the home name. No Wi-Fi
-    // was collected (standalone branch skipped) so Complete setup
-    // commits without a dialog. The commit ceremony reloads `/`; the
-    // gate sees `completedAt` and falls through to the existing
-    // Router which lands the user on /login (or mode-select).
+    // Step 5: Final Review. Summary contains the home name. The AP
+    // is unsecured, so Complete setup commits without opening the
+    // password dialog. The reload lands on mode-select / login.
     await expect(page.getByRole('heading', { level: 1, name: 'Final Review' })).toBeVisible();
     await expect(page.getByText('Olivia')).toBeVisible();
     await page.getByRole('button', { name: 'Complete setup' }).click();
 
-    // After reload the wizard is gone and the auth surface mounts.
-    // mode-select-route is the first thing a fresh user sees once
-    // device-config is set, so wait for either it or the login form.
     await expect(
       page.getByTestId('mode-select-route').or(page.getByTestId('login-device-form')),
     ).toBeVisible({ timeout: 10_000 });
@@ -100,12 +116,16 @@ test.describe('setup wizard @smoke', () => {
     // First run: walk the wizard end-to-end (compressed assertions).
     await page.goto('/');
     await page.getByLabel('Home Name').fill('Olivia');
-    await page.getByRole('button', { name: 'Next' }).click(); // Layout
-    await page.getByRole('button', { name: 'Next' }).click(); // Wi-Fi
-    await page.getByRole('button', { name: 'Next' }).click(); // Security
-    await page.getByLabel('Password', { exact: true }).fill('correct-horse');
-    await page.getByLabel('Confirm password', { exact: true }).fill('correct-horse');
-    await page.getByRole('button', { name: 'Next' }).click(); // Review
+    await page.getByRole('button', { name: 'Next' }).click(); // Home → Layout
+    await page.getByRole('button', { name: 'Next' }).click(); // Layout → Wi-Fi
+    await page.getByRole('button', { name: /PreviewGuest/i }).click();
+    await page.getByRole('button', { name: 'Next' }).click(); // Wi-Fi → Security
+    // SecurityStep labels render as "Password *" / "Confirm password *"
+    // (the asterisk lives inside the <label>), so getByLabel with
+    // exact:true misses. Use the placeholder text — unique per field.
+    await page.getByPlaceholder('At least 8 characters').fill('correct-horse');
+    await page.getByPlaceholder('Type the password again').fill('correct-horse');
+    await page.getByRole('button', { name: 'Next' }).click(); // Security → Review
     await page.getByRole('button', { name: 'Complete setup' }).click();
     await expect(
       page.getByTestId('mode-select-route').or(page.getByTestId('login-device-form')),

--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -1,0 +1,121 @@
+// Setup wizard @smoke spec (#549 — epic #533). Drives the first-run
+// device setup wizard end-to-end:
+//
+//   1. clear `glaon.device-config` so SetupGate routes to the wizard
+//      (the shared fixture in `support/test.ts` seeds a completedAt
+//      blob by default — we have to opt out).
+//   2. walk all 5 steps filling the minimum required fields:
+//        - Home Overview → set the home name + advance
+//        - Layout Setup  → advance (placeholder, no required field)
+//        - Wi-Fi         → standalone branch (the test build doesn't
+//          run the HA Supervisor); Next advances without selection
+//        - Device Security → password + confirm + advance
+//        - Final Review  → assert summary contains the typed home name,
+//          click Complete setup, assert no dialog opens (no Wi-Fi was
+//          collected), assert the wizard ConfigStore commit fires and
+//          `window.location.reload()` lands the user on /login
+//   3. forced commit failure path: same walk but a 5xx on the
+//      Supervisor push (or the absence of `wifi` collected at all
+//      means we cannot trigger the supervisor — instead verify the
+//      mode-select / login is the next render).
+//
+// Tagged `@smoke` so the CI matrix runs it on every PR.
+
+import type { Page } from '@playwright/test';
+
+import { expect, test } from './support/test';
+
+const DEVICE_CONFIG_KEY = 'glaon.device-config';
+
+async function clearDeviceConfig(page: Page): Promise<void> {
+  // Runs AFTER the shared fixture's seed init-script, so the wizard
+  // sees an empty store on the first render.
+  await page.addInitScript(
+    ({ key }) => {
+      window.localStorage.removeItem(key);
+    },
+    { key: DEVICE_CONFIG_KEY },
+  );
+}
+
+test.describe('setup wizard @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearDeviceConfig(page);
+  });
+
+  test('walks all 5 steps and lands on the login screen after commit', async ({ page }) => {
+    await page.goto('/');
+
+    // Step 1: Home Overview. The h1 from setup.homeOverview.title is
+    // "Home Overview" (en). Fill the required home name then Next.
+    await expect(page.getByRole('heading', { level: 1, name: 'Home Overview' })).toBeVisible();
+    await page.getByLabel('Home Name').fill('Olivia');
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // Step 2: Layout Setup (placeholder; no required fields).
+    await expect(page.getByRole('heading', { level: 1, name: 'Layout Setup' })).toBeVisible();
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // Step 3: Wi-Fi Configuration. The preview build runs without an
+    // HA Supervisor, so VITE_APP_MODE is whatever the build picked —
+    // the spec uses the standalone informational branch where Next
+    // advances unconditionally.
+    await expect(page.getByRole('heading', { level: 1, name: 'Wi-Fi Connection' })).toBeVisible();
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // Step 4: Device Security. Type a password + confirm.
+    await expect(page.getByRole('heading', { level: 1, name: 'Device Security' })).toBeVisible();
+    await page.getByLabel('Password', { exact: true }).fill('correct-horse');
+    await page.getByLabel('Confirm password', { exact: true }).fill('correct-horse');
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // Step 5: Final Review. Summary contains the home name. No Wi-Fi
+    // was collected (standalone branch skipped) so Complete setup
+    // commits without a dialog. The commit ceremony reloads `/`; the
+    // gate sees `completedAt` and falls through to the existing
+    // Router which lands the user on /login (or mode-select).
+    await expect(page.getByRole('heading', { level: 1, name: 'Final Review' })).toBeVisible();
+    await expect(page.getByText('Olivia')).toBeVisible();
+    await page.getByRole('button', { name: 'Complete setup' }).click();
+
+    // After reload the wizard is gone and the auth surface mounts.
+    // mode-select-route is the first thing a fresh user sees once
+    // device-config is set, so wait for either it or the login form.
+    await expect(
+      page.getByTestId('mode-select-route').or(page.getByTestId('login-device-form')),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // The persisted blob now has `completedAt` so a second visit
+    // never shows the wizard again.
+    const persistedRaw = await page.evaluate(
+      (key) => window.localStorage.getItem(key),
+      DEVICE_CONFIG_KEY,
+    );
+    expect(persistedRaw).not.toBeNull();
+    const persisted = JSON.parse(persistedRaw ?? '{}') as { completedAt?: string };
+    expect(persisted.completedAt).toBeDefined();
+  });
+
+  test('reload after completion never re-runs the wizard', async ({ page }) => {
+    // First run: walk the wizard end-to-end (compressed assertions).
+    await page.goto('/');
+    await page.getByLabel('Home Name').fill('Olivia');
+    await page.getByRole('button', { name: 'Next' }).click(); // Layout
+    await page.getByRole('button', { name: 'Next' }).click(); // Wi-Fi
+    await page.getByRole('button', { name: 'Next' }).click(); // Security
+    await page.getByLabel('Password', { exact: true }).fill('correct-horse');
+    await page.getByLabel('Confirm password', { exact: true }).fill('correct-horse');
+    await page.getByRole('button', { name: 'Next' }).click(); // Review
+    await page.getByRole('button', { name: 'Complete setup' }).click();
+    await expect(
+      page.getByTestId('mode-select-route').or(page.getByTestId('login-device-form')),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Second visit: gate falls through, wizard does not render.
+    await page.goto('/');
+    await expect(page.getByRole('heading', { level: 1, name: 'Home Overview' })).toHaveCount(0);
+    await expect(
+      page.getByTestId('mode-select-route').or(page.getByTestId('login-device-form')),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- New `apps/web-e2e/tests/setup-wizard.spec.ts` tagged `@smoke`. Drives the first-run device setup wizard end-to-end so CI catches a regression on any step.
- Two tests:
  - **Happy path:** opts out of the shared fixture's device-config seed → walks Home Overview → Layout → Wi-Fi (standalone branch) → Device Security → Final Review → asserts the post-commit reload lands on mode-select / login + the persisted blob has `completedAt`.
  - **Reload after completion:** walks the wizard once, reloads `/`, asserts the wizard never re-runs.

## Scope

### In

- `apps/web-e2e/tests/setup-wizard.spec.ts` — two `@smoke` tests covering the wizard's happy path and the post-completion reload.

### Out

- Forced commit-failure path (Toast assertion) — the preview build doesn't run an HA Supervisor, so the Wi-Fi step always takes the standalone branch and never reaches the Supervisor push. A failure-path test that mocks `/api/hassio/network/wlan0/update` to 5xx can land once the standalone branch is configurable per-test (separate refinement).
- Wi-Fi populated state coverage — needs a build with `VITE_APP_MODE=ingress`. Separate test fixture / project to revisit.
- Mocking `/api/hassio/network/info` per the original issue body — same reason: the standalone branch skips the fetch entirely, so there's nothing to mock for the happy path.

## Test plan

- [x] `pnpm --filter @glaon/web-e2e type-check` green
- [x] Pre-commit hook (commitlint + prettier + eslint) green
- [x] No `* 2.ts` backup files
- [x] CI required check (`playwright`) covers the new spec via the existing `@smoke` runner; per-spec Browser run lands during PR CI

Closes #549
Refs #533
