### PR TITLE
feat(api): wire apps/api to Pi Supervisor via dev add-on LAN port

### DIFF
--- a/addon-dev/config.yaml
+++ b/addon-dev/config.yaml
@@ -44,5 +44,32 @@ host_network: false
 # story ever simplifies (e.g. HA base drops s6-overlay v3 for a
 # leaner init), revisit and re-enable with a tight profile.
 apparmor: false
+# LAN-exposed port for apps/api integration (#615).
+#
+# Ingress is enough for the browser wizard, but apps/api running on a
+# dev box (laptop) can't mint Ingress tokens — those are ephemeral and
+# session-bound to a browser cookie. To let apps/api point its
+# HA_SUPERVISOR_URL at a real Supervisor, the add-on additionally
+# exposes nginx on a LAN port. Same nginx config handles both paths:
+# Ingress requests come through HA Core's wrapper, LAN requests hit
+# the container directly. Either way the `/api/hassio/network/`
+# location block overrides the incoming Authorization header with
+# the injected $SUPERVISOR_TOKEN, so apps/api can send a placeholder
+# token without weakening Supervisor's auth.
+#
+# Security trade-off: anything on the LAN can hit
+# http://homeassistant.local:8099/api/hassio/network/* and commit
+# Wi-Fi changes via Supervisor. This is dev-only, trusted-LAN
+# posture — production add-on (`addon/`) does NOT expose any LAN
+# port. If a real concern surfaces, a follow-up issue adds a
+# shared-secret header check in nginx.
+#
+# `null` host port lets HA pick (and is also a valid disclosure
+# pattern). We set "8099" for predictability; user can edit in HA
+# UI if the host port conflicts.
+ports:
+  '8099/tcp': 8099
+ports_description:
+  '8099/tcp': nginx (apps/api dev integration — LAN-trusted, see docs/dev-supervisor.md)
 options: {}
 schema: {}

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -37,34 +37,45 @@ GLAON_API_VERSION=0.0.0-dev
 GLAON_API_COMMIT=
 GLAON_API_BUILT_AT=
 
-# HA Supervisor proxy (#598, #602). Two dev modes — pick one:
+# HA Supervisor proxy (#598, #602, #615). Three dev modes — pick one:
 #
-#   1. Live mode (preferred when you have an HA OS / Supervised
-#      install reachable). Set HA_SUPERVISOR_URL + HA_SUPERVISOR_TOKEN
-#      and apps/api forwards GET /hassio/network/info + POST
-#      /hassio/network/:iface/update straight to the supervisor.
-#      The typical UTM HA OS setup uses HA Core's built-in
-#      /api/hassio/* proxy on port 8123 — full UTM walkthrough in
+#   1. Live mode via the Glaon dev add-on on Pi HA OS (preferred,
+#      #615). The add-on (`addon-dev/`) is installed on a real Pi
+#      HA OS box and exposes its nginx on a LAN port. nginx inside
+#      the add-on holds the real $SUPERVISOR_TOKEN (only available
+#      to add-ons with hassio_api: true) and overrides the incoming
+#      Authorization header — so apps/api can send a placeholder
+#      token. Full Pi install in docs/dev-addon-pi.md; route flow in
 #      docs/dev-supervisor.md.
 #
-#   2. Mock mode (fallback when no HA is reachable — CI, fresh
+#   2. Live mode direct to HA Core's /api/hassio/* proxy. Known
+#      broken against real HA — user LLTs return 401 because the
+#      Supervisor REST proxy only accepts the internal Supervisor
+#      token, not external LLTs (debugged in #602). Kept here only
+#      because some legacy dev setups expect this URL.
+#
+#   3. Mock mode (fallback when no HA is reachable — CI, fresh
 #      laptops, working on UI in isolation). HA_SUPERVISOR_MOCK=true
 #      returns a canned 3-network payload from GET and accepts any
 #      POST with 200. The setup wizard's apply step walks end-to-end
 #      without a real HA anywhere.
 #
-# Either is enough; with both unset /hassio/* responds 503 and the
-# wizard's apply step lands on its error retry affordance.
+# Any of the three is enough; with all unset /hassio/* responds 503.
 #
 # Production add-on deployments bypass this route entirely — the
-# add-on's own nginx proxies /api/hassio/* directly to the supervisor
-# over Ingress, no apps/api in the path.
+# production add-on (`addon/`) has its own cloud-relay flow; this
+# variable only affects standalone/dev runs of apps/api.
 
-# Live mode against an HA OS in UTM (#602). Replace the token with
-# your long-lived access token: HA UI → user profile → Security →
-# Long-lived access tokens → Create.
-HA_SUPERVISOR_URL=http://homeassistant.local:8123/api/hassio
-HA_SUPERVISOR_TOKEN=
+# === Path 1 (preferred) — apps/api via dev add-on on Pi ===
+HA_SUPERVISOR_URL=http://homeassistant.local:8099/api/hassio
+# Placeholder; the dev add-on's nginx overrides the Authorization
+# header with its own $SUPERVISOR_TOKEN before forwarding upstream.
+# Any non-empty value satisfies apps/api's config validator.
+HA_SUPERVISOR_TOKEN=via-addon-proxy
 
