### PR TITLE
fix(ui): CountrySelect polish — flag icons, globe glyph, error auto-clear, select-all-on-focus

### DIFF
--- a/packages/ui/src/components/CountrySelect/CountrySelect.mdx
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.mdx
@@ -117,9 +117,32 @@ browser supports — no shipped translation tables, no extra dependency.
 ## Search behaviour
 
 The filter is **diacritic-insensitive** — typing `turkiye` matches
-`Türkiye`, `reunion` matches `Réunion`, etc. The ISO code is also
-searchable, so typing `TR` lands on Türkiye and `US` on the United
-States.
+`Türkiye`, `reunion` matches `Réunion`, etc. Search is by country
+name only; ISO codes are intentionally not matched (they don't read
+naturally in the search affordance and add noise to the result list).
+
+The input **selects-all on focus**, so the next keystroke replaces
+the current label cleanly. Tab in, type, pick — the previous selection
+doesn't need to be cleared manually.
+
+## Flags and trigger glyph
+
+Every row renders the country flag (circular sprite from
+`flag-icons`) as a leading glyph. Once a country is selected, the
+trigger leading glyph swaps from a generic `Globe` to the selected
+country's flag, so the picker visually reads as "a country is
+chosen" at a glance.
+
+## Error UX
+
+`isInvalid` styling **clears automatically** the moment the user
+makes a selection — picking a country counts as resolving the error.
+If your re-validation rejects the new value, toggle `isInvalid` from
+`false` → `true` to force the error back on; the picker re-arms its
+suppression every time the prop transitions.
+
+Pair the styling with a descriptive `hint` ("Country is required.")
+so the user understands what's wrong before they pick.
 
 ## Related components
 

--- a/packages/ui/src/components/CountrySelect/CountrySelect.tsx
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.tsx
@@ -6,31 +6,38 @@
 //   - Bundled ISO 3166-1 alpha-2 list, localized at render time via
 //     `Intl.DisplayNames` — no shipped translation tables, no dep.
 //   - Diacritic-insensitive search (`turkiye` → `Türkiye`, `reunion`
-//     → `Réunion`) plus searchable ISO code (`TR` → `Türkiye`).
+//     → `Réunion`).
 //   - Optional one-shot browser locale auto-detection — when on, the
 //     picker preselects the user's country derived from
 //     `navigator.language` / `navigator.languages`. Pure browser API,
 //     no network call.
-//
-// State machine — three modes:
-//
-//   - **Controlled.** Host passes `value`; we forward it as
-//     `selectedKey`. Host owns the state.
-//   - **Uncontrolled, explicit default.** Host passes `defaultValue`;
-//     we forward it as `defaultSelectedKey`. RAC owns state.
-//   - **Uncontrolled, auto-detect.** Host passes neither and
-//     `autoDetect` is true. We hold an internal `selectedKey` so the
-//     async detection result (resolved in `useEffect`) can be injected
-//     after mount.
+//   - Flag glyphs (rounded sprite from `flag-icons`) in every list
+//     row and in the trigger once a country is selected. A `Globe`
+//     glyph stands in until the first selection.
+//   - Errors clear after the user picks a country. The host can
+//     re-assert `isInvalid` (toggle false → true) to force the error
+//     back when re-validation rejects the new value.
+//   - Select-all-on-focus inside the input so the next keystroke
+//     replaces the previous selection cleanly.
 //
 // Per CLAUDE.md's UUI Source Rule and Component Data-Fetching Boundary:
 // the visual + popover positioning + RAC plumbing come from the kit;
 // this wrapper's contribution is the prop API + the static country
 // list + locale detection. No network call lives here.
 
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type FC,
+  type FocusEvent,
+  type ReactNode,
+} from 'react';
+import { Globe01 } from '@untitledui/icons';
 import type { Key } from 'react-aria-components';
 
+import { Flag } from '../../icons/flag';
 import { ComboBox, SelectItem, type SelectItemType } from '../Select';
 import { buildCountryItems, detectBrowserCountry, diacriticInsensitiveFilter } from './countries';
 
