### PR TITLE
docs(supervisor): wire UTM HA OS as the default live-mode setup

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -37,25 +37,34 @@ GLAON_API_VERSION=0.0.0-dev
 GLAON_API_COMMIT=
 GLAON_API_BUILT_AT=
 
-# HA Supervisor proxy (#598). Two dev modes:
+# HA Supervisor proxy (#598, #602). Two dev modes — pick one:
 #
-#   - Mock mode: HA_SUPERVISOR_MOCK=true returns a canned 3-network
-#     payload from /hassio/network/info and accepts any POST to
-#     /hassio/network/:iface/update with 200. The setup wizard's
-#     apply step works end-to-end without a real HA running.
-#   - Live mode: HA_SUPERVISOR_URL + HA_SUPERVISOR_TOKEN forward
-#     the calls to a real HA Supervisor. URL points at the
-#     supervisor's /network root (e.g. http://supervisor/network
-#     inside an add-on, or http://localhost:4357/network when
-#     proxying from outside). Token is the long-lived HA token —
-#     see docs/dev-supervisor.md for how to mint one.
+#   1. Live mode (preferred when you have an HA OS / Supervised
+#      install reachable). Set HA_SUPERVISOR_URL + HA_SUPERVISOR_TOKEN
+#      and apps/api forwards GET /hassio/network/info + POST
+#      /hassio/network/:iface/update straight to the supervisor.
+#      The typical UTM HA OS setup uses HA Core's built-in
+#      /api/hassio/* proxy on port 8123 — full UTM walkthrough in
+#      docs/dev-supervisor.md.
 #
-# Either flag is enough; both unset → /hassio/* responds 503 and
-# the wizard's apply step lands on its error retry affordance.
+#   2. Mock mode (fallback when no HA is reachable — CI, fresh
+#      laptops, working on UI in isolation). HA_SUPERVISOR_MOCK=true
+#      returns a canned 3-network payload from GET and accepts any
+#      POST with 200. The setup wizard's apply step walks end-to-end
+#      without a real HA anywhere.
 #
-# Production add-on deployments bypass this route entirely; the
-# add-on's own nginx proxies /api/hassio/* straight to the
-# supervisor over Ingress.
-HA_SUPERVISOR_MOCK=true
-# HA_SUPERVISOR_URL=
-# HA_SUPERVISOR_TOKEN=
+# Either is enough; with both unset /hassio/* responds 503 and the
+# wizard's apply step lands on its error retry affordance.
+#
+# Production add-on deployments bypass this route entirely — the
+# add-on's own nginx proxies /api/hassio/* directly to the supervisor
+# over Ingress, no apps/api in the path.
+
+# Live mode against an HA OS in UTM (#602). Replace the token with
+# your long-lived access token: HA UI → user profile → Security →
+# Long-lived access tokens → Create.
+HA_SUPERVISOR_URL=http://homeassistant.local:8123/api/hassio
+HA_SUPERVISOR_TOKEN=
+
+# Mock mode fallback — uncomment when no HA Supervisor is reachable.
+# HA_SUPERVISOR_MOCK=true

--- a/apps/api/src/config.test.ts
+++ b/apps/api/src/config.test.ts
@@ -78,6 +78,28 @@ describe('loadConfig', () => {
     expect(() => loadConfig({ ...REQUIRED_BASE, HA_SUPERVISOR_URL: 'not-a-url' })).toThrow();
   });
 
