### PR TITLE
fix(addon-dev): allow HA Ingress iframe embed in nginx CSP

### DIFF
--- a/addon-dev/rootfs/etc/nginx/http.d/glaon-dev.conf.template
+++ b/addon-dev/rootfs/etc/nginx/http.d/glaon-dev.conf.template
@@ -8,9 +8,18 @@ server {
     # CSP is the production add-on's CSP minus Clerk (the dev add-on is
     # local-only — no cloud auth surface). Wizard apply step + Supervisor
     # proxy are the only flows here.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss: https:; img-src 'self' data:; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
+    #
+    # `frame-ancestors 'self'` (not 'none' like production) — HA Ingress
+    # always wraps the add-on UI in an iframe even when "Open Web UI"
+    # opens in a new tab. Parent (HA Core) and iframe (this add-on) both
+    # live on the same origin (everything served via HA Core's port 8123;
+    # only the path prefix `/api/hassio_ingress/<token>/` differs), so
+    # `'self'` is sufficient and X-Frame-Options goes from DENY to
+    # SAMEORIGIN as the same-origin-only complement. Production add-on
+    # (addon/) keeps 'none' / DENY — different deployment story (#613).
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss: https:; img-src 'self' data:; font-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'" always;
     add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Referrer-Policy "no-referrer" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
 


### PR DESCRIPTION
## Summary

- `addon-dev/rootfs/etc/nginx/http.d/glaon-dev.conf.template`:
  - `frame-ancestors 'none'` → `frame-ancestors 'self'`
  - `X-Frame-Options "DENY"` → `X-Frame-Options "SAMEORIGIN"`

That's it. No other CSP directive changes (`default-src 'self'`, `script-src 'self'`, no `unsafe-eval`, no `unsafe-inline` script — all kept strict).

## Why

HA Ingress always wraps add-on UIs in an iframe — even when "Open Web UI" opens a new tab, HA serves a wrapper that embeds the add-on as an iframe child. The wizard never rendered because the browser blocked the iframe load:

```
Refused to load http://homeassistant.local:8123/api/hassio_ingress/<token>/
because it does not appear in the frame-ancestors directive of the
Content Security Policy.
```

Parent (HA Core) and iframe (this add-on) live on the **same origin** — everything served through HA Core's port 8123, only the `/api/hassio_ingress/<token>/` path prefix differs. So `'self'` is sufficient and `SAMEORIGIN` is its X-Frame-Options counterpart.

## Scope

**In** — listed in Summary.

**Out**

- Production `addon/` — different deployment story (cloud-relay flow, not wizard Ingress). Keeps `'none'` / `DENY`. Separate issue if it ever needs the same fix.
- All other CSP directives.

## Test plan

- [x] Prettier + commitlint + gitleaks pass via lint-staged.
- [ ] CI green on PR.
- [ ] After merge + Pi rebuild: "Open Web UI" loads the wizard inside HA's Ingress iframe without the frame-ancestors error. _(local-verification, user-driven)_
- [ ] Wizard apply step calls /api/hassio/network/info and gets real Wi-Fi APs from the Pi. _(local-verification, user-driven)_

Closes #613
Refs #607, #609, #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)