### PR TITLE
feat(ui): add TimezoneSelect primitive with browser autodetect

### DIFF
--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.controls.ts
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.controls.ts
@@ -1,0 +1,118 @@
+// `TimezoneSelect.controls.ts` — single source of truth for
+// TimezoneSelect's variant matrix. Story (`TimezoneSelect.stories.tsx`)
+// imports the spec and spreads it into `meta.args` / `meta.argTypes`;
+// MDX docs (`TimezoneSelect.mdx`) reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+const localeOptions = ['', 'tr-TR', 'en-US', 'de-DE', 'fr-FR', 'ar-SA'] as const;
+
+export const timezoneSelectControls = {
+  label: {
+    type: 'text',
+    default: 'Timezone',
+    description:
+      'Visible label rendered above the trigger. Always provide one — labels satisfy axe `label` and pair the picker with assistive tech automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  placeholder: {
+    type: 'text',
+    default: 'Select a timezone',
+    description:
+      'Hint text shown when no option is selected. Never use placeholder as a substitute for the label.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the trigger. Doubles as the error message when `isInvalid` is true (the kit re-styles it red and adds `aria-describedby`).',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  autoDetect: {
+    type: 'boolean',
+    default: true,
+    description:
+      'When true (default), pre-select the timezone returned by `Intl.DateTimeFormat().resolvedOptions().timeZone` on mount. Ignored when `value` or `defaultValue` is set. Detection is one-shot — re-mount to re-detect.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  locale: {
+    type: 'select',
+    options: localeOptions,
+    default: '',
+    description:
+      'BCP-47 locale used for collation when sorting city labels. Leave empty to use the browser default (`navigator.language`). The labels themselves stay in English — only the sort order follows the locale.',
+    category: 'Content',
+  } satisfies ControlSpec<(typeof localeOptions)[number]>,
+  defaultValue: {
+    type: 'text',
+    description:
+      'Uncontrolled initial selection — IANA timezone identifier (e.g. `Europe/Istanbul`, `America/New_York`). When set, `autoDetect` is ignored.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale forwarded to the underlying ComboBox. `sm` for compact toolbars, `md` (default) for forms, `lg` for hero affordances.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Block all interaction and dim the trigger. The kit forwards `aria-disabled` so axe and assistive tech treat the field as inert.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isInvalid: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Surface validation error styling (red border + ring on the trigger). Auto-clears once the user makes a selection; the host can re-assert by toggling `false → true` after re-validation.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  isRequired: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Mark the field as required (renders an indicator next to the label and forwards `aria-required`).',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  hideRequiredIndicator: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Hide the visual `*` next to the label even when `isRequired` is true. Keep `isRequired` set so the a11y contract still reports the field as required.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  value: {
+    type: 'text',
+    description:
+      'Controlled selection — IANA timezone identifier. Pair with `onSelectionChange` to manage state outside.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onSelectionChange: {
+    type: false,
+    action: 'selection-changed',
+    description:
+      'Fires when the selected timezone changes — receives the new IANA identifier or `null` when cleared.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  popoverClassName: {
+    type: false,
+    description: 'Tailwind override hook for the popover surface that wraps the option list.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// No additional excludes — every public prop on `TimezoneSelect` is
+// represented above. The helper export is still required by the F6
+// prop-coverage gate's named-export contract.
+export const timezoneSelectExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.mdx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.mdx
@@ -1,0 +1,149 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as TimezoneSelectStories from './TimezoneSelect.stories';
+
+<Meta of={TimezoneSelectStories} />
+
+# TimezoneSelect
+
+App-primitive IANA timezone picker. Thin wrap over the kit
+[`<ComboBox>`](?path=/docs/web-primitives-select--docs#withsearch)
+that adds the built-in timezone list, locale-aware sorting,
+diacritic-insensitive search, and optional one-shot browser
+autodetection.
+
+Sister primitive to
+[CountrySelect](?path=/docs/app-primitives-countryselect--docs) —
+same prop contract, same state machine, same polish (auto-clear-error,
+select-all-on-focus). The differences come from the dataset (IANA
+zones, no flag glyphs) and the detection source
+(`Intl.DateTimeFormat().resolvedOptions().timeZone`).
+
+## When to use
+
+- Setup wizard's region / scheduling step.
+- Profile screen — user timezone for notifications, reminders, and
+  scheduled actions.
+- Automation editor — "run this at 8am in the user's timezone" vs
+  "run this at 8am UTC".
+
+## When NOT to use
+
+- A short curated list of "supported regions" — use a plain
+  [Select](?path=/docs/web-primitives-select--docs) with the curated
+  options.
+- A clock / time-of-day picker — that's a future `TimeInput`
+  primitive, not this one.
+
+## Auto-detection
+
+When `autoDetect` is `true` (the default), on mount the picker reads
+`Intl.DateTimeFormat().resolvedOptions().timeZone` and pre-selects
+the matching IANA identifier. The detection is **pure browser API**
+— no network call leaves the component, no geo-IP service is
+contacted.
+
+Detection is **one-shot** at mount. The picker doesn't re-detect
+when the runtime timezone changes mid-session (rare, but happens on
+some mobile platforms) — re-mount the component to re-run detection.
+
+Auto-detection is **skipped** when:
+
+- `value` is passed (the host owns the state).
+- `defaultValue` is passed (an explicit initial choice wins).
+- `autoDetect` is `false`.
+
+### Examples
+
+```tsx
+// Pre-select from the runtime timezone.
+<TimezoneSelect onSelectionChange={setTimezone} />
+
+// Always start empty; let the user pick.
+<TimezoneSelect autoDetect={false} onSelectionChange={setTimezone} />
+
+// Controlled, hydrated from a profile load.
+<TimezoneSelect value={user.timezone} onSelectionChange={updateTimezone} />
+```
+
+## Anatomy
+
+<Canvas of={TimezoneSelectStories.WithDefaultValue} />
+
+```tsx
+<TimezoneSelect
+  label="Timezone"
+  placeholder="Select a timezone"
+  onSelectionChange={(tz) => setTimezone(tz)}
+/>
+```
+
+Each row renders the city (last segment of the IANA id with
+underscores prettied) and the current UTC offset, e.g.
+`Istanbul — (UTC+03:00)`. The UTC zone itself shows as `UTC — (UTC)`.
+
+## Dataset and localization
+
+The list comes from `Intl.supportedValuesOf('timeZone')` — the
+runtime-built-in IANA database (~430 zones on a modern engine, no
+shipped table). The `locale` prop drives `Intl.Collator` for
+locale-aware sort order; labels themselves stay in English because
+the IANA database is English-only. If your design needs localized
+city names, that's a follow-up that needs a translation table.
+
+## Search behaviour
+
+The filter is **diacritic-insensitive** — typing `istanbul` matches
+`Istanbul`, `reunion` matches `Réunion`. Search is by the displayed
+label only (city + offset string).
+
+The input **selects-all on focus**, so the next keystroke replaces
+the current label cleanly. Tab in, type, pick — no manual clear.
+
+## Error UX
+
+`isInvalid` styling **clears automatically** the moment the user
+makes a selection — picking a timezone counts as resolving the
+error. If your re-validation rejects the new value, toggle
+`isInvalid` from `false` → `true` to force the error back on; the
+picker re-arms its suppression every time the prop transitions.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Always pass a `label` — the kit ComboBox binds it to the trigger
+  via the standard RAC label slot.
+- The popover is keyboard-navigable (Arrow up/down, Enter to select,
+  Esc to dismiss) and the search input is a real `<input>` with
+  `aria-autocomplete="list"`.
+- Pair `isInvalid` with a descriptive `hint` ("Timezone is
+  required.") — the kit wires `aria-invalid` + `aria-describedby`
+  automatically.
+- `isRequired` adds a visual `*` and forwards `aria-required`. Use
+  `hideRequiredIndicator` on dense forms to drop the asterisk while
+  keeping the a11y contract.
+
+## DST and runtime drift
+
+The UTC offset displayed in each label is a snapshot computed at
+module load. The picker doesn't track DST transitions live; in
+practice this is fine because user sessions rarely span a DST
+boundary, and the value the picker emits is the IANA id (not the
+offset), so downstream date arithmetic stays correct.
+
+## Related components
+
+- [CountrySelect](?path=/docs/app-primitives-countryselect--docs) —
+  sister primitive for ISO 3166-1 countries with the same
+  `autoDetect` contract.
+- [Select](?path=/docs/web-primitives-select--docs) — generic
+  single-value picker; use it for short curated lists.
+- [FormField](?path=/docs/app-primitives-formfield--docs) — wrapper
+  for label + control + error in compound forms.

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.stories.tsx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { TimezoneSelect } from './TimezoneSelect';
+import { timezoneSelectControls, timezoneSelectExcludeFromArgs } from './TimezoneSelect.controls';
+
+const { args, argTypes } = defineControls(timezoneSelectControls);
+
+// Explicit `Meta<typeof TimezoneSelect>` annotation (vs `satisfies`)
+// keeps the kit's deep RAC generic chains out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// `tags: ['autodocs']` is intentionally omitted because
+// `TimezoneSelect.mdx` replaces the docs tab.
+const meta: Meta<typeof TimezoneSelect> = {
+  title: 'App Primitives/TimezoneSelect',
+  component: TimezoneSelect,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=app-primitives-timezone-select',
+    },
+  },
+  args,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof TimezoneSelect>;
+
+export const excludeFromArgs = timezoneSelectExcludeFromArgs;
+
+/**
+ * Default — auto-detect on. On a browser whose runtime resolves to
+ * `Europe/Istanbul` the picker opens with that zone preselected.
+ * The Clock glyph stays put even after a country is chosen (no
+ * per-zone visual identity).
+ */
+export const Default: Story = {};
+
+/**
+ * Explicit `defaultValue`. The auto-detect path is skipped when the
+ * host provides a default; the picker starts with the host's choice.
+ */
+export const WithDefaultValue: Story = {
+  args: { defaultValue: 'Europe/Istanbul', autoDetect: false },
+};
+
+/**
+ * Auto-detect off — the picker starts empty regardless of the
+ * runtime's timezone. Use this when the host owns the state lifecycle
+ * (e.g. a profile form that hydrates from the server).
+ */
+export const AutoDetectOff: Story = {
+  args: { autoDetect: false },
+};
+
+/**
+ * Common US East Coast zone — confirms the city label drops the
+ * underscore (`America/New_York` renders as `New York — (UTC−04:00)`
+ * or similar, depending on DST at story-load time).
+ */
+export const NewYork: Story = {
+  args: { defaultValue: 'America/New_York', autoDetect: false },
+};
+
+/**
+ * UTC — the special-case zone the formatter normalises to `(UTC)`
+ * (no `±HH:MM` suffix).
+ */
+export const Utc: Story = {
+  args: { defaultValue: 'UTC', autoDetect: false },
+};
+
+/**
+ * Turkish locale — same dataset, Turkish collation order. Labels
+ * stay in English (the IANA database is English-only) but sort
+ * behaviour follows the locale's `Intl.Collator` rules.
+ */
+export const TurkishLocale: Story = {
+  args: {
+    locale: 'tr-TR',
+    autoDetect: false,
+    defaultValue: 'Europe/Istanbul',
+    label: 'Saat dilimi',
+  },
+};
+
+/**
+ * Arabic locale — exercises the RTL render path. The decorator wraps
+ * the field in `dir="rtl"` so the popover, input alignment, and
+ * indicator placement mirror correctly.
+ */
+export const ArabicRtl: Story = {
+  args: {
+    locale: 'ar-SA',
+    autoDetect: false,
+    defaultValue: 'Asia/Riyadh',
+    label: 'المنطقة الزمنية',
+  },
+  decorators: [
+    (Story) => (
+      <div dir="rtl" style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** Disabled — trigger is dimmed, popover does not open. */
+export const Disabled: Story = {
+  args: { defaultValue: 'Europe/Istanbul', autoDetect: false, isDisabled: true },
+};
+
+/** Invalid + hint — error styling with descriptive copy below.
+ *  Picking a zone auto-clears the styling. */
+export const WithError: Story = {
+  args: {
+    autoDetect: false,
+    isInvalid: true,
+    hint: 'Timezone is required.',
+  },
+};
+
+/** Helper text under the trigger when the field is valid. */
+export const WithHint: Story = {
+  args: {
+    autoDetect: false,
+    hint: 'Used for scheduling and reminders.',
+  },
+};
+
+/** Size matrix — `sm`, `md`, `lg`. */
+export const Sizes: Story = {
+  parameters: { controls: { exclude: ['size', 'label'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {(['sm', 'md', 'lg'] as const).map((size) => (
+        <TimezoneSelect
+          key={size}
+          {...args}
+          size={size}
+          label={`Size: ${size}`}
+          autoDetect={false}
+          defaultValue="Europe/Istanbul"
+        />
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.tsx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.tsx
@@ -1,0 +1,230 @@
+// Glaon TimezoneSelect — searchable IANA timezone picker that wraps
+// the kit `<ComboBox>` (`packages/ui/src/components/base/select/combobox.tsx`).
+//
+// Sister primitive to `CountrySelect` — same wrap pattern, same
+// state machine, same polish features (auto-clear-error,
+// select-all-on-focus, diacritic-insensitive filter):
+//
+//   - Built-in IANA list from `Intl.supportedValuesOf('timeZone')`,
+//     no shipped database, no extra dependency.
+//   - Display labels combine city (last segment of the IANA id, with
+//     underscores prettied) and current UTC offset
+//     (`(UTC+03:00)` etc.) so users can disambiguate at a glance.
+//   - Optional one-shot browser autodetection — when on, the picker
+//     preselects the zone returned by
+//     `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+//   - `Clock` glyph (`@untitledui/icons`) as the trigger leading
+//     icon. Unlike CountrySelect we don't swap the icon per-zone;
+//     timezones don't have a comparable visual identity.
+//
+// Per CLAUDE.md's UUI Source Rule and Component Data-Fetching Boundary:
+// the visual + popover positioning + RAC plumbing come from the kit;
+// this wrapper contributes the prop API + the dataset + detection.
+// No network call lives here.
+
+import { useCallback, useEffect, useMemo, useState, type FocusEvent, type ReactNode } from 'react';
+import { Clock } from '@untitledui/icons';
+import type { Key } from 'react-aria-components';
+
+import { ComboBox, SelectItem, type SelectItemType } from '../Select';
+import { buildTimezoneItems, detectBrowserTimezone, diacriticInsensitiveFilter } from './timezones';
+
+// Types stay un-exported per memory note `feedback_knip_props_interfaces.md`
+// — `react-docgen-typescript` still resolves the prop names for the
+// F6 prop-coverage gate without a top-level `export`. Promote to
+// `index.ts` once an external consumer needs them.
+type TimezoneSelectSize = 'sm' | 'md' | 'lg';
+
+interface TimezoneSelectProps {
+  /**
+   * Controlled selection — IANA timezone identifier (e.g.
+   * `'Europe/Istanbul'`, `'America/New_York'`). Pair with
+   * `onSelectionChange` to manage state outside. When set,
+   * `defaultValue` and `autoDetect` are ignored.
+   */
+  value?: string;
+  /**
+   * Uncontrolled initial selection — IANA timezone identifier to
+   * start with. When set, `autoDetect` is ignored.
+   */
+  defaultValue?: string;
+  /**
+   * Fires when the user (or the auto-detect path) changes the
+   * selection. Receives the IANA identifier, or `null` when the
+   * selection is cleared.
+   */
+  onSelectionChange?: (timezone: string | null) => void;
+  /**
+   * When `true` (default), pre-select the timezone returned by
+   * `Intl.DateTimeFormat().resolvedOptions().timeZone` on mount.
+   * Ignored when `value` or `defaultValue` is set. Detection is
+   * one-shot — re-mount to re-detect.
+   * @default true
+   */
+  autoDetect?: boolean;
+  /**
+   * BCP-47 locale tag used to sort city labels. Defaults to
+   * `navigator.language` in the browser, `'en'` on a runtime without
+   * `navigator` (e.g. SSR). The city labels themselves stay in
+   * English (the IANA database is English); only the sort order
+   * follows the locale's collation rules.
+   */
+  locale?: string;
+  /** Field label rendered above the trigger. */
+  label?: string;
+  /** Placeholder text shown when no option is selected. */
+  placeholder?: string;
+  /** Helper text shown under the trigger; doubles as the error
+   *  message when `isInvalid` is true. */
+  hint?: ReactNode;
+  /** Block all interaction and dim the trigger. */
+  isDisabled?: boolean;
+  /**
+   * Surface validation error styling. Pair with `hint` to describe
+   * the error; the kit wires `aria-invalid` + `aria-describedby`.
+   *
+   * The picker auto-clears this styling once the user makes a
+   * selection — the host can re-assert it by toggling `isInvalid`
+   * from `false` → `true` after re-validation.
+   */
+  isInvalid?: boolean;
+  /** Mark the field as required (renders an indicator next to the
+   *  label and forwards `aria-required`). */
+  isRequired?: boolean;
+  /** Hide the visual `*` next to the label even when `isRequired`
+   *  is true. Keeps the a11y contract. */
+  hideRequiredIndicator?: boolean;
+  /**
+   * Visual scale of the underlying ComboBox.
+   * @default 'md'
+   */
+  size?: TimezoneSelectSize;
+  /** Tailwind override hook for the outer wrapper. */
+  className?: string;
+  /** Tailwind override hook for the popover surface. */
+  popoverClassName?: string;
+}
+
+export function TimezoneSelect({
+  value,
+  defaultValue,
+  onSelectionChange,
+  autoDetect = true,
+  locale,
+  label,
+  placeholder,
+  hint,
+  isDisabled,
+  isInvalid,
+  isRequired,
+  hideRequiredIndicator,
+  size = 'md',
+  className,
+  popoverClassName,
+}: TimezoneSelectProps) {
+  const resolvedLocale = useResolvedLocale(locale);
+  const items = useMemo(() => buildTimezoneItems(resolvedLocale), [resolvedLocale]);
+
+  const isHostControlled = value !== undefined;
+
+  // Unified selection state — seeded from `defaultValue`; auto-detect
+  // promotes the seed when neither `value` nor `defaultValue` is set.
+  // Same shape as CountrySelect so the wrap pattern stays consistent
+  // across the sister pair.
+  const [internalKey, setInternalKey] = useState<string | null>(defaultValue ?? null);
+
+  useEffect(() => {
+    if (isHostControlled) return;
+    if (defaultValue !== undefined) return;
+    if (!autoDetect) return;
+    const detected = detectBrowserTimezone();
+    if (detected !== null) setInternalKey(detected);
+    // One-shot mount detection — explicit empty dep array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const effectiveKey = isHostControlled ? value : internalKey;
+
+  // Suppress the invalid styling once the user picks something. The
+  // host can re-assert `isInvalid` by toggling it false → true (the
+  // effect below resets the suppression when the prop transitions).
+  const [suppressInvalid, setSuppressInvalid] = useState(false);
+  useEffect(() => {
+    setSuppressInvalid(false);
+  }, [isInvalid]);
+
+  const handleSelectionChange = (key: Key | null) => {
+    const next = key === null ? null : String(key);
+    if (!isHostControlled) setInternalKey(next);
+    setSuppressInvalid(true);
+    onSelectionChange?.(next);
+  };
+
+  // Select-all-on-focus inside the inner search input so the next
+  // keystroke replaces the previous label cleanly. RAC's ComboBox
+  // doesn't forward `onFocus` to the input, so we capture at the
+  // wrapper and act on any input descendant. `requestAnimationFrame`
+  // defers the `.select()` until RAC's own focus handling settles.
+  const handleFocusCapture = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.disabled || target.readOnly) return;
+    requestAnimationFrame(() => {
+      try {
+        target.select();
+      } catch {
+        // Input may have unmounted between the focus event and the
+        // rAF tick — the failed `.select()` is harmless.
+      }
+    });
+  }, []);
+
+  const effectiveInvalid = isInvalid === true && !suppressInvalid;
+
+  // Build the ComboBox props bag conditionally — the @glaon/ui package
+  // compiles with `exactOptionalPropertyTypes: true`, so passing
+  // explicit `undefined` to an optional prop fails type-check.
+  const comboProps: Record<string, unknown> = {
+    items,
+    size,
+    selectedKey: effectiveKey ?? null,
+    onSelectionChange: handleSelectionChange,
+    defaultFilter: diacriticInsensitiveFilter,
+    shortcut: false,
+    icon: Clock,
+  };
+
+  if (label !== undefined) comboProps.label = label;
+  if (placeholder !== undefined) comboProps.placeholder = placeholder;
+  if (hint !== undefined) comboProps.hint = hint;
+  if (isDisabled === true) comboProps.isDisabled = true;
+  if (effectiveInvalid) comboProps.isInvalid = true;
+  if (isRequired === true) comboProps.isRequired = true;
+  if (hideRequiredIndicator === true) comboProps.hideRequiredIndicator = true;
+  if (className !== undefined) comboProps.className = className;
+  if (popoverClassName !== undefined) comboProps.popoverClassName = popoverClassName;
+
+  return (
+    <div onFocusCapture={handleFocusCapture}>
+      <ComboBox {...comboProps}>
+        {(item: SelectItemType) => <SelectItem id={item.id} label={item.label ?? ''} />}
+      </ComboBox>
+    </div>
+  );
+}
+
+/**
+ * Resolve the locale to use for the timezone collator. Reads
+ * `navigator.language` lazily so SSR builds don't crash on a missing
+ * `navigator`. Falls back to `'en'` when neither prop nor navigator
+ * is available.
+ */
+function useResolvedLocale(locale: string | undefined): string {
+  return useMemo(() => {
+    if (locale !== undefined && locale.length > 0) return locale;
+    if (typeof navigator !== 'undefined' && navigator.language) {
+      return navigator.language;
+    }
+    return 'en';
+  }, [locale]);
+}

--- a/packages/ui/src/components/TimezoneSelect/index.ts
+++ b/packages/ui/src/components/TimezoneSelect/index.ts
@@ -1,0 +1,10 @@
+// Per memory note `feedback_knip_props_interfaces.md`: keep prop /
+// utility types un-exported until an external consumer needs them.
+// The component itself is re-exported via the package barrel
+// (`packages/ui/src/index.ts`) and reachable as `@glaon/ui`'s
+// `TimezoneSelect`. Helpers (`buildTimezoneItems`,
+// `detectBrowserTimezone`, `diacriticInsensitiveFilter`, ...) ship in
+// the same module — add named exports here when an app feature
+// starts importing them and the same PR wires the consumer.
+
+export { TimezoneSelect } from './TimezoneSelect';

--- a/packages/ui/src/components/TimezoneSelect/timezones.ts
+++ b/packages/ui/src/components/TimezoneSelect/timezones.ts
@@ -1,0 +1,140 @@
+// TimezoneSelect data + helpers.
+//
+// The IANA timezone list comes from `Intl.supportedValuesOf('timeZone')`
+// — supported across modern engines (Chrome 99+, Firefox 93+,
+// Safari 15.4+). On a runtime without the API we fall back to `[UTC]`
+// so the picker at least surfaces *something* rather than erroring;
+// the fallback is intentionally minimal because every supported
+// browser meets the threshold.
+//
+// Display labels combine the city (last segment of the IANA id, with
+// underscores prettied) and the current UTC offset
+// (`Intl.DateTimeFormat` with `timeZoneName: 'longOffset'`). The
+// offset is a snapshot at module-load time — we don't track DST
+// transitions live; consumers that need that should observe the
+// underlying value and re-mount when the wall clock changes day.
+
+import type { SelectItemType } from '../base/select/select-shared';
+
+const FALLBACK_TIMEZONES = ['UTC'] as const;
+
+/**
+ * Resolve the list of IANA timezone identifiers exposed by the
+ * runtime. Built-in via `Intl.supportedValuesOf` on modern engines;
+ * falls back to a single-entry list on engines that predate the API.
+ *
+ * Internal — un-exported per memory note `feedback_knip_props_interfaces.md`
+ * (knip blocks PRs on unused exports). Promote when an external
+ * consumer needs the raw list.
+ */
+function getTimezoneList(): readonly string[] {
+  try {
+    const intlWithSupported = Intl as typeof Intl & {
+      supportedValuesOf?: (key: 'timeZone') => string[];
+    };
+    if (typeof intlWithSupported.supportedValuesOf === 'function') {
+      const zones = intlWithSupported.supportedValuesOf('timeZone');
+      if (zones.length > 0) return zones;
+    }
+  } catch {
+    // Fall through to the static fallback.
+  }
+  return FALLBACK_TIMEZONES;
+}
+
+/**
+ * Compute the `(UTC±HH:MM)` offset suffix for a given IANA timezone
+ * at the current moment. Returns the string suitable for direct
+ * concatenation into a display label, e.g. `'(UTC+03:00)'` for
+ * `'Europe/Istanbul'`. Falls back to `'(UTC)'` for the UTC zone or
+ * any zone the runtime cannot format.
+ */
+function formatUtcOffset(timeZone: string): string {
+  try {
+    const dtf = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      timeZoneName: 'longOffset',
+    });
+    const parts = dtf.formatToParts(new Date());
+    const tzPart = parts.find((p) => p.type === 'timeZoneName');
+    const raw = tzPart?.value ?? '';
+    // `longOffset` yields strings like `'GMT+03:00'`, `'GMT-05:30'`,
+    // or `'GMT'` for UTC. Normalize to the Glaon convention
+    // (`UTC` rather than `GMT`, explicit `±00:00` for the zero
+    // offset so the column visually aligns).
+    if (raw === 'GMT' || raw === '') return '(UTC)';
+    return `(${raw.replace('GMT', 'UTC')})`;
+  } catch {
+    return '(UTC)';
+  }
+}
+
+/**
+ * Derive a human-readable city label from an IANA timezone id:
+ * - `'Europe/Istanbul'` → `'Istanbul'`
+ * - `'America/New_York'` → `'New York'`
+ * - `'Pacific/Port_Moresby'` → `'Port Moresby'`
+ * - `'UTC'` → `'UTC'`
+ */
+function cityFromTimezone(timeZone: string): string {
+  const segments = timeZone.split('/');
+  const last = segments[segments.length - 1] ?? timeZone;
+  return last.replace(/_/g, ' ');
+}
+
+/**
+ * Build a `{ id, label }` list of timezones sorted by the localized
+ * city label using `Intl.Collator` so locale-aware collation kicks in
+ * (e.g. Turkish ordering for Turkish callers).
+ */
+export function buildTimezoneItems(locale: string): SelectItemType[] {
+  const zones = getTimezoneList();
+  const collator = new Intl.Collator(locale, { sensitivity: 'base' });
+  return zones
+    .map((tz) => {
+      const city = cityFromTimezone(tz);
+      const offset = formatUtcOffset(tz);
+      return { id: tz, label: `${city} — ${offset}` };
+    })
+    .sort((a, b) => collator.compare(a.label, b.label));
+}
+
+/**
+ * Detect the user's IANA timezone from the runtime's locale settings.
+ * Returns the IANA identifier (e.g. `'Europe/Istanbul'`) or `null`
+ * when the runtime exposes no `Intl.DateTimeFormat` (rare).
+ *
+ * Pure browser API — no network call. SSR-safe (returns `null` when
+ * `Intl` or the resolved-options call is unavailable).
+ */
+export function detectBrowserTimezone(): string | null {
+  if (typeof Intl === 'undefined') return null;
+  try {
+    const resolved = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (typeof resolved === 'string' && resolved.length > 0) return resolved;
+  } catch {
+    // Fall through.
+  }
+  return null;
+}
+
+/**
+ * Diacritic-insensitive substring filter for the ComboBox's
+ * `defaultFilter` prop — mirrors the helper inside
+ * `CountrySelect/countries.ts`. Duplicated rather than extracted to a
+ * shared util to keep this PR scoped to TimezoneSelect; a follow-up
+ * can pull both copies into a shared `_internal` module when there's
+ * a third caller.
+ */
+export function diacriticInsensitiveFilter(textValue: string, inputValue: string): boolean {
+  if (!inputValue) return true;
+  return normaliseForSearch(textValue).includes(normaliseForSearch(inputValue));
+}
+
+// Combining diacritical marks block — built once to keep the hot
+// path allocation-free. `̀`–`ͯ` covers U+0300–U+036F.
+const COMBINING_MARKS_RE = /[̀-ͯ]/g;
+
+function normaliseForSearch(s: string): string {
+  return s.normalize('NFD').replace(COMBINING_MARKS_RE, '').toLowerCase();
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -43,6 +43,7 @@ export * from './components/Switch';
 export * from './components/Table';
 export * from './components/Tabs';
 export * from './components/Textarea';
+export * from './components/TimezoneSelect';
 export * from './components/Toast';
 export * from './components/Tooltip';
 export * from './components/TopBar';


### PR DESCRIPTION
## Summary

Sister primitive to CountrySelect (#577 / #586). Same wrap pattern + state machine + polish features — different dataset and detection source.

- **Dataset:** `Intl.supportedValuesOf('timeZone')` — ~430 IANA zones on a modern engine, no shipped table, no extra dependency.
- **Labels:** `City — (UTC±HH:MM)` (e.g. `Istanbul — (UTC+03:00)`). UTC normalises to `UTC — (UTC)`.
- **Auto-detect (default on):** reads `Intl.DateTimeFormat().resolvedOptions().timeZone` on mount and pre-selects the matching identifier. Skipped when `value` / `defaultValue` is set or `autoDetect` is false.

Polish features inherited from the post-merge CountrySelect review (#586):

- `isInvalid` styling auto-clears the moment the user picks a zone; toggling `false → true` re-arms the error on re-validation.
- Inner search input selects-all on focus.
- Diacritic-insensitive filter on the city/offset label.

Differences from CountrySelect:

- Trigger leading glyph is `Clock` (untitled/icons) and kept static — timezones don't have a comparable per-zone visual identity, so no per-row glyph either.
- No flag registry consumption.
- Detection source is `Intl.DateTimeFormat`, not `navigator.language`.

Closes #578

## Scope

**In**
- New primitive `packages/ui/src/components/TimezoneSelect/` with `TimezoneSelect.tsx`, `.stories.tsx`, `.controls.ts`, `.mdx`, `timezones.ts` (data + helpers), `index.ts`.
- Re-export from the package barrel (`packages/ui/src/index.ts`).
- Storybook story catalogue: default (auto-detect on), explicit `defaultValue`, `autoDetect=false`, New York, UTC, Turkish locale, Arabic + RTL, disabled, error state, hint, size matrix.
- MDX docs page with when-to-use / when-not / auto-detection / dataset+localization / search behaviour / error UX / DST notes / related-components sections.
- F6 prop-coverage gate satisfied via `TimezoneSelect.controls.ts`.

**Out**
- LocationPicker (#579) — third primitive in the Phase 2 picker trio.
- Mobile / React-Native variant.
- Localized city names (would need a translation table; the IANA database is English-only).
- DST-transition live updates (the displayed UTC offset is a snapshot at module load).
- Region grouping in the dropdown — deferred to design review.

## Known rule deviations (per scoping with the user)

- **Design-System Fidelity Rule** — primitive ships without a pre-existing Figma frame. Code-first this round; design review and `parameters.design` node-id wiring follow in a separate PR. The story currently points at the Design System file root with a placeholder `?node-id=app-primitives-timezone-select`, matching the existing `Select.stories.tsx` / CountrySelect placeholder pattern.
- **Diacritic filter duplication** — copied from `CountrySelect/countries.ts` rather than extracted into a shared `_internal` module. Intentional: keeps this PR scoped to TimezoneSelect. Open a follow-up to extract once a third caller appears.

## Test plan

- [x] `pnpm type-check` green in `@glaon/ui`.
- [x] `pnpm lint` green in `@glaon/ui`.
- [x] `pnpm test` green in `@glaon/ui` (147 tests — 3 more than before; F6 prop-coverage now discovers TimezoneSelect).
- [x] `pnpm knip` doesn't flag any of the new files.
- [ ] CI: story-tests, Chromatic visual regression, unit-tests, knip, package-contract.
- [ ] Chromatic — baseline the new visuals (Clock glyph, city + offset labels, dropdown filtering).
- [ ] Manual sanity in Storybook:
  - `Default` story pre-selects the current runtime timezone (likely `Europe/Istanbul`).
  - `AutoDetectOff` story starts empty.
  - `WithDefaultValue` shows `Istanbul — (UTC+03:00)`.
  - `NewYork` story shows `New York — (UTC−04:00)` or similar (depending on DST at story-load time).
  - `Utc` story shows `UTC — (UTC)` (no offset suffix).
  - `WithError` story → pick any zone → red ring + red hint disappear.
  - Click into the input on `WithDefaultValue` → label fully selected.
  - Type `istanb` → only Istanbul (and any zone whose city label contains `istanb`) in the list.

## Follow-ups

- Sister primitive `LocationPicker` (#579) — third + most complex of the Phase 2 picker trio. Mapbox-based; involves CSP changes + new dep + Chromatic secret. Should land last.
- Design-review pass to draw the Figma frame and replace the placeholder `node-id` with a real Figma node.
- Extract the diacritic filter into a shared `_internal` module once a third caller (LocationPicker?) needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)