### PR TITLE
fix(addon): unblock dev add-on startup behind s6-overlay + apparmor

### DIFF
--- a/addon-dev/apparmor.txt
+++ b/addon-dev/apparmor.txt
@@ -1,16 +1,23 @@
 #include <tunables/global>
 
-# Glaon dev add-on AppArmor profile (#607). Single foreground process:
-# nginx (serves the web bundle on Ingress + reverse-proxies
-# /api/hassio/network/* to http://supervisor/network/* with the
-# Supervisor-injected token).
+# Glaon dev add-on AppArmor profile (#607, expanded in #609). Single
+# foreground process: nginx (serves the web bundle on Ingress +
+# reverse-proxies /api/hassio/network/* to http://supervisor/network/*
+# with the Supervisor-injected token).
 #
-# This profile intentionally narrower than the production addon/
+# This profile is intentionally narrower than the production addon/
 # profile — no Node, no agent, no /data/options.json writes. The
 # `network inet stream` capability is required for the nginx
 # reverse-proxy connection to `supervisor` (HA's Supervisor service
 # DNS name inside the add-on network). Per-destination ACLs around
 # the container itself are HA Supervisor's job.
+#
+# `init: false` in config.yaml tells Supervisor not to add its own init
+# wrapper, but the HA base image still has s6-overlay's `/init` baked
+# in as the container's ENTRYPOINT. The s6 bootstrap chain
+# (/init → bashio → with-contenv → run.sh) must therefore be
+# permitted by AppArmor, or boot fails with
+# "/bin/sh: can't open '/init': Permission denied" (#609).
 
 profile glaon_dev flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
