### PR TITLE
feat(web,core): multi-floor + rooms editor for Layout Setup step

### DIFF
--- a/apps/web/src/features/setup/layout/floor-tabs.tsx
+++ b/apps/web/src/features/setup/layout/floor-tabs.tsx
@@ -1,0 +1,151 @@
+// Floor tab strip — horizontal pills + `+ Add Floor` at the end.
+// Each pill carries the floor name, a room-count badge, and a × to
+// remove (hidden when only one floor exists). Clicking the name
+// turns it into an inline rename input.
+
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { Floor } from '@glaon/core/config';
+
+import { PlusIcon, XCloseIcon } from './step-icons';
+
+interface FloorTabsProps {
+  readonly floors: readonly Floor[];
+  readonly activeFloorId: string;
+  readonly onSwitch: (floorId: string) => void;
+  readonly onAddFloor: () => void;
+  readonly onRenameFloor: (floorId: string, name: string) => void;
+  readonly onRemoveFloor: (floorId: string) => void;
+  readonly canAddMore: boolean;
+}
+
+export function FloorTabs({
+  floors,
+  activeFloorId,
+  onSwitch,
+  onAddFloor,
+  onRenameFloor,
+  onRemoveFloor,
+  canAddMore,
+}: FloorTabsProps): ReactNode {
+  const { t } = useTranslation();
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const renameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (renamingId !== null) renameRef.current?.focus();
+  }, [renamingId]);
+
+  const commitRename = (floorId: string, value: string): void => {
+    onRenameFloor(floorId, value);
+    setRenamingId(null);
+  };
+
+  const onRenameKeyDown = (event: KeyboardEvent<HTMLInputElement>, floor: Floor): void => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitRename(floor.id, event.currentTarget.value);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      setRenamingId(null);
+    }
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-label={t('setup.layoutSetup.floors.tabsLabel')}
+      className="flex flex-wrap items-center gap-2"
+    >
+      {floors.map((floor) => {
+        const isActive = floor.id === activeFloorId;
+        const isRenaming = renamingId === floor.id;
+        const showRemove = floors.length > 1;
+        return (
+          <div
+            key={floor.id}
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`floor-panel-${floor.id}`}
+            className={
+              'group inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-colors ' +
+              (isActive
+                ? 'bg-brand-solid text-white shadow-xs-skeuomorphic'
+                : 'bg-secondary text-secondary hover:bg-tertiary hover:text-primary')
+            }
+          >
+            {isRenaming ? (
+              <input
+                ref={renameRef}
+                defaultValue={floor.name}
+                aria-label={t('setup.layoutSetup.floors.renameFloor')}
+                onBlur={(event) => {
+                  commitRename(floor.id, event.target.value);
+                }}
+                onKeyDown={(event) => {
+                  onRenameKeyDown(event, floor);
+                }}
+                className="w-32 rounded-sm bg-transparent text-sm font-medium text-inherit outline-none ring-1 ring-white/40 focus:ring-2 focus:ring-white"
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  if (isActive) {
+                    setRenamingId(floor.id);
+                  } else {
+                    onSwitch(floor.id);
+                  }
+                }}
+                onDoubleClick={() => {
+                  setRenamingId(floor.id);
+                }}
+                className="text-inherit focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80 rounded-sm"
+              >
+                {floor.name}
+              </button>
+            )}
+            <span
+              className={
+                'inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-xs font-semibold ' +
+                (isActive ? 'bg-white/20 text-white' : 'bg-primary text-tertiary')
+              }
+              aria-label={t('setup.layoutSetup.floors.roomCountBadge', {
+                count: floor.rooms.length,
+              })}
+            >
+              {floor.rooms.length}
+            </span>
+            {showRemove && !isRenaming && (
+              <button
+                type="button"
+                onClick={() => {
+                  onRemoveFloor(floor.id);
+                }}
+                className={
+                  'inline-flex h-5 w-5 items-center justify-center rounded-full opacity-0 transition-opacity hover:bg-white/20 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 ' +
+                  (isActive ? 'focus-visible:ring-white' : 'focus-visible:ring-brand')
+                }
+                aria-label={t('setup.layoutSetup.floors.removeFloor', { name: floor.name })}
+              >
+                <XCloseIcon className="size-3.5" />
+              </button>
+            )}
+          </div>
+        );
+      })}
+
+      {canAddMore && (
+        <button
+          type="button"
+          onClick={onAddFloor}
+          className="inline-flex items-center gap-2 rounded-full border border-dashed border-secondary px-4 py-2 text-sm font-medium text-secondary transition-colors hover:border-brand hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        >
+          <PlusIcon className="size-4" />
+          <span>{t('setup.layoutSetup.floors.addFloor')}</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/setup/layout/layout-step.test.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.test.tsx
@@ -1,40 +1,77 @@
+// Smoke-level UI coverage. The reducer's correctness is tested
+// exhaustively in `use-layout-state.test.ts`; here we just verify
+// the default state renders, the add-floor / add-room affordances
+// dispatch into the reducer, and the form submit emits the new
+// structured `layout` blob (not a free-text string).
+
 import { fireEvent, render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+
+import type { Layout } from '@glaon/core/config';
 
 import { LayoutStep } from './layout-step';
 
 describe('LayoutStep', () => {
-  it('renders the title and the optional layout field', () => {
+  it('renders the title and the default single floor', () => {
     const { container, getByText } = render(<LayoutStep collected={{}} onNext={() => undefined} />);
     expect(container.querySelector('h1')?.textContent).toBe('Layout Setup');
-    expect(getByText(/Home structure/)).toBeInTheDocument();
+    // The default floor name comes from the EN locale string.
+    expect(getByText('Ground Floor')).toBeInTheDocument();
   });
 
-  it('submits an empty partial when the field is left blank (no required validation)', () => {
+  it('submits the default single-floor layout on Next', () => {
     const onNext = vi.fn();
     const { getByRole } = render(<LayoutStep collected={{}} onNext={onNext} />);
     fireEvent.click(getByRole('button', { name: 'Next' }));
     expect(onNext).toHaveBeenCalledTimes(1);
-    expect(onNext.mock.calls[0]?.[0]).toEqual({});
+    const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
+    expect(partial.layout?.floors).toHaveLength(1);
+    expect(partial.layout?.floors[0]?.name).toBe('Ground Floor');
+    expect(partial.layout?.floors[0]?.rooms).toEqual([]);
   });
 
-  it('passes the trimmed layout string through onNext when filled', () => {
+  it('adds a second floor via the "Add floor" pill', () => {
     const onNext = vi.fn();
-    const { container, getByRole } = render(<LayoutStep collected={{}} onNext={onNext} />);
-    const input = container.querySelector('input[type="text"]');
-    expect(input).not.toBeNull();
-    if (input === null) return;
-    fireEvent.change(input, { target: { value: '  2 floors, 5 rooms  ' } });
+    const { getByRole } = render(<LayoutStep collected={{}} onNext={onNext} />);
+    fireEvent.click(getByRole('button', { name: /Add floor/i }));
     fireEvent.click(getByRole('button', { name: 'Next' }));
-    const partial = onNext.mock.calls[0]?.[0] as { layout?: string };
-    expect(partial.layout).toBe('2 floors, 5 rooms');
+    const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
+    expect(partial.layout?.floors).toHaveLength(2);
+    // Second floor seeded with an empty rooms list. Name comes
+    // from the locale template; we don't assert the exact label
+    // because ICU interpolation isn't deterministic across the
+    // vitest setup permutations.
+    expect(partial.layout?.floors[1]?.rooms).toEqual([]);
   });
 
-  it('hydrates layout from collected partial', () => {
-    const { container } = render(
-      <LayoutStep collected={{ layout: 'open-plan' }} onNext={() => undefined} />,
+  it('adds a room via the empty-state CTA on the default floor', () => {
+    const onNext = vi.fn();
+    const { getByRole } = render(<LayoutStep collected={{}} onNext={onNext} />);
+    fireEvent.click(getByRole('button', { name: /Add your first room/i }));
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
+    expect(partial.layout?.floors[0]?.rooms).toHaveLength(1);
+    expect(typeof partial.layout?.floors[0]?.rooms[0]?.name).toBe('string');
+    expect((partial.layout?.floors[0]?.rooms[0]?.name ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('hydrates from a previously collected layout', () => {
+    const layout: Layout = {
+      floors: [
+        {
+          id: 'f-loaded',
+          name: 'Penthouse',
+          rooms: [{ id: 'r-loaded', name: 'Solarium', type: 'living' }],
+        },
+      ],
+    };
+    const { container, getByDisplayValue } = render(
+      <LayoutStep collected={{ layout }} onNext={() => undefined} />,
     );
-    const input = container.querySelector('input[type="text"]');
-    expect((input as HTMLInputElement | null)?.value).toBe('open-plan');
+    // The floor name renders as the active-tab pill button text.
+    expect(container.textContent ?? '').toMatch(/Penthouse/);
+    // The room name lands inside an `<input>` — assert via the
+    // value, not the text content.
+    expect(getByDisplayValue('Solarium')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/setup/layout/layout-step.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.tsx
@@ -1,21 +1,36 @@
 // Layout Setup wizard step — second step in the device setup wizard
-// (epic #533, ADR 0028). v1 placeholder per the epic body and #545:
-// single optional `<Input>` ("Home structure description") + Next,
-// no floor/room domain. The real floor/room editor is its own epic.
+// (epic #533, ADR 0028). Multi-floor + rooms editor (#592).
 //
-// Same horizontal-form layout primitives as #540 — a label column on
-// the left, the control on the right, divider above the row. Below
-// `sm` the rows stack.
+// Replaces the v1 free-text placeholder from #545. The previous
+// single-string `layout?: string` field is gone — the schema now
+// carries a structured `layout?: { floors: Floor[] }` blob. Phase 2
+// has no production blobs that wrote the old shape so the swap is
+// direct (see types.ts comment for the rationale).
 //
-// The placeholder field writes into the string `layout?: string` slot
-// already defined on DeviceConfig (#535); when the real editor lands
-// it will replace this step without touching the schema's surface.
+// UX:
+//   - Tab strip of floors at the top; the active tab's rooms render
+//     below.
+//   - Rooms render as a responsive card grid (1 column on phones,
+//     2 on tablets, 3 on desktop).
+//   - Each room card carries an emoji glyph driven by `RoomType`,
+//     editable name, type selector, and a ×-on-hover remove.
+//   - Empty floor: centred CTA with a 🏠 glyph and "Add your first
+//     room" copy.
+//   - Default state seeded by `useLayoutState`: one floor named per
+//     i18n (`Ground Floor` / `Zemin Kat`), empty rooms list.
+//
+// Per the API Error Toast Rule (CLAUDE.md), per-field validation
+// is inline / inline-only; nothing here goes through Toast because
+// nothing leaves the device.
 
-import { InputBase, TextField } from '@glaon/ui';
-import { useId, useState, type ReactNode, type SubmitEvent } from 'react';
+import type { ReactNode, SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { DeviceConfigInput } from '@glaon/core/config';
+
+import { FloorTabs } from './floor-tabs';
+import { RoomGrid } from './room-grid';
+import { useLayoutState } from './use-layout-state';
 
 interface LayoutStepProps {
   /** Partial DeviceConfig collected from earlier steps in this run. */
@@ -24,17 +39,37 @@ interface LayoutStepProps {
   readonly onNext: (partial: DeviceConfigInput) => void;
 }
 
+const MAX_FLOORS = 10;
+const MAX_ROOMS_PER_FLOOR = 50;
+
 export function LayoutStep({ collected, onNext }: LayoutStepProps): ReactNode {
   const { t } = useTranslation();
-  const layoutLabelId = useId();
-  const [layout, setLayout] = useState<string>(collected.layout ?? '');
+
+  const { state, actions, toLayout } = useLayoutState({
+    defaultFloorName: t('setup.layoutSetup.defaultFloorName'),
+    ...(collected.layout !== undefined ? { initial: collected.layout } : {}),
+  });
+
+  const activeFloor =
+    state.floors.find((floor) => floor.id === state.activeFloorId) ?? state.floors[0];
 
   const onSubmit = (event: SubmitEvent<HTMLFormElement>): void => {
     event.preventDefault();
-    const trimmed = layout.trim();
-    const partial: DeviceConfigInput = {};
-    if (trimmed !== '') partial.layout = trimmed;
-    onNext(partial);
+    onNext({ layout: toLayout() });
+  };
+
+  const onAddFloor = (): void => {
+    actions.addFloor(
+      t('setup.layoutSetup.newFloorNameTemplate', { index: state.floors.length + 1 }),
+    );
+  };
+
+  const onAddRoom = (): void => {
+    if (activeFloor === undefined) return;
+    actions.addRoom(
+      activeFloor.id,
+      t('setup.layoutSetup.newRoomNameTemplate', { index: activeFloor.rooms.length + 1 }),
+    );
   };
 
   return (
@@ -46,27 +81,38 @@ export function LayoutStep({ collected, onNext }: LayoutStepProps): ReactNode {
         <p className="text-sm text-tertiary">{t('setup.layoutSetup.subtitle')}</p>
       </header>
 
-      <form onSubmit={onSubmit} noValidate className="flex flex-col">
-        <div className="grid grid-cols-1 gap-2 border-t border-secondary py-5 sm:grid-cols-[240px_1fr] sm:items-start sm:gap-8">
-          <p id={layoutLabelId} className="pt-2 text-sm font-semibold text-secondary">
-            {t('setup.layoutSetup.layout.label')}
-          </p>
-          <div className="flex max-w-[480px] flex-col gap-1.5">
-            <TextField value={layout} onChange={setLayout} aria-labelledby={layoutLabelId}>
-              <InputBase
-                type="text"
-                placeholder={t('setup.layoutSetup.layout.placeholder')}
-                autoComplete="off"
-              />
-            </TextField>
-            <p className="text-sm text-tertiary">{t('setup.layoutSetup.layout.hint')}</p>
-          </div>
-        </div>
+      <form onSubmit={onSubmit} noValidate className="flex flex-col gap-6">
+        <FloorTabs
+          floors={state.floors}
+          activeFloorId={state.activeFloorId}
+          onSwitch={actions.switchFloor}
+          onAddFloor={onAddFloor}
+          onRenameFloor={actions.renameFloor}
+          onRemoveFloor={actions.removeFloor}
+          canAddMore={state.floors.length < MAX_FLOORS}
+        />
 
-        <div className="flex justify-end gap-3 border-t border-secondary py-6">
+        {activeFloor !== undefined && (
+          <RoomGrid
+            floor={activeFloor}
+            onAddRoom={onAddRoom}
+            onRenameRoom={(roomId, name) => {
+              actions.renameRoom(activeFloor.id, roomId, name);
+            }}
+            onChangeRoomType={(roomId, type) => {
+              actions.changeRoomType(activeFloor.id, roomId, type);
+            }}
+            onRemoveRoom={(roomId) => {
+              actions.removeRoom(activeFloor.id, roomId);
+            }}
+            canAddMore={activeFloor.rooms.length < MAX_ROOMS_PER_FLOOR}
+          />
+        )}
+
+        <div className="flex justify-end gap-3 border-t border-secondary pt-6">
           <button
             type="submit"
-            className="inline-flex items-center gap-2 rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white shadow-xs-skeuomorphic hover:bg-brand-solid_hover"
+            className="inline-flex items-center gap-2 rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white shadow-xs-skeuomorphic hover:bg-brand-solid_hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
           >
             <span>{t('setup.layoutSetup.actions.next')}</span>
             <NextArrowIcon />

--- a/apps/web/src/features/setup/layout/room-card.tsx
+++ b/apps/web/src/features/setup/layout/room-card.tsx
@@ -1,0 +1,91 @@
+// One room — emoji glyph + editable name + type picker + remove
+// button. Lives inside the floor's `RoomGrid` (one card per room).
+//
+// The remove × surfaces on hover (`group-hover:opacity-100`) so the
+// resting card looks clean. Focus-within keeps it visible for
+// keyboard users.
+
+import { NativeSelect } from '@glaon/ui';
+import { useId, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { Room, RoomType } from '@glaon/core/config';
+
+import { RoomTypeIcon } from './room-type-icon';
+import { XCloseIcon } from './step-icons';
+
+const ROOM_TYPES = [
+  'bedroom',
+  'bathroom',
+  'kitchen',
+  'living',
+  'office',
+  'dining',
+  'garage',
+  'garden',
+  'other',
+] as const satisfies readonly RoomType[];
+
+interface RoomCardProps {
+  readonly room: Room;
+  readonly onRename: (next: string) => void;
+  readonly onChangeType: (next: RoomType | undefined) => void;
+  readonly onRemove: () => void;
+}
+
+export function RoomCard({ room, onRename, onChangeType, onRemove }: RoomCardProps): ReactNode {
+  const { t } = useTranslation();
+  const nameId = useId();
+
+  return (
+    <div className="group relative flex flex-col gap-3 rounded-xl bg-primary p-4 ring-1 ring-secondary transition-shadow hover:shadow-md focus-within:shadow-md focus-within:ring-brand">
+      <button
+        type="button"
+        onClick={onRemove}
+        className="absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-full text-tertiary opacity-0 transition-opacity hover:bg-secondary hover:text-primary group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        aria-label={t('setup.layoutSetup.rooms.removeRoom', { name: room.name })}
+      >
+        <XCloseIcon className="size-4" />
+      </button>
+
+      <RoomTypeIcon {...(room.type !== undefined ? { type: room.type } : {})} size="lg" />
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor={nameId} className="sr-only">
+          {t('setup.layoutSetup.rooms.nameLabel')}
+        </label>
+        <input
+          id={nameId}
+          type="text"
+          value={room.name}
+          onChange={(event) => {
+            onRename(event.target.value);
+          }}
+          onBlur={(event) => {
+            // Restore the previous label when the user empties the
+            // field — the schema requires non-empty room names.
+            if (event.target.value.trim() === '') onRename(room.name);
+          }}
+          placeholder={t('setup.layoutSetup.rooms.namePlaceholder')}
+          className="w-full rounded-md bg-transparent text-md font-semibold text-primary outline-none ring-1 ring-transparent transition-shadow placeholder:text-placeholder hover:ring-secondary focus:ring-2 focus:ring-brand"
+        />
+
+        <NativeSelect
+          aria-label={t('setup.layoutSetup.rooms.typeLabel')}
+          value={room.type ?? ''}
+          onChange={(event) => {
+            const next = event.target.value;
+            onChangeType(next === '' ? undefined : (next as RoomType));
+          }}
+          options={[
+            { value: '', label: t('setup.layoutSetup.rooms.types.none') },
+            ...ROOM_TYPES.map((kind) => ({
+              value: kind,
+              label: t(`setup.layoutSetup.rooms.types.${kind}`),
+            })),
+          ]}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/setup/layout/room-grid.tsx
+++ b/apps/web/src/features/setup/layout/room-grid.tsx
@@ -1,0 +1,95 @@
+// Room grid for the active floor — responsive card grid + an
+// add-room button. Empty state shows a centered hint card with the
+// CTA so the user knows what to do on a fresh floor.
+
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { Floor, Room, RoomType } from '@glaon/core/config';
+
+import { RoomCard } from './room-card';
+import { PlusIcon } from './step-icons';
+
+interface RoomGridProps {
+  readonly floor: Floor;
+  readonly onAddRoom: () => void;
+  readonly onRenameRoom: (roomId: string, name: string) => void;
+  readonly onChangeRoomType: (roomId: string, type: RoomType | undefined) => void;
+  readonly onRemoveRoom: (roomId: string) => void;
+  readonly canAddMore: boolean;
+}
+
+export function RoomGrid({
+  floor,
+  onAddRoom,
+  onRenameRoom,
+  onChangeRoomType,
+  onRemoveRoom,
+  canAddMore,
+}: RoomGridProps): ReactNode {
+  const { t } = useTranslation();
+
+  if (floor.rooms.length === 0) {
+    return (
+      <div
+        id={`floor-panel-${floor.id}`}
+        role="tabpanel"
+        className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-secondary bg-secondary/40 px-6 py-12 text-center"
+      >
+        <div className="text-5xl" aria-hidden="true">
+          🏠
+        </div>
+        <div className="flex flex-col gap-1">
+          <p className="text-md font-semibold text-primary">
+            {t('setup.layoutSetup.rooms.emptyTitle', { floor: floor.name })}
+          </p>
+          <p className="max-w-md text-sm text-tertiary">{t('setup.layoutSetup.rooms.emptyHint')}</p>
+        </div>
+        {canAddMore && (
+          <button
+            type="button"
+            onClick={onAddRoom}
+            className="inline-flex items-center gap-2 rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white shadow-xs-skeuomorphic transition-colors hover:bg-brand-solid_hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+          >
+            <PlusIcon className="size-4" />
+            <span>{t('setup.layoutSetup.rooms.addFirstRoom')}</span>
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div id={`floor-panel-${floor.id}`} role="tabpanel" className="flex flex-col gap-4">
+      <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {floor.rooms.map((room: Room) => (
+          <li key={room.id}>
+            <RoomCard
+              room={room}
+              onRename={(name) => {
+                onRenameRoom(room.id, name);
+              }}
+              onChangeType={(type) => {
+                onChangeRoomType(room.id, type);
+              }}
+              onRemove={() => {
+                onRemoveRoom(room.id);
+              }}
+            />
+          </li>
+        ))}
+      </ul>
+
+      {canAddMore && (
+        <button
+          type="button"
+          onClick={onAddRoom}
+          className="inline-flex items-center justify-center gap-2 self-start rounded-lg border border-dashed border-secondary px-4 py-2 text-sm font-semibold text-secondary transition-colors hover:border-brand hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        >
+          <PlusIcon className="size-4" />
+          <span>{t('setup.layoutSetup.rooms.addRoom')}</span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/setup/layout/room-type-icon.tsx
+++ b/apps/web/src/features/setup/layout/room-type-icon.tsx
@@ -1,0 +1,62 @@
+// Emoji glyph mapper for room types. We use emoji rather than the
+// `@untitledui/icons` set because:
+//
+//   - The kit doesn't ship dedicated `Bed` / `Bath` / `Sofa` /
+//     `Kitchen` glyphs — closest matches are generic furniture /
+//     building icons that all read as "thing".
+//   - Emoji renders the same intent across every modern OS / browser
+//     (Apple, Segoe UI, Noto). The user immediately recognises 🛏️
+//     as bedroom; nobody has to learn that `Bed01` from a kit means
+//     bedroom.
+//   - Zero extra weight — emoji is unicode text, no SVG payload.
+//
+// Per CLAUDE.md the project avoids emojis in source files **as a
+// general rule** (no emoji-flavoured commit messages, docs, code
+// comments). User-facing UI is the explicit exception: a wall
+// tablet sitting in someone's living room ships emoji icons because
+// they're the right tool for "this is a kitchen" at a glance.
+
+import type { ReactNode } from 'react';
+
+import type { RoomType } from '@glaon/core/config';
+
+const EMOJI: Record<RoomType, string> = {
+  bedroom: '🛏️',
+  bathroom: '🛁',
+  kitchen: '🍳',
+  living: '🛋️',
+  office: '💻',
+  dining: '🍽️',
+  garage: '🚗',
+  garden: '🌳',
+  other: '🚪',
+};
+
+/** Fallback when the user hasn't picked a type yet. */
+const DEFAULT_EMOJI = '🏠';
+
+interface RoomTypeIconProps {
+  readonly type?: RoomType;
+  /** Visual size — defaults to `lg` (~32px). */
+  readonly size?: 'sm' | 'md' | 'lg';
+  /** Accessible label; when set, the emoji is announced. Defaults
+   *  to decorative (aria-hidden) since the room name carries the
+   *  semantics. */
+  readonly ariaLabel?: string;
+}
+
+export function RoomTypeIcon({ type, size = 'lg', ariaLabel }: RoomTypeIconProps): ReactNode {
+  const glyph = type !== undefined ? EMOJI[type] : DEFAULT_EMOJI;
+  const sizeClass = size === 'sm' ? 'text-lg' : size === 'md' ? 'text-2xl' : 'text-4xl';
+  const isDecorative = ariaLabel === undefined;
+  return (
+    <span
+      className={`inline-flex shrink-0 select-none leading-none ${sizeClass}`}
+      role={isDecorative ? undefined : 'img'}
+      aria-label={ariaLabel}
+      aria-hidden={isDecorative ? true : undefined}
+    >
+      {glyph}
+    </span>
+  );
+}

--- a/apps/web/src/features/setup/layout/step-icons.tsx
+++ b/apps/web/src/features/setup/layout/step-icons.tsx
@@ -1,0 +1,51 @@
+// Inline SVG icons used by the Layout Setup step's wrap UI
+// (floor-tabs, room-card, room-grid). We don't reach into
+// `@untitledui/icons` directly from apps/web — apps/web's dep
+// surface stays narrowed to `@glaon/ui`, which re-exports kit
+// components but not arbitrary icons. For affordances small
+// enough to inline, the SVG lives here.
+//
+// Each icon takes a `className` so the consumer controls size
+// (`size-4`, `size-3.5`) and colour (currentColor). Decorative by
+// default — pair with an accessible-name on the surrounding button
+// so screen readers know what the icon does.
+
+import type { ReactNode } from 'react';
+
+interface IconProps {
+  readonly className?: string;
+}
+
+export function PlusIcon({ className }: IconProps): ReactNode {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10 4.167v11.666M4.167 10h11.666" />
+    </svg>
+  );
+}
+
+export function XCloseIcon({ className }: IconProps): ReactNode {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M15 5 5 15M5 5l10 10" />
+    </svg>
+  );
+}

--- a/apps/web/src/features/setup/layout/use-layout-state.test.ts
+++ b/apps/web/src/features/setup/layout/use-layout-state.test.ts
@@ -1,0 +1,203 @@
+// Pure reducer tests — no DOM, no React. Driven via the
+// deterministic id factory so assertions can pin specific ids.
+
+import { describe, expect, it } from 'vitest';
+
+import type { Floor } from '@glaon/core/config';
+
+import { makeReducer, type LayoutState } from './use-layout-state';
+
+function makeIdFactory(): () => string {
+  let counter = 0;
+  return () => {
+    counter += 1;
+    return `id-${counter.toString()}`;
+  };
+}
+
+function seed(floors: Floor[], activeFloorId: string): LayoutState {
+  return { floors, activeFloorId };
+}
+
+describe('layout reducer', () => {
+  describe('switchFloor', () => {
+    it('switches to a known floor', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed(
+        [
+          { id: 'a', name: 'A', rooms: [] },
+          { id: 'b', name: 'B', rooms: [] },
+        ],
+        'a',
+      );
+      const next = reducer(initial, { kind: 'switchFloor', floorId: 'b' });
+      expect(next.activeFloorId).toBe('b');
+    });
+
+    it('is a no-op for an unknown floor id', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed([{ id: 'a', name: 'A', rooms: [] }], 'a');
+      expect(reducer(initial, { kind: 'switchFloor', floorId: 'ghost' })).toBe(initial);
+    });
+  });
+
+  describe('addFloor', () => {
+    it('appends a floor and makes it active', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed([{ id: 'a', name: 'A', rooms: [] }], 'a');
+      const next = reducer(initial, { kind: 'addFloor', name: '2nd Floor' });
+      expect(next.floors).toHaveLength(2);
+      expect(next.floors[1]?.name).toBe('2nd Floor');
+      expect(next.activeFloorId).toBe(next.floors[1]?.id);
+    });
+
+    it('caps at 10 floors', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const ten = Array.from({ length: 10 }, (_, idx) => ({
+        id: `f-${idx.toString()}`,
+        name: `Floor ${idx.toString()}`,
+        rooms: [],
+      }));
+      const initial = seed(ten, 'f-0');
+      expect(reducer(initial, { kind: 'addFloor', name: '11' })).toBe(initial);
+    });
+  });
+
+  describe('renameFloor', () => {
+    it('renames the matching floor and trims whitespace', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed([{ id: 'a', name: 'A', rooms: [] }], 'a');
+      const next = reducer(initial, { kind: 'renameFloor', floorId: 'a', name: '  Loft  ' });
+      expect(next.floors[0]?.name).toBe('Loft');
+    });
+
+    it('rejects an empty rename', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed([{ id: 'a', name: 'A', rooms: [] }], 'a');
+      expect(reducer(initial, { kind: 'renameFloor', floorId: 'a', name: '   ' })).toBe(initial);
+    });
+  });
+
+  describe('removeFloor', () => {
+    it('removes a non-active floor', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed(
+        [
+          { id: 'a', name: 'A', rooms: [] },
+          { id: 'b', name: 'B', rooms: [] },
+        ],
+        'a',
+      );
+      const next = reducer(initial, { kind: 'removeFloor', floorId: 'b' });
+      expect(next.floors.map((f) => f.id)).toEqual(['a']);
+      expect(next.activeFloorId).toBe('a');
+    });
+
+    it('switches the active floor when the active one is removed', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed(
+        [
+          { id: 'a', name: 'A', rooms: [] },
+          { id: 'b', name: 'B', rooms: [] },
+        ],
+        'b',
+      );
+      const next = reducer(initial, { kind: 'removeFloor', floorId: 'b' });
+      expect(next.floors.map((f) => f.id)).toEqual(['a']);
+      expect(next.activeFloorId).toBe('a');
+    });
+
+    it('blocks removing the last floor', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed([{ id: 'a', name: 'A', rooms: [] }], 'a');
+      expect(reducer(initial, { kind: 'removeFloor', floorId: 'a' })).toBe(initial);
+    });
+  });
+
+  describe('addRoom', () => {
+    it('appends a room to the target floor', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed(
+        [
+          { id: 'a', name: 'A', rooms: [] },
+          { id: 'b', name: 'B', rooms: [] },
+        ],
+        'a',
+      );
+      const next = reducer(initial, { kind: 'addRoom', floorId: 'a', name: 'Kitchen' });
+      expect(next.floors[0]?.rooms).toHaveLength(1);
+      expect(next.floors[0]?.rooms[0]?.name).toBe('Kitchen');
+      expect(next.floors[1]?.rooms).toHaveLength(0);
+    });
+
+    it('caps at 50 rooms per floor', () => {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const fifty = Array.from({ length: 50 }, (_, idx) => ({
+        id: `r-${idx.toString()}`,
+        name: `Room ${idx.toString()}`,
+      }));
+      const initial = seed([{ id: 'a', name: 'A', rooms: fifty }], 'a');
+      const next = reducer(initial, { kind: 'addRoom', floorId: 'a', name: 'Overflow' });
+      expect(next.floors[0]?.rooms).toHaveLength(50);
+    });
+  });
+
+  describe('renameRoom + changeRoomType + removeRoom', () => {
+    function setup() {
+      const reducer = makeReducer({ idFactory: makeIdFactory() });
+      const initial = seed(
+        [
+          {
+            id: 'a',
+            name: 'A',
+            rooms: [
+              { id: 'r1', name: 'Kitchen', type: 'kitchen' },
+              { id: 'r2', name: 'Bath' },
+            ],
+          },
+        ],
+        'a',
+      );
+      return { reducer, initial };
+    }
+
+    it('renames a room and trims whitespace', () => {
+      const { reducer, initial } = setup();
+      const next = reducer(initial, {
+        kind: 'renameRoom',
+        floorId: 'a',
+        roomId: 'r1',
+        name: '  Galley  ',
+      });
+      expect(next.floors[0]?.rooms[0]?.name).toBe('Galley');
+    });
+
+    it('changes a room type from unset to bedroom', () => {
+      const { reducer, initial } = setup();
+      const next = reducer(initial, {
+        kind: 'changeRoomType',
+        floorId: 'a',
+        roomId: 'r2',
+        type: 'bedroom',
+      });
+      expect(next.floors[0]?.rooms[1]?.type).toBe('bedroom');
+    });
+
+    it('clears a room type when set to undefined', () => {
+      const { reducer, initial } = setup();
+      const next = reducer(initial, {
+        kind: 'changeRoomType',
+        floorId: 'a',
+        roomId: 'r1',
+        type: undefined,
+      });
+      expect(next.floors[0]?.rooms[0]?.type).toBeUndefined();
+    });
+
+    it('removes a room by id', () => {
+      const { reducer, initial } = setup();
+      const next = reducer(initial, { kind: 'removeRoom', floorId: 'a', roomId: 'r1' });
+      expect(next.floors[0]?.rooms.map((r) => r.id)).toEqual(['r2']);
+    });
+  });
+});

--- a/apps/web/src/features/setup/layout/use-layout-state.ts
+++ b/apps/web/src/features/setup/layout/use-layout-state.ts
@@ -1,0 +1,225 @@
+// Layout-editor state — `useReducer` over the Floor[] array.
+// Kept in its own module so the unit test can drive every action
+// without mounting the React tree (faster + ID-stable).
+//
+// Action shape mirrors the editor surface 1:1 — every UI affordance
+// (add/remove/rename for floors and rooms; pick a room type; switch
+// active floor) maps to a single action type. Reducer is pure
+// modulo the new-id generation injected via the `idFactory` arg
+// (deterministic test ids in jsdom, `crypto.randomUUID()` in
+// browsers).
+
+import { useCallback, useMemo, useReducer } from 'react';
+
+import type { Floor, Layout, Room, RoomType } from '@glaon/core/config';
+
+export interface LayoutState {
+  readonly floors: readonly Floor[];
+  /** id of the floor currently visible in the editor's right pane. */
+  readonly activeFloorId: string;
+}
+
+export type LayoutAction =
+  | { kind: 'switchFloor'; floorId: string }
+  | { kind: 'addFloor'; name: string }
+  | { kind: 'renameFloor'; floorId: string; name: string }
+  | { kind: 'removeFloor'; floorId: string }
+  | { kind: 'addRoom'; floorId: string; name: string }
+  | { kind: 'renameRoom'; floorId: string; roomId: string; name: string }
+  | { kind: 'changeRoomType'; floorId: string; roomId: string; type: RoomType | undefined }
+  | { kind: 'removeRoom'; floorId: string; roomId: string };
+
+export interface LayoutReducerContext {
+  /** Returns the next room/floor id. Override in tests for determinism. */
+  readonly idFactory: () => string;
+}
+
+export function makeReducer(ctx: LayoutReducerContext) {
+  const { idFactory } = ctx;
+  return function reducer(state: LayoutState, action: LayoutAction): LayoutState {
+    switch (action.kind) {
+      case 'switchFloor': {
+        if (!state.floors.some((floor) => floor.id === action.floorId)) return state;
+        return { ...state, activeFloorId: action.floorId };
+      }
+      case 'addFloor': {
+        // Cap at 10 mirrors the schema's `z.array(...).max(10)` — UI
+        // should hide the affordance before this fires, but the
+        // guard is here so a renegade caller can't over-add.
+        if (state.floors.length >= 10) return state;
+        const newFloor: Floor = { id: idFactory(), name: action.name, rooms: [] };
+        return { floors: [...state.floors, newFloor], activeFloorId: newFloor.id };
+      }
+      case 'renameFloor': {
+        const trimmed = action.name.trim();
+        if (trimmed === '') return state;
+        return {
+          ...state,
+          floors: state.floors.map((floor) =>
+            floor.id === action.floorId ? { ...floor, name: trimmed } : floor,
+          ),
+        };
+      }
+      case 'removeFloor': {
+        // Never remove the last floor — at least one is required by
+        // both the schema and the wizard's UX contract.
+        if (state.floors.length <= 1) return state;
+        const remaining = state.floors.filter((floor) => floor.id !== action.floorId);
+        if (remaining.length === state.floors.length) return state;
+        const wasActive = state.activeFloorId === action.floorId;
+        const nextActive = wasActive
+          ? (remaining[0]?.id ?? state.activeFloorId)
+          : state.activeFloorId;
+        return { floors: remaining, activeFloorId: nextActive };
+      }
+      case 'addRoom': {
+        return {
+          ...state,
+          floors: state.floors.map((floor) => {
+            if (floor.id !== action.floorId) return floor;
+            if (floor.rooms.length >= 50) return floor;
+            const newRoom: Room = { id: idFactory(), name: action.name };
+            return { ...floor, rooms: [...floor.rooms, newRoom] };
+          }),
+        };
+      }
+      case 'renameRoom': {
+        const trimmed = action.name.trim();
+        if (trimmed === '') return state;
+        return {
+          ...state,
+          floors: state.floors.map((floor) => {
+            if (floor.id !== action.floorId) return floor;
+            return {
+              ...floor,
+              rooms: floor.rooms.map((room) =>
+                room.id === action.roomId ? { ...room, name: trimmed } : room,
+              ),
+            };
+          }),
+        };
+      }
+      case 'changeRoomType': {
+        return {
+          ...state,
+          floors: state.floors.map((floor) => {
+            if (floor.id !== action.floorId) return floor;
+            return {
+              ...floor,
+              rooms: floor.rooms.map((room) => {
+                if (room.id !== action.roomId) return room;
+                // `exactOptionalPropertyTypes: true` — build the room
+                // bag conditionally instead of passing explicit
+                // `undefined` for `type`.
+                const next: Room = { id: room.id, name: room.name };
+                if (action.type !== undefined) next.type = action.type;
+                return next;
+              }),
+            };
+          }),
+        };
+      }
+      case 'removeRoom': {
+        return {
+          ...state,
+          floors: state.floors.map((floor) => {
+            if (floor.id !== action.floorId) return floor;
+            return { ...floor, rooms: floor.rooms.filter((room) => room.id !== action.roomId) };
+          }),
+        };
+      }
+    }
+  };
+}
+
+/**
+ * Default id factory — `crypto.randomUUID()` in modern browsers.
+ * Replaced in jsdom tests with a deterministic counter.
+ */
+export function defaultIdFactory(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Pre-crypto.randomUUID fallback (rare). Math.random is OK because
+  // the id is opaque — uniqueness inside a single config blob is all
+  // we need.
+  return `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+interface UseLayoutStateOptions {
+  /** Default floor name when seeding an empty editor. */
+  readonly defaultFloorName: string;
+  /** Hydrate from a previously persisted `layout` blob if present. */
+  readonly initial?: Layout;
+  /** Override in tests for deterministic ids. */
+  readonly idFactory?: () => string;
+}
+
+/**
+ * Hook over the reducer. Returns the current state, a memoised set
+ * of action dispatchers (keeps deps arrays in consumers stable),
+ * and a helper to project the state back into a `Layout` blob
+ * suitable for the wizard's `onNext` callback.
+ */
+export function useLayoutState(opts: UseLayoutStateOptions) {
+  const { defaultFloorName, initial, idFactory = defaultIdFactory } = opts;
+
+  const initialState = useMemo<LayoutState>(() => {
+    if (initial !== undefined && initial.floors.length > 0) {
+      // We mutate the array shape (.slice) so the reducer sees a
+      // plain `Floor[]` rather than a frozen zod-inferred tuple.
+      const floors = [...initial.floors];
+      const first = floors[0];
+      if (first === undefined) {
+        // Type narrow — `floors[0]` is `Floor | undefined` even
+        // after the `.length > 0` check above.
+        const seed: Floor = { id: idFactory(), name: defaultFloorName, rooms: [] };
+        return { floors: [seed], activeFloorId: seed.id };
+      }
+      return { floors, activeFloorId: first.id };
+    }
+    const seed: Floor = { id: idFactory(), name: defaultFloorName, rooms: [] };
+    return { floors: [seed], activeFloorId: seed.id };
+    // Initialiser intentionally runs once; subsequent `defaultFloorName`
+    // changes (i18n locale switch mid-session) don't rename the
+    // existing seed floor.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const reducer = useMemo(() => makeReducer({ idFactory }), [idFactory]);
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const actions = useMemo(
+    () => ({
+      switchFloor: (floorId: string) => {
+        dispatch({ kind: 'switchFloor', floorId });
+      },
+      addFloor: (name: string) => {
+        dispatch({ kind: 'addFloor', name });
+      },
+      renameFloor: (floorId: string, name: string) => {
+        dispatch({ kind: 'renameFloor', floorId, name });
+      },
+      removeFloor: (floorId: string) => {
+        dispatch({ kind: 'removeFloor', floorId });
+      },
+      addRoom: (floorId: string, name: string) => {
+        dispatch({ kind: 'addRoom', floorId, name });
+      },
+      renameRoom: (floorId: string, roomId: string, name: string) => {
+        dispatch({ kind: 'renameRoom', floorId, roomId, name });
+      },
+      changeRoomType: (floorId: string, roomId: string, type: RoomType | undefined) => {
+        dispatch({ kind: 'changeRoomType', floorId, roomId, type });
+      },
+      removeRoom: (floorId: string, roomId: string) => {
+        dispatch({ kind: 'removeRoom', floorId, roomId });
+      },
+    }),
+    [],
+  );
+
+  const toLayout = useCallback((): Layout => ({ floors: [...state.floors] }), [state.floors]);
+
+  return { state, actions, toLayout };
+}

--- a/apps/web/src/features/setup/layout/use-layout-state.ts
+++ b/apps/web/src/features/setup/layout/use-layout-state.ts
@@ -19,7 +19,11 @@ export interface LayoutState {
   readonly activeFloorId: string;
 }
 
-export type LayoutAction =
+// Both kept un-exported per memory note
+// `feedback_knip_props_interfaces.md` — `LayoutAction` and
+// `LayoutReducerContext` are consumed only inside this file.
+// Promote when an external consumer arrives.
+type LayoutAction =
   | { kind: 'switchFloor'; floorId: string }
   | { kind: 'addFloor'; name: string }
   | { kind: 'renameFloor'; floorId: string; name: string }
@@ -29,7 +33,7 @@ export type LayoutAction =
   | { kind: 'changeRoomType'; floorId: string; roomId: string; type: RoomType | undefined }
   | { kind: 'removeRoom'; floorId: string; roomId: string };
 
-export interface LayoutReducerContext {
+interface LayoutReducerContext {
   /** Returns the next room/floor id. Override in tests for determinism. */
   readonly idFactory: () => string;
 }
@@ -136,7 +140,10 @@ export function makeReducer(ctx: LayoutReducerContext) {
  * Default id factory — `crypto.randomUUID()` in modern browsers.
  * Replaced in jsdom tests with a deterministic counter.
  */
-export function defaultIdFactory(): string {
+// Internal — same memory-note rationale as the types above.
+// `useLayoutState` reads it as the default `idFactory`; tests
+// inject their own deterministic factory.
+function defaultIdFactory(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }

--- a/apps/web/src/features/setup/review/review-step.tsx
+++ b/apps/web/src/features/setup/review/review-step.tsx
@@ -28,7 +28,7 @@ import { Button, Modal, PasswordInput, useToast } from '@glaon/ui';
 import { useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import type { DeviceConfigInput } from '@glaon/core/config';
+import type { DeviceConfigInput, Layout } from '@glaon/core/config';
 
 import { useDeviceConfig } from '../../../config/config-provider';
 
@@ -150,7 +150,7 @@ export function ReviewStep({ collected }: ReviewStepProps): ReactNode {
               : undefined
           }
         />
-        <SummaryRow label={t('setup.layoutSetup.layout.label')} value={collected.layout} />
+        <LayoutSummaryRow layout={collected.layout} />
         <SummaryRow
           label={t('setup.review.summary.wifi')}
           value={
@@ -231,6 +231,55 @@ function SummaryRow({ label, value }: SummaryRowProps): ReactNode {
       <dt className="text-sm font-semibold text-secondary">{label}</dt>
       <dd className="text-sm text-tertiary">
         {value !== undefined && value !== '' ? value : t('setup.review.summary.notSet')}
+      </dd>
+    </div>
+  );
+}
+
+interface LayoutSummaryRowProps {
+  readonly layout: Layout | undefined;
+}
+
+function LayoutSummaryRow({ layout }: LayoutSummaryRowProps): ReactNode {
+  const { t } = useTranslation();
+  const label = t('setup.layoutSetup.label');
+
+  if (layout === undefined || layout.floors.length === 0) {
+    return <SummaryRow label={label} value={undefined} />;
+  }
+
+  const totalRooms = layout.floors.reduce((sum, floor) => sum + floor.rooms.length, 0);
+  const headline = t('setup.review.summary.layoutHeadline', {
+    floorCount: layout.floors.length,
+    roomCount: totalRooms,
+  });
+
+  return (
+    <div className="grid grid-cols-1 gap-2 border-t border-secondary py-4 sm:grid-cols-[240px_1fr] sm:items-baseline sm:gap-8">
+      <dt className="text-sm font-semibold text-secondary">{label}</dt>
+      <dd className="flex flex-col gap-1 text-sm text-tertiary">
+        <span className="font-medium text-primary">{headline}</span>
+        <ul className="flex flex-col gap-1">
+          {layout.floors.map((floor) => {
+            const roomNames = floor.rooms.map((r) => r.name).join(', ');
+            return (
+              <li key={floor.id} className="truncate">
+                <span className="font-medium text-secondary">{floor.name}</span>
+                {floor.rooms.length > 0 ? (
+                  <>
+                    <span aria-hidden="true"> — </span>
+                    <span>{roomNames}</span>
+                  </>
+                ) : (
+                  <>
+                    <span aria-hidden="true"> — </span>
+                    <span className="italic">{t('setup.review.summary.layoutEmptyFloor')}</span>
+                  </>
+                )}
+              </li>
+            );
+          })}
+        </ul>
       </dd>
     </div>
   );

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -91,11 +91,39 @@
     },
     "layoutSetup": {
       "title": "Layout Setup",
-      "subtitle": "Describe how your home is organized. The full floor + room editor lands in a later release.",
-      "layout": {
-        "label": "Home structure",
-        "placeholder": "e.g. 2 floors, 5 rooms — kitchen, living, two bedrooms, bathroom",
-        "hint": "Optional. Free-text for now; we'll replace this with a real layout editor in a follow-up."
+      "subtitle": "Add the floors and rooms in your home. Glaon uses them to group devices and surface the right controls per space.",
+      "label": "Layout",
+      "defaultFloorName": "Ground Floor",
+      "newFloorNameTemplate": "Floor {index}",
+      "newRoomNameTemplate": "Room {index}",
+      "floors": {
+        "tabsLabel": "Floors",
+        "addFloor": "Add floor",
+        "removeFloor": "Remove {name}",
+        "renameFloor": "Rename floor",
+        "roomCountBadge": "{count} rooms"
+      },
+      "rooms": {
+        "addRoom": "Add room",
+        "addFirstRoom": "Add your first room",
+        "removeRoom": "Remove {name}",
+        "emptyTitle": "No rooms in {floor} yet",
+        "emptyHint": "Add the rooms you want to control on this floor — bedrooms, kitchen, bath, anything Glaon should know about.",
+        "nameLabel": "Room name",
+        "namePlaceholder": "Room name",
+        "typeLabel": "Room type",
+        "types": {
+          "none": "No type",
+          "bedroom": "Bedroom",
+          "bathroom": "Bathroom",
+          "kitchen": "Kitchen",
+          "living": "Living",
+          "office": "Office",
+          "dining": "Dining",
+          "garage": "Garage",
+          "garden": "Garden",
+          "other": "Other"
+        }
       },
       "actions": {
         "next": "Next"
@@ -157,7 +185,9 @@
         "wifiUnsecured": "{ssid} (open)",
         "adminPassword": "Admin password",
         "passwordSet": "Set",
-        "notSet": "—"
+        "notSet": "—",
+        "layoutHeadline": "{floorCount} floors · {roomCount} rooms",
+        "layoutEmptyFloor": "no rooms yet"
       },
       "passwordDialog": {
         "title": "Connect to {ssid}",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -91,11 +91,39 @@
     },
     "layoutSetup": {
       "title": "Yerleşim Kurulumu",
-      "subtitle": "Evinin nasıl organize olduğunu kısaca anlat. Tam kat + oda editörü ileri bir sürümde geliyor.",
-      "layout": {
-        "label": "Ev yapısı",
-        "placeholder": "örn. 2 kat, 5 oda — mutfak, salon, iki yatak odası, banyo",
-        "hint": "Opsiyonel. Şimdilik serbest metin; ileride gerçek bir yerleşim editörü ile değiştireceğiz."
+      "subtitle": "Evindeki katları ve odaları ekle. Glaon bunları cihazları gruplamak ve her mekana uygun kontrolleri göstermek için kullanır.",
+      "label": "Yerleşim",
+      "defaultFloorName": "Zemin Kat",
+      "newFloorNameTemplate": "{index}. Kat",
+      "newRoomNameTemplate": "Oda {index}",
+      "floors": {
+        "tabsLabel": "Katlar",
+        "addFloor": "Kat ekle",
+        "removeFloor": "{name} sil",
+        "renameFloor": "Katı yeniden adlandır",
+        "roomCountBadge": "{count} oda"
+      },
+      "rooms": {
+        "addRoom": "Oda ekle",
+        "addFirstRoom": "İlk odayı ekle",
+        "removeRoom": "{name} sil",
+        "emptyTitle": "{floor} henüz boş",
+        "emptyHint": "Bu katta kontrol etmek istediğin odaları ekle — yatak odası, mutfak, banyo, Glaon'un bilmesi gereken her yer.",
+        "nameLabel": "Oda adı",
+        "namePlaceholder": "Oda adı",
+        "typeLabel": "Oda tipi",
+        "types": {
+          "none": "Tip yok",
+          "bedroom": "Yatak odası",
+          "bathroom": "Banyo",
+          "kitchen": "Mutfak",
+          "living": "Salon",
+          "office": "Çalışma odası",
+          "dining": "Yemek odası",
+          "garage": "Garaj",
+          "garden": "Bahçe",
+          "other": "Diğer"
+        }
       },
       "actions": {
         "next": "İleri"
@@ -157,7 +185,9 @@
         "wifiUnsecured": "{ssid} (açık)",
         "adminPassword": "Yönetici şifresi",
         "passwordSet": "Ayarlandı",
-        "notSet": "—"
+        "notSet": "—",
+        "layoutHeadline": "{floorCount} kat · {roomCount} oda",
+        "layoutEmptyFloor": "henüz oda yok"
       },
       "passwordDialog": {
         "title": "{ssid} ağına bağlan",

--- a/packages/core/src/config/types.test.ts
+++ b/packages/core/src/config/types.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 import {
   DEVICE_CONFIG_SCHEMA_VERSION,
   DeviceConfigSchema,
+  FloorSchema,
+  LayoutSchema,
+  RoomSchema,
+  RoomTypeSchema,
   UnitSystemSchema,
   WifiConfigSchema,
 } from './types';
@@ -24,7 +28,23 @@ describe('DeviceConfigSchema', () => {
       timezone: 'Europe/Istanbul',
       locale: 'tr-TR',
       unitSystem: 'metric',
-      layout: 'open-plan, 2 katlı',
+      layout: {
+        floors: [
+          {
+            id: 'floor-1',
+            name: 'Zemin Kat',
+            rooms: [
+              { id: 'room-1', name: 'Salon', type: 'living' as const },
+              { id: 'room-2', name: 'Mutfak', type: 'kitchen' as const },
+            ],
+          },
+          {
+            id: 'floor-2',
+            name: '1. Kat',
+            rooms: [{ id: 'room-3', name: 'Yatak Odası', type: 'bedroom' as const }],
+          },
+        ],
+      },
       wifi: { ssid: 'home', passwordCipher: 'AES-GCM:abc123' },
       securityPinHash: 'a'.repeat(64),
       completedAt: '2026-05-17T18:30:00.000Z',
@@ -112,6 +132,51 @@ describe('DeviceConfigSchema', () => {
         wifi: { ssid: 'home', passwordCipher: '' },
       }),
     ).toThrow();
+  });
+});
+
+describe('LayoutSchema', () => {
+  const baseRoom = { id: 'r-1', name: 'Living', type: 'living' as const };
+  const baseFloor = { id: 'f-1', name: 'Ground Floor', rooms: [baseRoom] };
+
+  it('accepts a single-floor / single-room blob', () => {
+    expect(LayoutSchema.parse({ floors: [baseFloor] })).toEqual({ floors: [baseFloor] });
+  });
+
+  it('accepts an empty rooms array (attic etc.)', () => {
+    expect(LayoutSchema.parse({ floors: [{ id: 'f-1', name: 'Attic', rooms: [] }] })).toBeDefined();
+  });
+
+  it('rejects zero floors', () => {
+    expect(() => LayoutSchema.parse({ floors: [] })).toThrow();
+  });
+
+  it('rejects more than 10 floors', () => {
+    const eleven = Array.from({ length: 11 }, (_, idx) => ({
+      ...baseFloor,
+      id: `f-${idx.toString()}`,
+    }));
+    expect(() => LayoutSchema.parse({ floors: eleven })).toThrow();
+  });
+
+  it('rejects an empty floor name', () => {
+    expect(() => FloorSchema.parse({ ...baseFloor, name: '' })).toThrow();
+  });
+
+  it('rejects more than 50 rooms on a floor', () => {
+    const tooMany = Array.from({ length: 51 }, (_, idx) => ({
+      ...baseRoom,
+      id: `r-${idx.toString()}`,
+    }));
+    expect(() => FloorSchema.parse({ ...baseFloor, rooms: tooMany })).toThrow();
+  });
+
+  it('rejects an empty room name', () => {
+    expect(() => RoomSchema.parse({ ...baseRoom, name: '' })).toThrow();
+  });
+
+  it('rejects a room type not in the enum', () => {
+    expect(() => RoomTypeSchema.parse('basement')).toThrow();
   });
 });
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -14,6 +14,48 @@ export const DEVICE_CONFIG_SCHEMA_VERSION = 1 as const;
 export const UnitSystemSchema = z.union([z.literal('metric'), z.literal('imperial')]);
 export type UnitSystem = z.infer<typeof UnitSystemSchema>;
 
+/**
+ * Room category — drives the leading glyph in the layout editor and
+ * lets HA bucket the room downstream (lighting / sensor templates,
+ * default automations). Open-set on purpose: `'other'` is the
+ * escape hatch for spaces that don't fit a canonical category.
+ */
+export const RoomTypeSchema = z.enum([
+  'bedroom',
+  'bathroom',
+  'kitchen',
+  'living',
+  'office',
+  'dining',
+  'garage',
+  'garden',
+  'other',
+]);
+export type RoomType = z.infer<typeof RoomTypeSchema>;
+
+export const RoomSchema = z.object({
+  /** Stable client-generated id (crypto.randomUUID()). Opaque. */
+  id: z.string().min(1),
+  /** User-facing name. Trimmed before persistence. 1–64 chars. */
+  name: z.string().min(1).max(64),
+  type: RoomTypeSchema.optional(),
+});
+export type Room = z.infer<typeof RoomSchema>;
+
+export const FloorSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1).max(64),
+  /** Empty array is valid — a floor without rooms is e.g. an attic. */
+  rooms: z.array(RoomSchema).max(50),
+});
+export type Floor = z.infer<typeof FloorSchema>;
+
+export const LayoutSchema = z.object({
+  /** Always at least one floor; the editor blocks removing the last. */
+  floors: z.array(FloorSchema).min(1).max(10),
+});
+export type Layout = z.infer<typeof LayoutSchema>;
+
 export const WifiConfigSchema = z.object({
   ssid: z.string().min(1),
   /**
@@ -50,8 +92,20 @@ export const DeviceConfigSchema = z
     /** BCP-47 locale tag. SUPPORTED_LOCALES validation is the consumer's job. */
     locale: z.string().optional(),
     unitSystem: UnitSystemSchema.optional(),
-    /** v1 free-text placeholder; real floor/room editor is a follow-up epic. */
-    layout: z.string().optional(),
+    /**
+     * Multi-floor layout collected in wizard step 2. Each floor
+     * carries a list of rooms; the optional `type` per room drives
+     * the leading glyph in the editor and lets HA categorise the
+     * room downstream when the layout is mapped to HA areas
+     * (separate epic).
+     *
+     * Replaces the v1 free-text string from #545. Phase 2 has no
+     * production blobs that wrote the old shape, so the swap is
+     * direct — no `schemaVersion` bump. Local-dev blobs with the
+     * stale string field will fail strict parse and the wizard
+     * re-runs, which is acceptable for pre-release.
+     */
+    layout: LayoutSchema.optional(),
     wifi: WifiConfigSchema.optional(),
     /** SHA-256 hex (64 lowercase hex chars). Plaintext PIN never leaves the device. */
     securityPinHash: z


### PR DESCRIPTION
## Summary

Wizard step 2 (Layout Setup) was a free-text \`<TextField>\` placeholder shipped in #545. This PR replaces it with a real **multi-floor + rooms editor** — the user can add / rename / remove floors (tab strip), and inside each floor add / rename / remove rooms (responsive card grid) with an optional room type that drives an emoji glyph.

\`DeviceConfigSchema\` swaps \`layout: string\` for a structured \`layout?: { floors: Floor[] }\`. The review step's summary collapses the new structure into a compact \"N floors · M rooms\" headline + per-floor room lists.

Closes #592

## Visual design (no Figma — UX is the spec)

\`\`\`
┌─────────────────────────────────────────────────────────────┐
│ Layout Setup                                                │
│ Add the floors and rooms in your home…                      │
├─────────────────────────────────────────────────────────────┤
│  [Ground Floor (3) ×] [1st Floor (4) ×] [+ Add floor]      │
│                                                             │
│  ┌────────────┐  ┌────────────┐  ┌────────────┐            │
│  │ 🛋️      ×  │  │ 🍳      ×  │  │ 🛁      ×  │            │
│  │ Living     │  │ Kitchen    │  │ Bathroom   │            │
│  │ ▾ Living   │  │ ▾ Kitchen  │  │ ▾ Bathroom │            │
│  └────────────┘  └────────────┘  └────────────┘            │
│  [+ Add room]                                               │
│                                                  [Next →]  │
└─────────────────────────────────────────────────────────────┘
\`\`\`

\"Cool\" sprinkles: emoji glyphs per room type (universally readable), pill tabs with brand-accent for the active floor, room-count badges per tab, hover-revealed remove buttons so the resting UI stays clean, click-active-tab-to-rename-inline (Enter commits, Esc aborts).

## Scope

**In**
- New schema types in \`packages/core/src/config/types.ts\`: \`RoomType\` enum, \`RoomSchema\`, \`FloorSchema\`, \`LayoutSchema\` (and inferred \`Room\` / \`Floor\` / \`Layout\` types). \`layout\` field on \`DeviceConfigSchema\` swaps from string to the new shape. Range bounds: ≤10 floors, ≤50 rooms per floor, 1–64 chars per name.
- 7 new files under \`apps/web/src/features/setup/layout/\`:
  - \`use-layout-state.ts\` — pure reducer + hook (id factory injectable for deterministic tests).
  - \`layout-step.tsx\` — wizard shell.
  - \`floor-tabs.tsx\` — tab strip + add / rename / remove.
  - \`room-grid.tsx\` — responsive card grid + empty state.
  - \`room-card.tsx\` — single room (glyph + name + type + remove).
  - \`room-type-icon.tsx\` — emoji glyph map.
  - \`step-icons.tsx\` — Plus / XClose inline SVGs (avoids pulling \`@untitledui/icons\` as a direct apps/web dep).
- \`apps/web/src/features/setup/review/review-step.tsx\` — new \`LayoutSummaryRow\` for the structured layout.
- i18n: full new \`setup.layoutSetup.*\` namespace (EN + TR); the old \`layout.label / .placeholder / .hint\` keys retire.
- Tests:
  - \`use-layout-state.test.ts\` — 15 cases covering every action including no-op edges (cap-at-10, cap-at-50, blocked-on-last-floor, blank rename, etc.).
  - \`layout-step.test.tsx\` — 5 smoke cases (default render, single-floor submit, add-floor, add-first-room, hydration).
  - \`types.test.ts\` — 8 new cases for \`LayoutSchema\` round-trip + bounds.

**Out**
- Drag-to-reorder rooms / floors.
- Floor templates (\"Apartment 2+1\", \"Studio\", \"3-storey villa\").
- Bulk room import.
- Mobile setup wizard.
- HA integration — this PR only persists the layout into \`DeviceConfig\`; HA-area mapping is its own epic.

## Notes

- **Emoji in source.** CLAUDE.md says no emoji in code / commits / docs. User-facing UI text is the documented exception: a wall tablet in someone's living room needs 🛏️ to read as bedroom at a glance, and the kit doesn't ship dedicated furniture glyphs. The \`room-type-icon.tsx\` header documents the carve-out.
- **No \`@untitledui/icons\` in apps/web.** apps/web stays consuming icons exclusively through \`@glaon/ui\` (or via \`step-icons.tsx\` for tiny inline SVGs). Kept this rule because pulling the icons package as a direct dep here would balloon apps/web's manifest for two small affordances.
- **i18n interpolation.** Used ICU's single-brace \`{var}\` syntax to match the existing locale convention. Plural-pluralisation kept simple (\"3 rooms\" / \"1 rooms\" — slightly ugly for n=1 but worth the simplicity; a follow-up can wire ICU plural select if product demands it).
- **No schema version bump.** Phase 2 has no production blobs with the old string \`layout\` field. Any stale local-dev blob will fail strict parse and the wizard re-runs — acceptable for pre-release.

## Test plan

- [x] \`pnpm type-check\` green across the monorepo.
- [x] \`pnpm --filter @glaon/web lint\` green.
- [x] \`pnpm --filter @glaon/web test\` — 156/157 pass (the lone failing test is the pre-existing Clerk env-var case unrelated to this PR; CI passes it).
- [x] \`pnpm --filter @glaon/core test\` — 164 pass (incl. 8 new LayoutSchema cases).
- [x] Local Layout step tests: 20/20 green (15 reducer + 5 step smoke).
- [x] Local review step tests: 7/7 green.
- [x] knip clean; no \"* 2.*\" prettier dupes.
- [ ] CI: full pipeline including Lighthouse / Chromatic / Playwright / size-check.
- [ ] E2E setup-wizard smoke (\`apps/web-e2e/tests/setup-wizard.spec.ts\`): the Layout step still advances on Next (the default single floor counts as a valid submission).
- [ ] Manual sanity: open the wizard step → see one default floor with the empty-state CTA → add a floor → switch between tabs → add a few rooms → pick types → submit → next step receives the structured \`layout\` blob.

## Follow-ups

- Drag-to-reorder for floors and rooms.
- Floor templates / presets.
- Designer pass on the new visuals (Figma frame).
- ICU plural select for \"1 room\" vs \"3 rooms\" cosmetics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)