### PR TITLE
feat(addon): dev add-on with HA Supervisor proxy for wizard testing

### DIFF
--- a/addon-dev/Dockerfile
+++ b/addon-dev/Dockerfile
@@ -1,0 +1,33 @@
+ARG BUILD_FROM
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM}
+
+ENV LANG=C.UTF-8
+
+# Dev add-on (#607). The whole job of this image is:
+#
+#   1. Serve the apps/web bundle on Ingress port 8099 (same packaging story
+#      as production addon/).
+#   2. Reverse-proxy /api/hassio/network/* to http://supervisor/network/*
+#      with the SUPERVISOR_TOKEN injected as Authorization: Bearer.
+#
+# No Node, no apps/api, no agent — keeps the image small + the surface
+# narrow. The wizard's apply step is the only flow exercised against this
+# add-on; everything else in the wizard talks to the hosted apps/api over
+# HTTPS like every other Glaon client (see ADR 0026).
+#
+# `gettext` is included for `envsubst` — run.sh uses it to substitute
+# $SUPERVISOR_TOKEN into the nginx config at boot. The token is
+# Supervisor-injected at container start so we can't bake it into the
+# image; envsubst-at-boot is the simplest path.
+# hadolint ignore=DL3018
+RUN apk add --no-cache nginx gettext
+
+COPY rootfs /
+COPY dist /var/www/glaon
+
+RUN chmod a+x /run.sh
+
+EXPOSE 8099
+
+CMD ["/run.sh"]