-# Mock mode fallback — uncomment when no HA Supervisor is reachable.
+# === Path 2 (broken — only for legacy dev setups) ===
+# HA_SUPERVISOR_URL=http://homeassistant.local:8123/api/hassio
+# HA_SUPERVISOR_TOKEN=<long-lived-access-token>
+
+# === Path 3 (mock) ===
 # HA_SUPERVISOR_MOCK=true

--- a/docs/dev-addon-pi.md
+++ b/docs/dev-addon-pi.md
@@ -118,7 +118,9 @@ UI üzerinden:
 
 ## 5. Open Web UI
 
-HA UI → Add-on sayfasında **OPEN WEB UI** butonuna bas. Wizard, Ingress URL'i üzerinden açılır (HA kullanıcı oturumu kontrolünde — harici port yok).
+HA UI → Add-on sayfasında **OPEN WEB UI** butonuna bas. Wizard, Ingress URL'i üzerinden açılır (HA kullanıcı oturumu kontrolünde — Ingress'in kendi auth gate'i devrede).
+
+> **LAN portu (#615):** Add-on aynı zamanda nginx'i `8099/tcp` üzerinden LAN'a açar. Bu port **apps/api'nın kendi `/hassio/*` route'unu Pi'deki Supervisor'a yönlendirebilmesi için** var — dev box'tan `HA_SUPERVISOR_URL=http://homeassistant.local:8099/api/hassio` ile kullanılır. Ingress yerine LAN portu kullanıldığında HA oturum kontrolü devreden çıkar; nginx side'ında auth yok — yani LAN'daki herhangi bir cihaz `/api/hassio/network/*` çağırabilir. **Sadece güvenilir LAN için.** Production add-on (`addon/`) bu portu açmaz. Detay: [docs/dev-supervisor.md](dev-supervisor.md#path-1-preferred--glaon-dev-add-on-on-a-pi-615).
 
 ## 6. Doğrulama: gerçek Wi-Fi handoff
 

--- a/docs/dev-supervisor.md
+++ b/docs/dev-supervisor.md
@@ -44,6 +44,35 @@ Mock mode is enough for most wizard work. Switch to live when you need
 to verify the actual network-update path — e.g. credentials really
 apply, real APs come back from the scan.
 
+> **Important — user LLTs cannot reach `/api/hassio/*` (#602).** Long-lived access tokens authenticate against HA Core's REST API but the `/api/hassio/*` Supervisor proxy only accepts the Supervisor-internal token (which is injected into add-ons with `hassio_api: true`, never available outside). Any external client (apps/api on a dev box, curl from your laptop, etc.) using an LLT against `http://homeassistant.local:8123/api/hassio/*` will 401 — that's HA by-design, not a misconfig. The two real-Supervisor paths below either run **inside an add-on** (browser wizard via Ingress) or **bounce through one** (apps/api via the dev add-on's LAN port).
+
+### Path 1 (preferred) — Glaon dev add-on on a Pi (#615)
+
+The dev add-on (`addon-dev/`) is a sibling of the production add-on. It runs nginx inside an add-on container with `hassio_api: true`, so it gets the real `$SUPERVISOR_TOKEN`. The browser wizard talks to it via HA Ingress; **apps/api** on your dev box talks to it via a LAN port the add-on exposes specifically for this purpose.
+
+Full Pi install runbook: [`docs/dev-addon-pi.md`](dev-addon-pi.md). Once the add-on is running:
+
+```bash
+# apps/api/.env on the dev box
+HA_SUPERVISOR_URL=http://homeassistant.local:8099/api/hassio
+HA_SUPERVISOR_TOKEN=via-addon-proxy   # placeholder — nginx overrides
+```
+
+```bash
+# from anywhere on the LAN
+curl http://localhost:8080/healthz/supervisor
+# { "status": "ok", "mode": "live" }
+
+curl http://localhost:8080/hassio/network/info | jq '.data.interfaces[0].accesspoints | length'
+# real AP count from the Pi
+```
+
+Security trade-off: anything on the LAN can hit `http://homeassistant.local:8099/api/hassio/network/*` and commit Wi-Fi changes. Dev-only, trusted-LAN posture. Production add-on (`addon/`) doesn't expose any LAN port.
+
+### Path 2 — UTM HA OS on macOS (browser wizard only)
+
+Use this when you don't have a Pi handy and need to test the browser wizard against a real Supervisor. **apps/api integration via this path is broken** (LLT 401 against `/api/hassio/*`, see the box above); browser path works because HA Ingress generates session-bound tokens for it.
+
 ### Why not `apps/dev-ha/`?
 
 The fixture in `apps/dev-ha/` runs **HA Core** (the standalone Python
@@ -54,20 +83,13 @@ Supervisor.
 
 You need one of:
 
-1. **HA OS in UTM** (macOS dev — easiest path; covered below).
-2. **HA OS in a VM** (VirtualBox / VMware / Proxmox / Hyper-V).
-3. **HA Supervised** running natively on a Linux host.
-4. **The actual production add-on** running on a real Home Assistant
+1. **Glaon dev add-on on a Pi** (preferred — works for both browser wizard AND apps/api integration; #615 / [docs/dev-addon-pi.md](dev-addon-pi.md)).
+2. **HA OS in UTM** (macOS dev — browser wizard only; apps/api integration won't work via this path due to the LLT 401 problem).
+3. **HA OS in a VM** (VirtualBox / VMware / Proxmox / Hyper-V).
+4. **HA Supervised** running natively on a Linux host.
+5. **The actual production add-on** running on a real Home Assistant
    instance — your dev box runs apps/api + apps/web against it over
    the LAN.
-5. **The Glaon dev add-on** (`addon-dev/`, #607). When live mode below
-   keeps 401-ing on `/api/hassio/*` (it will — see "User-LLT vs
-   Supervisor token" below), this is the only path that actually
-   exercises a real Supervisor + real Wi-Fi. Skips the apps/api proxy
-   entirely; the dev add-on's nginx forwards `/api/hassio/network/*`
-   to `http://supervisor/network/*` from _inside_ the add-on container,
-   where `$SUPERVISOR_TOKEN` works. Setup runbook:
-   [docs/dev-addon-pi.md](dev-addon-pi.md).
 
 ### Live mode: HA OS in UTM (#602)
 


### PR DESCRIPTION
## Summary

- `addon-dev/config.yaml` — add `ports: { 8099/tcp: 8099 }` exposing nginx on the LAN (in addition to `ingress: true`). `ports_description` discloses LAN-trusted posture.
- `apps/api/.env.example` — rewrite the HA Supervisor section: Path 1 (preferred) = dev add-on LAN port with placeholder token; Path 2 = HA Core LLT (flagged broken-against-real-HA per #602); Path 3 = mock.
- `docs/dev-supervisor.md` — front-load the user-LLT 401 disclosure as a callout box; add a "Path 1 (preferred) — Glaon dev add-on on a Pi" section with curl examples; demote the existing UTM section to "browser wizard only" since apps/api via that path is broken; collapse the duplicate Glaon-dev-add-on entry in the path-choices list.
- `docs/dev-addon-pi.md` — brief callout about the LAN port + the trusted-LAN trade-off.

**apps/api code does not change** — it's already a thin passthrough; the add-on's nginx-side `proxy_set_header Authorization` override handles the token.

## Why

The dev add-on (#607 / #608, #610, #612, #614) brought real Supervisor reachability for the browser wizard via HA Ingress. apps/api still couldn't reach a real Supervisor: external LLTs 401 on `/api/hassio/*` (HA by-design, #602), and the Ingress URL token is ephemeral. Result: apps/api was effectively mock-only against real HA, blocking any integration test of its proxy + downstream logic against actual Supervisor responses.

Exposing the dev add-on's nginx on a LAN port reuses the same proxy + token-injection chain that already works for the browser wizard — apps/api becomes a transparent passthrough that bounces through the add-on to reach Supervisor.

## Scope

**In** — listed in Summary.

**Out**

- Bundling `apps/api` inside the add-on container (heavy; would need Mongo too; contradicts ADR 0026's hosted-api positioning).
- Authentication/HMAC on the LAN port — first iteration relies on "trusted LAN" disclosure. If/when a real concern surfaces, follow-up issue adds a shared-secret header.
- Changes to `apps/api/src/routes/hassio-network.ts` — it's already a thin passthrough; nginx-side Authorization override is enough.
- Production `addon/` — does NOT expose any LAN port; this is strictly a dev-variant capability.

## Security trade-off

LAN port = anything on the LAN can hit `/api/hassio/network/*` and commit Wi-Fi changes via Supervisor. Documented in both `docs/dev-supervisor.md` and `docs/dev-addon-pi.md`. Dev-only, trusted-LAN posture is the intentional choice for first iteration.

## Test plan

- [x] Prettier + commitlint + gitleaks pass via lint-staged.
- [ ] CI green on PR.
- [ ] After merge + Pi reinstall: `curl http://localhost:8080/healthz/supervisor` returns `{ status: "ok", mode: "live" }`. _(local-verification, user-driven)_
- [ ] `curl http://localhost:8080/hassio/network/info | jq '.data.interfaces[0].accesspoints | length'` returns a non-zero AP count from the Pi. _(local-verification, user-driven)_
- [ ] POST `/hassio/network/wlan0/update` against apps/api lands the new connection in `nmcli connection show` on the Pi. _(local-verification, user-driven)_

Closes #615
Refs #600, #602, #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)