### PR TITLE
feat(api,web): add HA Supervisor proxy + mock for the wizard apply step

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -36,3 +36,26 @@ WEB_ORIGINS=http://localhost:5173
 GLAON_API_VERSION=0.0.0-dev
 GLAON_API_COMMIT=
 GLAON_API_BUILT_AT=
+
+# HA Supervisor proxy (#598). Two dev modes:
+#
+#   - Mock mode: HA_SUPERVISOR_MOCK=true returns a canned 3-network
+#     payload from /hassio/network/info and accepts any POST to
+#     /hassio/network/:iface/update with 200. The setup wizard's
+#     apply step works end-to-end without a real HA running.
+#   - Live mode: HA_SUPERVISOR_URL + HA_SUPERVISOR_TOKEN forward
+#     the calls to a real HA Supervisor. URL points at the
+#     supervisor's /network root (e.g. http://supervisor/network
+#     inside an add-on, or http://localhost:4357/network when
+#     proxying from outside). Token is the long-lived HA token —
+#     see docs/dev-supervisor.md for how to mint one.
+#
+# Either flag is enough; both unset → /hassio/* responds 503 and
+# the wizard's apply step lands on its error retry affordance.
+#
+# Production add-on deployments bypass this route entirely; the
+# add-on's own nginx proxies /api/hassio/* straight to the
+# supervisor over Ingress.
+HA_SUPERVISOR_MOCK=true
+# HA_SUPERVISOR_URL=
+# HA_SUPERVISOR_TOKEN=

--- a/apps/api/src/config.test.ts
+++ b/apps/api/src/config.test.ts
@@ -55,6 +55,29 @@ describe('loadConfig', () => {
     expect(config.webOrigins).toEqual(['https://app.glaon.com', 'http://localhost:5173']);
   });
 
