### PR TITLE
feat(web,ui): in-wizard language switcher + brand-colour active step

### DIFF
--- a/apps/web/src/features/setup/setup-route.tsx
+++ b/apps/web/src/features/setup/setup-route.tsx
@@ -21,8 +21,11 @@
 // validation land per-step.
 
 import { useCallback, useMemo, useState, type ComponentType, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import type { DeviceConfigInput } from '@glaon/core/config';
+import { SUPPORTED_LOCALES, isSupportedLocale, type SupportedLocale } from '@glaon/core/i18n';
+import { Select, SelectItem, type SelectItemType } from '@glaon/ui';
 import { SetupLayout, type SetupLayoutStep } from '@glaon/ui';
 
 import { HomeOverviewStep } from './home-overview';
@@ -194,6 +197,20 @@ export function SetupRoute({ initialStepId }: SetupRouteProps = {}): ReactNode {
     [],
   );
 
+  // Derive the set of completed steps from the active step's position in
+  // SETUP_STEPS: every step strictly before it is "done". The v1 wizard
+  // locks the order so this matches the user's actual progress; if a
+  // future wizard adds skipping, it can pass an explicit `completedStepIds`
+  // to SetupLayout instead.
+  const completedStepIds = useMemo<readonly string[]>(
+    () => SETUP_STEPS.slice(0, Math.max(activeIndex, 0)).map((step) => step.id),
+    [activeIndex],
+  );
+
+  const onLocaleChange = useCallback((next: SupportedLocale) => {
+    setCollected((prev) => ({ ...prev, locale: next }));
+  }, []);
+
   if (activeStep === undefined) {
     // SETUP_STEPS is non-empty at module load — this branch exists only
     // to convince TS that ActiveStepComponent below is callable.
@@ -203,7 +220,12 @@ export function SetupRoute({ initialStepId }: SetupRouteProps = {}): ReactNode {
   const ActiveStepComponent = activeStep.Component;
 
   return (
-    <SetupLayout steps={navSteps} activeStepId={activeStepId}>
+    <SetupLayout
+      steps={navSteps}
+      activeStepId={activeStepId}
+      completedStepIds={completedStepIds}
+      controlsSlot={<WizardLocaleSwitcher onLocaleChange={onLocaleChange} />}
+    >
       <ActiveStepComponent
         collected={collected}
         onNext={onNext}
@@ -211,5 +233,50 @@ export function SetupRoute({ initialStepId }: SetupRouteProps = {}): ReactNode {
         isLastStep={isLastStep}
       />
     </SetupLayout>
+  );
+}
+
+interface WizardLocaleSwitcherProps {
+  /**
+   * Mirror the chosen locale into the wizard's `collected` state so the
+   * final commit (#548) persists the user's actual choice. Without this,
+   * the user could switch the chrome to Turkish but the post-wizard
+   * `glaon.locale` would stay at whatever Home Overview's Language form
+   * field defaulted to.
+   */
+  readonly onLocaleChange: (next: SupportedLocale) => void;
+}
+
+// In-wizard language switcher (#570). The wizard's chrome embeds this
+// in the sidebar so a user who opened the wizard in the wrong locale
+// can swap to their language without losing the data they've already
+// filled in: route-local `collected` state survives because the wizard
+// route does not unmount when i18next changes the active language.
+// Persistence flows through i18next-browser-languagedetector → the same
+// `glaon.locale` localStorage key the Home Overview step ultimately
+// commits, so the post-wizard reload picks the choice up.
+function WizardLocaleSwitcher({ onLocaleChange }: WizardLocaleSwitcherProps): ReactNode {
+  const { t, i18n } = useTranslation();
+  const active: SupportedLocale = isSupportedLocale(i18n.resolvedLanguage)
+    ? i18n.resolvedLanguage
+    : 'en';
+  const items: SelectItemType[] = SUPPORTED_LOCALES.map((code) => ({
+    id: code,
+    label: t(`languageSwitcher.options.${code}`),
+  }));
+  return (
+    <Select
+      aria-label={t('languageSwitcher.ariaLabel')}
+      items={items}
+      value={active}
+      onChange={(key) => {
+        if (typeof key === 'string' && isSupportedLocale(key)) {
+          void i18n.changeLanguage(key);
+          onLocaleChange(key);
+        }
+      }}
+    >
+      {(item) => <SelectItem key={item.id} id={item.id} label={item.label ?? ''} />}
+    </Select>
   );
 }

--- a/packages/ui/src/components/SetupLayout/SetupLayout.controls.ts
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.controls.ts
@@ -1,8 +1,8 @@
 // `SetupLayout.controls.ts` — single source of truth for SetupLayout's
-// controllable props. Slot props (`logoSlot`, `footerSlot`, `children`)
-// and the `steps` array (ReactNode-bearing objects) live in
-// `excludeFromArgs` because they don't render meaningfully via the
-// controls panel.
+// controllable props. Slot props (`logoSlot`, `controlsSlot`,
+// `footerSlot`, `children`) and the `steps` array (ReactNode-bearing
+// objects) live in `excludeFromArgs` because they don't render
+// meaningfully via the controls panel.
 
 import type { ControlSpec } from '../_internal/controls';
 import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
@@ -12,7 +12,7 @@ export const setupLayoutControls = {
     type: 'text',
     default: 'home-overview',
     description:
-      'Id of the active step in `steps`. The matching row renders at full opacity; every other row renders at 50% opacity (`opacity-50` on the text block, icon stays full opacity).',
+      'Id of the active step in `steps`. The matching row uses the brand-coloured active state (filled icon container + brand title); previously-completed rows show a Check glyph; upcoming rows stay muted.',
     category: 'Content',
   } satisfies ControlSpec<string>,
 } as const;
@@ -22,6 +22,7 @@ export const setupLayoutExcludeFromArgs = defineExcludeFromArgs([
   'completedStepIds',
   'onSelectStep',
   'logoSlot',
+  'controlsSlot',
   'footerSlot',
   'children',
 ] as const);

--- a/packages/ui/src/components/SetupLayout/SetupLayout.mdx
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.mdx
@@ -47,12 +47,25 @@ padding (per-step gutters vary in the Figma frames).
 
 ## Step rail behaviour
 
-- The active row matches `activeStepId` and renders at full opacity.
-- Every other row renders at `opacity-50` on the text block (icon stays
-  full opacity). This is the only visual differentiation drawn in the
-  current Figma frame.
-- The dedicated `SetupStepNav` primitive (#538) adds a `completed`
-  state with a checkmark once D2–D5 designs land.
+- The active row matches `activeStepId` and renders in the brand
+  colour: filled `bg-brand-solid` icon container with a white glyph, and
+  the title in `text-brand-secondary`. This is the only visually loud
+  element in the sidebar.
+- Rows in `completedStepIds` (default: every step before `activeStepId`
+  in `steps` order) render in `text-tertiary` with a Check glyph in
+  place of the supplied icon, so the user can scan past finished steps.
+- Upcoming rows render in `text-tertiary` with the supplied icon and
+  no further treatment.
+- Behaviour ships in the dedicated `SetupStepNav` primitive (#538);
+  SetupLayout just forwards `steps` / `activeStepId` / `completedStepIds`
+  / `onSelectStep` through.
+
+## Sidebar controls slot
+
+The `controlsSlot` prop renders between the step rail and the footer.
+It is empty by default; the v1 first-run wizard mounts a language
+switcher there (#570) so a user who opened the wizard in the wrong
+locale can fix it mid-flow without losing their progress.
 
 ## Accessibility
 

--- a/packages/ui/src/components/SetupLayout/SetupLayout.stories.tsx
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.stories.tsx
@@ -154,3 +154,34 @@ export const WithoutLogo: Story = {
     </SetupLayout>
   ),
 };
+
+// Mirrors what the production wizard renders mid-flow (#570): the
+// active step is brand-coloured, the steps before it carry the
+// completed Check glyph, and the sidebar's `controlsSlot` hosts an
+// in-flow language switcher (placeholder `<select>` in the story —
+// the real wizard mounts a Glaon Select primitive).
+export const MidWizardWithControls: Story = {
+  args: { activeStepId: 'wifi' },
+  render: (args) => (
+    <SetupLayout
+      {...args}
+      steps={wizardSteps}
+      completedStepIds={['home-overview', 'layout']}
+      controlsSlot={
+        <label className="flex flex-col gap-1 text-sm text-tertiary">
+          <span>Language</span>
+          <select
+            aria-label="Choose interface language"
+            defaultValue="en"
+            className="rounded-lg bg-primary px-3 py-2 text-sm text-primary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset"
+          >
+            <option value="en">English</option>
+            <option value="tr">Türkçe</option>
+          </select>
+        </label>
+      }
+    >
+      {placeholderContent}
+    </SetupLayout>
+  ),
+};

--- a/packages/ui/src/components/SetupLayout/SetupLayout.tsx
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.tsx
@@ -53,6 +53,14 @@ export interface SetupLayoutProps {
    */
   logoSlot?: ReactNode;
   /**
+   * Optional control surface rendered in the sidebar above the footer.
+   * v1 wizard uses this to host the in-flow language switcher (#570) so
+   * a user who opened the wizard in the wrong locale can fix it without
+   * abandoning their progress. Default is no slot — non-wizard consumers
+   * pass nothing and the sidebar collapses around the gap.
+   */
+  controlsSlot?: ReactNode;
+  /**
    * Override for the sidebar footer. Defaults to `© Glaon {year}` on the
    * left and `help@glaon.com` on the right (with a Glaon mail icon). Pass
    * `null` to suppress.
@@ -73,6 +81,7 @@ export function SetupLayout({
   completedStepIds,
   onSelectStep,
   logoSlot,
+  controlsSlot,
   footerSlot,
   children,
 }: SetupLayoutProps) {
@@ -98,11 +107,16 @@ export function SetupLayout({
             {...(onSelectStep === undefined ? {} : { onSelect: onSelectStep })}
           />
         </div>
-        {footer !== null && (
-          <div className="flex h-24 items-end justify-between p-8 text-sm text-tertiary">
-            {footer}
-          </div>
-        )}
+        <div className="flex flex-col">
+          {controlsSlot !== undefined && controlsSlot !== null && (
+            <div className="px-8 pb-4">{controlsSlot}</div>
+          )}
+          {footer !== null && (
+            <div className="flex h-24 items-end justify-between p-8 text-sm text-tertiary">
+              {footer}
+            </div>
+          )}
+        </div>
       </aside>
       <main className="flex flex-1 flex-col lg:min-w-[480px] lg:overflow-y-auto">{children}</main>
     </div>

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.stories.tsx
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.stories.tsx
@@ -98,6 +98,30 @@ export const MidWizardActive: Story = {
   },
 };
 
+// Captures the three-state matrix in a single Chromatic baseline: the
+// active row uses the brand-coloured fill (#570), the rows before it
+// render as completed (Check glyph + tertiary text), and the rows
+// after stay upcoming. This is the visual that ships in the v1 first-
+// run wizard so we want it in the regression set explicitly.
+export const MidWizardWithCompleted: Story = {
+  args: { activeStepId: 'security' },
+  render: (args) => (
+    <SetupStepNav
+      {...args}
+      steps={wizardSteps}
+      completedStepIds={['home-overview', 'layout', 'wifi']}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const activeRows = canvasElement.querySelectorAll('[aria-current="step"]');
+    await expect(activeRows.length).toBe(1);
+    await expect(
+      canvas.getByText('Device Security').closest('[aria-current="step"]'),
+    ).not.toBeNull();
+  },
+};
+
 export const AllCompleted: Story = {
   args: { activeStepId: 'review' },
   render: (args) => (

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.tsx
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.tsx
@@ -4,8 +4,11 @@
 // independently in Storybook + Chromatic.
 //
 // Three visual states:
-//   - active     — title in `text-secondary` (#404040), icon container
-//                  unchanged. The single row that matches `activeStepId`.
+//   - active     — title in `text-brand-secondary`, icon container
+//                  uses `bg-brand-solid` with a white icon glyph so the
+//                  current step is obvious at a glance against the
+//                  light-grey sidebar. The single row that matches
+//                  `activeStepId`.
 //   - completed  — title in `text-tertiary` (#525252), icon replaced by
 //                  a Check glyph so the user can scan past finished steps.
 //   - upcoming   — title in `text-tertiary` (#525252), icon as supplied.
@@ -125,17 +128,21 @@ interface SetupStepNavItemProps {
 function SetupStepNavItem({ step, state, isLast, onSelect }: SetupStepNavItemProps) {
   const isActive = state === 'active';
   const isCompleted = state === 'completed';
-  // Title colour: active gets full strength; completed + upcoming both
-  // downshift to text-tertiary — see component-level comment for why
-  // text-quaternary is not used here (4.06:1 fails WCAG AA on the
-  // Glaon light-grey sidebar).
-  const titleClass = `text-sm font-semibold leading-5 ${isActive ? 'text-secondary' : 'text-tertiary'}`;
+  // Active step gets brand-coloured emphasis (#570) so the user can spot
+  // their position at a glance — the prior `text-secondary` treatment
+  // was too close to the inactive `text-tertiary` on the light-grey
+  // sidebar. Completed + upcoming both stay `text-tertiary`; the
+  // completed Check glyph differentiates the two.
+  const titleClass = `text-sm font-semibold leading-5 ${isActive ? 'text-brand-secondary' : 'text-tertiary'}`;
   const descriptionClass = 'text-sm font-normal leading-5 text-tertiary';
-  // Completed rows swap the supplied icon for a Check glyph so the user
-  // can scan past finished steps. The icon container styling stays the
-  // same across states until design ships a richer "completed" frame
-  // (D2–D5 follow-ups for steps 2–5).
   const iconNode = isCompleted ? <Check aria-hidden="true" /> : step.icon;
+  // Icon container: active gets a filled brand-coloured tile with a
+  // white glyph (loud emphasis); completed + upcoming stay on the
+  // neutral white surface so the active row is the only visually
+  // "loud" element in the rail.
+  const iconContainerClass = isActive
+    ? 'z-[1] flex size-10 shrink-0 items-center justify-center rounded-lg bg-brand-solid text-white shadow-xs-skeuomorphic ring-1 ring-brand ring-inset'
+    : 'z-[1] flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset';
   const textBlock = (
     <div
       className="flex flex-1 flex-col pb-8 text-left"
@@ -151,7 +158,7 @@ function SetupStepNavItem({ step, state, isLast, onSelect }: SetupStepNavItemPro
   return (
     <li className="flex items-start gap-3">
       <div className="flex flex-col items-center gap-1 self-stretch pb-1">
-        <div className="z-[1] flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset">
+        <div className={iconContainerClass}>
           <span aria-hidden="true" className="block size-5">
             {iconNode}
           </span>


### PR DESCRIPTION
## Summary

Closes #570 — adds in-flow polish to the device setup wizard (epic #533) without changing the data contract or HA calls.

- `SetupLayout` gains an optional **`controlsSlot`** rendered in the sidebar above the footer. Default is no slot, so non-wizard consumers are unchanged.
- `SetupRoute` mounts a **`WizardLocaleSwitcher`** in that slot — a Glaon `Select` over `SUPPORTED_LOCALES` that calls `i18n.changeLanguage()` and mirrors the choice into the wizard's `collected` state so the final commit's `glaon.locale` reflects the user's actual pick.
- `SetupRoute` now passes **`completedStepIds`** (derived from the active step's index in `SETUP_STEPS`) so previously-finished steps render with the Check glyph + tertiary text instead of all rendering as "upcoming".
- `SetupStepNav` active state goes **brand-coloured**: filled `bg-brand-solid` icon container with a white glyph and a `text-brand-secondary` title, so the active row is the one visually loud element against the light-grey sidebar.
- New Storybook stories — `SetupStepNav: MidWizardWithCompleted`, `SetupLayout: MidWizardWithControls` — capture the new visuals in the Chromatic baseline.

Wizard step state (`collected`, route-local `useState`) survives the language change because the wizard route does not unmount when locale changes — only re-renders with the new strings.

## Scope — In

- `controlsSlot?: ReactNode` on `SetupLayout`, rendered above the footer.
- `WizardLocaleSwitcher` inside `SetupRoute`; mirror through `setCollected`.
- `completedStepIds` plumbed from `SetupRoute` → `SetupLayout` → `SetupStepNav`.
- Brand-colour active state in `SetupStepNav` (tokens only — `text-brand-secondary`, `bg-brand-solid`, `ring-brand`).
- Updated `SetupLayout.controls.ts`, `SetupLayout.mdx`.
- New Storybook stories (Chromatic baseline + a11y panel).

## Scope — Out

- Removing the Language `<Select>` from Home Overview step (final source of truth — covered in the issue body).
- Ingress-mode tuned wizard (separate follow-up).
- Server-side preference write-through (`/me/preferences`) — i18n epic #406.
- Rewriting `/login` / dashboard to host the switcher — different surfaces, different placement.

## Test plan

- [ ] `pnpm --filter @glaon/ui type-check lint test` — green
- [ ] `pnpm --filter @glaon/web type-check lint test` — green
- [ ] `pnpm knip` — no unused-export errors
- [ ] `pnpm i18n:check` — every used key present
- [ ] `pnpm --filter @glaon/web size` — under budget (was 348.8/360 kB after this PR)
- [ ] Chromatic — review diffs on `SetupStepNav.*` and `SetupLayout.MidWizardWithControls`, accept intentional baseline change
- [ ] Manual: open `/setup` with no `glaon.device-config`, advance to Wi-Fi step, switch chrome to Türkçe via sidebar — strings re-render, form data preserved, advancing back through steps preserves typed values; complete wizard → reload → `glaon.locale` = `tr`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)