@@ -81,8 +88,14 @@ interface CountrySelectProps {
   hint?: ReactNode;
   /** Block all interaction and dim the trigger. */
   isDisabled?: boolean;
-  /** Surface validation error styling. Pair with `hint` to describe
-   *  the error; the kit wires `aria-invalid` + `aria-describedby`. */
+  /**
+   * Surface validation error styling. Pair with `hint` to describe
+   * the error; the kit wires `aria-invalid` + `aria-describedby`.
+   *
+   * The picker auto-clears this styling once the user makes a
+   * selection — the host can re-assert it by toggling `isInvalid`
+   * from `false` → `true` after re-validation.
+   */
   isInvalid?: boolean;
   /** Mark the field as required (renders an indicator next to the
    *  label and forwards `aria-required`). */
@@ -121,25 +134,64 @@ export function CountrySelect({
   const resolvedLocale = useResolvedLocale(locale);
   const items = useMemo(() => buildCountryItems(resolvedLocale), [resolvedLocale]);
 
-  const isControlled = value !== undefined;
-  const willAutoDetect = !isControlled && defaultValue === undefined && autoDetect;
+  const isHostControlled = value !== undefined;
 
-  // Internal controlled state for the auto-detect path. We can't use
-  // `defaultSelectedKey` for auto-detect because the detected value
-  // isn't known until after the first paint (useEffect runs post-mount).
-  const [internalKey, setInternalKey] = useState<string | null>(null);
+  // Unified selection state — held by the wrapper so the trigger
+  // can render the selected country's flag in every mode (the kit's
+  // ComboBoxStateContext is only readable from inside the ComboBox).
+  // Seeded from `defaultValue`; auto-detect (in the useEffect below)
+  // promotes the seed when neither `value` nor `defaultValue` is set.
+  const [internalKey, setInternalKey] = useState<string | null>(defaultValue ?? null);
 
   useEffect(() => {
-    if (!willAutoDetect) return;
+    if (isHostControlled) return;
+    if (defaultValue !== undefined) return;
+    if (!autoDetect) return;
     const detected = detectBrowserCountry();
     if (detected !== null) setInternalKey(detected);
-  }, [willAutoDetect]);
+    // One-shot mount detection — explicit empty dep array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const effectiveKey = isHostControlled ? value : internalKey;
+
+  // Suppress the invalid styling once the user picks something. The
+  // host can re-assert `isInvalid` by toggling it false → true (the
+  // effect below resets the suppression when the prop transitions).
+  const [suppressInvalid, setSuppressInvalid] = useState(false);
+  useEffect(() => {
+    setSuppressInvalid(false);
+  }, [isInvalid]);
 
   const handleSelectionChange = (key: Key | null) => {
     const next = key === null ? null : String(key);
-    if (willAutoDetect) setInternalKey(next);
+    if (!isHostControlled) setInternalKey(next);
+    setSuppressInvalid(true);
     onSelectionChange?.(next);
   };
+
+  // Select-all-on-focus inside the inner search input so the next
+  // keystroke replaces the previous label cleanly. RAC's ComboBox
+  // doesn't forward `onFocus` to the input, so we capture at the
+  // wrapper and act on any input descendant. `requestAnimationFrame`
+  // defers the `.select()` until RAC's own focus handling settles.
+  const handleFocusCapture = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.disabled || target.readOnly) return;
+    requestAnimationFrame(() => {
+      try {
+        target.select();
+      } catch {
+        // Input may have unmounted (e.g. dropdown closed) between
+        // the focus event and the rAF tick — the failed `.select()`
+        // is harmless and we don't need to surface it.
+      }
+    });
+  }, []);
+
+  const effectiveInvalid = isInvalid === true && !suppressInvalid;
+  const triggerIcon = renderTriggerIcon(effectiveKey);
 
   // Build the ComboBox props bag conditionally — the @glaon/ui package
   // compiles with `exactOptionalPropertyTypes: true`, so passing
@@ -147,43 +199,35 @@ export function CountrySelect({
   const comboProps: Record<string, unknown> = {
     items,
     size,
+    selectedKey: effectiveKey ?? null,
     onSelectionChange: handleSelectionChange,
     defaultFilter: diacriticInsensitiveFilter,
     shortcut: false,
+    icon: triggerIcon,
   };
-
-  if (isControlled) {
-    comboProps.selectedKey = value;
-  } else if (willAutoDetect) {
-    comboProps.selectedKey = internalKey;
-  } else if (defaultValue !== undefined) {
-    comboProps.defaultSelectedKey = defaultValue;
-  }
 
   if (label !== undefined) comboProps.label = label;
   if (placeholder !== undefined) comboProps.placeholder = placeholder;
   if (hint !== undefined) comboProps.hint = hint;
   if (isDisabled === true) comboProps.isDisabled = true;
-  if (isInvalid === true) comboProps.isInvalid = true;
+  if (effectiveInvalid) comboProps.isInvalid = true;
   if (isRequired === true) comboProps.isRequired = true;
   if (hideRequiredIndicator === true) comboProps.hideRequiredIndicator = true;
   if (className !== undefined) comboProps.className = className;
   if (popoverClassName !== undefined) comboProps.popoverClassName = popoverClassName;
 
   return (
-    <ComboBox {...comboProps}>
-      {(item: SelectItemType) => (
-        <SelectItem
-          id={item.id}
-          label={item.label ?? ''}
-          // Include the ISO code in the searchable text so users can
-          // type "TR" and find Türkiye / Turkey. `item.id` is `string |
-          // number` per the kit's SelectItemType — coerce explicitly so
-          // template-literal restrictions don't flag the row.
-          textValue={`${item.label ?? ''} ${String(item.id)}`}
-        />
-      )}
-    </ComboBox>
+    <div onFocusCapture={handleFocusCapture}>
+      <ComboBox {...comboProps}>
+        {(item: SelectItemType) => (
+          <SelectItem
+            id={item.id}
+            label={item.label ?? ''}
+            icon={renderListItemFlag(String(item.id))}
+          />
+        )}
+      </ComboBox>
+    </div>
   );
 }
 
@@ -201,4 +245,34 @@ function useResolvedLocale(locale: string | undefined): string {
     }
     return 'en';
   }, [locale]);