+  it('treats an empty HA_SUPERVISOR_TOKEN as undefined (#602)', () => {
+    // A fresh `.env`-from-example carries `HA_SUPERVISOR_TOKEN=` with
+    // no value while the developer is still pasting their LLT. The
+    // proxy must treat that as "not configured" rather than forward
+    // an empty Bearer to HA.
+    const config = loadConfig({
+      ...REQUIRED_BASE,
+      HA_SUPERVISOR_URL: 'http://homeassistant.local:8123/api/hassio',
+      HA_SUPERVISOR_TOKEN: '',
+    });
+    expect(config.supervisorToken).toBeUndefined();
+  });
+
+  it('treats an empty HA_SUPERVISOR_URL as undefined (#602)', () => {
+    const config = loadConfig({
+      ...REQUIRED_BASE,
+      HA_SUPERVISOR_URL: '',
+      HA_SUPERVISOR_TOKEN: 'tok',
+    });
+    expect(config.supervisorUrl).toBeUndefined();
+  });
+
   it('honors build info env vars', () => {
     const config = loadConfig({
       ...REQUIRED_BASE,

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -61,8 +61,13 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     sessionJwtSecret: env.SESSION_JWT_SECRET ?? '',
     sessionTtlSeconds: ttl,
     webOrigins: parseOrigins(env.WEB_ORIGINS),
-    supervisorUrl: env.HA_SUPERVISOR_URL,
-    supervisorToken: env.HA_SUPERVISOR_TOKEN,
+    // Empty-string coercion to undefined keeps the proxy's
+    // "supervisor-not-configured" branch firing on a fresh
+    // .env-from-example where the developer hasn't pasted the LLT
+    // yet — otherwise apps/api would forward an empty Bearer to
+    // HA and trigger a 401 (#602).
+    supervisorUrl: env.HA_SUPERVISOR_URL === '' ? undefined : env.HA_SUPERVISOR_URL,
+    supervisorToken: env.HA_SUPERVISOR_TOKEN === '' ? undefined : env.HA_SUPERVISOR_TOKEN,
     supervisorMock: parseBool(env.HA_SUPERVISOR_MOCK),
     buildInfo: {
       commit: env.GLAON_API_COMMIT ?? 'unknown',

--- a/apps/dev-ha/README.md
+++ b/apps/dev-ha/README.md
@@ -26,5 +26,6 @@ pnpm ha:reset   # durdur + config'i sıfırla (onboarding tekrar)
 - HA Add-on test ortamı — [`addon/`](../../addon/) ayrı akış.
 - E2E mock'ları — [#13](https://github.com/toss-cengiz/glaon/issues/13) ve [#358](https://github.com/toss-cengiz/glaon/issues/358) `page.route()` ile gider; bu fixture **dev** içindir.
 - Production HA / TLS / sertifika pinning.
+- **HA Supervisor endpoint'leri** (`/api/hassio/network/*`) — bu container HA Core, Supervisor'sız. Setup wizard'ın apply step'i (Wi-Fi scan + commit) Supervisor istiyor; macOS dev için UTM HA OS önerilir, kurulum [docs/dev-supervisor.md](../../docs/dev-supervisor.md#live-mode-ha-os-in-utm-602)'de.
 
 Refs #331.

--- a/docs/dev-supervisor.md
+++ b/docs/dev-supervisor.md
@@ -44,56 +44,90 @@ Mock mode is enough for most wizard work. Switch to live when you need
 to verify the actual network-update path — e.g. credentials really
 apply, real APs come back from the scan.
 
-### Prerequisites
+### Why not `apps/dev-ha/`?
 
-The standard HA Core container (the one in `apps/dev-ha/`) **does not
-expose the supervisor endpoints**. You need either:
+The fixture in `apps/dev-ha/` runs **HA Core** (the standalone Python
+container) — it intentionally does not expose the Supervisor's
+`/api/hassio/*` endpoints. That fixture is for OAuth2 + WebSocket
+work where Core is enough; the network-update path needs a real
+Supervisor.
 
-1. **HA Supervised** running natively on a Linux host (full supervisor
-   - Docker + NetworkManager stack).
-2. **HA OS in a VM** (e.g. VirtualBox / UTM / VMware).
-3. **The actual production add-on** running on a real Home Assistant
-   instance — your dev box just runs apps/api + apps/web against it.
+You need one of:
 
-Inside any of these, the supervisor's HTTP API lives at
-`http://supervisor` (DNS resolves inside the supervisor's Docker
-network). From outside the supervisor container, you typically need
-to expose / port-forward.
+1. **HA OS in UTM** (macOS dev — easiest path; covered below).
+2. **HA OS in a VM** (VirtualBox / VMware / Proxmox / Hyper-V).
+3. **HA Supervised** running natively on a Linux host.
+4. **The actual production add-on** running on a real Home Assistant
+   instance — your dev box runs apps/api + apps/web against it over
+   the LAN.
 
-### Token
+### Live mode: HA OS in UTM (#602)
 
-The supervisor expects a **long-lived access token** as `Authorization:
-Bearer <token>`. Inside an add-on the supervisor mints one automatically
-via the `SUPERVISOR_TOKEN` env var; for external dev you generate one
-manually:
+The recommended dev path on macOS.
 
-1. Open HA web UI → user profile → "Long-lived access tokens" → Create.
-2. Copy the token into `apps/api/.env`:
+**1. Spin up HA OS in UTM.** Download the UTM-compatible HA OS image
+from <https://www.home-assistant.io/installation/macos>, create a
+new UTM VM with it, boot, complete the on-screen onboarding (create
+your first user). After onboarding the HA UI lands on
+`http://homeassistant.local:8123`.
 
-   ```bash
-   HA_SUPERVISOR_URL=http://supervisor.local:4357/network   # or wherever
-   HA_SUPERVISOR_TOKEN=eyJ0eXAi...                          # the LLT
-   ```
+**2. Mint a long-lived access token (LLT).** In the HA UI:
 
-3. Drop `HA_SUPERVISOR_MOCK` (or set it to `false`).
+- Click your user avatar (bottom-left) → **Security** tab.
+- Scroll to **Long-lived access tokens** → **Create token**.
+- Name it something like `glaon-dev`, copy the token (it's only
+  shown once).
 
-Restart `apps/api`. Hit `http://localhost:8080/healthz/supervisor` —
-should return `{ status: 'ok', mode: 'live' }`.
-
-### Verifying a commit actually applied
-
-After clicking **Save and switch network** in the wizard, the
-supervisor's NetworkManager should have a new connection. Exec into
-the HA container and check:
+**3. Wire `apps/api/.env`.** The example file already carries the
+correct URL — paste the token, drop the mock flag if it's set:
 
 ```bash
-docker exec -it homeassistant nmcli connection show
-docker exec -it homeassistant nmcli connection show <ssid>
+# apps/api/.env
+HA_SUPERVISOR_URL=http://homeassistant.local:8123/api/hassio
+HA_SUPERVISOR_TOKEN=<paste-the-LLT-here>
+# HA_SUPERVISOR_MOCK=true    # leave this commented out for live mode
 ```
 
-If `glaon.local` resolves on your home network, opening
-`http://glaon.local` should land you on the wizard's post-setup
-surface (login screen).
+HA Core's `/api/hassio/*` proxy is what forwards apps/api's calls to
+the supervisor inside the VM, so we point at port 8123 (HA Core),
+not at the supervisor itself.
+
+**4. Restart apps/api** so the new env vars apply:
+
+```bash
+pnpm --filter @glaon/api dev
+```
+
+**5. Verify reachability.**
+
+```bash
+curl http://localhost:8080/healthz/supervisor
+# {"status":"ok","mode":"live"}
+```
+
+If you get `{ mode: 'live' }` with `status: 'unavailable'`, the
+URL or token is wrong (or `homeassistant.local` doesn't resolve from
+the host — check `ping homeassistant.local`).
+
+**6. Walk the wizard.** Open `http://localhost:5173`, walk to the
+apply step, you should see the actual Wi-Fi networks the UTM VM can
+see. macOS doesn't forward the host's Wi-Fi adapter to UTM by
+default; if the AP list is empty, that's the OS-side limitation
+(see "Wi-Fi visibility" below) — the API path is still working, it
+just has nothing to enumerate.
+
+**7. Pick a network → Save and switch network.** The supervisor
+should accept the POST and add the connection to its NetworkManager.
+Verify on the HA side:
+
+- HA UI → **Settings** → **System** → **Network** — the new
+  connection appears in the list.
+- Or, more directly, SSH into HA OS and `nmcli connection show`.
+
+### Live mode: real device on the LAN
+
+Same flow, different URL. Replace `homeassistant.local:8123` with the
+device's IP / hostname. Token generation is the same.
 
 ## Health probe
 
@@ -143,9 +177,12 @@ deployments either:
 
 ## Refs
 
-- Open issue: #598.
+- Tracking issues: #598 (proxy + mock), #602 (UTM HA OS setup).
 - Sister wizard collapse: #597 / PR #599.
+- Persistence + crypto wrap: #595 / PR #601.
 - Setup wizard apply step: `apps/web/src/features/setup/apply/`.
 - HA Supervisor network API:
   <https://developers.home-assistant.io/docs/api/supervisor/endpoints/#network>
-- HA dev fixture (Core, not Supervisor): `apps/dev-ha/`.
+- HA dev fixture (Core, not Supervisor): `apps/dev-ha/` — for
+  OAuth2 + WebSocket work; for the network endpoints use UTM HA OS
+  (see "Live mode" above).


### PR DESCRIPTION
## Summary

#601 closed the wizard persistence + crypto loop. The dev box now runs HA OS in UTM at \`http://homeassistant.local:8123\`, which exposes the Supervisor's network endpoints via HA Core's built-in \`/api/hassio/*\` proxy. This PR switches the documented default from mock mode to live mode against that VM, so the wizard's apply step talks to a real Supervisor by default.

Closes #602

## Changes

| File | Change |
|---|---|
| `apps/api/.env.example` | Live-mode block is now the uncommented default (`HA_SUPERVISOR_URL=http://homeassistant.local:8123/api/hassio` + token placeholder). Mock mode survives as a commented-out fallback for CI / fresh laptops / UI-only work. |
| `apps/api/src/config.ts` | Coerce empty `HA_SUPERVISOR_URL` / `HA_SUPERVISOR_TOKEN` env values to `undefined`. A fresh `.env`-from-example carries `HA_SUPERVISOR_TOKEN=` with no value while the developer is still pasting their LLT — without the coercion, apps/api would forward an empty Bearer to HA and trip a 401 instead of the much clearer 503 \`supervisor-not-configured\` response. |
| `apps/api/src/config.test.ts` | Two new cases for the empty-string coercion. |
| `docs/dev-supervisor.md` | Full UTM walkthrough under a new "Live mode: HA OS in UTM" section. Spin up UTM, complete HA onboarding, mint a long-lived access token, paste into `.env`, verify with `/healthz/supervisor`. Real-device variant documented as a one-line swap. Refs section updated. |
| `apps/dev-ha/README.md` | New "Kapsam dışı" entry pointing at the UTM HA OS path — the Core fixture stays scoped to OAuth2 + WebSocket work; Supervisor endpoints belong to the UTM setup. |

## Why the URL targets port 8123 (HA Core), not Supervisor directly

The Supervisor's HTTP API lives at \`http://supervisor\` from inside the supervisor's own Docker network — unreachable from the macOS host. HA Core (port 8123) proxies the Supervisor's endpoints under \`/api/hassio/*\` with long-lived-token auth. That's the path we hit from apps/api.

## Test plan

- [x] `pnpm --filter @glaon/api type-check` + `lint` green.
- [x] `pnpm --filter @glaon/api test` — 117/117 green (+2 for the empty-string coercion).
- [ ] CI: full pipeline.
- [ ] Manual sanity (on a machine with HA OS in UTM):
  - `cp apps/api/.env.example apps/api/.env`
  - Paste LLT into `HA_SUPERVISOR_TOKEN`.
  - `pnpm --filter @glaon/api dev`.
  - `curl http://localhost:8080/healthz/supervisor` → `{ "status": "ok", "mode": "live" }`.
  - Open `http://localhost:5173`, walk the wizard, see real APs in the apply step.

## Refs

- Phase 2 epic: #533.
- Wi-Fi handoff trio: #594 (closed), #595/PR #601 (persistence + crypto), #598/PR #600 (proxy + mock).
- HA Supervisor API: https://developers.home-assistant.io/docs/api/supervisor/endpoints/#network

🤖 Generated with [Claude Code](https://claude.com/claude-code)