### PR TITLE
fix(api): surface upstream status + reason in supervisor probe

### DIFF
--- a/apps/api/src/routes/hassio-network.test.ts
+++ b/apps/api/src/routes/hassio-network.test.ts
@@ -151,15 +151,26 @@ describe('probeSupervisor', () => {
       baseConfig({ supervisorUrl: 'http://supervisor.test/network', supervisorToken: 't' }),
       fetchImpl,
     );
-    expect(result).toEqual({ ok: true, mode: 'live' });
+    expect(result).toEqual({ ok: true, mode: 'live', status: 200 });
   });
 
-  it('reports mode=live + ok=false when the live supervisor errors', async () => {
+  it('reports mode=live + ok=false + upstream status when the live supervisor returns non-2xx', async () => {
+    const fetchImpl: typeof fetch = vi.fn(() =>
+      Promise.resolve(mockResponse({ status: 401, body: { error: 'unauthorized' } })),
+    );
+    const result = await probeSupervisor(
+      baseConfig({ supervisorUrl: 'http://supervisor.test/network', supervisorToken: 't' }),
+      fetchImpl,
+    );
+    expect(result).toEqual({ ok: false, mode: 'live', status: 401 });
+  });
+
+  it('reports mode=live + ok=false + reason when the fetch throws', async () => {
     const fetchImpl: typeof fetch = vi.fn(() => Promise.reject(new Error('boom')));
     const result = await probeSupervisor(
       baseConfig({ supervisorUrl: 'http://supervisor.test/network', supervisorToken: 't' }),
       fetchImpl,
     );
-    expect(result).toEqual({ ok: false, mode: 'live' });
+    expect(result).toEqual({ ok: false, mode: 'live', reason: 'boom' });
   });
 });

--- a/apps/api/src/routes/hassio-network.ts
+++ b/apps/api/src/routes/hassio-network.ts
@@ -162,21 +162,38 @@ function passThroughResponse(text: string, upstream: Response): Response {
 export async function probeSupervisor(
   config: Config,
   fetchImpl: typeof fetch = fetch,
-): Promise<{ readonly ok: boolean; readonly mode: 'mock' | 'live' | 'unconfigured' }> {
+  logger?: Logger,
+): Promise<{
+  readonly ok: boolean;
+  readonly mode: 'mock' | 'live' | 'unconfigured';
+  readonly status?: number;
+  readonly reason?: string;
+}> {
   if (config.supervisorMock) {
     return { ok: true, mode: 'mock' };
   }
   if (config.supervisorUrl === undefined || config.supervisorToken === undefined) {
     return { ok: false, mode: 'unconfigured' };
   }
+  const url = `${trim(config.supervisorUrl)}/network/info`;
   try {
-    const upstream = await fetchImpl(`${trim(config.supervisorUrl)}/network/info`, {
+    const upstream = await fetchImpl(url, {
       method: 'GET',
       headers: { Authorization: `Bearer ${config.supervisorToken}` },
     });
-    return { ok: upstream.ok, mode: 'live' };
-  } catch {
-    return { ok: false, mode: 'live' };
+    if (!upstream.ok) {
+      logger?.warn({
+        event: 'hassio-network.probe.non-ok',
+        url,
+        status: upstream.status,
+      });
+      return { ok: false, mode: 'live', status: upstream.status };
+    }
+    return { ok: true, mode: 'live', status: upstream.status };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : 'unknown';
+    logger?.error({ event: 'hassio-network.probe.threw', url, reason });
+    return { ok: false, mode: 'live', reason };
   }
 }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -118,11 +118,14 @@ export function createServer(deps: ServerDeps): Hono {
   //                                  is set (the proxy will respond
   //                                  503 to wizard calls too).
   app.get('/healthz/supervisor', async (c) => {
-    const probe = await probeSupervisor(deps.config, deps.fetchImpl ?? fetch);
-    return c.json(
-      { status: probe.ok ? 'ok' : 'unavailable', mode: probe.mode },
-      probe.ok ? 200 : 503,
-    );
+    const probe = await probeSupervisor(deps.config, deps.fetchImpl ?? fetch, logger);
+    const body: Record<string, unknown> = {
+      status: probe.ok ? 'ok' : 'unavailable',
+      mode: probe.mode,
+    };
+    if (probe.status !== undefined) body.upstreamStatus = probe.status;
+    if (probe.reason !== undefined) body.reason = probe.reason;
+    return c.json(body, probe.ok ? 200 : 503);
   });
 
   // Build info — useful for the deploy pipeline + manual debugging.


### PR DESCRIPTION
## Summary

The `/healthz/supervisor` probe was swallowing the *why* behind a 503. Hit the wall in the UTM live-mode dev loop (#602) and you couldn't tell whether the LLT was wrong, the URL was off, or `homeassistant.local` didn't resolve — no logs, no upstream status, just `{ status: 'unavailable', mode: 'live' }`.

## What changes

`probeSupervisor` now returns two new optional fields:

- `upstreamStatus` — set when HA responded with non-2xx (401 / 403 / 404 / 5xx).
- `reason` — set when the `fetch` call threw (DNS / connection / timeout).

The probe also takes an optional logger; the catch + non-ok branches log at `warn` / `error` so the dev-loop's stdout surfaces the failure context without anyone enabling verbose logging.

`/healthz/supervisor` response now includes those fields when present, so the curl one-liner becomes self-diagnostic:

```bash
curl http://localhost:8080/healthz/supervisor
# Before: {"status":"unavailable","mode":"live"}
# After:  {"status":"unavailable","mode":"live","upstreamStatus":401}
#         {"status":"unavailable","mode":"live","reason":"getaddrinfo ENOTFOUND homeassistant.local"}
```

## Test plan

- [x] `pnpm --filter @glaon/api type-check` + `lint` green.
- [x] `pnpm --filter @glaon/api test` — 118/118 green. Existing probe tests updated to assert the new `status` / `reason` fields; one new test added for the non-2xx branch.
- [ ] CI.
- [ ] Manual: hit the probe with a deliberately wrong LLT → expect `upstreamStatus: 401`. With a wrong URL → expect `reason: 'fetch failed'` (or the runtime equivalent).

## Refs

- Diagnostic gap surfaced during #602 / PR #603 (UTM live-mode setup).
- Probe + proxy: `apps/api/src/routes/hassio-network.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)