+  it('reads HA Supervisor env vars (#598) — URL + token + mock flag', () => {
+    const config = loadConfig({
+      ...REQUIRED_BASE,
+      HA_SUPERVISOR_URL: 'http://supervisor.test/network',
+      HA_SUPERVISOR_TOKEN: 'long-lived',
+      HA_SUPERVISOR_MOCK: 'true',
+    });
+    expect(config.supervisorUrl).toBe('http://supervisor.test/network');
+    expect(config.supervisorToken).toBe('long-lived');
+    expect(config.supervisorMock).toBe(true);
+  });
+
+  it('defaults HA_SUPERVISOR_MOCK to false and leaves URL/token undefined', () => {
+    const config = loadConfig(REQUIRED_BASE);
+    expect(config.supervisorMock).toBe(false);
+    expect(config.supervisorUrl).toBeUndefined();
+    expect(config.supervisorToken).toBeUndefined();
+  });
+
+  it('rejects an invalid HA_SUPERVISOR_URL (not a URL)', () => {
+    expect(() => loadConfig({ ...REQUIRED_BASE, HA_SUPERVISOR_URL: 'not-a-url' })).toThrow();
+  });
+
   it('honors build info env vars', () => {
     const config = loadConfig({
       ...REQUIRED_BASE,

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -25,6 +25,22 @@ const ConfigSchema = z.object({
     .min(32, 'SESSION_JWT_SECRET must be at least 32 bytes (use a 256-bit random value)'),
   sessionTtlSeconds: z.number().int().positive().default(3600),
   webOrigins: z.array(z.string().url()).default([]),
+  // HA Supervisor proxy (#598). Dev mode — the wizard's apply step
+  // hits `/api/hassio/network/*` on the web origin; the Vite dev
+  // proxy routes those calls to apps/api which forwards them to a
+  // real HA Supervisor (when `supervisorUrl` is set) or returns
+  // a canned mock payload (when `supervisorMock` is true). Both
+  // unset → the proxy responds 503 with a hint, the wizard's apply
+  // step lands on its error retry affordance.
+  //
+  // Production add-on deployments bypass this route entirely — the
+  // add-on's own nginx proxies the wizard's network calls directly
+  // to the supervisor over Ingress. The proxy lives here so the
+  // standalone / dev wizard can talk to a real HA without the
+  // add-on harness.
+  supervisorUrl: z.string().url().optional(),
+  supervisorToken: z.string().optional(),
+  supervisorMock: z.boolean().default(false),
   buildInfo: z.object({
     commit: z.string().default('unknown'),
     builtAt: z.string().default(''),
@@ -45,6 +61,9 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     sessionJwtSecret: env.SESSION_JWT_SECRET ?? '',
     sessionTtlSeconds: ttl,
     webOrigins: parseOrigins(env.WEB_ORIGINS),
+    supervisorUrl: env.HA_SUPERVISOR_URL,
+    supervisorToken: env.HA_SUPERVISOR_TOKEN,
+    supervisorMock: parseBool(env.HA_SUPERVISOR_MOCK),
     buildInfo: {
       commit: env.GLAON_API_COMMIT ?? 'unknown',
       builtAt: env.GLAON_API_BUILT_AT ?? '',
@@ -59,4 +78,12 @@ function parseOrigins(raw: string | undefined): string[] {
     .split(',')
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
+}
+
+function parseBool(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined;
+  const v = raw.trim().toLowerCase();
+  if (v === '1' || v === 'true' || v === 'yes' || v === 'on') return true;
+  if (v === '0' || v === 'false' || v === 'no' || v === 'off') return false;
+  return undefined;
 }

--- a/apps/api/src/routes/hassio-network.test.ts
+++ b/apps/api/src/routes/hassio-network.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Config } from '../config';
+import { createHassioNetworkRouter, probeSupervisor } from './hassio-network';
+
+function baseConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    port: 8080,
+    mongodbUri: 'mongodb://localhost:27017',
+    mongodbDb: 'glaon-test',
+    logLevel: 'info',
+    sessionJwtSecret: 'a'.repeat(32),
+    sessionTtlSeconds: 3600,
+    webOrigins: [],
+    supervisorMock: false,
+    buildInfo: { version: '0.0.0-test', commit: 'deadbeef', builtAt: '2026-05-09T00:00:00Z' },
+    ...overrides,
+  };
+}
+
+function mockResponse(init: { status?: number; body: unknown; contentType?: string }): Response {
+  const text = typeof init.body === 'string' ? init.body : JSON.stringify(init.body);
+  return new Response(text, {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': init.contentType ?? 'application/json' },
+  });
+}
+
+describe('hassio-network — mock mode', () => {
+  it('returns a canned access-point list on GET /network/info', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
+    const res = await router.request('/network/info');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { interfaces: { accesspoints: { ssid: string }[] }[] };
+    };
+    expect(body.data.interfaces[0]?.accesspoints.length).toBeGreaterThan(0);
+  });
+
+  it('accepts any POST /network/:iface/update with 200 + { mocked: true }', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
+    const res = await router.request('/network/wlan0/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ wifi: { mode: 'infrastructure', auth: 'open', ssid: 'X' } }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ mocked: true });
+  });
+});
+
+describe('hassio-network — unconfigured', () => {
+  it('returns 503 on GET when neither URL nor mock is set', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig() });
+    const res = await router.request('/network/info');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ error: 'supervisor-not-configured' });
+  });
+
+  it('returns 503 on POST when neither URL nor mock is set', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig() });
+    const res = await router.request('/network/wlan0/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ wifi: { auth: 'open', ssid: 'X' } }),
+    });
+    expect(res.status).toBe(503);
+  });
+});
+
+describe('hassio-network — live proxy', () => {
+  const config = baseConfig({
+    supervisorUrl: 'http://supervisor.test/network',
+    supervisorToken: 'long-lived-token',
+  });
+
+  it('forwards GET to the upstream supervisor with the bearer token', async () => {
+    const fetchImpl: typeof fetch = vi.fn(() =>
+      Promise.resolve(mockResponse({ body: { data: { interfaces: [{ accesspoints: [] }] } } })),
+    );
+    const router = createHassioNetworkRouter({ config, fetchImpl });
+    const res = await router.request('/network/info');
+    expect(res.status).toBe(200);
+    const mock = vi.mocked(fetchImpl);
+    const call = mock.mock.calls[0];
+    if (call === undefined) throw new Error('expected upstream call');
+    expect(call[0]).toBe('http://supervisor.test/network/network/info');
+    const init = call[1];
+    if (init === undefined) throw new Error('expected init');
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer long-lived-token');
+  });
+
+  it('forwards POST body verbatim, preserves status, and re-emits content-type', async () => {
+    const upstreamBody = { result: 'ok' };
+    const fetchImpl: typeof fetch = vi.fn(() =>
+      Promise.resolve(mockResponse({ status: 202, body: upstreamBody })),
+    );
+    const router = createHassioNetworkRouter({ config, fetchImpl });
+    const res = await router.request('/network/wlan0/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ wifi: { auth: 'wpa-psk', psk: 'secret' } }),
+    });
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual(upstreamBody);
+    const mock = vi.mocked(fetchImpl);
+    const call = mock.mock.calls[0];
+    if (call === undefined) throw new Error('expected upstream call');
+    expect(call[0]).toBe('http://supervisor.test/network/network/wlan0/update');
+    const init = call[1];
+    if (init === undefined) throw new Error('expected init');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toMatchObject({ wifi: { psk: 'secret' } });
+  });
+
+  it('returns 502 when the supervisor is unreachable', async () => {
+    const fetchImpl: typeof fetch = vi.fn(() => Promise.reject(new TypeError('network down')));
+    const router = createHassioNetworkRouter({ config, fetchImpl });
+    const res = await router.request('/network/info');
+    expect(res.status).toBe(502);
+  });
+
+  it('rejects malformed POST bodies with 400 before touching the supervisor', async () => {
+    const fetchImpl: typeof fetch = vi.fn();
+    const router = createHassioNetworkRouter({ config, fetchImpl });
+    const res = await router.request('/network/wlan0/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(fetchImpl)).not.toHaveBeenCalled();
+  });
+});
+
+describe('probeSupervisor', () => {
+  it('reports mode=mock when mock is on', async () => {
+    const result = await probeSupervisor(baseConfig({ supervisorMock: true }));
+    expect(result).toEqual({ ok: true, mode: 'mock' });
+  });
+
+  it('reports mode=unconfigured when neither URL nor mock is set', async () => {
+    const result = await probeSupervisor(baseConfig());
+    expect(result).toEqual({ ok: false, mode: 'unconfigured' });
+  });
+
+  it('reports mode=live + ok=true when the live supervisor answers 2xx', async () => {
+    const fetchImpl: typeof fetch = vi.fn(() => Promise.resolve(mockResponse({ body: {} })));
+    const result = await probeSupervisor(
+      baseConfig({ supervisorUrl: 'http://supervisor.test/network', supervisorToken: 't' }),
+      fetchImpl,
+    );
+    expect(result).toEqual({ ok: true, mode: 'live' });
+  });
+
+  it('reports mode=live + ok=false when the live supervisor errors', async () => {
+    const fetchImpl: typeof fetch = vi.fn(() => Promise.reject(new Error('boom')));
+    const result = await probeSupervisor(
+      baseConfig({ supervisorUrl: 'http://supervisor.test/network', supervisorToken: 't' }),
+      fetchImpl,
+    );
+    expect(result).toEqual({ ok: false, mode: 'live' });
+  });
+});