@@ -19,16 +26,33 @@ profile glaon_dev flags=(attach_disconnected,mediate_deleted) {
 
   # 8099 binding for nginx Ingress endpoint.
   capability net_bind_service,
+  # bashio's `with-contenv` wrapper inherits the s6 contenv state.
+  capability setuid,
+  capability setgid,
 
   network inet stream,
   network inet6 stream,
   network unix stream,
 
-  # ---- Boot path (run.sh, envsubst) ---------------------------------------
+  # ---- s6-overlay init chain (base image ENTRYPOINT) ----------------------
+  # /init is the s6-overlay PID 1 that the base image runs. It bootstraps
+  # stage 2 from /etc/s6-overlay/** and writes runtime state to /run/s6/**.
+  /init rix,
+  /etc/s6-overlay/** r,
+  /etc/s6/** r,
+  /run/s6/** rw,
+  /run/s6-rc** rw,
+  /var/run/s6/** rw,
+
+  # ---- Boot path (run.sh, bashio, envsubst) -------------------------------
   /run.sh rix,
+  /usr/bin/with-contenv rix,
+  /usr/bin/bashio rix,
   /usr/bin/envsubst rix,
   /usr/bin/env rix,
+  /usr/bin/jq rix,
   /bin/sh rix,
+  /bin/bash rix,
   /etc/services r,
   /etc/passwd r,
   /etc/group r,

--- a/addon-dev/config.yaml
+++ b/addon-dev/config.yaml
@@ -16,8 +16,13 @@ panel_title: Glaon (dev)
 # `$SUPERVISOR_TOKEN` and lets the container reach `http://supervisor/network/*`.
 # The production add-on (`addon/`) keeps this `false` per ADR 0026; this
 # manifest is dev-only and never ships to the HA Add-on store.
+#
+# We deliberately do NOT set `hassio_role` — the default role (which is
+# what the Supervisor assigns when the field is omitted) already permits
+# the /network/* endpoints we proxy. Setting `hassio_role: default`
+# explicitly is redundant noise; setting it to anything else widens
+# privilege past what the proxy actually exposes.
 hassio_api: true
-hassio_role: default
 homeassistant_api: false
 auth_api: false
 host_network: false

--- a/addon-dev/rootfs/run.sh
+++ b/addon-dev/rootfs/run.sh
@@ -1,14 +1,19 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/with-contenv bashio
+set -euo pipefail
 
-# Dev add-on bootstrap (#607). Two jobs:
+# Dev add-on bootstrap (#607, fixed in #609). Two jobs:
 #
 #   1. Render the nginx config template with the Supervisor-injected
 #      bearer token. The token only exists inside the add-on container
 #      at start time (Supervisor sets $SUPERVISOR_TOKEN per
 #      `hassio_api: true`), so we can't bake it in.
-#   2. exec nginx in the foreground as PID 1 — the add-on's liveness
-#      keys on the server, like in production.
+#   2. exec nginx in the foreground — the add-on's liveness keys on
+#      the server, like in production.
+#
+# Shebang note: `#!/usr/bin/with-contenv bashio` is the HA base image's
+# expected init handoff for `init: false` add-ons. A plain `#!/bin/sh`
+# tripped the s6-overlay bootstrap with an AppArmor denial on `/init`
+# (#609 root cause); bashio is what s6 expects to see.
 #
 # If $SUPERVISOR_TOKEN isn't set (shouldn't happen with hassio_api: true
 # in config.yaml, but cheap to guard), bail loudly rather than silently
@@ -16,11 +21,11 @@ set -eu
 # would 401 on — same failure mode we're trying to *escape* with this
 # add-on, just less obvious.
 if [ -z "${SUPERVISOR_TOKEN:-}" ]; then
-  echo "[run.sh] FATAL: SUPERVISOR_TOKEN is not set. Check config.yaml has hassio_api: true." >&2
+  bashio::log.fatal "SUPERVISOR_TOKEN is not set. Check config.yaml has hassio_api: true."
   exit 1
 fi
 
-echo "[run.sh] Rendering nginx config with Supervisor token..."
+bashio::log.info "Rendering nginx config with Supervisor token..."
 # Only substitute the one variable we know — the rest of the config has
 # nginx-native `$variable` references (e.g. $remote_addr) that envsubst
 # must not touch.
@@ -28,5 +33,5 @@ envsubst '${SUPERVISOR_TOKEN}' \
   < /etc/nginx/http.d/glaon-dev.conf.template \
   > /etc/nginx/http.d/glaon-dev.conf
 
-echo "[run.sh] Starting nginx on :8099..."
+bashio::log.info "Starting nginx on :8099..."
 exec nginx -g 'daemon off;'

--- a/docs/dev-addon-pi.md
+++ b/docs/dev-addon-pi.md
@@ -74,11 +74,11 @@ UI üzerinden:
 
 1. **Glaon (dev)** kartına tıkla → **Install**. İlk install Pi üzerinde Docker image'ı **lokal olarak build eder** (~1-3 dakika; nginx + gettext apk install adımları log'da görünür).
 2. Install bittiğinde **Start** bas.
-3. **Log** sekmesini aç — şunu görmelisin:
+3. **Log** sekmesini aç — şunu görmelisin (bashio's varsayılan log formatı, `[HH:MM:SS] INFO:` prefix'iyle):
 
    ```
-   [run.sh] Rendering nginx config with Supervisor token...
-   [run.sh] Starting nginx on :8099...
+   [hh:mm:ss] INFO: Rendering nginx config with Supervisor token...
+   [hh:mm:ss] INFO: Starting nginx on :8099...
    ```
 
    `FATAL: SUPERVISOR_TOKEN is not set` görünürse `config.yaml` içinde `hassio_api: true` doğrulanmamış demektir — manifest'i kontrol et.
@@ -109,13 +109,14 @@ Yeni eklenen connection listede görünmeli.
 
 ## Sorun giderme
 
-| Belirti                                        | Olası neden                                                                                                                                                                                                                                    |
-| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Local add-ons` bölümünde Glaon (dev) yok      | `addons/local/glaon_dev/` path'i yanlış (slug eşleşmiyor), `ha addons reload` koşulmamış, ya da `config.yaml` parse hatası var. `ha addons logs glaon_dev` (install öncesi yok ama logs panel) yerine `ha supervisor logs` bakmak gerekebilir. |
-| Install başarısız: "BUILD_FROM not found"      | Pi mimarisi `aarch64` olmalı — `build.yaml` zaten her iki arch için image map'liyor. Pi'de `uname -m` ile doğrula.                                                                                                                             |
-| Log'da `FATAL: SUPERVISOR_TOKEN is not set`    | `config.yaml`'da `hassio_api: true` eksik veya yanlış scope. Manifest'i doğrula, add-on'u kaldırıp tekrar install et.                                                                                                                          |
-| Wi-Fi listesi boş veya mock SSID'ler görünüyor | Mock'a düşmüş — apps/web `VITE_APP_MODE=ingress` ile build edilmemiş olabilir. Build script'ini kontrol et (`apps/web/.env.production`).                                                                                                       |
-| `/api/hassio/network/info` 502                 | nginx Supervisor'a ulaşamıyor. `ha network info` çalışıyor mu? Çalışmıyorsa Supervisor'ın kendisi sorunlu. Çalışıyorsa add-on'un network ayarları (`host_network: false` doğru) gözden geçirilmeli.                                            |
+| Belirti                                                 | Olası neden                                                                                                                                                                                                                                    |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Local add-ons` bölümünde Glaon (dev) yok               | `addons/local/glaon_dev/` path'i yanlış (slug eşleşmiyor), `ha addons reload` koşulmamış, ya da `config.yaml` parse hatası var. `ha addons logs glaon_dev` (install öncesi yok ama logs panel) yerine `ha supervisor logs` bakmak gerekebilir. |
+| Install başarısız: "BUILD_FROM not found"               | Pi mimarisi `aarch64` olmalı — `build.yaml` zaten her iki arch için image map'liyor. Pi'de `uname -m` ile doğrula.                                                                                                                             |
+| Log'da `FATAL: SUPERVISOR_TOKEN is not set`             | `config.yaml`'da `hassio_api: true` eksik veya yanlış scope. Manifest'i doğrula, add-on'u kaldırıp tekrar install et.                                                                                                                          |
+| Log'da `/bin/sh: can't open '/init': Permission denied` | Eski (#609 öncesi) build'de görünür: AppArmor profili s6-overlay bootstrap chain'ine izin vermiyordu. Çözüldü — `git pull` ile en güncel `addon-dev/`'i çek, `pnpm build:addon-dev`, Pi'ye tekrar kopyala, `ha addons rebuild glaon_dev`.      |
+| Wi-Fi listesi boş veya mock SSID'ler görünüyor          | Mock'a düşmüş — apps/web `VITE_APP_MODE=ingress` ile build edilmemiş olabilir. Build script'ini kontrol et (`apps/web/.env.production`).                                                                                                       |
+| `/api/hassio/network/info` 502                          | nginx Supervisor'a ulaşamıyor. `ha network info` çalışıyor mu? Çalışmıyorsa Supervisor'ın kendisi sorunlu. Çalışıyorsa add-on'un network ayarları (`host_network: false` doğru) gözden geçirilmeli.                                            |
 
 ## Güvenlik notları
 


### PR DESCRIPTION
## Summary

- `addon-dev/rootfs/run.sh`: switch shebang from `#!/bin/sh` to `#!/usr/bin/with-contenv bashio` and route logs through `bashio::log.*`. Matches the production add-on's bootstrap pattern.
- `addon-dev/apparmor.txt`: grant access to `/init`, `/etc/s6-overlay/**`, `/run/s6/**`, `/usr/bin/bashio`, `/usr/bin/with-contenv`, `/usr/bin/jq`, `/bin/bash` — the s6-overlay boot chain that the HA base image's `ENTRYPOINT ["/init"]` exercises before our CMD is reached.
- `addon-dev/config.yaml`: drop the redundant `hassio_role: default` (the default role applies automatically when `hassio_api: true` is set).
- `docs/dev-addon-pi.md`: update expected-log block to bashio's `[hh:mm:ss] INFO:` format and add the `/init: Permission denied` symptom to the troubleshooting table.

## Why

The dev add-on installed and built on the user's Pi but failed to start with:

```
/bin/sh: can't open '/init': Permission denied
```

Tracked down in #609. Three things compounded:

1. The HA base image (`ghcr.io/home-assistant/aarch64-base:3.21`) bakes `ENTRYPOINT ["/init"]` (s6-overlay). `init: false` only suppresses Supervisor's *own* init wrapper; it doesn't strip the base image entrypoint.
2. s6's `/init` runs first, then needs to bootstrap stage 2 (spawning `/bin/sh` to invoke our CMD).
3. Our AppArmor profile permitted `/run.sh` but not `/init` or the bashio chain → AppArmor denied the `open(/init)` syscall → `/bin/sh` reported "Permission denied".

The production add-on (`addon/`) doesn't hit this because its `run.sh` already uses `#!/usr/bin/with-contenv bashio` and its profile permits the bashio chain. This PR mirrors that pattern for the dev variant.

## Scope

**In**

- run.sh shebang + bashio logging.
- apparmor.txt s6 + bashio chain additions.
- config.yaml hassio_role clean-up.
- docs/dev-addon-pi.md expected-log + troubleshooting update.

**Out**

- Production `addon/` (works correctly; no changes).
- nginx config or `/api/hassio/network/*` proxy logic (works; just couldn't start to prove it).
- Wider AppArmor restructuring (#24 territory).

## Test plan

- [x] Prettier + commitlint + gitleaks pass via lint-staged.
- [ ] CI green on PR.
- [ ] On Pi HA OS: `git pull && pnpm build:addon-dev`, rsync `addon-dev/` to `/addons/local/glaon_dev/`, `ha addons rebuild glaon_dev`, start. Log shows `[hh:mm:ss] INFO: Rendering nginx config…` and `[hh:mm:ss] INFO: Starting nginx on :8099…`. _(local-verification, user-driven)_
- [ ] **Open Web UI** loads the wizard. Apply step now shows real Wi-Fi scan results. _(local-verification, user-driven)_

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)