### PR TITLE
feat(ui): add CountrySelect primitive with locale autodetect

### DIFF
--- a/packages/ui/src/components/CountrySelect/CountrySelect.controls.ts
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.controls.ts
@@ -1,0 +1,118 @@
+// `CountrySelect.controls.ts` — single source of truth for
+// CountrySelect's variant matrix. Story (`CountrySelect.stories.tsx`)
+// imports the spec and spreads it into `meta.args` / `meta.argTypes`;
+// MDX docs (`CountrySelect.mdx`) reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+const localeOptions = ['', 'tr-TR', 'en-US', 'de-DE', 'fr-FR', 'ar-SA'] as const;
+
+export const countrySelectControls = {
+  label: {
+    type: 'text',
+    default: 'Country',
+    description:
+      'Visible label rendered above the trigger. Always provide one — labels satisfy axe `label` and pair the picker with assistive tech automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  placeholder: {
+    type: 'text',
+    default: 'Select a country',
+    description:
+      'Hint text shown when no option is selected. Never use placeholder as a substitute for the label.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the trigger. Doubles as the error message when `isInvalid` is true (the kit re-styles it red and adds `aria-describedby`).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  autoDetect: {
+    type: 'boolean',
+    default: true,
+    description:
+      'When true (default), pre-select the country derived from `navigator.language` on mount. Ignored when `value` or `defaultValue` is set. Detection is one-shot — re-mount to re-detect.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  locale: {
+    type: 'select',
+    options: localeOptions,
+    default: '',
+    description:
+      'BCP-47 locale used to localize country names and sort them. Leave empty to use the browser default (`navigator.language`).',
+    category: 'Content',
+  } satisfies ControlSpec<(typeof localeOptions)[number]>,
+  defaultValue: {
+    type: 'text',
+    description:
+      'Uncontrolled initial selection — ISO 3166-1 alpha-2 code (e.g. `TR`, `US`). When set, `autoDetect` is ignored.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale forwarded to the underlying ComboBox. `sm` for compact toolbars, `md` (default) for forms, `lg` for hero affordances.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Block all interaction and dim the trigger. The kit forwards `aria-disabled` so axe and assistive tech treat the field as inert.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isInvalid: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Surface validation error styling (red border + ring on the trigger). Pair with `hint` to describe the error; the kit wires `aria-invalid` + `aria-describedby` automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  isRequired: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Mark the field as required (renders an indicator next to the label and forwards `aria-required`).',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  hideRequiredIndicator: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Hide the visual `*` next to the label even when `isRequired` is true. Keep `isRequired` set so the a11y contract still reports the field as required.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  value: {
+    type: 'text',
+    description:
+      'Controlled selection — ISO 3166-1 alpha-2 code. Pair with `onSelectionChange` to manage state outside.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onSelectionChange: {
+    type: false,
+    action: 'selection-changed',
+    description:
+      'Fires when the selected country changes — receives the new ISO code or `null` when cleared.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  popoverClassName: {
+    type: false,
+    description: 'Tailwind override hook for the popover surface that wraps the option list.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// No additional excludes — every public prop on `CountrySelect` is
+// represented above. The helper export is still required by the F6
+// prop-coverage gate's named-export contract.
+export const countrySelectExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/CountrySelect/CountrySelect.mdx
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.mdx
@@ -1,0 +1,132 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as CountrySelectStories from './CountrySelect.stories';
+
+<Meta of={CountrySelectStories} />
+
+# CountrySelect
+
+App-primitive country picker. Thin wrap over the kit
+[`<ComboBox>`](?path=/docs/web-primitives-select--docs#withsearch) that
+adds the ISO 3166-1 alpha-2 list, runtime localization through
+`Intl.DisplayNames`, diacritic-insensitive search, and optional
+one-shot browser locale auto-detection.
+
+The wrap layer is what you import. The visual + popover positioning +
+RAC plumbing all come from the kit ComboBox.
+
+## When to use
+
+- Setup wizard's region / address step.
+- Profile screen — billing country, shipping country, residence
+  country.
+- Any form that asks the user to pick a single country from the full
+  ISO 3166-1 list.
+
+## When NOT to use
+
+- A short curated list of "supported regions" — use a plain
+  [Select](?path=/docs/web-primitives-select--docs) with the curated
+  options.
+- A phone-number country prefix — that lives in a future
+  `PhoneInput` primitive that pairs flag + prefix + national-number
+  formatter (open follow-up issue if you need it now).
+- A region/state sub-picker — out of scope for this primitive.
+
+## Auto-detection
+
+When `autoDetect` is `true` (the default), on mount the picker reads
+`navigator.language` (and `navigator.languages` if the primary tag
+has no region) and pre-selects the corresponding country. The
+detection is **pure browser API** — no network call leaves the
+component, no IP-geolocation service is contacted, no token is
+required.
+
+Detection is **one-shot** at mount. The picker doesn't re-detect when
+the browser locale changes mid-session — re-mount the component to
+re-run detection.
+
+Auto-detection is **skipped** when:
+
+- `value` is passed (the host owns the state).
+- `defaultValue` is passed (an explicit initial choice wins).
+- `autoDetect` is `false`.
+
+### Examples
+
+```tsx
+// Pre-select from the browser locale.
+<CountrySelect onSelectionChange={setCountry} />
+
+// Always start empty; let the user pick.
+<CountrySelect autoDetect={false} onSelectionChange={setCountry} />
+
+// Controlled, hydrated from a profile load.
+<CountrySelect value={user.country} onSelectionChange={updateCountry} />
+```
+
+## Anatomy
+
+<Canvas of={CountrySelectStories.Default} />
+
+```tsx
+<CountrySelect
+  label="Country"
+  placeholder="Select a country"
+  onSelectionChange={(iso) => setCountry(iso)}
+/>
+```
+
+The trigger renders the localized country name once a selection is
+made; the input becomes a search field while the popover is open.
+
+## Localization
+
+Country names are derived at render time via
+`new Intl.DisplayNames([locale], { type: 'region' }).of(code)`. The
+`locale` prop accepts any BCP-47 tag; when omitted, the component
+uses `navigator.language`. Sort order is locale-aware (`Intl.Collator`
+with `sensitivity: 'base'`), so "Çekya" lands where Turkish
+collation expects it.
+
+The same dataset (249 ISO codes) renders correctly in any locale the
+browser supports — no shipped translation tables, no extra dependency.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Always pass a `label` — the kit ComboBox binds it to the trigger
+  via the standard RAC label slot. Visually-hidden labels are not
+  supported in this primitive.
+- The popover is keyboard-navigable (Arrow up/down, Enter to select,
+  Esc to dismiss) and the search input is a real `<input>` element
+  with `aria-autocomplete="list"`.
+- Pair `isInvalid` with a descriptive `hint` ("Country is required.")
+  — the kit wires `aria-invalid` + `aria-describedby` automatically.
+- `isRequired` adds a visual `*` and forwards `aria-required`. Use
+  `hideRequiredIndicator` on dense forms to drop the asterisk while
+  keeping the a11y contract.
+
+## Search behaviour
+
+The filter is **diacritic-insensitive** — typing `turkiye` matches
+`Türkiye`, `reunion` matches `Réunion`, etc. The ISO code is also
+searchable, so typing `TR` lands on Türkiye and `US` on the United
+States.
+
+## Related components
+
+- [Select](?path=/docs/web-primitives-select--docs) — generic single-
+  value picker; use it for short curated lists.
+- [TimezoneSelect](?path=/docs/app-primitives-timezoneselect--docs) —
+  sister primitive for IANA timezones with the same `autoDetect`
+  contract.
+- [FormField](?path=/docs/app-primitives-formfield--docs) — wrapper
+  for label + control + error in compound forms.

--- a/packages/ui/src/components/CountrySelect/CountrySelect.stories.tsx
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { CountrySelect } from './CountrySelect';
+import { countrySelectControls, countrySelectExcludeFromArgs } from './CountrySelect.controls';
+
+const { args, argTypes } = defineControls(countrySelectControls);
+
+// Explicit `Meta<typeof CountrySelect>` annotation (vs `satisfies`)
+// keeps the kit's deep RAC generic chains out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// `tags: ['autodocs']` is intentionally omitted because
+// `CountrySelect.mdx` replaces the docs tab.
+const meta: Meta<typeof CountrySelect> = {
+  title: 'App Primitives/CountrySelect',
+  component: CountrySelect,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=app-primitives-country-select',
+    },
+  },
+  args,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CountrySelect>;
+
+export const excludeFromArgs = countrySelectExcludeFromArgs;
+
+/**
+ * Default — auto-detect on. On a browser with `navigator.language =
+ * 'tr-TR'` the picker opens with Türkiye preselected. Clear the
+ * selection or pick something else to override.
+ */
+export const Default: Story = {};
+
+/**
+ * Explicit `defaultValue`. The auto-detect path is skipped when the
+ * host provides a default; the picker starts with the host's choice.
+ */
+export const WithDefaultValue: Story = {
+  args: { defaultValue: 'TR', autoDetect: false },
+};
+
+/**
+ * Auto-detect off — the picker starts empty regardless of the
+ * browser's locale. Use this when the host owns the state lifecycle
+ * (e.g. a profile form that hydrates from the server).
+ */
+export const AutoDetectOff: Story = {
+  args: { autoDetect: false },
+};
+
+/**
+ * Turkish locale — names render as "Türkiye / Almanya / Birleşik
+ * Krallık" and sort with `Intl.Collator('tr')` so "Çekya" comes after
+ * "Ç" and not after "C".
+ */
+export const TurkishLocale: Story = {
+  args: { locale: 'tr-TR', autoDetect: false, defaultValue: 'TR', label: 'Ülke' },
+};
+
+/**
+ * German locale — same dataset, different rendered names ("Türkei",
+ * "Vereinigte Staaten").
+ */
+export const GermanLocale: Story = {
+  args: { locale: 'de-DE', autoDetect: false, defaultValue: 'DE', label: 'Land' },
+};
+
+/**
+ * Arabic locale — exercises the RTL render path. The decorator wraps
+ * the field in `dir="rtl"` so the popover, input alignment, and
+ * indicator placement mirror correctly.
+ */
+export const ArabicRtl: Story = {
+  args: { locale: 'ar-SA', autoDetect: false, defaultValue: 'SA', label: 'الدولة' },
+  decorators: [
+    (Story) => (
+      <div dir="rtl" style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** Disabled — trigger is dimmed, popover does not open. */
+export const Disabled: Story = {
+  args: { defaultValue: 'TR', autoDetect: false, isDisabled: true },
+};
+
+/** Invalid + hint — error styling with descriptive copy below. */
+export const WithError: Story = {
+  args: {
+    autoDetect: false,
+    isInvalid: true,
+    hint: 'Country is required.',
+  },
+};
+
+/** Helper text under the trigger when the field is valid. */
+export const WithHint: Story = {
+  args: {
+    autoDetect: false,
+    hint: 'Select your billing country.',
+  },
+};
+
+/** Size matrix — `sm`, `md`, `lg`. */
+export const Sizes: Story = {
+  parameters: { controls: { exclude: ['size', 'label'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {(['sm', 'md', 'lg'] as const).map((size) => (
+        <CountrySelect
+          key={size}
+          {...args}
+          size={size}
+          label={`Size: ${size}`}
+          autoDetect={false}
+          defaultValue="TR"
+        />
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/CountrySelect/CountrySelect.tsx
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.tsx
@@ -1,0 +1,204 @@
+// Glaon CountrySelect — searchable country picker that wraps the
+// kit `<ComboBox>` (`packages/ui/src/components/base/select/combobox.tsx`).
+//
+// Domain logic this wrapper adds on top of the kit ComboBox:
+//
+//   - Bundled ISO 3166-1 alpha-2 list, localized at render time via
+//     `Intl.DisplayNames` — no shipped translation tables, no dep.
+//   - Diacritic-insensitive search (`turkiye` → `Türkiye`, `reunion`
+//     → `Réunion`) plus searchable ISO code (`TR` → `Türkiye`).
+//   - Optional one-shot browser locale auto-detection — when on, the
+//     picker preselects the user's country derived from
+//     `navigator.language` / `navigator.languages`. Pure browser API,
+//     no network call.
+//
+// State machine — three modes:
+//
+//   - **Controlled.** Host passes `value`; we forward it as
+//     `selectedKey`. Host owns the state.
+//   - **Uncontrolled, explicit default.** Host passes `defaultValue`;
+//     we forward it as `defaultSelectedKey`. RAC owns state.
+//   - **Uncontrolled, auto-detect.** Host passes neither and
+//     `autoDetect` is true. We hold an internal `selectedKey` so the
+//     async detection result (resolved in `useEffect`) can be injected
+//     after mount.
+//
+// Per CLAUDE.md's UUI Source Rule and Component Data-Fetching Boundary:
+// the visual + popover positioning + RAC plumbing come from the kit;
+// this wrapper's contribution is the prop API + the static country
+// list + locale detection. No network call lives here.
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { Key } from 'react-aria-components';
+
+import { ComboBox, SelectItem, type SelectItemType } from '../Select';
+import { buildCountryItems, detectBrowserCountry, diacriticInsensitiveFilter } from './countries';
+
+// Types stay un-exported per memory note `feedback_knip_props_interfaces.md`
+// — `react-docgen-typescript` still resolves the prop names for the
+// F6 prop-coverage gate without a top-level `export`. Promote them
+// to the index.ts barrel once an external consumer needs them.
+type CountrySelectSize = 'sm' | 'md' | 'lg';
+
+interface CountrySelectProps {
+  /**
+   * Controlled selection — the ISO 3166-1 alpha-2 country code (e.g.
+   * `'TR'`, `'US'`). Pair with `onSelectionChange` to manage state
+   * outside. When set, `defaultValue` and `autoDetect` are ignored.
+   */
+  value?: string;
+  /**
+   * Uncontrolled initial selection — the ISO 3166-1 alpha-2 country
+   * code to start with. When set, `autoDetect` is ignored.
+   */
+  defaultValue?: string;
+  /**
+   * Fires when the user (or the auto-detect path) changes the
+   * selection. Receives the ISO 3166-1 alpha-2 code, or `null` when
+   * the selection is cleared.
+   */
+  onSelectionChange?: (iso: string | null) => void;
+  /**
+   * When `true` (default), pre-select the user's country derived from
+   * the browser's locale on mount. Ignored when `value` or
+   * `defaultValue` is set. Detection is one-shot — re-mount to
+   * re-detect.
+   * @default true
+   */
+  autoDetect?: boolean;
+  /**
+   * BCP-47 locale tag used to localize country names and sort them.
+   * Defaults to `navigator.language` in the browser, `'en'` on a
+   * runtime without `navigator` (e.g. SSR).
+   */
+  locale?: string;
+  /** Field label rendered above the trigger. */
+  label?: string;
+  /** Placeholder text shown when no option is selected. */
+  placeholder?: string;
+  /** Helper text shown under the trigger; doubles as the error
+   *  message when `isInvalid` is true. */
+  hint?: ReactNode;
+  /** Block all interaction and dim the trigger. */
+  isDisabled?: boolean;
+  /** Surface validation error styling. Pair with `hint` to describe
+   *  the error; the kit wires `aria-invalid` + `aria-describedby`. */
+  isInvalid?: boolean;
+  /** Mark the field as required (renders an indicator next to the
+   *  label and forwards `aria-required`). */
+  isRequired?: boolean;
+  /** Hide the visual `*` next to the label even when `isRequired`
+   *  is true. Keeps the a11y contract. */
+  hideRequiredIndicator?: boolean;
+  /**
+   * Visual scale of the underlying ComboBox.
+   * @default 'md'
+   */
+  size?: CountrySelectSize;
+  /** Tailwind override hook for the outer wrapper. */
+  className?: string;
+  /** Tailwind override hook for the popover surface. */
+  popoverClassName?: string;
+}
+
+export function CountrySelect({
+  value,
+  defaultValue,
+  onSelectionChange,
+  autoDetect = true,
+  locale,
+  label,
+  placeholder,
+  hint,
+  isDisabled,
+  isInvalid,
+  isRequired,
+  hideRequiredIndicator,
+  size = 'md',
+  className,
+  popoverClassName,
+}: CountrySelectProps) {
+  const resolvedLocale = useResolvedLocale(locale);
+  const items = useMemo(() => buildCountryItems(resolvedLocale), [resolvedLocale]);
+
+  const isControlled = value !== undefined;
+  const willAutoDetect = !isControlled && defaultValue === undefined && autoDetect;
+
+  // Internal controlled state for the auto-detect path. We can't use
+  // `defaultSelectedKey` for auto-detect because the detected value
+  // isn't known until after the first paint (useEffect runs post-mount).
+  const [internalKey, setInternalKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!willAutoDetect) return;
+    const detected = detectBrowserCountry();
+    if (detected !== null) setInternalKey(detected);
+  }, [willAutoDetect]);
+
+  const handleSelectionChange = (key: Key | null) => {
+    const next = key === null ? null : String(key);
+    if (willAutoDetect) setInternalKey(next);
+    onSelectionChange?.(next);
+  };
+
+  // Build the ComboBox props bag conditionally — the @glaon/ui package
+  // compiles with `exactOptionalPropertyTypes: true`, so passing
+  // explicit `undefined` to an optional prop fails type-check.
+  const comboProps: Record<string, unknown> = {
+    items,
+    size,
+    onSelectionChange: handleSelectionChange,
+    defaultFilter: diacriticInsensitiveFilter,
+    shortcut: false,
+  };
+
+  if (isControlled) {
+    comboProps.selectedKey = value;
+  } else if (willAutoDetect) {
+    comboProps.selectedKey = internalKey;
+  } else if (defaultValue !== undefined) {
+    comboProps.defaultSelectedKey = defaultValue;
+  }
+
+  if (label !== undefined) comboProps.label = label;
+  if (placeholder !== undefined) comboProps.placeholder = placeholder;
+  if (hint !== undefined) comboProps.hint = hint;
+  if (isDisabled === true) comboProps.isDisabled = true;
+  if (isInvalid === true) comboProps.isInvalid = true;
+  if (isRequired === true) comboProps.isRequired = true;
+  if (hideRequiredIndicator === true) comboProps.hideRequiredIndicator = true;
+  if (className !== undefined) comboProps.className = className;
+  if (popoverClassName !== undefined) comboProps.popoverClassName = popoverClassName;
+
+  return (
+    <ComboBox {...comboProps}>
+      {(item: SelectItemType) => (
+        <SelectItem
+          id={item.id}
+          label={item.label ?? ''}
+          // Include the ISO code in the searchable text so users can
+          // type "TR" and find Türkiye / Turkey. `item.id` is `string |
+          // number` per the kit's SelectItemType — coerce explicitly so
+          // template-literal restrictions don't flag the row.
+          textValue={`${item.label ?? ''} ${String(item.id)}`}
+        />
+      )}
+    </ComboBox>
+  );
+}
+
+/**
+ * Resolve the locale to use for country-name display + sort. Reads
+ * `navigator.language` lazily so SSR builds don't crash on a missing
+ * `navigator`. Falls back to `'en'` when neither prop nor navigator
+ * is available.
+ */
+function useResolvedLocale(locale: string | undefined): string {
+  return useMemo(() => {
+    if (locale !== undefined && locale.length > 0) return locale;
+    if (typeof navigator !== 'undefined' && navigator.language) {
+      return navigator.language;
+    }
+    return 'en';
+  }, [locale]);
+}

--- a/packages/ui/src/components/CountrySelect/countries.ts
+++ b/packages/ui/src/components/CountrySelect/countries.ts
@@ -17,8 +17,13 @@ import type { SelectItemType } from '../base/select/select-shared';
  * ISO 3166-1 alpha-2 country codes (249 entries, source: ISO 3166
  * Maintenance Agency). Order is alphabetical to make grep-by-code
  * easy; the picker re-sorts by localized name at render time.
+ *
+ * Internal — un-exported per memory note
+ * `feedback_knip_props_interfaces.md` (knip blocks PRs on unused
+ * exports). Promote to a named export here + in `index.ts` when an
+ * external consumer needs to read or re-use the list.
  */
-export const COUNTRY_CODES = [
+const COUNTRY_CODES = [
   'AD',
   'AE',
   'AF',
@@ -270,7 +275,10 @@ export const COUNTRY_CODES = [
   'ZW',
 ] as const;
 
-export type CountryCode = (typeof COUNTRY_CODES)[number];
+// `CountryCode` is only used internally by `detectBrowserCountry`'s
+// return type; kept un-exported per the same memory-note rationale
+// as `COUNTRY_CODES` above.
+type CountryCode = (typeof COUNTRY_CODES)[number];
 
 /**
  * Build a `{ id, label }` list sorted by the localized country name.

--- a/packages/ui/src/components/CountrySelect/countries.ts
+++ b/packages/ui/src/components/CountrySelect/countries.ts
@@ -1,0 +1,368 @@
+// CountrySelect data + helpers.
+//
+// We deliberately ship only the ISO 3166-1 alpha-2 code list (249
+// entries). Display names are derived at runtime via
+// `Intl.DisplayNames(locale, { type: 'region' })` so the same list
+// renders correctly in any locale the browser supports — no shipped
+// translation tables, no extra dependency.
+//
+// `buildCountryItems(locale)` returns a list of `{ id, label }` items
+// sorted by the localized label using `Intl.Collator`. Codes that the
+// runtime can't localize (rare — usually deprecated entries) are
+// filtered out rather than displayed as raw two-letter codes.
+
+import type { SelectItemType } from '../base/select/select-shared';
+
+/**
+ * ISO 3166-1 alpha-2 country codes (249 entries, source: ISO 3166
+ * Maintenance Agency). Order is alphabetical to make grep-by-code
+ * easy; the picker re-sorts by localized name at render time.
+ */
+export const COUNTRY_CODES = [
+  'AD',
+  'AE',
+  'AF',
+  'AG',
+  'AI',
+  'AL',
+  'AM',
+  'AO',
+  'AQ',
+  'AR',
+  'AS',
+  'AT',
+  'AU',
+  'AW',
+  'AX',
+  'AZ',
+  'BA',
+  'BB',
+  'BD',
+  'BE',
+  'BF',
+  'BG',
+  'BH',
+  'BI',
+  'BJ',
+  'BL',
+  'BM',
+  'BN',
+  'BO',
+  'BQ',
+  'BR',
+  'BS',
+  'BT',
+  'BV',
+  'BW',
+  'BY',
+  'BZ',
+  'CA',
+  'CC',
+  'CD',
+  'CF',
+  'CG',
+  'CH',
+  'CI',
+  'CK',
+  'CL',
+  'CM',
+  'CN',
+  'CO',
+  'CR',
+  'CU',
+  'CV',
+  'CW',
+  'CX',
+  'CY',
+  'CZ',
+  'DE',
+  'DJ',
+  'DK',
+  'DM',
+  'DO',
+  'DZ',
+  'EC',
+  'EE',
+  'EG',
+  'EH',
+  'ER',
+  'ES',
+  'ET',
+  'FI',
+  'FJ',
+  'FK',
+  'FM',
+  'FO',
+  'FR',
+  'GA',
+  'GB',
+  'GD',
+  'GE',
+  'GF',
+  'GG',
+  'GH',
+  'GI',
+  'GL',
+  'GM',
+  'GN',
+  'GP',
+  'GQ',
+  'GR',
+  'GS',
+  'GT',
+  'GU',
+  'GW',
+  'GY',
+  'HK',
+  'HM',
+  'HN',
+  'HR',
+  'HT',
+  'HU',
+  'ID',
+  'IE',
+  'IL',
+  'IM',
+  'IN',
+  'IO',
+  'IQ',
+  'IR',
+  'IS',
+  'IT',
+  'JE',
+  'JM',
+  'JO',
+  'JP',
+  'KE',
+  'KG',
+  'KH',
+  'KI',
+  'KM',
+  'KN',
+  'KP',
+  'KR',
+  'KW',
+  'KY',
+  'KZ',
+  'LA',
+  'LB',
+  'LC',
+  'LI',
+  'LK',
+  'LR',
+  'LS',
+  'LT',
+  'LU',
+  'LV',
+  'LY',
+  'MA',
+  'MC',
+  'MD',
+  'ME',
+  'MF',
+  'MG',
+  'MH',
+  'MK',
+  'ML',
+  'MM',
+  'MN',
+  'MO',
+  'MP',
+  'MQ',
+  'MR',
+  'MS',
+  'MT',
+  'MU',
+  'MV',
+  'MW',
+  'MX',
+  'MY',
+  'MZ',
+  'NA',
+  'NC',
+  'NE',
+  'NF',
+  'NG',
+  'NI',
+  'NL',
+  'NO',
+  'NP',
+  'NR',
+  'NU',
+  'NZ',
+  'OM',
+  'PA',
+  'PE',
+  'PF',
+  'PG',
+  'PH',
+  'PK',
+  'PL',
+  'PM',
+  'PN',
+  'PR',
+  'PS',
+  'PT',
+  'PW',
+  'PY',
+  'QA',
+  'RE',
+  'RO',
+  'RS',
+  'RU',
+  'RW',
+  'SA',
+  'SB',
+  'SC',
+  'SD',
+  'SE',
+  'SG',
+  'SH',
+  'SI',
+  'SJ',
+  'SK',
+  'SL',
+  'SM',
+  'SN',
+  'SO',
+  'SR',
+  'SS',
+  'ST',
+  'SV',
+  'SX',
+  'SY',
+  'SZ',
+  'TC',
+  'TD',
+  'TF',
+  'TG',
+  'TH',
+  'TJ',
+  'TK',
+  'TL',
+  'TM',
+  'TN',
+  'TO',
+  'TR',
+  'TT',
+  'TV',
+  'TW',
+  'TZ',
+  'UA',
+  'UG',
+  'UM',
+  'US',
+  'UY',
+  'UZ',
+  'VA',
+  'VC',
+  'VE',
+  'VG',
+  'VI',
+  'VN',
+  'VU',
+  'WF',
+  'WS',
+  'YE',
+  'YT',
+  'ZA',
+  'ZM',
+  'ZW',
+] as const;
+
+export type CountryCode = (typeof COUNTRY_CODES)[number];
+
+/**
+ * Build a `{ id, label }` list sorted by the localized country name.
+ * The returned items satisfy the kit `SelectItemType` shape so the
+ * `<ComboBox>` consumes them directly.
+ */
+export function buildCountryItems(locale: string): SelectItemType[] {
+  let displayNames: Intl.DisplayNames;
+  try {
+    displayNames = new Intl.DisplayNames([locale], { type: 'region' });
+  } catch {
+    // Fallback if the runtime rejects the locale (e.g. malformed BCP-47).
+    displayNames = new Intl.DisplayNames(['en'], { type: 'region' });
+  }
+  const collator = new Intl.Collator(locale, { sensitivity: 'base' });
+  return (
+    COUNTRY_CODES.map((code) => {
+      const label = displayNames.of(code) ?? code;
+      return { id: code, label };
+    })
+      // Drop codes the runtime couldn't localize — surfacing raw alpha-2
+      // codes in a country picker is worse than silently omitting them.
+      .filter((item) => item.label !== item.id)
+      .sort((a, b) => collator.compare(a.label, b.label))
+  );
+}
+
+/**
+ * Derive the user's country from the browser's locale settings.
+ * Returns the ISO 3166-1 alpha-2 region tag (e.g. `'TR'`, `'US'`) or
+ * `null` when no region can be inferred (locale has no region tag, or
+ * the runtime exposes no `navigator.language`).
+ *
+ * Pure browser API — no network call. SSR-safe (returns `null` when
+ * `navigator` is undefined).
+ */
+export function detectBrowserCountry(): CountryCode | null {
+  if (typeof navigator === 'undefined') return null;
+  const candidates: string[] = [];
+  if (navigator.language) candidates.push(navigator.language);
+  // `navigator.languages` is typed as a non-nullable `ReadonlyArray<string>`
+  // in lib.dom.d.ts, so the runtime presence check that eslint flagged
+  // as dead code is dropped; an empty array is harmless to spread.
+  candidates.push(...navigator.languages);
+  for (const tag of candidates) {
+    const region = extractRegion(tag);
+    if (region && (COUNTRY_CODES as readonly string[]).includes(region)) {
+      return region as CountryCode;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the region subtag (two uppercase letters) from a BCP-47
+ * language tag. Returns `null` when the tag has no region subtag.
+ *
+ * Examples:
+ * - `'tr-TR'` → `'TR'`
+ * - `'en-US'` → `'US'`
+ * - `'zh-Hans-CN'` → `'CN'`
+ * - `'en'` → `null`
+ */
+function extractRegion(tag: string): string | null {
+  const parts = tag.split('-');
+  // Region is a 2-letter uppercase subtag; iterate right-to-left so
+  // we pick the rightmost region tag in extended tags.
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i];
+    if (part && /^[A-Z]{2}$/.test(part)) return part;
+    if (part && /^[a-z]{2}$/.test(part)) return part.toUpperCase();
+  }
+  return null;
+}
+
+/**
+ * Diacritic-insensitive substring filter for the ComboBox's
+ * `defaultFilter` prop. Normalises both sides to NFD, strips combining
+ * marks, lowercases — so `"turkiye"` matches `"Türkiye"` and
+ * `"reunion"` matches `"Réunion"`.
+ */
+export function diacriticInsensitiveFilter(textValue: string, inputValue: string): boolean {
+  if (!inputValue) return true;
+  return normaliseForSearch(textValue).includes(normaliseForSearch(inputValue));
+}
+
+// Combining diacritical marks block — built once to keep the hot
+// path allocation-free. `̀`–`ͯ` covers U+0300–U+036F.
+const COMBINING_MARKS_RE = /[̀-ͯ]/g;
+
+function normaliseForSearch(s: string): string {
+  // NFD splits accented characters into base + combining mark; the
+  // regex strips the combining marks (U+0300–U+036F).
+  return s.normalize('NFD').replace(COMBINING_MARKS_RE, '').toLowerCase();
+}

--- a/packages/ui/src/components/CountrySelect/index.ts
+++ b/packages/ui/src/components/CountrySelect/index.ts
@@ -1,0 +1,10 @@
+// Per memory note `feedback_knip_props_interfaces.md`: keep prop /
+// utility types un-exported until an external consumer needs them.
+// The component itself is re-exported via the package barrel
+// (`packages/ui/src/index.ts`) and is reachable as `@glaon/ui`'s
+// `CountrySelect`. Types + helpers (`buildCountryItems`,
+// `detectBrowserCountry`, `diacriticInsensitiveFilter`, ...) ship in
+// the same module — add named exports here when an app feature
+// starts importing them and the same PR wires the consumer.
+
+export { CountrySelect } from './CountrySelect';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,6 +16,7 @@ export * from './components/ButtonGroup';
 export * from './components/Calendar';
 export * from './components/Card';
 export * from './components/Checkbox';
+export * from './components/CountrySelect';
 export * from './components/DatePicker';
 export * from './components/DateRangePicker';
 export * from './components/Drawer';


### PR DESCRIPTION
## Summary

Searchable country picker that wraps the kit `<ComboBox>`. Ships the 249-entry ISO 3166-1 alpha-2 list; country names are localized at render time via `Intl.DisplayNames` so the same dataset renders in any locale the browser supports — no shipped translation tables, no extra dependency.

When the new `autoDetect` prop is `true` (default), the picker pre-selects the user's country derived from `navigator.language` / `navigator.languages` on mount. Pure browser API, no network call. Auto-detection is skipped when `value` or `defaultValue` is set.

Search is diacritic-insensitive (`turkiye` matches `Türkiye`, `reunion` matches `Réunion`) and the ISO code is searchable too (`TR` → Türkiye). Sort uses `Intl.Collator` so locale-specific collation works (`Çekya` lands where Turkish expects it).

Closes #577

## Scope

**In**
- New primitive `packages/ui/src/components/CountrySelect/` with `CountrySelect.tsx`, `.stories.tsx`, `.controls.ts`, `.mdx`, `countries.ts` (data + helpers), `index.ts`.
- Re-export from the package barrel (`packages/ui/src/index.ts`).
- Storybook story catalogue: default (auto-detect on), explicit `defaultValue`, `autoDetect=false`, Turkish locale, German locale, Arabic + RTL, disabled, error state, hint, size matrix.
- MDX docs page with when-to-use / when-not / accessibility / search behaviour / related-components sections.
- F6 prop-coverage gate satisfied via `CountrySelect.controls.ts`.

**Out**
- Region / state sub-pickers (separate primitive if needed).
- Phone-number country prefix (lives in a future `PhoneInput` primitive).
- IP-based geolocation — out of scope and a privacy concern; this primitive only reads browser locale.
- Wiring into specific feature forms — each consumer opens its own follow-up issue.

## Layout note

The issue body said \"lives in `packages/ui/src/components/app/...`\" but the repo's actual convention is flat — `SetupLayout`, `PasswordInput`, `VerificationCodeInput` and every other primitive live directly under `components/`. Following the existing convention here; will update the issue body to match.

## Known rule deviations (per scoping with the user)

- **Design-System Fidelity Rule** — primitive ships without a pre-existing Figma frame. Code-first this round; design review and `parameters.design` node-id wiring follow in a separate PR. The story currently points at the Design System file root with a placeholder `?node-id=app-primitives-country-select`, matching the existing `Select.stories.tsx` placeholder pattern.

## Test plan

- [x] `pnpm type-check` green in `@glaon/ui`.
- [x] `pnpm lint` green in `@glaon/ui`.
- [x] `pnpm test` green in `@glaon/ui` (144 tests, includes F6 prop-coverage gate over 17 primitives).
- [x] `pnpm build-storybook` green — full Storybook build compiles the new component + MDX docs.
- [ ] Story-tests pass in CI (Playwright not installed locally; trusting CI to verify rendered output).
- [ ] Chromatic baseline reviewed — accept the new `CountrySelect/*` snapshots if visually correct.
- [ ] Manual sanity in Storybook dev server: `Default` story preselects current browser country; `AutoDetectOff` starts empty; `WithDefaultValue` shows Türkiye; `TurkishLocale` renders names in Turkish and sorts correctly; `ArabicRtl` renders right-to-left; `WithError` shows red border + red hint.

## Follow-ups

- Sister primitive `TimezoneSelect` (#578) will reuse the same wrap pattern.
- Design-review pass to draw the Figma frame and replace the placeholder `node-id` with a real Figma node.
- Once an app feature consumes `CountrySelectProps` (e.g. setup wizard region step), re-export the type from `CountrySelect/index.ts` in the same PR that wires the consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)