--- a/addon-dev/apparmor.txt
+++ b/addon-dev/apparmor.txt
@@ -1,0 +1,60 @@
+#include <tunables/global>
+
+# Glaon dev add-on AppArmor profile (#607). Single foreground process:
+# nginx (serves the web bundle on Ingress + reverse-proxies
+# /api/hassio/network/* to http://supervisor/network/* with the
+# Supervisor-injected token).
+#
+# This profile intentionally narrower than the production addon/
+# profile — no Node, no agent, no /data/options.json writes. The
+# `network inet stream` capability is required for the nginx
+# reverse-proxy connection to `supervisor` (HA's Supervisor service
+# DNS name inside the add-on network). Per-destination ACLs around
+# the container itself are HA Supervisor's job.
+
+profile glaon_dev flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+  #include <abstractions/nameservice>
+  #include <abstractions/openssl>
+
+  # 8099 binding for nginx Ingress endpoint.
+  capability net_bind_service,
+
+  network inet stream,
+  network inet6 stream,
+  network unix stream,
+
+  # ---- Boot path (run.sh, envsubst) ---------------------------------------
+  /run.sh rix,
+  /usr/bin/envsubst rix,
+  /usr/bin/env rix,
+  /bin/sh rix,
+  /etc/services r,
+  /etc/passwd r,
+  /etc/group r,
+  # envsubst reads the staged nginx template and writes the rendered
+  # config back into /etc/nginx/http.d/glaon-dev.conf at boot.
+  /etc/nginx/http.d/glaon-dev.conf.template r,
+  /etc/nginx/http.d/glaon-dev.conf rw,
+
+  # ---- nginx --------------------------------------------------------------
+  /usr/sbin/nginx rix,
+  /etc/nginx/** r,
+  /var/www/glaon/** r,
+  /var/log/nginx/** w,
+  /var/lib/nginx/** rw,
+  /run/nginx.pid rw,
+  /run/nginx/** rw,
+
+  # ---- Explicit denies for defense-in-depth ------------------------------
+  deny /etc/shadow rw,
+  deny /etc/sudoers rw,
+  deny /root/** rw,
+  deny /data/** rw,
+  deny capability sys_admin,
+  deny capability sys_module,
+  deny capability sys_ptrace,
+  deny capability dac_override,
+  deny capability mac_admin,
+  deny capability mac_override,
+}

--- a/addon-dev/build.yaml
+++ b/addon-dev/build.yaml
@@ -1,0 +1,8 @@
+build_from:
+  amd64: ghcr.io/home-assistant/amd64-base:3.21
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.21
+labels:
+  org.opencontainers.image.title: Glaon (dev)
+  org.opencontainers.image.description: Dev-only Glaon add-on with HA Supervisor proxy for wizard testing.
+  org.opencontainers.image.source: https://github.com/Glaon-Smart/glaon
+  org.opencontainers.image.licenses: MIT

--- a/addon-dev/config.yaml
+++ b/addon-dev/config.yaml
@@ -1,0 +1,26 @@
+name: Glaon (dev)
+version: '0.0.0-dev'
+slug: glaon_dev
+description: Glaon dev add-on — wires the setup wizard to a real HA Supervisor for Wi-Fi handoff testing on a dev HA OS box. NOT for production.
+url: https://github.com/Glaon-Smart/glaon
+arch:
+  - amd64
+  - aarch64
+init: false
+ingress: true
+ingress_port: 8099
+ingress_stream: false
+panel_icon: mdi:home-flood
+panel_title: Glaon (dev)
+# `hassio_api: true` is the whole point of this dev variant — it injects
+# `$SUPERVISOR_TOKEN` and lets the container reach `http://supervisor/network/*`.
+# The production add-on (`addon/`) keeps this `false` per ADR 0026; this
+# manifest is dev-only and never ships to the HA Add-on store.
+hassio_api: true
+hassio_role: default
+homeassistant_api: false
+auth_api: false
+host_network: false
+apparmor: true
+options: {}
+schema: {}

--- a/addon-dev/rootfs/etc/nginx/http.d/glaon-dev.conf.template
+++ b/addon-dev/rootfs/etc/nginx/http.d/glaon-dev.conf.template
@@ -1,0 +1,50 @@
+server {
+    listen 8099 default_server;
+    server_name _;
+
+    root /var/www/glaon;
+    index index.html;
+
+    # CSP is the production add-on's CSP minus Clerk (the dev add-on is
+    # local-only — no cloud auth surface). Wizard apply step + Supervisor
+    # proxy are the only flows here.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss: https:; img-src 'self' data:; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+    location ~ /\. {
+        deny all;
+    }
+
+    # HA Supervisor reverse-proxy (#607). This is the dev add-on's reason
+    # to exist — apps/web's wizard hits these paths verbatim (same paths
+    # the standalone-dev Vite proxy + production-route layouts use). We
+    # forward to `http://supervisor/network/*` and inject the bearer
+    # token at boot via envsubst (run.sh substitutes ${SUPERVISOR_TOKEN}
+    # into this file before nginx starts).
+    #
+    # The trailing slashes on `location` and `proxy_pass` strip the
+    # `/api/hassio/` prefix — the wizard calls `/api/hassio/network/info`
+    # which becomes `http://supervisor/network/info` upstream. No double
+    # `/api/hassio/` and no path leakage.
+    location /api/hassio/network/ {
+        proxy_pass http://supervisor/network/;
+        proxy_http_version 1.1;
+        proxy_set_header Host supervisor;
+        proxy_set_header Authorization "Bearer ${SUPERVISOR_TOKEN}";
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_buffering off;
+        proxy_read_timeout 30s;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(?:js|css|woff2?|png|jpg|svg)$ {
+        expires 7d;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/addon-dev/rootfs/run.sh
+++ b/addon-dev/rootfs/run.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+# Dev add-on bootstrap (#607). Two jobs:
+#
+#   1. Render the nginx config template with the Supervisor-injected
+#      bearer token. The token only exists inside the add-on container
+#      at start time (Supervisor sets $SUPERVISOR_TOKEN per
+#      `hassio_api: true`), so we can't bake it in.
+#   2. exec nginx in the foreground as PID 1 — the add-on's liveness
+#      keys on the server, like in production.
+#
+# If $SUPERVISOR_TOKEN isn't set (shouldn't happen with hassio_api: true
+# in config.yaml, but cheap to guard), bail loudly rather than silently
+# rendering an empty `Authorization: Bearer ` header that the Supervisor
+# would 401 on — same failure mode we're trying to *escape* with this
+# add-on, just less obvious.
+if [ -z "${SUPERVISOR_TOKEN:-}" ]; then
+  echo "[run.sh] FATAL: SUPERVISOR_TOKEN is not set. Check config.yaml has hassio_api: true." >&2
+  exit 1
+fi
+
+echo "[run.sh] Rendering nginx config with Supervisor token..."
+# Only substitute the one variable we know — the rest of the config has
+# nginx-native `$variable` references (e.g. $remote_addr) that envsubst
+# must not touch.
+envsubst '${SUPERVISOR_TOKEN}' \
+  < /etc/nginx/http.d/glaon-dev.conf.template \
+  > /etc/nginx/http.d/glaon-dev.conf
+
+echo "[run.sh] Starting nginx on :8099..."
+exec nginx -g 'daemon off;'

--- a/docs/dev-addon-pi.md
+++ b/docs/dev-addon-pi.md
@@ -1,0 +1,135 @@
+# Glaon dev add-on — Raspberry Pi install
+
+Bu doküman, [`addon-dev/`](../addon-dev/) klasöründeki **dev-only** Glaon add-on'unu bir Raspberry Pi üzerinde çalışan Home Assistant OS instance'ına yükleme adımlarını anlatır. Amaç: setup wizard'ın apply step'ini (#597) gerçek HA Supervisor + gerçek Wi-Fi adapter ile uçtan uca test etmek.
+
+> Bu add-on **production değildir**. Production add-on için bkz. [`addon/`](../addon/). İki add-on'un slug'ları farklıdır (`glaon` vs `glaon_dev`) ve aynı HA instance'ında birlikte yaşayabilirler.
+
+## Neden ayrı bir dev add-on?
+
+Glaon'un harici (laptop'tan) HA Supervisor REST endpoint'lerine erişmesi mümkün değil: long-lived access token (LLT) HA Core API'sine yeter ama `/api/hassio/*` proxy'sine 401 döner. HA'nın by-design davranışı — Supervisor REST endpoint'leri yalnızca **add-on container'ı içinden** `$SUPERVISOR_TOKEN` ile erişilebilir. Detay: [docs/dev-supervisor.md](dev-supervisor.md#health-probe) + #602 tartışması.
+
+Üretim add-on'u (`addon/`) [ADR 0026](adr/0026-apps-api-delivery-hosted.md) gereği Supervisor-blind: `hassio_api: false`. Bu dev add-on tek bir konfigürasyon değişikliğiyle (`hassio_api: true`) bu duvarı aşar, nginx içinde `/api/hassio/network/*` → `http://supervisor/network/*` proxy'si kurar ve `$SUPERVISOR_TOKEN`'ı boot anında `Authorization: Bearer` başlığına yerleştirir.
+
+## Ön koşullar
+
+- Raspberry Pi (3B+ veya üstü) üzerinde HA OS kurulu, ağda erişilebilir (örn. `homeassistant.local:8123` veya `http://<pi-ip>:8123`).
+- HA UI'da admin yetkili bir kullanıcın var.
+- Geliştirme makinende:
+  - Bu repo clone'lu.
+  - `pnpm install` koşulmuş.
+  - Pi'ye **SSH erişimi** (HA Community SSH add-on'u veya HA OS'un kendi `ha` CLI'sı — aşağıda iki path da var).
+
+## 1. Add-on bundle'ını build et
+
+Dev add-on `apps/web` static dist'ini içerir. Build:
+
+```bash
+pnpm build:addon-dev
+```
+
+Çıktı: `addon-dev/dist/` dolar. Bu klasör `.gitignore`'da, commit edilmez.
+
+## 2. Add-on kaynaklarını Pi'ye kopyala
+
+İki yaygın yol var. Hangisini kullanırsan kullan, hedef path **`/addons/local/glaon_dev/`** olmalı (HA Supervisor `local/` prefix'i ile local add-on'ları keşfeder; klasör adı manifest'teki `slug` ile birebir eşleşmeli).
+
+### Yol A — Samba add-on (en hızlı)
+
+1. HA UI → Settings → Add-ons → Add-on Store → **Samba share** kur + başlat.
+2. macOS Finder → Cmd-K → `smb://homeassistant.local` → mount.
+3. `addon-dev/` içeriğini (sadece içeriğini, klasörün kendisini değil) `addons/local/glaon_dev/` altına kopyala:
+
+   ```bash
+   rsync -av --delete addon-dev/ /Volumes/addons/glaon_dev/
+   ```
+
+   `dist/` dahil tüm klasörler kopyalanmalı.
+
+### Yol B — SSH + rsync
+
+1. HA UI → Settings → Add-ons → **Advanced SSH & Web Terminal** add-on (community, "Protection mode" KAPALI lazım — host'a `/addons/` erişimi için).
+2. Public key'ini add-on config'ine ekle.
+3. Yerel makinenden:
+
+   ```bash
+   rsync -av --delete -e "ssh -p 22222" \
+     addon-dev/ root@homeassistant.local:/addons/local/glaon_dev/
+   ```
+
+   Port `22222` SSH add-on'un default'u; UI'daki seçimine göre değiştir.
+
+## 3. Supervisor'a add-on'u tanıt
+
+Pi'de (SSH veya `ha` CLI üzerinden):
+
+```bash
+ha addons reload
+```
+
+Sonrasında HA UI → Settings → Add-ons → **Add-on Store** → sayfa sonunda **"Local add-ons"** bölümünde **Glaon (dev)** görünmeli.
+
+## 4. Install + start
+
+UI üzerinden:
+
+1. **Glaon (dev)** kartına tıkla → **Install**. İlk install Pi üzerinde Docker image'ı **lokal olarak build eder** (~1-3 dakika; nginx + gettext apk install adımları log'da görünür).
+2. Install bittiğinde **Start** bas.
+3. **Log** sekmesini aç — şunu görmelisin:
+
+   ```
+   [run.sh] Rendering nginx config with Supervisor token...
+   [run.sh] Starting nginx on :8099...
+   ```
+
+   `FATAL: SUPERVISOR_TOKEN is not set` görünürse `config.yaml` içinde `hassio_api: true` doğrulanmamış demektir — manifest'i kontrol et.
+
+## 5. Open Web UI
+
+HA UI → Add-on sayfasında **OPEN WEB UI** butonuna bas. Wizard, Ingress URL'i üzerinden açılır (HA kullanıcı oturumu kontrolünde — harici port yok).
+
+## 6. Doğrulama: gerçek Wi-Fi handoff
+
+1. Wizard'ı **Apply** step'ine kadar yürüt (Home Overview → Layout → Security → Apply).
+2. Apply step Wi-Fi network listesini load ederken `/api/hassio/network/info`'ya gider — bu istek dev add-on'un nginx'inden Supervisor'a forward edilir.
+3. **Pi'nin gerçek Wi-Fi tarama sonuçlarını** görmelisin (mock listesi değil — `GlaonDev-*` SSID'ler **görünmemeli**). Pi'ye fiziksel olarak hangi AP'ler erişilebiliyorsa onlar görünür.
+4. Bir SSID seç, password gir, **Save and switch network** bas.
+5. POST `/api/hassio/network/wlan0/update` Supervisor'a forward edilir, NetworkManager yeni connection'ı NM config'ine yazar.
+
+### Pi tarafında doğrulama
+
+SSH üzerinden:
+
+```bash
+ha network info
+# veya
+ssh root@homeassistant.local -p 22222 "nmcli connection show"
+```
+
+Yeni eklenen connection listede görünmeli.
+
+## Sorun giderme
+
+| Belirti                                        | Olası neden                                                                                                                                                                                                                                    |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Local add-ons` bölümünde Glaon (dev) yok      | `addons/local/glaon_dev/` path'i yanlış (slug eşleşmiyor), `ha addons reload` koşulmamış, ya da `config.yaml` parse hatası var. `ha addons logs glaon_dev` (install öncesi yok ama logs panel) yerine `ha supervisor logs` bakmak gerekebilir. |
+| Install başarısız: "BUILD_FROM not found"      | Pi mimarisi `aarch64` olmalı — `build.yaml` zaten her iki arch için image map'liyor. Pi'de `uname -m` ile doğrula.                                                                                                                             |
+| Log'da `FATAL: SUPERVISOR_TOKEN is not set`    | `config.yaml`'da `hassio_api: true` eksik veya yanlış scope. Manifest'i doğrula, add-on'u kaldırıp tekrar install et.                                                                                                                          |
+| Wi-Fi listesi boş veya mock SSID'ler görünüyor | Mock'a düşmüş — apps/web `VITE_APP_MODE=ingress` ile build edilmemiş olabilir. Build script'ini kontrol et (`apps/web/.env.production`).                                                                                                       |
+| `/api/hassio/network/info` 502                 | nginx Supervisor'a ulaşamıyor. `ha network info` çalışıyor mu? Çalışmıyorsa Supervisor'ın kendisi sorunlu. Çalışıyorsa add-on'un network ayarları (`host_network: false` doğru) gözden geçirilmeli.                                            |
+
+## Güvenlik notları
+
+- Bu add-on `hassio_api: true` ile çalışır, yani `$SUPERVISOR_TOKEN`'a sahiptir. Token Supervisor'ın tüm REST endpoint'lerine erişim verir — nginx config bu yetkiyi **yalnızca `/network/*` prefix'i için** delege eder. Başka path'leri proxy'lemiyoruz; bu kasıtlı.
+- Add-on Ingress üzerinden çalışır, harici port açmaz. Erişim HA kullanıcı oturumuyla gate'lidir.
+- Wizard akışı bu add-on içinde **authentication gerektirmez** — kullanıcı zaten HA'ya login olarak Ingress'e ulaşmıştır. Üretim wizard akışı (cloud-relay add-on) farklı bir auth modeline sahip.
+- Production add-on'unu (`addon/`) bu add-on'a dönüştürmeye **kalkışma**. Production manifest'i [ADR 0026](adr/0026-apps-api-delivery-hosted.md) gereği Supervisor-blind kalmalı.
+
+## Refs
+
+- #607 — bu add-on'un tracking issue'su.
+- #597 — wizard collapse (Apply step).
+- #598 / #600 — Supervisor proxy + mock mode (apps/api tarafı).
+- #602 — UTM HA OS denemesi (user-LLT 401 burada teşhis edildi).
+- [docs/dev-supervisor.md](dev-supervisor.md) — mock mode + (mostly-broken) LLT live mode.
+- [ADR 0026](adr/0026-apps-api-delivery-hosted.md) — apps/api delivery model.
+- HA local add-on geliştirme: <https://developers.home-assistant.io/docs/add-ons/tutorial>.

--- a/docs/dev-supervisor.md
+++ b/docs/dev-supervisor.md
@@ -60,6 +60,14 @@ You need one of:
 4. **The actual production add-on** running on a real Home Assistant
    instance — your dev box runs apps/api + apps/web against it over
    the LAN.
+5. **The Glaon dev add-on** (`addon-dev/`, #607). When live mode below
+   keeps 401-ing on `/api/hassio/*` (it will — see "User-LLT vs
+   Supervisor token" below), this is the only path that actually
+   exercises a real Supervisor + real Wi-Fi. Skips the apps/api proxy
+   entirely; the dev add-on's nginx forwards `/api/hassio/network/*`
+   to `http://supervisor/network/*` from _inside_ the add-on container,
+   where `$SUPERVISOR_TOKEN` works. Setup runbook:
+   [docs/dev-addon-pi.md](dev-addon-pi.md).
 
 ### Live mode: HA OS in UTM (#602)
 
@@ -105,9 +113,19 @@ curl http://localhost:8080/healthz/supervisor
 # {"status":"ok","mode":"live"}
 ```
 
-If you get `{ mode: 'live' }` with `status: 'unavailable'`, the
-URL or token is wrong (or `homeassistant.local` doesn't resolve from
-the host — check `ping homeassistant.local`).
+If you get `{ mode: 'live' }` with `status: 'unavailable'` and
+`upstreamStatus: 401`, the URL + token are reaching HA but HA is
+rejecting the auth on the `/api/hassio/*` path. **This is HA's
+by-design behaviour** — the Supervisor REST proxy only accepts the
+add-on-injected `$SUPERVISOR_TOKEN`, never an external user LLT —
+not a token misconfiguration. For most dev work mock mode is fine;
+when you specifically need real Supervisor + real Wi-Fi, switch to
+the Glaon dev add-on path (#607,
+[docs/dev-addon-pi.md](dev-addon-pi.md)).
+
+If `upstreamStatus` is anything else (404, 502, timeout), the URL is
+wrong or `homeassistant.local` doesn't resolve from the host — check
+`ping homeassistant.local`.
 
 **6. Walk the wizard.** Open `http://localhost:5173`, walk to the
 apply step, you should see the actual Wi-Fi networks the UTM VM can

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "scripts": {
     "build": "turbo run build",
     "build:addon": "pnpm --filter @glaon/web build:addon && pnpm --filter @glaon/addon-agent build && rm -rf addon/dist addon/agent && cp -R apps/web/dist addon/dist && mkdir -p addon/agent && cp apps/addon-agent/dist/agent.cjs addon/agent/agent.cjs && cp -R apps/addon-agent/dist/static addon/agent/static",
+    "build:addon-dev": "pnpm --filter @glaon/web build:addon && rm -rf addon-dev/dist && cp -R apps/web/dist addon-dev/dist",
     "build:api": "pnpm --filter @glaon/api build",
     "build:cloud": "pnpm --filter @glaon/cloud build",
     "clean": "turbo run clean && rm -rf node_modules .turbo",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "pnpm": {
     "overrides": {
       "basic-ftp": ">=5.3.1",
-      "js-cookie": ">=3.0.7"
+      "js-cookie": ">=3.0.7",
+      "tmp": ">=0.2.6"
     }
   },
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   basic-ftp: '>=5.3.1'
   js-cookie: '>=3.0.7'
+  tmp: '>=0.2.6'
 
 importers:
 
@@ -6398,10 +6399,6 @@ packages:
     resolution: {integrity: sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==}
     engines: {node: '>=6'}
 
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
-
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -6930,11 +6927,6 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -7561,13 +7553,9 @@ packages:
   tmcp@1.19.3:
     resolution: {integrity: sha512-plz/TLKNFrdfQN32LjCTN6ULy6pynfGPgHcU7KGCI5dBrxQ9Mub99SmcYuzxEkLjJooQuOD3gosSwZEl1htOtw==}
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
-
-  tmp@0.1.0:
-    resolution: {integrity: sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==}
-    engines: {node: '>=6'}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
+    engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -9978,7 +9966,7 @@ snapshots:
       lighthouse-logger: 1.2.0
       open: 7.4.2
       proxy-agent: 6.5.0
-      tmp: 0.1.0
+      tmp: 0.2.6
       uuid: 8.3.2
       yargs: 15.4.1
       yargs-parser: 13.1.2
@@ -10390,7 +10378,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.84.3(bufferutil@4.1.0)
-      metro-config: 0.84.3(bufferutil@4.1.0)
+      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.84.3
       semver: 7.7.4
     transitivePeerDependencies:
@@ -10404,7 +10392,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      metro-config: 0.84.3(bufferutil@4.1.0)
+      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.84.3
       semver: 7.7.4
     transitivePeerDependencies:
@@ -11807,9 +11795,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.13(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser': 4.1.5(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -13362,7 +13350,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.0.33
+      tmp: 0.2.6
 
   extract-zip@2.0.1:
     dependencies:
@@ -14589,12 +14577,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.84.3(bufferutil@4.1.0):
+  metro-config@0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       connect: 3.7.0
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.84.3(bufferutil@4.1.0)
+      metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-cache: 0.84.3
       metro-core: 0.84.3
       metro-runtime: 0.84.3
@@ -14877,7 +14865,7 @@ snapshots:
       metro-babel-transformer: 0.84.3
       metro-cache: 0.84.3
       metro-cache-key: 0.84.3
-      metro-config: 0.84.3(bufferutil@4.1.0)
+      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.84.3
       metro-file-map: 0.84.3
       metro-resolver: 0.84.3
@@ -14924,7 +14912,7 @@ snapshots:
       metro-babel-transformer: 0.84.3
       metro-cache: 0.84.3
       metro-cache-key: 0.84.3
-      metro-config: 0.84.3(bufferutil@4.1.0)
+      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       metro-core: 0.84.3
       metro-file-map: 0.84.3
       metro-resolver: 0.84.3
@@ -15199,8 +15187,6 @@ snapshots:
       log-symbols: 2.2.0
       strip-ansi: 5.2.0
       wcwidth: 1.0.1
-
-  os-tmpdir@1.0.2: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -15918,10 +15904,6 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
-
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
 
   rimraf@3.0.2:
     dependencies:
@@ -16700,13 +16682,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
-
-  tmp@0.1.0:
-    dependencies:
-      rimraf: 2.7.1
+  tmp@0.2.6: {}
 
   tmpl@1.0.5: {}
 


### PR DESCRIPTION
## Summary

- New `addon-dev/` sibling directory — separate dev-only add-on with `hassio_api: true`, slug `glaon_dev`, panel "Glaon (dev)". Production `addon/` is untouched.
- nginx in the dev add-on reverse-proxies `/api/hassio/network/*` → `http://supervisor/network/*`, injecting `$SUPERVISOR_TOKEN` at boot via `envsubst`.
- New `pnpm build:addon-dev` script + full Pi install runbook at `docs/dev-addon-pi.md`. Cross-linked from `docs/dev-supervisor.md`.
- **Drive-by**: pin `tmp >= 0.2.6` in `pnpm.overrides` to clear the GHSA-ph9p-34f9-6g65 advisory that was breaking the repo-wide `pnpm audit --audit-level high` gate (blocks every open PR). Mirrors the existing `basic-ftp` / `js-cookie` override pattern. Dep-dashboard tracker: #61.

## Why

External user LLTs cannot reach `/api/hassio/*` on HA OS — confirmed on both UTM HA OS and Raspberry Pi HA OS (both 401 despite valid admin LLT + loaded `hassio` integration). This is HA's by-design behaviour: the Supervisor REST proxy only accepts the add-on-injected `$SUPERVISOR_TOKEN`. Full debug trail in #602.

The production add-on (`addon/`) is intentionally Supervisor-blind per [ADR 0026](../blob/development/docs/adr/0026-apps-api-delivery-hosted.md). Flipping `hassio_api: true` on the production manifest would widen production attack surface and couple production capability decisions to a dev convenience. A separate dev add-on is the clean fix.

## Scope

**In**

- `addon-dev/config.yaml` (`hassio_api: true`, `ingress: true`, slug `glaon_dev`, no agent, no apps/api).
- `addon-dev/build.yaml` (multi-arch base images).
- `addon-dev/Dockerfile` (nginx + gettext only, no Node).
- `addon-dev/apparmor.txt` (narrower than production: no Node, no /data writes).
- `addon-dev/rootfs/etc/nginx/http.d/glaon-dev.conf.template` (CSP-hardened, `/api/hassio/network/*` proxy).
- `addon-dev/rootfs/run.sh` (envsubst-at-boot, fail-fast on missing `$SUPERVISOR_TOKEN`).
- `pnpm build:addon-dev` script.
- `docs/dev-addon-pi.md` — full Pi install + verification runbook (Turkish per language policy).
- `docs/dev-supervisor.md` — cross-link to the new path + clarify that user-LLT 401 on `/api/hassio/*` is by-design, not a misconfig.
- `pnpm.overrides` for `tmp >= 0.2.6` + matching lockfile update. Unblocks CI per the Dependency Freshness rule's "(b) unblocking migration work that has its own issue" exception.

**Out**

- Bundling `apps/api` into the add-on (ADR 0026 keeps it hosted).
- Touching production `addon/`.
- Multi-arch CI publish for `addon-dev` (it's not a release artefact — Pi builds the image locally on install).
- HA Add-on store submission for the dev variant.
- AppArmor refinement beyond the new narrower profile (#24 territory).

## Test plan

- [x] `pnpm build:addon-dev` produces `addon-dev/dist/` populated with the web bundle.
- [x] Prettier + commitlint + gitleaks pass via lint-staged.
- [x] `pnpm audit --audit-level high` clean locally after the `tmp` override (14 → 10 advisories, 2 high → 0 high).
- [ ] CI (Chromatic / lint / type-check / size / lhci) green on PR.
- [ ] On Pi HA OS: drop `addon-dev/` under `/addons/local/glaon_dev/`, `ha addons reload`, "Glaon (dev)" appears in Local add-ons. _(local-verification, user-driven)_
- [ ] Install + start succeeds; logs show `[run.sh] Rendering nginx config with Supervisor token...` followed by nginx startup. _(local-verification, user-driven)_
- [ ] Wizard apply step shows the Pi's real Wi-Fi scan results (no `GlaonDev-*` mock SSIDs). _(local-verification, user-driven)_
- [ ] SSID + password commit returns 2xx; new connection appears in `ha network info`. _(local-verification, user-driven)_

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)