### PR TITLE
chore(repo): add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Claude Code on the web bootstrap. Runs at SessionStart; idempotent.
+# Skipped on local sessions ($CLAUDE_CODE_REMOTE unset) so it never touches
+# a developer's machine.
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+log() { printf '[session-start] %s\n' "$*" >&2; }
+
+log "node $(node -v), corepack $(corepack --version 2>/dev/null || echo 'missing')"
+
+# Pin pnpm to packageManager from package.json (9.15.9 at time of writing).
+corepack enable >/dev/null
+corepack prepare pnpm@9.15.9 --activate >/dev/null
+log "pnpm $(pnpm -v)"
+
+log "installing workspace dependencies"
+pnpm install --prefer-frozen-lockfile
+
+log "pre-building @glaon/core + @glaon/ui (warms lint/type-check)"
+pnpm --filter @glaon/core --filter @glaon/ui build
+
+# gitleaks is required by .husky/pre-commit (see docs/SECURITY.md). Without it,
+# every `git commit` in the session fails. Install the v8 binary if absent.
+if ! command -v gitleaks >/dev/null 2>&1; then
+  log "installing gitleaks (pre-commit dependency)"
+  gitleaks_version="8.21.2"
+  case "$(uname -m)" in
+    x86_64) gitleaks_arch="linux_x64" ;;
+    aarch64|arm64) gitleaks_arch="linux_arm64" ;;
+    *) gitleaks_arch="linux_$(uname -m)" ;;
+  esac
+  tmp="$(mktemp -d)"
+  curl -fsSL -o "$tmp/gitleaks.tgz" \
+    "https://github.com/gitleaks/gitleaks/releases/download/v${gitleaks_version}/gitleaks_${gitleaks_version}_${gitleaks_arch}.tar.gz"
+  tar -xzf "$tmp/gitleaks.tgz" -C "$tmp" gitleaks
+  install_dir="/usr/local/bin"
+  if [ ! -w "$install_dir" ]; then
+    install_dir="$HOME/.local/bin"
+    mkdir -p "$install_dir"
+    case ":$PATH:" in
+      *":$install_dir:"*) ;;
+      *) echo "export PATH=\"$install_dir:\$PATH\"" >> "${CLAUDE_ENV_FILE:-/dev/null}" ;;
+    esac
+  fi
+  mv "$tmp/gitleaks" "$install_dir/gitleaks"
+  rm -rf "$tmp"
+fi
+log "gitleaks $(gitleaks version)"
+
+# MCP servers (Untitled UI, Chromatic, Storybook, Figma) read tokens from the
+# session environment. Hook does not fail when they are missing — secrets are
+# managed via the Claude Code on the web Environment configuration UI.
+missing_env=()
+for var in UNTITLED_TOKEN CHROMATIC_PROJECT_TOKEN; do
+  if [ -z "${!var:-}" ]; then
+    missing_env+=("$var")
+  fi
+done
+
+if [ ${#missing_env[@]} -gt 0 ]; then
+  log "WARN: MCP secrets not set in environment: ${missing_env[*]}"
+  log "      Set them via Claude Code on the web → Environment configuration."
+fi
+
+log "ready"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,5 +25,17 @@
       "Bash(git remote)",
       "Bash(git remote -v)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Web container'da `node_modules` boş geliyor; `pnpm lint` / `type-check` / `test` ve `git commit` ilk komutta düşüyor. Bu PR bir `SessionStart` hook ekleyerek Claude Code on the web (mobil + tarayıcı) session açılışında repo'yu otomatik hazırlıyor.

Hook (`.claude/hooks/session-start.sh`):

- `corepack` ile `pnpm@9.15.9` aktive eder.
- `pnpm install --prefer-frozen-lockfile`.
- `pnpm --filter @glaon/core --filter @glaon/ui build` ile workspace package'larını ön-build eder (lint/type-check için gerekli).
- `gitleaks` v8 binary'sini kurar — `.husky/pre-commit` aksi halde her commit'i blokluyor (bkz. [docs/SECURITY.md](docs/SECURITY.md#lokal-gitleaks-kurulumu)).
- `UNTITLED_TOKEN` + `CHROMATIC_PROJECT_TOKEN` yoksa stderr'e **uyarı** verir (fatal değil — secret'lar Claude Code on the web Environment UI'sinden gelir, hook doldurmaz).
- `CLAUDE_CODE_REMOTE != "true"` ise no-op (local session'lara dokunmaz).

`.claude/settings.json`'da mevcut `permissions` korunarak `hooks.SessionStart` bloğu eklendi.

## Scope

### In
- `.claude/hooks/session-start.sh` (yeni, executable)
- `.claude/settings.json` (hook kaydı)
- Hook senkron çalışır: ilk açılış ~30–60 s, sonraki komutlar dependency hazır.

### Out (ayrı issue'lara push'lanır)
- Docker bağımlı script'ler (`pnpm ha:up`, `pnpm dev:mongo:up`) — web container'da Docker yok.
- Async hook modu — talep gelirse ayrı PR.
- Secret yönetimi otomasyonu — Environment UI'sinin görevi.
- Mobile (Expo) native build — web session'dan anlamsız; TS lint kapsamda kalır.

## Test plan

- [x] `CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` temiz repo'da hatasız (~29 s install + 2 paket build).
- [x] Hook idempotent — ikinci çağrıda re-install / re-download yok.
- [x] `node_modules/.pnpm`, `packages/core/dist`, `packages/ui/dist` dolu.
- [x] `pnpm exec eslint apps/web/src/App.tsx` → exit 0.
- [x] `cd packages/core && pnpm exec vitest run src/ha/services.test.ts` → 8 / 8 pass.
- [x] `gitleaks version` → 8.21.2 (pre-commit hook çalıştı, "no leaks found").
- [x] Eksik secret uyarısı stderr'e düştü, exit 0 korundu.
- [ ] Reviewer: yeni bir web session açıldığında hook otomatik tetiklenir, manuel adım gerekmez (PR `development`'a merge edildikten sonra teyit edilebilir).

## Notes

- Branch konvansiyonu istisnası: bu session agent SDK tarafından `claude/list-phase2-issues-8XKq5` üzerine bağlandığı için `<issue-no>-session-start-hook` formatına dönüştürülmedi. Squash-merge sonrası commit subject yeterli izlenebilirlik sağlar.
- Hook modu: **senkron**. *Pro*: dependency'ler garantili kurulu; ilk komutlar çalışır. *Con*: ilk session açılışı ~1 dk yavaş. Async'e geçmek isterse ayrı PR.

Closes #572

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhbALXL32fbve4B6pxBvrs)_