--- a/apps/api/src/routes/hassio-network.ts
+++ b/apps/api/src/routes/hassio-network.ts
@@ -1,0 +1,199 @@
+// HA Supervisor network-proxy route (#598). The setup wizard's
+// apply step (#597) hits `/api/hassio/network/info` for enumeration
+// and `/api/hassio/network/wlan0/update` for the commit. In two
+// runtime modes:
+//
+//   - **Add-on (production / kiosk).** The add-on's nginx proxies
+//     these paths directly to HA Supervisor over Ingress. apps/api
+//     is not in the path — the routes here never fire.
+//
+//   - **Standalone / dev.** apps/web's Vite dev server proxies
+//     `/api/hassio/*` to apps/api (`/hassio/*`). This router
+//     forwards to a real HA Supervisor (when `supervisorUrl` is
+//     set) or returns a deterministic mock payload (when
+//     `supervisorMock` is true).
+//
+// Three configurations to keep in mind:
+//
+//   - `supervisorUrl=…` + `supervisorToken=…` → live proxy. The
+//     bearer token is the HA long-lived access token; we don't
+//     forward the client's auth (the wizard isn't authenticated
+//     yet — the user is mid-setup before any login exists).
+//   - `supervisorMock=true` → return a canned 2-network payload
+//     for the GET and accept any POST with a 200. Used by the
+//     Playwright wizard smoke + local dev where no HA is running.
+//   - Neither set → 503 with a hint pointing at the dev docs.
+//
+// Authentication: this route is **not gated by requireSession** on
+// purpose. The wizard runs before any user account exists. CORS
+// + dev-only mode (production add-on bypasses this entirely) are
+// the only barriers. Don't expose this route from a production
+// apps/api unless you understand the implications — see
+// `docs/dev-supervisor.md` for the operational guardrails.
+
+import { Hono } from 'hono';
+
+import type { Config } from '../config';
+import type { Logger } from '../observability/logger';
+
+interface HassioNetworkRouterDeps {
+  readonly config: Config;
+  /** Injectable for tests — defaults to global `fetch`. */
+  readonly fetchImpl?: typeof fetch;
+  readonly logger?: Logger;
+}
+
+const MOCK_NETWORK_INFO = {
+  data: {
+    interfaces: [
+      {
+        accesspoints: [
+          { ssid: 'GlaonDev-Home', auth: 'wpa-psk' },
+          { ssid: 'GlaonDev-Guest', auth: 'none' },
+          { ssid: 'GlaonDev-Office', auth: 'wpa-psk' },
+        ],
+      },
+    ],
+  },
+};
+
+export function createHassioNetworkRouter(deps: HassioNetworkRouterDeps): Hono {
+  const router = new Hono();
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const { supervisorUrl, supervisorToken, supervisorMock } = deps.config;
+
+  router.get('/network/info', async (c) => {
+    if (supervisorMock) {
+      return c.json(MOCK_NETWORK_INFO);
+    }
+    if (supervisorUrl === undefined || supervisorToken === undefined) {
+      return c.json(
+        {
+          error: 'supervisor-not-configured',
+          hint: 'Set HA_SUPERVISOR_URL + HA_SUPERVISOR_TOKEN, or HA_SUPERVISOR_MOCK=true for a canned payload. See docs/dev-supervisor.md.',
+        },
+        503,
+      );
+    }
+    try {
+      const upstream = await fetchImpl(`${trim(supervisorUrl)}/network/info`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${supervisorToken}` },
+      });
+      const text = await upstream.text();
+      deps.logger?.info({ event: 'hassio-network.proxy.get', status: upstream.status });
+      return passThroughResponse(text, upstream);
+    } catch (err) {
+      deps.logger?.error({
+        event: 'hassio-network.proxy.get.failed',
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+      return c.json({ error: 'supervisor-unreachable' }, 502);
+    }
+  });
+
+  router.post('/network/:iface/update', async (c) => {
+    const iface = c.req.param('iface');
+    const body: unknown = await c.req.json().catch(() => null);
+    if (body === null || typeof body !== 'object') {
+      return c.json({ error: 'invalid-body' }, 400);
+    }
+    if (supervisorMock) {
+      return c.json({ result: 'ok', mocked: true });
+    }
+    if (supervisorUrl === undefined || supervisorToken === undefined) {
+      return c.json(
+        {
+          error: 'supervisor-not-configured',
+          hint: 'Set HA_SUPERVISOR_URL + HA_SUPERVISOR_TOKEN, or HA_SUPERVISOR_MOCK=true for a canned payload. See docs/dev-supervisor.md.',
+        },
+        503,
+      );
+    }
+    try {
+      const upstream = await fetchImpl(
+        `${trim(supervisorUrl)}/network/${encodeURIComponent(iface)}/update`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${supervisorToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        },
+      );
+      const text = await upstream.text();
+      // Redact the PSK before logging the body.
+      const redacted = redactWifiBody(body);
+      deps.logger?.info({
+        event: 'hassio-network.proxy.post',
+        iface,
+        status: upstream.status,
+        body: redacted,
+      });
+      return passThroughResponse(text, upstream);
+    } catch (err) {
+      deps.logger?.error({
+        event: 'hassio-network.proxy.post.failed',
+        iface,
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+      return c.json({ error: 'supervisor-unreachable' }, 502);
+    }
+  });
+
+  return router;
+}
+
+// Mirror the upstream supervisor response back to the caller. Returning
+// a raw `Response` from a Hono handler short-circuits Hono's status-
+// literal narrowing — important because HA Supervisor can return any
+// numeric status and `c.body` / `c.json` only accept Hono's curated
+// literal set.
+function passThroughResponse(text: string, upstream: Response): Response {
+  const contentType = upstream.headers.get('content-type') ?? 'application/json';
+  return new Response(text, {
+    status: upstream.status,
+    headers: { 'Content-Type': contentType },
+  });
+}
+
+/** Probe used by `/healthz/supervisor` (see server.ts). */
+export async function probeSupervisor(
+  config: Config,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ readonly ok: boolean; readonly mode: 'mock' | 'live' | 'unconfigured' }> {
+  if (config.supervisorMock) {
+    return { ok: true, mode: 'mock' };
+  }
+  if (config.supervisorUrl === undefined || config.supervisorToken === undefined) {
+    return { ok: false, mode: 'unconfigured' };
+  }
+  try {
+    const upstream = await fetchImpl(`${trim(config.supervisorUrl)}/network/info`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${config.supervisorToken}` },
+    });
+    return { ok: upstream.ok, mode: 'live' };
+  } catch {
+    return { ok: false, mode: 'live' };
+  }
+}
+
+function trim(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function redactWifiBody(body: unknown): unknown {
+  if (body === null || typeof body !== 'object') return body;
+  const candidate = body as { wifi?: { psk?: unknown } };
+  if (
+    candidate.wifi !== undefined &&
+    typeof candidate.wifi === 'object' &&
+    'psk' in candidate.wifi &&
+    candidate.wifi.psk !== undefined
+  ) {
+    return { ...candidate, wifi: { ...candidate.wifi, psk: '[redacted]' } };
+  }
+  return body;
+}

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -29,6 +29,7 @@ function makeDeps(overrides: { dbCommand?: () => Promise<unknown> } = {}): Serve
     sessionJwtSecret: 'a'.repeat(32),
     sessionTtlSeconds: 3600,
     webOrigins: [],
+    supervisorMock: false,
     buildInfo: {
       version: '0.0.0-test',
       commit: 'deadbeef',

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -14,6 +14,7 @@ import { observabilityMiddleware } from './middleware/observability';
 import { createLogger, type Logger } from './observability/logger';
 import { Metrics } from './observability/metrics';
 import { createAuthRouter } from './routes/auth';
+import { createHassioNetworkRouter, probeSupervisor } from './routes/hassio-network';
 import { createLayoutsRouter } from './routes/layouts';
 import { createMeRouter } from './routes/me';
 
@@ -74,6 +75,21 @@ export function createServer(deps: ServerDeps): Hono {
 
   app.route('/me', createMeRouter({ db: deps.db, secret, revocations }));
 
+  // HA Supervisor network proxy (#598). Used by the setup wizard's
+  // apply step in standalone / dev runtimes; the production add-on
+  // bypasses this entirely via its own nginx → supervisor proxy.
+  // See `docs/dev-supervisor.md` + the route header for the
+  // operational guardrails (unauthenticated by design, but CORS-
+  // gated and dev-mode).
+  app.route(
+    '/hassio',
+    createHassioNetworkRouter({
+      config: deps.config,
+      ...(deps.fetchImpl !== undefined ? { fetchImpl: deps.fetchImpl } : {}),
+      logger,
+    }),
+  );
+
   // Liveness probe with Mongo ping. Returns 200 when the driver
   // command succeeds, 503 otherwise so a load balancer can drop the
   // instance from rotation. The metrics gauge is updated on every
@@ -89,6 +105,23 @@ export function createServer(deps: ServerDeps): Hono {
         commit: deps.config.buildInfo.commit,
       },
       result.ok ? 200 : 503,
+    );
+  });
+
+  // Supervisor reachability probe (#598). Returns:
+  //   - 200 + { mode: 'mock' }       when HA_SUPERVISOR_MOCK is on.
+  //   - 200 + { mode: 'live' }       when the real supervisor proxy
+  //                                  answers /network/info OK.
+  //   - 503 + { mode: 'live' }       supervisor configured but not
+  //                                  reachable.
+  //   - 503 + { mode: 'unconfigured' } neither mock nor live config
+  //                                  is set (the proxy will respond
+  //                                  503 to wizard calls too).
+  app.get('/healthz/supervisor', async (c) => {
+    const probe = await probeSupervisor(deps.config, deps.fetchImpl ?? fetch);
+    return c.json(
+      { status: probe.ok ? 'ok' : 'unavailable', mode: probe.mode },
+      probe.ok ? 200 : 503,
     );
   });
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -88,6 +88,24 @@ export default defineConfig(({ command, mode }) => {
     server: {
       port: 5173,
       strictPort: true,
+      proxy: {
+        // #598 — the setup wizard's apply step calls
+        // `/api/hassio/network/*` for HA Supervisor enumeration +
+        // commit. In dev, apps/web's bundler can't serve those
+        // paths, so route them to apps/api (which has the
+        // hassio-network proxy + mock-mode toggle). The `/api`
+        // prefix is stripped so apps/api's router mounts cleanly
+        // at `/hassio`.
+        //
+        // Production add-on bypasses this — nginx routes
+        // /api/hassio/* directly to the supervisor's Ingress
+        // endpoint, no Vite involved.
+        '/api/hassio': {
+          target: env.VITE_API_BASE_URL ?? 'http://localhost:8080',
+          changeOrigin: true,
+          rewrite: (path: string) => path.replace(/^\/api/, ''),
+        },
+      },
     },
     build: {
       target: 'es2022',

--- a/docs/dev-supervisor.md
+++ b/docs/dev-supervisor.md
@@ -1,0 +1,151 @@
+# HA Supervisor proxy — dev guide
+
+The setup wizard's apply step (#597) talks to HA Supervisor at two
+endpoints:
+
+- `GET /api/hassio/network/info` — enumerate Wi-Fi access points.
+- `POST /api/hassio/network/wlan0/update` — commit the chosen SSID +
+  password (this is the disconnect / handoff moment).
+
+Two runtime modes:
+
+| Mode                               | Path                                                                                                                                |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **HA Add-on (production / kiosk)** | The add-on's own nginx proxies `/api/hassio/*` straight to HA Supervisor over Ingress. apps/api is not in the picture.              |
+| **Standalone / dev**               | apps/web's Vite dev server proxies `/api/hassio/*` → apps/api (`/hassio/*`). apps/api owns the actual proxy (or returns mock data). |
+
+This doc covers **standalone / dev**.
+
+## Quick start (mock mode — recommended for daily dev)
+
+Mock mode gives you a canned 3-network payload from `GET /network/info`
+and accepts any `POST /network/:iface/update` with a 200. The wizard's
+apply step walks end-to-end without a real HA running anywhere.
+
+```bash
+cp apps/api/.env.example apps/api/.env
+# the example already sets HA_SUPERVISOR_MOCK=true
+pnpm --filter @glaon/api dev   # apps/api on :8080
+pnpm --filter @glaon/web dev   # apps/web on :5173
+```
+
+Open `http://localhost:5173`, walk the wizard to the apply step, and
+you'll see `GlaonDev-Home`, `GlaonDev-Guest`, `GlaonDev-Office` in the
+network list. Picking one and clicking **Save and switch network**
+fires the POST; the mock route accepts it and the page reloads onto
+the login surface.
+
+The mock list is hard-coded in `apps/api/src/routes/hassio-network.ts`;
+extend `MOCK_NETWORK_INFO` if you need more flavours in dev.
+
+## Live mode (against a real HA Supervisor)
+
+Mock mode is enough for most wizard work. Switch to live when you need
+to verify the actual network-update path — e.g. credentials really
+apply, real APs come back from the scan.
+
+### Prerequisites
+
+The standard HA Core container (the one in `apps/dev-ha/`) **does not
+expose the supervisor endpoints**. You need either:
+
+1. **HA Supervised** running natively on a Linux host (full supervisor
+   - Docker + NetworkManager stack).
+2. **HA OS in a VM** (e.g. VirtualBox / UTM / VMware).
+3. **The actual production add-on** running on a real Home Assistant
+   instance — your dev box just runs apps/api + apps/web against it.
+
+Inside any of these, the supervisor's HTTP API lives at
+`http://supervisor` (DNS resolves inside the supervisor's Docker
+network). From outside the supervisor container, you typically need
+to expose / port-forward.
+
+### Token
+
+The supervisor expects a **long-lived access token** as `Authorization:
+Bearer <token>`. Inside an add-on the supervisor mints one automatically
+via the `SUPERVISOR_TOKEN` env var; for external dev you generate one
+manually:
+
+1. Open HA web UI → user profile → "Long-lived access tokens" → Create.
+2. Copy the token into `apps/api/.env`:
+
+   ```bash
+   HA_SUPERVISOR_URL=http://supervisor.local:4357/network   # or wherever
+   HA_SUPERVISOR_TOKEN=eyJ0eXAi...                          # the LLT
+   ```
+
+3. Drop `HA_SUPERVISOR_MOCK` (or set it to `false`).
+
+Restart `apps/api`. Hit `http://localhost:8080/healthz/supervisor` —
+should return `{ status: 'ok', mode: 'live' }`.
+
+### Verifying a commit actually applied
+
+After clicking **Save and switch network** in the wizard, the
+supervisor's NetworkManager should have a new connection. Exec into
+the HA container and check:
+
+```bash
+docker exec -it homeassistant nmcli connection show
+docker exec -it homeassistant nmcli connection show <ssid>
+```
+
+If `glaon.local` resolves on your home network, opening
+`http://glaon.local` should land you on the wizard's post-setup
+surface (login screen).
+
+## Health probe
+
+`apps/api` exposes `GET /healthz/supervisor` for liveness / dev-loop
+diagnostics:
+
+| Response                       | Meaning                                                                                   |
+| ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `200 { mode: 'mock' }`         | Mock mode is on; no real supervisor is contacted.                                         |
+| `200 { mode: 'live' }`         | Live URL is set and the supervisor's `/network/info` answered 2xx.                        |
+| `503 { mode: 'live' }`         | Live URL is set but the supervisor didn't respond. Check the token + URL.                 |
+| `503 { mode: 'unconfigured' }` | Neither mock nor URL is configured. The wizard's apply step will land on its error retry. |
+
+## Wi-Fi visibility inside Docker (open question)
+
+Even in live mode, getting the supervisor to enumerate _real_ Wi-Fi
+APs from a Docker container is non-trivial. Three plausible paths:
+
+1. **Privileged + host network.** Run HA with `--network host
+--privileged --cap-add NET_ADMIN`. The supervisor sees the host's
+   wifi adapter on Linux. Docker Desktop on macOS / Windows doesn't
+   forward Wi-Fi adapters to containers, so this only works on Linux.
+2. **D-Bus mock for NetworkManager.** Inject a fake NetworkManager via
+   a D-Bus mock so the supervisor returns a deterministic AP list.
+   Best for CI / Playwright; takes effort to set up.
+3. **Manual SSID injection.** Skip the scan; type the SSID + password
+   manually in the wizard (the apply step doesn't ship a manual-SSID
+   input yet — sister issue tracks it). Then verify the commit path
+   against a real HA + NM.
+
+For now, mock mode is the recommended default. The above paths exist
+when you specifically need to test against a real supervisor.
+
+## Security
+
+The `/hassio/*` proxy on apps/api is **not gated by `requireSession`**
+on purpose — the wizard runs before any user account exists. CORS
+(allow-list in `WEB_ORIGINS`) and the dev-only nature of standalone
+mode are the only barriers.
+
+Don't expose this route from a production apps/api. Production
+deployments either:
+
+- Run the wizard inside the HA Add-on, where nginx proxies these
+  paths directly to the supervisor and apps/api is never in the path.
+- Don't run the wizard at all (the device is already configured).
+
+## Refs
+
+- Open issue: #598.
+- Sister wizard collapse: #597 / PR #599.
+- Setup wizard apply step: `apps/web/src/features/setup/apply/`.
+- HA Supervisor network API:
+  <https://developers.home-assistant.io/docs/api/supervisor/endpoints/#network>
+- HA dev fixture (Core, not Supervisor): `apps/dev-ha/`.


### PR DESCRIPTION
## Summary

The setup wizard's apply step (#599) hits two HA Supervisor endpoints:

- `GET  /api/hassio/network/info`
- `POST /api/hassio/network/wlan0/update`

Inside the HA add-on the add-on's own nginx proxies these straight to the supervisor over Ingress. In standalone / dev nothing in the stack served those paths — the apply step fell into its error Toast branch and the wizard's commit never fired against anything real.

This PR wires the standalone / dev path end-to-end with three configurations: **mock**, **live proxy**, **unconfigured-503**. Production stays on the add-on path; apps/api is never in the loop there.

Closes #598

## apps/api

**New `routes/hassio-network.ts` proxy.** Three modes:

| Mode | Trigger | Behaviour |
|---|---|---|
| Mock | `HA_SUPERVISOR_MOCK=true` | Canned 3-network payload from GET, accepts any POST with 200. Lets the Playwright wizard smoke + local dev walk end-to-end without a real HA. |
| Live | `HA_SUPERVISOR_URL` + `HA_SUPERVISOR_TOKEN` | Forward GET/POST to the real supervisor with `Authorization: Bearer <token>`. PSK redacted from observability logs before stdout. |
| Unconfigured | neither set | 503 with a hint pointing at `docs/dev-supervisor.md`. |

**New `GET /healthz/supervisor` probe.** Returns `{ status, mode }`:

- `200 { mode: 'mock' }` — mock mode on, no upstream contacted.
- `200 { mode: 'live' }` — live URL set, supervisor answered 2xx.
- `503 { mode: 'live' }` — live URL set, supervisor didn't respond.
- `503 { mode: 'unconfigured' }` — neither mock nor URL.

**Config schema.** `supervisorUrl?`, `supervisorToken?`, `supervisorMock: boolean` — Zod-validated; URL rejected up front when not a valid URL. `.env.example` documents all three vars with full rationale.

**Auth note.** This route is **intentionally NOT gated by `requireSession`** — the wizard runs before any user account exists. CORS (allow-list in `WEB_ORIGINS`) + dev-only nature (production bypasses apps/api entirely) are the only barriers. Documented in the route header.

## apps/web

Vite dev server gains a `/api/hassio` → apps/api (`/hassio`) proxy with the `/api` prefix stripped. Target URL is overridable via `VITE_API_BASE_URL` for non-default dev-port setups. No code change in the wizard — the same fetch path that worked inside the add-on now works in dev too.

## docs/dev-supervisor.md

New operational guide:

- Quick-start for mock mode (recommended for daily dev).
- Live-mode prereqs (HA Supervised / HA OS / a real add-on) and how to mint a long-lived token.
- Wi-Fi-visibility-inside-Docker open question with three plausible paths (privileged host-net / D-Bus mock for NetworkManager / manual SSID injection).
- `/healthz/supervisor` response matrix.
- Security caveat for the unauthenticated dev-only proxy.

## Test plan

- [x] `pnpm type-check` green across the monorepo.
- [x] `pnpm --filter @glaon/api lint` green.
- [x] `pnpm --filter @glaon/api test` — 115/115 green (+12 for the new route + probe; +3 for config).
- [x] `pnpm knip` clean for the new files.
- [ ] CI: full pipeline.
- [ ] Manual sanity (mock mode):
  - `cp apps/api/.env.example apps/api/.env` (already has `HA_SUPERVISOR_MOCK=true`).
  - `pnpm --filter @glaon/api dev` + `pnpm --filter @glaon/web dev`.
  - Open `http://localhost:5173`, walk the wizard, see `GlaonDev-Home` / `Guest` / `Office` in the apply step's network list, click one, hit Save and switch network, page reloads onto login.
  - `curl http://localhost:8080/healthz/supervisor` → `{ "status": "ok", "mode": "mock" }`.
- [ ] Manual sanity (live mode, optional): switch to `HA_SUPERVISOR_URL` + token against a real HA — verify scan returns real APs + the commit reaches NetworkManager.

## Out of scope (deliberately deferred)

- A docker-compose for the HA Supervisor itself — the Supervisor stack is multi-container + DBus-dependent, doesn't fit the lightweight `apps/dev-ha` shape. Mock mode covers 95% of dev work; live mode is documented for the rare cases that need it.
- Wi-Fi visibility from inside Docker — documented as an open question with three paths; pick when a real-AP test becomes blocking.
- Auth on the proxy — the wizard runs pre-account; revisit when production deployment shape solidifies.

## Refs

- Phase 2 epic: #533.
- Sister wizard collapse: #597 / PR #599.
- HA Supervisor network API: https://developers.home-assistant.io/docs/api/supervisor/endpoints/#network

🤖 Generated with [Claude Code](https://claude.com/claude-code)