+}
+
+/**
+ * Trigger leading icon. Returns the `Globe01` component (so the kit
+ * applies the standard `*:data-icon:size-5` styling) until the user
+ * picks a country; once a country is selected, returns a pre-tagged
+ * `<span data-icon>` wrapping the country's flag so the kit's
+ * `isValidElement` branch renders it verbatim — `data-icon` is what
+ * pulls the sizing + colour utilities through.
+ */
+function renderTriggerIcon(code: string | null | undefined): FC | ReactNode {
+  if (!code) return Globe01;
+  return (
+    <span data-icon className="flex shrink-0 items-center" aria-hidden="true">
+      <Flag country={code} shape="circle" />
+    </span>
+  );
+}
+
+/**
+ * Per-row flag for each country in the popover. Same `data-icon` trick
+ * as the trigger icon — the kit's `*:data-icon:size-5` selector on
+ * the row container picks it up.
+ */
+function renderListItemFlag(code: string): ReactNode {
+  return (
+    <span data-icon className="flex shrink-0 items-center" aria-hidden="true">
+      <Flag country={code} shape="circle" />
+    </span>
+  );
 }


### PR DESCRIPTION
## Summary

Follow-up to the merged #584. Review feedback on the shipped primitive surfaced five visual + UX gaps; all five land here.

1. **Search-by-ISO-code dropped.** The first cut packed the alpha-2 code into each row's `textValue` so typing `TR` matched Türkiye — but the code reads as noise next to the country name. Search is now by localized name only (still diacritic-insensitive).
2. **`isInvalid` styling auto-clears** the moment the user picks a country. The host can re-assert by toggling `isInvalid` false → true after re-validation.
3. **Trigger leading glyph** swaps Search for Globe (`@untitledui/icons` `Globe01`). When a country is selected, the glyph upgrades to that country's flag.
4. **Every list row** carries the country's flag as its leading glyph (circular `flag-icons` sprite via the existing `<Flag>` registry).
5. **Select-all-on-focus** in the search input — tabbing in and typing replaces the previous label cleanly.

Closes #585

## Scope

**In**
- `packages/ui/src/components/CountrySelect/CountrySelect.tsx` — state machine collapsed to one mode (always-controlled-from-wrapper) so the trigger can read the selected key in every mode; new flag/globe icon helpers; new focus-capture select-all handler; new `suppressInvalid` state with reset-on-prop-transition.
- `packages/ui/src/components/CountrySelect/CountrySelect.mdx` — Search behaviour section drops the ISO-code line; new Flags / Trigger glyph + Error UX sections explain the new contracts.

**Out**
- TimezoneSelect (#578).
- LocationPicker (#579).
- Mobile / React Native CountrySelect variant.
- Figma frame for the new visual — still pending per the rule-deviation we accepted for #577.

## Implementation notes

- The kit ComboBox doesn't forward `onFocus` to its inner `<AriaInput>`. The select-all-on-focus rides on a wrapper `onFocusCapture` that walks any descendant input. A `requestAnimationFrame` defers `.select()` until RAC's own focus handling settles.
- ComboBox `icon` prop accepts `FC | ReactNode`. The `FC` path picks up the kit's `*:data-icon:size-5` selector automatically. For our flag span (the `ReactNode` path), we pre-attach `data-icon` so the same selector matches.
- `isInvalid` auto-clear: local `suppressInvalid` flag, set on every selection, reset whenever the `isInvalid` prop transitions (`false → true` after re-validation re-arms the error).

## Process note

The polish commits originally went up to the `577-country-select` branch after #584 had already merged, so they never reached a PR. Cherry-picked the meaningful commit onto a fresh branch off `development`; the stale `577-country-select` branch will be deleted as cleanup once this lands.

## Test plan

- [x] `pnpm type-check` green in `@glaon/ui`.
- [x] `pnpm lint` green in `@glaon/ui`.
- [x] `pnpm knip` doesn't flag any of the touched files.
- [ ] CI: story-tests, Chromatic visual regression, unit-tests, knip, package-contract.
- [ ] Chromatic — baseline the new visuals (flag glyph in trigger, per-row flags, Globe-when-empty, auto-cleared error).
- [ ] Manual sanity in Storybook:
  - Trigger glyph: Globe when empty, flag once a country is picked.
  - Every row shows its flag (circle shape).
  - `WithError` story: pick a country → red ring + red hint disappear.
  - Click into the input on `WithDefaultValue` story → label fully selected.
  - Type `tr` → only Türkiye in the list (no rows where `tr` matched the code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)