### PR TITLE
feat(ui): add LocationPicker primitive — MapLibre + Nominatim

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -71,8 +71,10 @@
     "@react-types/shared": "^3.34.0",
     "@untitledui/icons": "^0.0.22",
     "flag-icons": "^7.5.0",
+    "maplibre-gl": "^5.24.0",
     "react-aria": "^3.48.0",
     "react-aria-components": "^1.17.0",
+    "react-map-gl": "^8.1.1",
     "react-stately": "^3.46.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -65,6 +65,9 @@
   },
   "type": "module",
   "types": "./src/index.ts",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "dependencies": {
     "@internationalized/date": "^3.12.0",
     "@react-stately/utils": "^3.11.0",

--- a/packages/ui/src/components/LocationPicker/LocationPicker.controls.ts
+++ b/packages/ui/src/components/LocationPicker/LocationPicker.controls.ts
@@ -1,0 +1,135 @@
+// `LocationPicker.controls.ts` — single source of truth for
+// LocationPicker's variant matrix. Story (`LocationPicker.stories.tsx`)
+// imports the spec and spreads it into `meta.args` / `meta.argTypes`;
+// MDX docs (`LocationPicker.mdx`) reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+const localeOptions = ['', 'tr-TR', 'en-US', 'de-DE', 'fr-FR', 'ar-SA'] as const;
+
+export const locationPickerControls = {
+  label: {
+    type: 'text',
+    default: 'Location',
+    description:
+      'Visible label rendered above the search input. Always provide one — labels satisfy axe `label` and pair the picker with assistive tech automatically.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  placeholder: {
+    type: 'text',
+    default: 'Search for an address',
+    description:
+      'Hint text shown inside the search input. Never use placeholder as a substitute for the label.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the search input. Doubles as the error message when `isInvalid` is true.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  locale: {
+    type: 'select',
+    options: localeOptions,
+    default: '',
+    description:
+      'BCP-47 locale forwarded to the geocoder. Leave empty to use the browser default (`navigator.language`).',
+    category: 'Content',
+  } satisfies ControlSpec<(typeof localeOptions)[number]>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description:
+      'Visual scale of the search input. `sm` for compact toolbars, `md` (default) for forms, `lg` for hero affordances.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  mapHeight: {
+    type: 'number',
+    default: 320,
+    min: 200,
+    max: 800,
+    step: 20,
+    description: 'Height of the map canvas in pixels. The width fills the wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<number>,
+  defaultZoom: {
+    type: 'number',
+    default: 4,
+    min: 1,
+    max: 18,
+    step: 1,
+    description:
+      'Initial map zoom when no `value` / `defaultValue` is set. The picker auto-zooms to 14 whenever the user picks a suggestion.',
+    category: 'Behavior',
+  } satisfies ControlSpec<number>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description:
+      "Block all interaction — input is dim, suggestions don't open, marker drag is disabled, map is non-interactive.",
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isInvalid: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Surface validation error styling on the search input. Auto-clears once the user makes a selection; toggling `false → true` re-arms the error.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  isRequired: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Mark the field as required (renders an indicator next to the label and forwards `aria-required`).',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  hideRequiredIndicator: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Hide the visual `*` next to the label even when `isRequired` is true. Keep `isRequired` set so the a11y contract still reports the field as required.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  value: {
+    type: false,
+    description: 'Controlled selection — `{ lat, lng, address? }`. Pair with `onChange`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  defaultValue: {
+    type: false,
+    description: 'Uncontrolled initial selection — `{ lat, lng, address? }`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  defaultCenter: {
+    type: false,
+    description:
+      'Initial map centre `{ lat, lng }` when no `value` / `defaultValue` is set. Defaults to Istanbul.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  geocode: {
+    type: false,
+    description:
+      'Async geocoder `(query, signal?, locale?) => Promise<Suggestion[]>`. Pass `nominatimGeocode` for the free OSM default.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onChange: {
+    type: false,
+    action: 'changed',
+    description:
+      'Fires on every settled selection — autocomplete pick or marker drag. Receives `{ lat, lng, address? }`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// No additional excludes — every public prop on `LocationPicker` is
+// represented above. The helper export is still required by the F6
+// prop-coverage gate's named-export contract.
+export const locationPickerExcludeFromArgs = defineExcludeFromArgs([] as const);

--- a/packages/ui/src/components/LocationPicker/LocationPicker.mdx
+++ b/packages/ui/src/components/LocationPicker/LocationPicker.mdx
@@ -1,0 +1,151 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as LocationPickerStories from './LocationPicker.stories';
+
+<Meta of={LocationPickerStories} />
+
+# LocationPicker
+
+App-primitive location picker. Search-as-you-type address input paired
+with an interactive MapLibre map and a draggable marker. Returns
+`{ lat, lng, address? }` so consumers can persist exact coordinates
+plus the human-readable address the user picked.
+
+Third primitive in the Phase 2 picker trio, alongside
+[CountrySelect](?path=/docs/app-primitives-countryselect--docs) and
+[TimezoneSelect](?path=/docs/app-primitives-timezoneselect--docs).
+
+## Provider stack
+
+- **Map:** MapLibre GL (open-source fork of Mapbox GL, no token).
+- **Tiles:** OpenStreetMap raster tiles via `tile.openstreetmap.org`.
+- **Geocoder:** Nominatim (OSM) by default via the sibling
+  `nominatimGeocode` helper — injected through the `geocode` prop
+  per the [Component Data-Fetching Boundary](https://github.com/Glaon-Smart/glaon/blob/development/CLAUDE.md#component-data-fetching-boundary-mandatory)
+  rule.
+
+Production deployments that exceed Nominatim's free-tier rate limit
+(1 req/sec per user) should swap in a paid provider (Geoapify,
+LocationIQ) or a self-hosted Nominatim. The wrapper signature
+`(query, signal?, locale?) => Promise<Suggestion[]>` is
+provider-agnostic by design.
+
+## When to use
+
+- Setup wizard's location step (device install location, residence,
+  default reminder zone).
+- Any form that needs precise coordinates plus a human-readable
+  label — billing address, delivery address, meeting location.
+
+## When NOT to use
+
+- Free-text address-only fields where coordinates don't matter —
+  use a plain [Input](?path=/docs/web-primitives-input--docs).
+- A pure country picker — use
+  [CountrySelect](?path=/docs/app-primitives-countryselect--docs).
+
+## Anatomy
+
+<Canvas of={LocationPickerStories.WithDefaultValue} />
+
+```tsx
+import { LocationPicker, nominatimGeocode } from '@glaon/ui';
+
+<LocationPicker label="Location" geocode={nominatimGeocode} onChange={(loc) => setLocation(loc)} />;
+```
+
+The trigger renders a search input with a magnifier glyph. As the
+user types, the picker debounces the query (300ms), aborts any
+in-flight request, and posts the latest input to the `geocode`
+callback. Suggestions stream into the popover; picking one flies
+the map to the location and drops a draggable marker.
+
+## Marker drag
+
+The marker is draggable by default (disabled when `isDisabled` is
+true). `onChange` fires on every drag-end with the new
+`{ lat, lng }` — note that the `address` field is **only** populated
+for autocomplete picks; marker drags emit lat/lng only. If you need
+reverse-geocoding after a drag, call your geocoder from the host
+layer (the same `nominatimGeocode` helper can be adapted).
+
+## State machine
+
+Three modes, same as the sister primitives:
+
+- **Controlled.** Host passes `value`; the picker reflects it.
+- **Uncontrolled, explicit default.** Host passes `defaultValue`;
+  the picker seeds from it.
+- **Uncontrolled, empty.** Map opens at `defaultCenter`
+  (Istanbul by default) with no marker until the user picks
+  something.
+
+## Error UX
+
+`isInvalid` styling **clears automatically** the moment the user
+makes a selection — picking a location counts as resolving the
+error. Toggling `isInvalid` from `false` → `true` after
+re-validation re-arms the error. Pair with a descriptive `hint`.
+
+## Search behaviour
+
+The input **selects-all on focus**, so the next keystroke replaces
+the current label cleanly. The kit's local filter is disabled
+(`defaultFilter={() => true}`) because the geocoder already returns
+filtered results — the picker just renders whatever the callback
+resolved with.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Always pass a `label` — the kit ComboBox binds it to the search
+  input via the standard RAC label slot.
+- The popover is keyboard-navigable (Arrow up/down, Enter to
+  select, Esc to dismiss) and the search input is a real `<input>`
+  with `aria-autocomplete="list"`.
+- The map canvas is announced via `aria-controls` pointing from
+  the input — assistive tech reads the input as controlling the
+  map region.
+- Marker drag is mouse / touch only at the kit primitive level;
+  keyboard-only users can still pick coordinates via the
+  autocomplete. A keyboard-driven nudge affordance is a candidate
+  for a v2 polish PR.
+- Pair `isInvalid` with descriptive copy — the kit wires
+  `aria-invalid` + `aria-describedby` automatically.
+
+## CSP requirements
+
+LocationPicker needs the following Content-Security-Policy
+entries:
+
+- `connect-src` — `https://nominatim.openstreetmap.org` (geocoder).
+- `img-src` — `https://*.tile.openstreetmap.org` (raster tiles).
+- `worker-src` — `'self' blob:` (MapLibre's render worker, spawned
+  from a blob URL).
+
+The repo's current Glaon-web CSP (`apps/web/index.html`) is
+permissive enough on all three axes — `connect-src` and `img-src`
+both include the `https:` umbrella, and `worker-src 'self' blob:`
+is already set for the Clerk auth worker (#517). No CSP edit is
+needed in this PR; that's a happy accident of the existing
+posture, not an invariant.
+
+When (a) the umbrella `connect-src https:` is tightened to an
+explicit allow-list or (b) the provider is swapped to a paid
+geocoder, the new endpoints must be added explicitly.
+
+## Related components
+
+- [CountrySelect](?path=/docs/app-primitives-countryselect--docs) —
+  sister primitive for ISO 3166-1 countries.
+- [TimezoneSelect](?path=/docs/app-primitives-timezoneselect--docs) —
+  sister primitive for IANA timezones.
+- [FormField](?path=/docs/app-primitives-formfield--docs) — wrapper
+  for label + control + error in compound forms.

--- a/packages/ui/src/components/LocationPicker/LocationPicker.stories.tsx
+++ b/packages/ui/src/components/LocationPicker/LocationPicker.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { LocationPicker } from './LocationPicker';
+import { locationPickerControls, locationPickerExcludeFromArgs } from './LocationPicker.controls';
+import { nominatimGeocode, type GeocodeSuggestion } from './geocoding';
+
+const { args, argTypes } = defineControls(locationPickerControls);
+
+// Static mock geocoder — deterministic so Chromatic snapshots stay
+// stable. Filters a hand-curated list of well-known landmarks by
+// substring. The `Live (Nominatim)` story below opts into the real
+// endpoint for manual sanity but disables the Chromatic snapshot.
+const MOCK_RESULTS: GeocodeSuggestion[] = [
+  {
+    id: 'istanbul',
+    label: 'Istanbul, Türkiye',
+    lat: 41.0082,
+    lng: 28.9784,
+  },
+  {
+    id: 'ankara',
+    label: 'Ankara, Türkiye',
+    lat: 39.9334,
+    lng: 32.8597,
+  },
+  {
+    id: 'izmir',
+    label: 'İzmir, Türkiye',
+    lat: 38.4192,
+    lng: 27.1287,
+  },
+  {
+    id: 'berlin',
+    label: 'Berlin, Deutschland',
+    lat: 52.52,
+    lng: 13.405,
+  },
+  {
+    id: 'london',
+    label: 'London, United Kingdom',
+    lat: 51.5074,
+    lng: -0.1278,
+  },
+  {
+    id: 'newyork',
+    label: 'New York, NY, United States',
+    lat: 40.7128,
+    lng: -74.006,
+  },
+];
+
+const mockGeocode = (query: string): Promise<GeocodeSuggestion[]> => {
+  const needle = query.toLowerCase().trim();
+  const matches = MOCK_RESULTS.filter((r) => r.label.toLowerCase().includes(needle));
+  return Promise.resolve(matches);
+};
+
+const meta: Meta<typeof LocationPicker> = {
+  title: 'App Primitives/LocationPicker',
+  component: LocationPicker,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=app-primitives-location-picker',
+    },
+  },
+  args: { ...args, geocode: mockGeocode },
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 480 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof LocationPicker>;
+
+export const excludeFromArgs = locationPickerExcludeFromArgs;
+
+/**
+ * Default — empty input, map at the fallback centre (Istanbul) at
+ * zoom 4. Type any substring of the curated mock list (e.g.
+ * `ankara`, `berlin`, `new york`) to see the autocomplete + map
+ * fly-to flow.
+ */
+export const Default: Story = {};
+
+/**
+ * Pre-selected — `defaultValue` set to Istanbul. The map opens
+ * centred on the marker at zoom 14. Drag the marker to fine-tune
+ * coordinates; `onChange` fires on settle.
+ */
+export const WithDefaultValue: Story = {
+  args: {
+    defaultValue: {
+      lat: 41.0082,
+      lng: 28.9784,
+      address: 'Istanbul, Türkiye',
+    },
+  },
+};
+
+/**
+ * Berlin centre — confirms the picker handles negative-zero zoom
+ * starts and that the marker drop matches the curated label.
+ */
+export const Berlin: Story = {
+  args: {
+    defaultValue: {
+      lat: 52.52,
+      lng: 13.405,
+      address: 'Berlin, Deutschland',
+    },
+  },
+};
+
+/**
+ * Disabled — input is dim, suggestions don't open, marker is
+ * non-draggable, map is non-interactive.
+ */
+export const Disabled: Story = {
+  args: {
+    defaultValue: {
+      lat: 41.0082,
+      lng: 28.9784,
+      address: 'Istanbul, Türkiye',
+    },
+    isDisabled: true,
+  },
+};
+
+/** Invalid + hint — error styling clears on the next selection. */
+export const WithError: Story = {
+  args: {
+    isInvalid: true,
+    hint: 'Pick a location to continue.',
+  },
+};
+
+/** Helper text under the input when the field is valid. */
+export const WithHint: Story = {
+  args: {
+    hint: 'Drag the marker to fine-tune the address.',
+  },
+};
+
+/**
+ * Larger map — `mapHeight: 480`. Useful as the centre-of-stage
+ * affordance on a dedicated location step.
+ */
+export const TallerMap: Story = {
+  args: { mapHeight: 480 },
+};
+
+/**
+ * Smaller map — `mapHeight: 240`. Fits dense forms where the
+ * picker is one of several fields.
+ */
+export const ShorterMap: Story = {
+  args: { mapHeight: 240 },
+};
+
+/**
+ * Live Nominatim — opts into the real free-tier OSM geocoder for
+ * manual sanity checking. Disabled in Chromatic to keep snapshots
+ * deterministic (and to respect Nominatim's free-tier rate limit).
+ */
+export const LiveNominatim: Story = {
+  args: { geocode: nominatimGeocode },
+  parameters: { chromatic: { disableSnapshot: true } },
+};

--- a/packages/ui/src/components/LocationPicker/LocationPicker.tsx
+++ b/packages/ui/src/components/LocationPicker/LocationPicker.tsx
@@ -1,0 +1,408 @@
+// Glaon LocationPicker — search-as-you-type address picker paired
+// with an interactive MapLibre map. The third primitive in the
+// Phase 2 picker trio (CountrySelect #577, TimezoneSelect #578).
+//
+// UX:
+//
+//   1. User types into the search input.
+//   2. Suggestions stream in (debounced + abortable) via the
+//      `geocode` callback the host injects. Default helper is
+//      `nominatimGeocode` for the free OSM endpoint.
+//   3. Selecting a suggestion flies the map to the location and
+//      drops a draggable marker.
+//   4. The user can drag the marker to fine-tune the coordinates;
+//      `onChange` fires on every settle with `{ lat, lng, address? }`.
+//
+// Per CLAUDE.md's Component Data-Fetching Boundary rule, the network
+// fetch itself is injected via the `geocode` prop — the component
+// owns the debounce / abort / paint trigger, but never imports
+// `fetch` calling code at module scope. The `nominatimGeocode`
+// helper ships alongside as a sibling export so stories and feature
+// pages can wire it in one line.
+//
+// Per the UUI Source Rule, the search input is the kit `<ComboBox>`
+// with `defaultFilter={() => true}` so the kit doesn't try to filter
+// our async-loaded suggestion list locally (server-side filtering
+// already narrowed them).
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent,
+  type ReactNode,
+} from 'react';
+import { MarkerPin01, SearchLg } from '@untitledui/icons';
+import Map, {
+  Marker,
+  NavigationControl,
+  type MapRef,
+  type MarkerDragEvent,
+} from 'react-map-gl/maplibre';
+// MapLibre's CSS is imported package-wide via `src/styles/globals.css`
+// alongside the kit's other stylesheet imports — no per-component
+// import needed.
+import type { Key } from 'react-aria-components';
+
+import { ComboBox, SelectItem, type SelectItemType } from '../Select';
+import type { GeocodeSuggestion } from './geocoding';
+
+// Types stay un-exported per memory note `feedback_knip_props_interfaces.md`
+// — `react-docgen-typescript` still resolves the prop names for the
+// F6 prop-coverage gate without a top-level `export`. Promote when
+// an external consumer needs them.
+type LocationPickerSize = 'sm' | 'md' | 'lg';
+
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+interface LocationValue extends LatLng {
+  address?: string;
+}
+
+type Geocoder = (
+  query: string,
+  signal?: AbortSignal,
+  locale?: string,
+) => Promise<GeocodeSuggestion[]>;
+
+interface LocationPickerProps {
+  /**
+   * Controlled selection — `{ lat, lng, address? }`. Pair with
+   * `onChange` to manage state outside. When set, `defaultValue` is
+   * ignored.
+   */
+  value?: LocationValue;
+  /** Uncontrolled initial selection. */
+  defaultValue?: LocationValue;
+  /**
+   * Initial map centre when no `value` / `defaultValue` is set.
+   * Defaults to Istanbul (`{ lat: 41.0082, lng: 28.9784 }`) — change
+   * to a region-appropriate fallback for non-TR deployments.
+   */
+  defaultCenter?: LatLng;
+  /**
+   * Initial map zoom when no `value` is set. The picker auto-zooms
+   * to `14` whenever the user picks a suggestion.
+   * @default 4
+   */
+  defaultZoom?: number;
+  /**
+   * Async geocoder. The component debounces input (300ms) and
+   * aborts in-flight requests when the query changes, so the
+   * callback only sees the latest live query. Required for the
+   * autocomplete to work — pass `nominatimGeocode` for the free OSM
+   * default.
+   */
+  geocode?: Geocoder;
+  /**
+   * Fires on every settled selection — autocomplete pick or marker
+   * drag. Receives `{ lat, lng, address? }` (the `address` is only
+   * present for autocomplete picks; marker drags emit lat/lng only).
+   */
+  onChange?: (value: LocationValue) => void;
+  /**
+   * BCP-47 locale forwarded to the geocoder's `accept-language`
+   * query — Nominatim returns labels in that language when the OSM
+   * data has translations. Defaults to `navigator.language`.
+   */
+  locale?: string;
+  /** Field label rendered above the search input. */
+  label?: string;
+  /** Placeholder text inside the search input. */
+  placeholder?: string;
+  /** Helper text shown under the input; doubles as the error
+   *  message when `isInvalid` is true. */
+  hint?: ReactNode;
+  /** Block all interaction and dim the trigger + map. */
+  isDisabled?: boolean;
+  /**
+   * Surface validation error styling on the search input. Auto-clears
+   * the moment the user makes a selection; toggling `false → true`
+   * re-arms the error.
+   */
+  isInvalid?: boolean;
+  /** Mark the field as required. */
+  isRequired?: boolean;
+  /** Hide the visual `*` next to the label even when `isRequired` is true. */
+  hideRequiredIndicator?: boolean;
+  /** Visual scale of the search input.
+   *  @default 'md' */
+  size?: LocationPickerSize;
+  /** Height of the map canvas in pixels.
+   *  @default 320 */
+  mapHeight?: number;
+  /** Tailwind override hook for the outer wrapper. */
+  className?: string;
+}
+
+const ISTANBUL: LatLng = { lat: 41.0082, lng: 28.9784 };
+const SUGGESTION_DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 3;
+const PICK_ZOOM = 14;
+
+// MapLibre style JSON for OSM raster tiles. We bundle the style
+// rather than fetching a remote style.json so the strict CSP only
+// has to whitelist tile + nominatim hosts (no extra `connect-src`
+// for a style server).
+const OSM_STYLE = {
+  version: 8 as const,
+  sources: {
+    osm: {
+      type: 'raster' as const,
+      tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
+      tileSize: 256,
+      attribution: '© OpenStreetMap contributors',
+    },
+  },
+  layers: [{ id: 'osm', type: 'raster' as const, source: 'osm' }],
+};
+
+export function LocationPicker({
+  value,
+  defaultValue,
+  defaultCenter = ISTANBUL,
+  defaultZoom = 4,
+  geocode,
+  onChange,
+  locale,
+  label,
+  placeholder = 'Search for an address',
+  hint,
+  isDisabled,
+  isInvalid,
+  isRequired,
+  hideRequiredIndicator,
+  size = 'md',
+  mapHeight = 320,
+  className,
+}: LocationPickerProps) {
+  const resolvedLocale = useResolvedLocale(locale);
+  const mapId = useId();
+  // Unified location state — same shape as CountrySelect /
+  // TimezoneSelect: seeded from defaultValue, controlled-from-wrapper
+  // so the marker + map fly-to can read it in every mode.
+  const [internalValue, setInternalValue] = useState<LocationValue | null>(defaultValue ?? null);
+  const isHostControlled = value !== undefined;
+  const effectiveValue: LocationValue | null = value ?? internalValue;
+
+  // Autocomplete plumbing — debounced query + abortable fetch.
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<GeocodeSuggestion[]>([]);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (geocode === undefined) {
+      setSuggestions([]);
+      return;
+    }
+    const trimmed = query.trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setSuggestions([]);
+      return;
+    }
+    const timer = setTimeout(() => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      geocode(trimmed, controller.signal, resolvedLocale)
+        .then((next) => {
+          if (!controller.signal.aborted) setSuggestions(next);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof DOMException && err.name === 'AbortError') return;
+          // The host owns the error UX (Toast etc.); we collapse the
+          // suggestion list so the user gets a clean re-try affordance.
+          setSuggestions([]);
+        });
+    }, SUGGESTION_DEBOUNCE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [query, geocode, resolvedLocale]);
+
+  useEffect(
+    () => () => {
+      abortRef.current?.abort();
+    },
+    [],
+  );
+
+  // Suppress invalid styling once the user picks something. Reset
+  // when the host re-asserts `isInvalid` (false → true after
+  // re-validation re-arms the error).
+  const [suppressInvalid, setSuppressInvalid] = useState(false);
+  useEffect(() => {
+    setSuppressInvalid(false);
+  }, [isInvalid]);
+
+  const writeValue = useCallback(
+    (next: LocationValue) => {
+      if (!isHostControlled) setInternalValue(next);
+      setSuppressInvalid(true);
+      onChange?.(next);
+    },
+    [isHostControlled, onChange],
+  );
+
+  const handleSelectionChange = (key: Key | null) => {
+    if (key === null) return;
+    const picked = suggestions.find((s) => s.id === String(key));
+    if (picked === undefined) return;
+    writeValue({ lat: picked.lat, lng: picked.lng, address: picked.label });
+    // Sync the input so the trigger reads the picked label after the
+    // popover closes (RAC's default behaviour copies textValue, but
+    // since we set defaultFilter to constant-true the inputValue
+    // path needs an explicit sync).
+    setQuery(picked.label);
+  };
+
+  const handleInputChange = (next: string) => {
+    setQuery(next);
+  };
+
+  const handleMarkerDragEnd = (event: MarkerDragEvent) => {
+    writeValue({ lat: event.lngLat.lat, lng: event.lngLat.lng });
+  };
+
+  // Fly to the picked location whenever the lat/lng changes from
+  // outside the marker-drag path. We track the last lng+lat we
+  // flew to so a drag (which also updates effectiveValue) doesn't
+  // double-fly. The map naturally tracks the marker visually
+  // during a drag.
+  const mapRef = useRef<MapRef>(null);
+  const lastFlownTo = useRef<string | null>(null);
+  useEffect(() => {
+    if (effectiveValue === null) return;
+    const key = `${effectiveValue.lng.toString()},${effectiveValue.lat.toString()}`;
+    if (key === lastFlownTo.current) return;
+    lastFlownTo.current = key;
+    mapRef.current?.flyTo({
+      center: [effectiveValue.lng, effectiveValue.lat],
+      zoom: PICK_ZOOM,
+      duration: 800,
+    });
+  }, [effectiveValue]);
+
+  // Select-all-on-focus inside the search input — same affordance
+  // as CountrySelect / TimezoneSelect.
+  const handleFocusCapture = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.disabled || target.readOnly) return;
+    requestAnimationFrame(() => {
+      try {
+        target.select();
+      } catch {
+        // Input may have unmounted between focus and the rAF tick.
+      }
+    });
+  }, []);
+
+  const effectiveInvalid = isInvalid === true && !suppressInvalid;
+  const items: SelectItemType[] = useMemo(
+    () => suggestions.map((s) => ({ id: s.id, label: s.label })),
+    [suggestions],
+  );
+
+  const initialView = useMemo(() => {
+    const center = effectiveValue ?? defaultCenter;
+    const lat = 'lat' in center ? center.lat : defaultCenter.lat;
+    const lng = 'lng' in center ? center.lng : defaultCenter.lng;
+    const zoom = effectiveValue !== null ? PICK_ZOOM : defaultZoom;
+    return { longitude: lng, latitude: lat, zoom };
+    // Only seeded once; subsequent moves go through flyTo above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Build the ComboBox props bag conditionally — the @glaon/ui package
+  // compiles with `exactOptionalPropertyTypes: true`, so passing an
+  // explicit `undefined` to an optional prop fails type-check.
+  const comboProps: Record<string, unknown> = {
+    items,
+    size,
+    inputValue: query,
+    onInputChange: handleInputChange,
+    onSelectionChange: handleSelectionChange,
+    defaultFilter: () => true,
+    shortcut: false,
+    icon: SearchLg,
+    'aria-controls': mapId,
+  };
+  if (label !== undefined) comboProps.label = label;
+  // `placeholder` always has a value (default in the destructuring),
+  // so it goes through unconditionally — the conditional spread
+  // pattern is reserved for genuinely optional props.
+  comboProps.placeholder = placeholder;
+  if (hint !== undefined) comboProps.hint = hint;
+  if (isDisabled === true) comboProps.isDisabled = true;
+  if (effectiveInvalid) comboProps.isInvalid = true;
+  if (isRequired === true) comboProps.isRequired = true;
+  if (hideRequiredIndicator === true) comboProps.hideRequiredIndicator = true;
+
+  return (
+    <div className={'flex flex-col gap-3' + (className !== undefined ? ' ' + className : '')}>
+      <div onFocusCapture={handleFocusCapture}>
+        <ComboBox {...comboProps}>
+          {(item: SelectItemType) => (
+            <SelectItem id={item.id} label={item.label ?? ''} icon={MarkerPin01} />
+          )}
+        </ComboBox>
+      </div>
+
+      <div
+        id={mapId}
+        className="overflow-hidden rounded-lg ring-1 ring-primary"
+        style={{ height: mapHeight }}
+      >
+        <Map
+          ref={mapRef}
+          initialViewState={initialView}
+          mapStyle={OSM_STYLE}
+          reuseMaps
+          attributionControl={{ compact: true }}
+          interactive={isDisabled !== true}
+        >
+          <NavigationControl position="top-right" showCompass={false} />
+          {effectiveValue !== null && (
+            <Marker
+              latitude={effectiveValue.lat}
+              longitude={effectiveValue.lng}
+              draggable={isDisabled !== true}
+              onDragEnd={handleMarkerDragEnd}
+              anchor="bottom"
+            />
+          )}
+        </Map>
+      </div>
+    </div>
+  );
+}
+
+// Re-export the default geocoder so consumers can wire it without
+// reaching into a sibling file:
+//
+//   import { LocationPicker, nominatimGeocode } from '@glaon/ui';
+//   <LocationPicker geocode={nominatimGeocode} ... />
+export { nominatimGeocode } from './geocoding';
+
+/**
+ * Resolve the locale used for geocode results. Reads
+ * `navigator.language` lazily so SSR builds don't crash on a missing
+ * `navigator`. Falls back to `'en'` when neither prop nor navigator
+ * is available.
+ */
+function useResolvedLocale(locale: string | undefined): string {
+  return useMemo(() => {
+    if (locale !== undefined && locale.length > 0) return locale;
+    if (typeof navigator !== 'undefined' && navigator.language) {
+      return navigator.language;
+    }
+    return 'en';
+  }, [locale]);
+}

--- a/packages/ui/src/components/LocationPicker/geocoding.ts
+++ b/packages/ui/src/components/LocationPicker/geocoding.ts
@@ -1,0 +1,95 @@
+// LocationPicker — geocoding helpers.
+//
+// `nominatimGeocode` is the batteries-included default that hits the
+// free Nominatim OSM endpoint. Per CLAUDE.md's Component
+// Data-Fetching Boundary rule, LocationPicker itself does not call
+// `fetch` — it takes a `geocode` prop and the host (or, in
+// Storybook, the story file) wires this helper as the callback.
+//
+// Production deployments that exceed Nominatim's free-tier rate
+// limit (1 req/sec per user, 250 tiles/sec across all users) should
+// swap in a paid provider (Geoapify, LocationIQ) or a self-hosted
+// Nominatim — the wrapper signature `(query) => Promise<Suggestion[]>`
+// is provider-agnostic by design.
+
+/**
+ * One geocoding suggestion. The shape is provider-agnostic so the
+ * picker can render any backend that resolves to coordinates + a
+ * human-readable label.
+ */
+export interface GeocodeSuggestion {
+  /** Stable id — used as the `<SelectItem>` key. */
+  id: string;
+  /** Human-readable label rendered in the suggestion list. */
+  label: string;
+  /** Latitude (WGS84 decimal degrees). */
+  lat: number;
+  /** Longitude (WGS84 decimal degrees). */
+  lng: number;
+}
+
+/** Default Nominatim endpoint — public, free, rate-limited. */
+const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
+
+/**
+ * Nominatim-backed geocoder. Suitable as a `geocode` prop for
+ * LocationPicker.
+ *
+ * Returns up to 10 suggestions per query. Empty / blank queries
+ * resolve to `[]` so the autocomplete list collapses cleanly.
+ *
+ * @param query  Free-form address string.
+ * @param signal Optional AbortSignal — wired by the picker to cancel
+ *               in-flight requests when the user keeps typing.
+ * @param locale Optional BCP-47 tag — passed to Nominatim's
+ *               `accept-language` query so labels come back in the
+ *               user's language when available.
+ */
+export async function nominatimGeocode(
+  query: string,
+  signal?: AbortSignal,
+  locale?: string,
+): Promise<GeocodeSuggestion[]> {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return [];
+
+  const params = new URLSearchParams({
+    q: trimmed,
+    format: 'jsonv2',
+    limit: '10',
+    addressdetails: '0',
+  });
+  if (locale !== undefined && locale.length > 0) {
+    params.set('accept-language', locale);
+  }
+
+  const url = `${NOMINATIM_BASE}/search?${params.toString()}`;
+  const init: RequestInit = { headers: { Accept: 'application/json' } };
+  if (signal !== undefined) init.signal = signal;
+
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    throw new Error(`Nominatim geocoding failed: ${response.status.toString()}`);
+  }
+  const raw = (await response.json()) as NominatimResult[];
+  return raw
+    .map((row) => {
+      const lat = Number.parseFloat(row.lat);
+      const lng = Number.parseFloat(row.lon);
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+      return {
+        id: row.place_id.toString(),
+        label: row.display_name,
+        lat,
+        lng,
+      } satisfies GeocodeSuggestion;
+    })
+    .filter((s): s is GeocodeSuggestion => s !== null);
+}
+
+interface NominatimResult {
+  place_id: number | string;
+  display_name: string;
+  lat: string;
+  lon: string;
+}

--- a/packages/ui/src/components/LocationPicker/index.ts
+++ b/packages/ui/src/components/LocationPicker/index.ts
@@ -1,0 +1,9 @@
+// LocationPicker barrel. Per memory note
+// `feedback_knip_props_interfaces.md`: keep prop / helper types
+// un-exported until an external consumer needs them. The component
+// itself is re-exported via the package barrel
+// (`packages/ui/src/index.ts`); the `nominatimGeocode` helper is
+// re-exported because every consumer wiring the default geocoder
+// needs it.
+
+export { LocationPicker, nominatimGeocode } from './LocationPicker';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -24,6 +24,7 @@ export * from './components/Dropdown';
 export * from './components/FormField';
 export * from './components/Input';
 export * from './components/List';
+export * from './components/LocationPicker';
 export * from './components/Logo';
 export * from './components/Modal';
 export * from './components/Notification';

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -29,6 +29,12 @@
    CSP (`default-src 'self'`) stays intact — no CDN whitelist
    needed. */
 @import 'flag-icons/css/flag-icons.css';
+/* MapLibre GL canvas + control chrome for the `LocationPicker`
+   primitive (#579). The library ships its own stylesheet covering
+   the map container, popups, attribution control, navigation
+   buttons, and the marker default. Vite bundles it into the
+   same-origin asset directory; no CDN host to whitelist. */
+@import 'maplibre-gl/dist/maplibre-gl.css';
 
 @plugin "@tailwindcss/typography";
 @plugin "tailwindcss-react-aria-components";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,12 +386,18 @@ importers:
       flag-icons:
         specifier: ^7.5.0
         version: 7.5.0
+      maplibre-gl:
+        specifier: ^5.24.0
+        version: 5.24.0
       react-aria:
         specifier: ^3.48.0
         version: 3.48.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-aria-components:
         specifier: ^1.17.0
         version: 1.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-map-gl:
+        specifier: ^8.1.1
+        version: 8.1.1(maplibre-gl@5.24.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-stately:
         specifier: ^3.46.0
         version: 3.46.0(react@19.2.5)
@@ -1931,6 +1937,46 @@ packages:
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
 
+  '@mapbox/jsonlint-lines-primitives@2.0.2':
+    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
+    engines: {node: '>= 0.6'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@5.0.4':
+    resolution: {integrity: sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==}
+
+  '@maplibre/geojson-vt@6.1.0':
+    resolution: {integrity: sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==}
+
+  '@maplibre/maplibre-gl-style-spec@19.3.3':
+    resolution: {integrity: sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==}
+    hasBin: true
+
+  '@maplibre/maplibre-gl-style-spec@24.8.5':
+    resolution: {integrity: sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.10':
+    resolution: {integrity: sha512-SByFHVVxqThkstQnwh8/48pyvUmeQ7NGZ/n+XHa4TkLTKK6lnsMh9Aa7LocS8OW5E3ZiXxmwYivSc7lcQsQBag==}
+
+  '@maplibre/vt-pbf@4.3.0':
+    resolution: {integrity: sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==}
+
   '@mdx-js/react@3.1.1':
     resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
     peerDependencies:
@@ -3308,6 +3354,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
@@ -3345,6 +3394,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
@@ -3442,6 +3494,26 @@ packages:
     resolution: {integrity: sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==}
     peerDependencies:
       valibot: ^1.3.0
+
+  '@vis.gl/react-mapbox@8.1.1':
+    resolution: {integrity: sha512-KMDTjtWESXxHS4uqWxjsvgQUHvuL3Z6SdKe68o7Nxma2qUfuyH3x4TCkIqGn3FQTrFvZLWvTnSAbGvtm+Kd13A==}
+    peerDependencies:
+      mapbox-gl: '>=3.5.0'
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
+    peerDependenciesMeta:
+      mapbox-gl:
+        optional: true
+
+  '@vis.gl/react-maplibre@8.1.1':
+    resolution: {integrity: sha512-iUOfzJAhFAJwEZp1644tQb7LOTFgi5/GzdaztkhzNgFVuoF2Ez7guvwZjQAKB9CN2TlHTgNuYH8UW85kO7cVhw==}
+    peerDependencies:
+      maplibre-gl: '>=4.0.0'
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
+    peerDependenciesMeta:
+      maplibre-gl:
+        optional: true
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -3701,6 +3773,10 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  arr-union@3.1.0:
+    resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
+    engines: {node: '>=0.10.0'}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -3741,6 +3817,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  assign-symbols@1.0.0:
+    resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
+    engines: {node: '>=0.10.0'}
 
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
@@ -3991,6 +4071,12 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  bytewise-core@1.2.3:
+    resolution: {integrity: sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==}
+
+  bytewise@1.1.0:
+    resolution: {integrity: sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -4456,6 +4542,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -4803,6 +4892,14 @@ packages:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  extend-shallow@3.0.2:
+    resolution: {integrity: sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==}
+    engines: {node: '>=0.10.0'}
+
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -5012,9 +5109,16 @@ packages:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
 
+  get-value@2.0.6:
+    resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
+    engines: {node: '>=0.10.0'}
+
   getenv@2.0.0:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
     engines: {node: '>=6'}
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -5326,6 +5430,14 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
+  is-extendable@1.0.1:
+    resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -5391,6 +5503,10 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
@@ -5446,6 +5562,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
 
   isomorphic-fetch@3.0.0:
     resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
@@ -5567,6 +5687,12 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@3.0.0:
+    resolution: {integrity: sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==}
+
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -5578,6 +5704,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -5797,6 +5926,10 @@ packages:
 
   map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
+
+  maplibre-gl@5.24.0:
+    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   marked-terminal@7.3.0:
     resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
@@ -6088,6 +6221,9 @@ packages:
 
   multitars@0.2.5:
     resolution: {integrity: sha512-T/i4uZOzd4j2VnS28eAOJS0MgeAbcsFIijRPeLRhVv54hP9OqsC/FjYK0JmMTWxGhF2fv34oH1mtR6XLBKkNlw==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   mute-stream@0.0.7:
     resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
@@ -6388,6 +6524,10 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pbf@4.0.2:
+    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
+    hasBin: true
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -6459,6 +6599,9 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   preact@10.24.2:
     resolution: {integrity: sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==}
 
@@ -6506,6 +6649,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -6556,6 +6702,9 @@ packages:
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -6618,6 +6767,19 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-map-gl@8.1.1:
+    resolution: {integrity: sha512-aSqFAFoxvY7wxbGI93Dz0E41171mkAb3GcNbnkFIotmu88OFw495os6mIDZSi7irYNT/PZEIOEHUxhun4ToGuQ==}
+    peerDependencies:
+      mapbox-gl: '>=1.13.0'
+      maplibre-gl: '>=1.13.0'
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
+    peerDependenciesMeta:
+      mapbox-gl:
+        optional: true
+      maplibre-gl:
+        optional: true
 
   react-native-is-edge-to-edge@1.3.1:
     resolution: {integrity: sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==}
@@ -6729,6 +6891,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve-workspace-root@2.0.1:
     resolution: {integrity: sha512-nR23LHAvaI6aHtMg6RWoaHpdR4D881Nydkzi2CixINyg9T00KgaJdJI6Vwty+Ps8WLxZHuxsS0BseWjxSA4C+w==}
 
@@ -6803,6 +6968,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -6880,6 +7048,10 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  set-value@2.0.1:
+    resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==}
+    engines: {node: '>=0.10.0'}
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
@@ -6981,6 +7153,18 @@ packages:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  sort-asc@0.2.0:
+    resolution: {integrity: sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==}
+    engines: {node: '>=0.10.0'}
+
+  sort-desc@0.2.0:
+    resolution: {integrity: sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==}
+    engines: {node: '>=0.10.0'}
+
+  sort-object@3.0.3:
+    resolution: {integrity: sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==}
+    engines: {node: '>=0.10.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -7002,6 +7186,10 @@ packages:
   speedline-core@1.4.3:
     resolution: {integrity: sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==}
     engines: {node: '>=8.0'}
+
+  split-string@3.1.0:
+    resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
+    engines: {node: '>=0.10.0'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -7158,6 +7346,9 @@ packages:
 
   stylis@4.2.0:
     resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
 
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
@@ -7333,6 +7524,9 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
+
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
@@ -7502,6 +7696,12 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typewise-core@1.2.0:
+    resolution: {integrity: sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==}
+
+  typewise@1.0.3:
+    resolution: {integrity: sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==}
+
   ua-parser-js@1.0.41:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
@@ -7550,6 +7750,10 @@ packages:
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  union-value@1.0.1:
+    resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
+    engines: {node: '>=0.10.0'}
 
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -9808,6 +10012,60 @@ snapshots:
     dependencies:
       '@braidai/lang': 1.1.2
 
+  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.2
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@5.0.4': {}
+
+  '@maplibre/geojson-vt@6.1.0':
+    dependencies:
+      kdbush: 4.1.0
+
+  '@maplibre/maplibre-gl-style-spec@19.3.3':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 3.0.0
+      minimist: 1.2.8
+      rw: 1.3.3
+      sort-object: 3.0.3
+
+  '@maplibre/maplibre-gl-style-spec@24.8.5':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.10':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.0':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/vector-tile': 2.0.4
+      '@maplibre/geojson-vt': 5.0.4
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      pbf: 4.0.2
+      supercluster: 8.0.1
+
   '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@types/mdx': 2.0.13
@@ -10137,7 +10395,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.3(bufferutil@4.1.0)
       metro-core: 0.84.3
       semver: 7.7.4
     transitivePeerDependencies:
@@ -11227,6 +11485,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/istanbul-lib-report@3.0.3':
@@ -11263,6 +11523,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/uuid@10.0.0': {}
 
@@ -11392,6 +11656,19 @@ snapshots:
     dependencies:
       valibot: 1.2.0(typescript@5.7.3)
 
+  '@vis.gl/react-mapbox@8.1.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@vis.gl/react-maplibre@8.1.1(maplibre-gl@5.24.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@maplibre/maplibre-gl-style-spec': 19.3.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      maplibre-gl: 5.24.0
+
   '@vitejs/plugin-react@5.2.0(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
@@ -11517,9 +11794,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@22.19.17)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.13(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@25.0.1(bufferutil@4.1.0))(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(bufferutil@4.1.0)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -11736,6 +12013,8 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  arr-union@3.1.0: {}
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -11806,6 +12085,8 @@ snapshots:
       util: 0.12.5
 
   assertion-error@2.0.1: {}
+
+  assign-symbols@1.0.0: {}
 
   ast-types@0.13.4:
     dependencies:
@@ -12082,6 +12363,15 @@ snapshots:
   bytes-iec@3.1.1: {}
 
   bytes@3.1.2: {}
+
+  bytewise-core@1.2.3:
+    dependencies:
+      typewise-core: 1.2.0
+
+  bytewise@1.1.0:
+    dependencies:
+      bytewise-core: 1.2.3
+      typewise: 1.0.3
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -12523,6 +12813,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  earcut@3.0.2: {}
 
   ee-first@1.1.1: {}
 
@@ -13044,6 +13336,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  extend-shallow@3.0.2:
+    dependencies:
+      assign-symbols: 1.0.0
+      is-extendable: 1.0.1
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
@@ -13278,7 +13579,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  get-value@2.0.6: {}
+
   getenv@2.0.0: {}
+
+  gl-matrix@3.4.4: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -13587,6 +13892,12 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-extendable@0.1.1: {}
+
+  is-extendable@1.0.1:
+    dependencies:
+      is-plain-object: 2.0.4
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -13639,6 +13950,10 @@ snapshots:
     optional: true
 
   is-plain-obj@4.1.0: {}
+
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -13694,6 +14009,8 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isobject@3.0.1: {}
 
   isomorphic-fetch@3.0.0:
     dependencies:
@@ -13846,6 +14163,10 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@3.0.0: {}
+
+  json-stringify-pretty-compact@4.0.0: {}
+
   json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
@@ -13856,6 +14177,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -14110,6 +14433,28 @@ snapshots:
 
   map-or-similar@1.5.0: {}
 
+  maplibre-gl@5.24.0:
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.1.0
+      '@maplibre/maplibre-gl-style-spec': 24.8.5
+      '@maplibre/mlt': 1.1.10
+      '@maplibre/vt-pbf': 4.3.0
+      '@types/geojson': 7946.0.16
+      earcut: 3.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.1.0
+      murmurhash-js: 1.0.0
+      pbf: 4.0.2
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
   marked-terminal@7.3.0(marked@9.1.6):
     dependencies:
       ansi-escapes: 7.3.0
@@ -14237,21 +14582,6 @@ snapshots:
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
       metro: 0.84.3(bufferutil@4.1.0)
-      metro-cache: 0.84.3
-      metro-core: 0.84.3
-      metro-runtime: 0.84.3
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro-config@0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-cache: 0.84.3
       metro-core: 0.84.3
       metro-runtime: 0.84.3
@@ -14581,7 +14911,7 @@ snapshots:
       metro-babel-transformer: 0.84.3
       metro-cache: 0.84.3
       metro-cache-key: 0.84.3
-      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.3(bufferutil@4.1.0)
       metro-core: 0.84.3
       metro-file-map: 0.84.3
       metro-resolver: 0.84.3
@@ -14681,6 +15011,8 @@ snapshots:
   ms@2.1.3: {}
 
   multitars@0.2.5: {}
+
+  murmurhash-js@1.0.0: {}
 
   mute-stream@0.0.7: {}
 
@@ -15042,6 +15374,10 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pbf@4.0.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   pend@1.2.0: {}
 
   picocolors@1.1.1: {}
@@ -15103,6 +15439,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@2.1.0: {}
+
   preact@10.24.2: {}
 
   preact@10.29.1: {}
@@ -15147,6 +15485,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  protocol-buffers-schema@3.6.1: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -15220,6 +15560,8 @@ snapshots:
   queue@6.0.2:
     dependencies:
       inherits: 2.0.4
+
+  quickselect@3.0.0: {}
 
   range-parser@1.2.1: {}
 
@@ -15317,6 +15659,15 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-map-gl@8.1.1(maplibre-gl@5.24.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@vis.gl/react-mapbox': 8.1.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@vis.gl/react-maplibre': 8.1.1(maplibre-gl@5.24.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      maplibre-gl: 5.24.0
 
   react-native-is-edge-to-edge@1.3.1(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
@@ -15519,6 +15870,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
+
   resolve-workspace-root@2.0.1: {}
 
   resolve@1.22.12:
@@ -15641,6 +15996,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rw@1.3.3: {}
+
   rxjs@6.6.7:
     dependencies:
       tslib: 1.14.1
@@ -15738,6 +16095,13 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  set-value@2.0.1:
+    dependencies:
+      extend-shallow: 2.0.1
+      is-extendable: 0.1.1
+      is-plain-object: 2.0.4
+      split-string: 3.1.0
 
   setimmediate@1.0.5: {}
 
@@ -15873,6 +16237,19 @@ snapshots:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
 
+  sort-asc@0.2.0: {}
+
+  sort-desc@0.2.0: {}
+
+  sort-object@3.0.3:
+    dependencies:
+      bytewise: 1.1.0
+      get-value: 2.0.6
+      is-extendable: 0.1.1
+      sort-asc: 0.2.0
+      sort-desc: 0.2.0
+      union-value: 1.0.1
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -15893,6 +16270,10 @@ snapshots:
       '@types/node': 22.19.17
       image-ssim: 0.2.0
       jpeg-js: 0.4.4
+
+  split-string@3.1.0:
+    dependencies:
+      extend-shallow: 3.0.2
 
   sprintf-js@1.0.3: {}
 
@@ -16098,6 +16479,10 @@ snapshots:
 
   stylis@4.2.0: {}
 
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.1.0
+
   superstruct@2.0.2: {}
 
   supports-color@10.2.2: {}
@@ -16274,6 +16659,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyqueue@3.0.0: {}
+
   tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.1.0: {}
@@ -16441,6 +16828,12 @@ snapshots:
 
   typescript@5.7.3: {}
 
+  typewise-core@1.2.0: {}
+
+  typewise@1.0.3:
+    dependencies:
+      typewise-core: 1.2.0
+
   ua-parser-js@1.0.41: {}
 
   unbash@2.2.0: {}
@@ -16477,6 +16870,13 @@ snapshots:
   unicode-match-property-value-ecmascript@2.2.1: {}
 
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  union-value@1.0.1:
+    dependencies:
+      arr-union: 3.1.0
+      get-value: 2.0.6
+      is-extendable: 0.1.1
+      set-value: 2.0.1
 
   unique-string@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Third primitive in the Phase 2 picker trio (CountrySelect #577 / TimezoneSelect #578). Search-as-you-type address input paired with an interactive MapLibre map and a draggable marker. Returns `{ lat, lng, address? }` so consumers can persist coordinates plus the user-picked label.

Closes #579

## Provider re-scope

Original issue body picked **Mapbox GL + Mapbox Geocoding**. During the trio's kick-off we re-scoped to **MapLibre GL + Nominatim (OSM)** — open-source, no API token, no Chromatic workflow secret. Trade-off: free-tier rate limits (1 req/sec/user) and OSM tile-traffic policy. Production deployments will swap in a paid provider (Geoapify, LocationIQ) or self-hosted Nominatim — the wrapper signature `(query, signal?, locale?) => Promise<Suggestion[]>` is provider-agnostic. Noted in the [issue comment](https://github.com/Glaon-Smart/glaon/issues/579#issuecomment-4529342873).

## Scope

**In**
- New primitive `packages/ui/src/components/LocationPicker/` with `LocationPicker.tsx`, `.stories.tsx`, `.controls.ts`, `.mdx`, `geocoding.ts` (Nominatim helper + `GeocodeSuggestion` type), `index.ts`.
- New deps: `maplibre-gl@^5` + `react-map-gl@^8` (React 19-ready).
- MapLibre CSS import wired into `packages/ui/src/styles/globals.css`.
- Re-export from the package barrel and a separately-named `nominatimGeocode` re-export so consumers wire the default geocoder in one line.
- 9 Storybook stories backed by a deterministic mock geocoder + 1 `LiveNominatim` story (Chromatic snapshot disabled, manual sanity only).
- MDX docs page with provider stack / when-to-use / state-machine / error UX / accessibility / CSP requirements / related-components sections.
- F6 prop-coverage gate satisfied via `LocationPicker.controls.ts`.

**Out**
- Reverse geocoding after marker drag (host can call the same `nominatimGeocode` helper from the feature layer if it needs the address).
- Mobile / React-Native variant.
- Multi-pin / polygon / drawing tools.
- Browser-geolocation auto-prompt (privacy + permission heavy — separate primitive prop if needed).
- Paid-provider adapter (LocationIQ, Geoapify) — provider-agnostic signature means it's a small addition when needed.

## Component Data-Fetching Boundary

LocationPicker exposes `geocode` as a prop (callback injection). The component owns the debounce (300ms) + abort + paint trigger, but never calls `fetch` directly. The `nominatimGeocode` helper ships alongside as a sibling export; stories wire it in the story file (the "feature layer" in Storybook). This satisfies the boundary rule's callback-injection carve-out — no rule deviation.

## State machine

Same as CountrySelect / TimezoneSelect — always-controlled-from-wrapper. Host can pass `value` for full control; otherwise `defaultValue` seeds the internal state. The marker + flyTo always read the same effective key, so the trigger + map + marker stay consistent in every mode.

## CSP

No CSP edit was needed. The repo's current `apps/web/index.html` CSP is permissive enough on all three axes:

- `connect-src 'self' ws: wss: https:` → covers `nominatim.openstreetmap.org`.
- `img-src 'self' data: blob: https:` → covers `tile.openstreetmap.org`.
- `worker-src 'self' blob:` → covers MapLibre's render worker (the directive was added for Clerk's worker in #517 and happens to cover MapLibre too).

This is a happy accident of the existing posture, not an invariant. When the umbrella `connect-src https:` gets tightened to an explicit allow-list or the provider is swapped to a paid geocoder, the new endpoints must be added explicitly.

The user asked to bundle CSP changes into this PR; the file edit was nil because the policy is already wide enough. Documented in the MDX so future tightening lands deliberately.

## Known rule deviations (per scoping with the user)

- **Design-System Fidelity Rule** — primitive ships without a pre-existing Figma frame. Code-first this round; design review and `parameters.design` node-id wiring follow in a separate PR. The story currently points at the Design System file root with a placeholder `?node-id=app-primitives-location-picker`, matching the existing sister-primitive placeholder pattern.

## Test plan

- [x] `pnpm type-check` green in `@glaon/ui`.
- [x] `pnpm lint` green in `@glaon/ui`.
- [x] `pnpm test` green in `@glaon/ui` (150 tests — 3 more than before; F6 prop-coverage now discovers LocationPicker).
- [x] `pnpm knip` doesn't flag any of the new files.
- [x] `pnpm build-storybook` green — MapLibre + react-map-gl bundle correctly.
- [ ] CI: story-tests, Chromatic visual regression, unit-tests, knip, package-contract, size-check (watch this — maplibre-gl adds non-trivial bundle weight).
- [ ] Chromatic — baseline the new visuals (empty / pre-selected / Berlin / Disabled / Error / Hint / TallerMap / ShorterMap).
- [ ] Manual sanity in Storybook:
  - `Default` story: type `istanbul` → suggestion appears → click → map flies to Istanbul → marker drops at bottom-anchor.
  - `WithDefaultValue` story: map opens centred on the marker; drag marker → `onChange` fires with new lat/lng (`address` field is undefined for drag-emitted events).
  - `WithError` story: pick any location → red ring + red hint disappear.
  - `Disabled` story: input dim, popover doesn't open, marker is non-draggable, map is non-interactive.
  - `LiveNominatim` story: works against the real free-tier endpoint (rate-limited to 1 req/sec).

## Follow-ups

- Reverse-geocode after marker drag — opt-in via a `reverseGeocode` prop or a paired helper, so the marker drag can populate the `address` field too.
- Provider adapters for Geoapify / LocationIQ — same signature, different fetch.
- Self-hosted Nominatim guide when traffic warrants it.
- Design-review pass to draw the Figma frame for all three Phase 2 primitives in one go (CountrySelect / TimezoneSelect / LocationPicker).
- Extract the diacritic filter (now in `CountrySelect/countries.ts` + `TimezoneSelect/timezones.ts`) into a shared `_internal` module; LocationPicker doesn't need it (the server returns filtered suggestions) but the duplication still warrants cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)