### PR TITLE
feat(api,core,web): push wizard settings to HA Core config + areas

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -79,3 +79,23 @@ HA_SUPERVISOR_TOKEN=via-addon-proxy
 
 # === Path 3 (mock) ===
 # HA_SUPERVISOR_MOCK=true
+
+# HA Core WebSocket — wizard settings push (#617). The wizard's apply
+# step sends the collected home settings (location, timezone,
+# unit-system, country, language, floors/rooms) to apps/api's
+# POST /setup/apply-ha, which pushes them into HA via WebSocket
+# (config/core/update + config/{floor,area}_registry/create). These
+# commands are WS-only — no REST equivalent.
+#
+# Unlike the Supervisor /api/hassio/* proxy, HA Core's WebSocket auth
+# accepts a long-lived access token (#602). So this DOES work directly
+# from a dev box against HA Core, no add-on bounce needed.
+#
+#   HA_CORE_URL  — HA Core HTTP base (scheme rewritten to ws/wss).
+#   HA_CORE_TOKEN — long-lived access token: HA UI → profile →
+#                   Security → Long-lived access tokens → Create.
+#
+# Both unset → POST /setup/apply-ha responds 503. Dev-first capability
+# (ADR 0029); production onboarding routes through the relay / add-on.
+HA_CORE_URL=http://homeassistant.local:8123
+HA_CORE_TOKEN=

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -41,6 +41,21 @@ const ConfigSchema = z.object({
   supervisorUrl: z.string().url().optional(),
   supervisorToken: z.string().optional(),
   supervisorMock: z.boolean().default(false),
+  // HA Core WebSocket (#617). The setup wizard's apply step pushes the
+  // collected home settings (location, timezone, unit-system, country,
+  // language, floors/rooms) into HA via `config/core/update` +
+  // `config/{floor,area}_registry/create` — all WebSocket-only commands
+  // with no REST equivalent. apps/api opens a WS to HA Core with the
+  // long-lived access token (which HA Core accepts, unlike the
+  // Supervisor `/api/hassio/*` proxy — see #602).
+  //
+  // `haCoreUrl` is the HA Core HTTP base (e.g.
+  // `http://homeassistant.local:8123`); the WS transport rewrites the
+  // scheme. Both unset → `POST /setup/apply-ha` responds 503. This is a
+  // dev-first capability (ADR 0029) — production onboarding routes
+  // through the relay / add-on, not a direct apps/api → HA Core WS.
+  haCoreUrl: z.string().url().optional(),
+  haCoreToken: z.string().optional(),
   buildInfo: z.object({
     commit: z.string().default('unknown'),
     builtAt: z.string().default(''),
@@ -69,6 +84,12 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     supervisorUrl: env.HA_SUPERVISOR_URL === '' ? undefined : env.HA_SUPERVISOR_URL,
     supervisorToken: env.HA_SUPERVISOR_TOKEN === '' ? undefined : env.HA_SUPERVISOR_TOKEN,
     supervisorMock: parseBool(env.HA_SUPERVISOR_MOCK),
+    // Empty-string → undefined, same rationale as the supervisor vars:
+    // a fresh .env-from-example leaves these blank, and the route's
+    // "ha-core-not-configured" 503 branch must fire rather than apps/api
+    // dialing an empty WS URL with an empty token.
+    haCoreUrl: env.HA_CORE_URL === '' ? undefined : env.HA_CORE_URL,
+    haCoreToken: env.HA_CORE_TOKEN === '' ? undefined : env.HA_CORE_TOKEN,
     buildInfo: {
       commit: env.GLAON_API_COMMIT ?? 'unknown',
       builtAt: env.GLAON_API_BUILT_AT ?? '',

--- a/apps/api/src/ha/ha-setup-service.ts
+++ b/apps/api/src/ha/ha-setup-service.ts
@@ -1,0 +1,159 @@
+// HA Core setup service (#617). Pushes the wizard's collected home
+// settings into Home Assistant over the WebSocket API:
+//
+//   - `config/core/update`           → location / timezone / unit-system
+//                                       / country / language
+//   - `config/floor_registry/create` → one per wizard floor
+//   - `config/area_registry/create`  → one per room, linked to its floor
+//
+// These are WebSocket-only commands (no REST). We reuse @glaon/core's
+// `HaClient` + `DirectWsTransport` (globalThis.WebSocket — present in
+// Node 22) and authenticate with the long-lived access token, which HA
+// Core accepts (unlike the Supervisor `/api/hassio/*` proxy — see #602).
+//
+// Execution is best-effort + per-step: every command runs even when an
+// earlier one fails, so the caller gets a full picture rather than a
+// fail-fast that leaves HA half-configured with no record of what
+// landed. A floor-create failure degrades gracefully — its rooms are
+// still created, just without a `floor_id` (older HA builds with no
+// floor registry).
+//
+// Connection failure (WS unreachable / auth rejected) is the one
+// fail-loud case: it throws `HaCoreUnreachableError` so the route maps
+// it to 502 rather than reporting an all-failed step list.
+
+import {
+  HaClient,
+  buildHaSetupPlan,
+  type HaAreaRegistryEntry,
+  type HaFloorRegistryEntry,
+  type HaSetupInput,
+} from '@glaon/core/ha';
+import type { ApplyHaResponse, ApplyHaStepResult } from '@glaon/core/api-client';
+
+import type { Logger } from '../observability/logger';
+import { NodeWsTransport } from './node-ws-transport';
+
+/**
+ * The slice of `HaClient` the service drives. Declared narrowly so tests
+ * inject a fake without a live WebSocket; the real `HaClient` is
+ * structurally assignable.
+ */
+export interface HaSetupClient {
+  connect(): Promise<void>;
+  request<TResult = unknown>(frame: Parameters<HaClient['request']>[0]): Promise<TResult>;
+  close(): Promise<void>;
+}
+
+export class HaCoreUnreachableError extends Error {
+  constructor(cause: string) {
+    super(`HA Core unreachable: ${cause}`);
+    this.name = 'HaCoreUnreachableError';
+  }
+}
+
+interface ApplyHaSetupDeps {
+  /** Builds a fresh client per call. Production wraps DirectWsTransport. */
+  readonly clientFactory: () => HaSetupClient;
+  readonly logger?: Logger;
+}
+
+/**
+ * Run the setup plan against HA. Resolves with per-step results
+ * (`ok: true` only when every attempted step succeeded). Rejects with
+ * `HaCoreUnreachableError` when the connection itself can't be
+ * established — the route turns that into a 502.
+ */
+export async function applyHaSetup(
+  input: HaSetupInput,
+  deps: ApplyHaSetupDeps,
+): Promise<ApplyHaResponse> {
+  const plan = buildHaSetupPlan(input);
+  const steps: ApplyHaStepResult[] = [];
+  const client = deps.clientFactory();
+
+  try {
+    await client.connect();
+  } catch (err) {
+    // Couldn't even open/auth the WS — nothing landed in HA.
+    throw new HaCoreUnreachableError(errMessage(err));
+  }
+
+  try {
+    if (plan.coreUpdate !== null) {
+      steps.push(
+        await runStep('core', deps.logger, () =>
+          client.request({ type: 'config/core/update', ...plan.coreUpdate }),
+        ),
+      );
+    }
+
+    for (const floor of plan.floors) {
+      let floorId: string | undefined;
+      const floorStep = await runStep(`floor:${floor.name}`, deps.logger, async () => {
+        const result = await client.request<HaFloorRegistryEntry>({
+          type: 'config/floor_registry/create',
+          name: floor.name,
+          level: floor.level,
+        });
+        floorId = result.floor_id;
+      });
+      steps.push(floorStep);
+
+      for (const room of floor.rooms) {
+        steps.push(
+          await runStep(`area:${room.name}`, deps.logger, () =>
+            client.request<HaAreaRegistryEntry>({
+              type: 'config/area_registry/create',
+              name: room.name,
+              // Omit floor_id entirely on the degrade path so HA doesn't
+              // reject an `undefined` link.
+              ...(floorId !== undefined ? { floor_id: floorId } : {}),
+            }),
+          ),
+        );
+      }
+    }
+  } finally {
+    // Best-effort close — we already have our results; a close error
+    // shouldn't mask them.
+    await client.close().catch(() => {
+      /* ignore */
+    });
+  }
+
+  return { ok: steps.every((step) => step.ok), steps };
+}
+
+/**
+ * Production client factory — a real `HaClient` over a direct WS to HA
+ * Core, authenticating with the long-lived access token. Heartbeat is
+ * disabled: the connection lives only for the duration of one apply run.
+ */
+export function createHaCoreClientFactory(baseUrl: string, token: string): () => HaSetupClient {
+  return () =>
+    new HaClient(() => new NodeWsTransport({ baseUrl }), {
+      getAccessToken: () => Promise.resolve(token),
+      heartbeatIntervalMs: 0,
+    });
+}
+
+async function runStep(
+  step: string,
+  logger: Logger | undefined,
+  fn: () => Promise<unknown>,
+): Promise<ApplyHaStepResult> {
+  try {
+    await fn();
+    logger?.info({ event: 'ha-setup.step.ok', step });
+    return { step, ok: true };
+  } catch (err) {
+    const error = errMessage(err);
+    logger?.warn({ event: 'ha-setup.step.failed', step, error });
+    return { step, ok: false, error };
+  }
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : 'unknown';
+}

--- a/apps/api/src/ha/node-ws-transport.ts
+++ b/apps/api/src/ha/node-ws-transport.ts
@@ -48,7 +48,9 @@ interface Listeners {
   error: Set<(err: Error) => void>;
 }
 
-export interface NodeWsTransportOptions {
+// Not exported — callers construct NodeWsTransport with an object
+// literal; knip flags an exported-but-unconsumed interface otherwise.
+interface NodeWsTransportOptions {
   /** HA base URL (e.g. `http://homeassistant.local:8123`). Scheme rewritten to ws/wss. */
   readonly baseUrl: string;
   /** Constructor injection for tests; defaults to Node's global WebSocket. */

--- a/apps/api/src/ha/node-ws-transport.ts
+++ b/apps/api/src/ha/node-ws-transport.ts
@@ -1,0 +1,171 @@
+// Node-side HA WebSocket transport (#617). The mirror of @glaon/core's
+// DirectWsTransport, but for the apps/api Node runtime.
+//
+// Why a separate transport: DirectWsTransport is written against the
+// DOM/RN `WebSocket` types (generic `MessageEvent<T>`, `CloseEvent`),
+// which don't exist under apps/api's Node-only tsconfig — and per the
+// package-boundary rule (CLAUDE.md), platform-specific transports live
+// in `apps/*`, not in @glaon/core. This uses Node 22's native global
+// `WebSocket` (undici), typed via a minimal local interface because
+// @types/node 22 doesn't declare the global yet.
+//
+// HaClient drives the auth handshake + id correlation over this wire;
+// the transport just pumps opaque frames (ADR 0016).
+
+import type {
+  CloseInfo,
+  HaInboundFrame,
+  HaOutboundFrame,
+  HaTransport,
+  TransportEvent,
+  TransportEventHandler,
+  TransportSubscription,
+} from '@glaon/core/ha';
+
+/** The slice of the WHATWG WebSocket Node 22 exposes globally that we use. */
+interface NodeWebSocket {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: 'open' | 'error', listener: () => void, opts?: { once?: boolean }): void;
+  addEventListener(
+    type: 'message',
+    listener: (ev: { readonly data: unknown }) => void,
+    opts?: { once?: boolean },
+  ): void;
+  addEventListener(
+    type: 'close',
+    listener: (ev: { readonly code: number; readonly reason: string }) => void,
+    opts?: { once?: boolean },
+  ): void;
+  removeEventListener(type: string, listener: (...args: never[]) => void): void;
+}
+
+type NodeWebSocketCtor = new (url: string) => NodeWebSocket;
+
+interface Listeners {
+  message: Set<(frame: HaInboundFrame) => void>;
+  close: Set<(info: CloseInfo) => void>;
+  error: Set<(err: Error) => void>;
+}
+
+export interface NodeWsTransportOptions {
+  /** HA base URL (e.g. `http://homeassistant.local:8123`). Scheme rewritten to ws/wss. */
+  readonly baseUrl: string;
+  /** Constructor injection for tests; defaults to Node's global WebSocket. */
+  readonly webSocketImpl?: NodeWebSocketCtor;
+}
+
+export class NodeWsTransport implements HaTransport {
+  private socket: NodeWebSocket | null = null;
+  private clientInitiatedClose = false;
+  private readonly listeners: Listeners = {
+    message: new Set(),
+    close: new Set(),
+    error: new Set(),
+  };
+
+  constructor(private readonly options: NodeWsTransportOptions) {}
+
+  connect(): Promise<void> {
+    if (this.socket !== null) {
+      throw new Error('NodeWsTransport.connect: already connected');
+    }
+    const Ctor = this.options.webSocketImpl ?? resolveGlobalWebSocket();
+    const socket = new Ctor(buildWsUrl(this.options.baseUrl));
+    this.socket = socket;
+    this.clientInitiatedClose = false;
+
+    socket.addEventListener('message', (ev) => {
+      const data = typeof ev.data === 'string' ? ev.data : String(ev.data);
+      let parsed: HaInboundFrame;
+      try {
+        parsed = JSON.parse(data) as HaInboundFrame;
+      } catch (cause) {
+        const err = cause instanceof Error ? cause : new Error('NodeWsTransport: malformed frame');
+        for (const listener of this.listeners.error) listener(err);
+        return;
+      }
+      for (const listener of this.listeners.message) listener(parsed);
+    });
+
+    socket.addEventListener('close', (ev) => {
+      const info: CloseInfo = {
+        code: ev.code,
+        reason: ev.reason,
+        clientInitiated: this.clientInitiatedClose,
+      };
+      this.socket = null;
+      for (const listener of this.listeners.close) listener(info);
+    });
+
+    socket.addEventListener('error', () => {
+      const err = new Error('NodeWsTransport: socket error');
+      for (const listener of this.listeners.error) listener(err);
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      socket.addEventListener(
+        'open',
+        () => {
+          resolve();
+        },
+        { once: true },
+      );
+      socket.addEventListener(
+        'error',
+        () => {
+          reject(new Error('NodeWsTransport: failed to open socket'));
+        },
+        { once: true },
+      );
+    });
+  }
+
+  send(frame: HaOutboundFrame): void {
+    if (this.socket === null) {
+      throw new Error('NodeWsTransport.send: not connected');
+    }
+    this.socket.send(JSON.stringify(frame));
+  }
+
+  on<TEvent extends TransportEvent>(
+    event: TEvent,
+    handler: TransportEventHandler<TEvent>,
+  ): TransportSubscription {
+    const bucket = this.listeners[event] as Set<TransportEventHandler<TEvent>>;
+    bucket.add(handler);
+    return () => {
+      bucket.delete(handler);
+    };
+  }
+
+  close(): Promise<void> {
+    const socket = this.socket;
+    if (socket === null) return Promise.resolve();
+    this.clientInitiatedClose = true;
+    return new Promise<void>((resolve) => {
+      socket.addEventListener(
+        'close',
+        () => {
+          resolve();
+        },
+        { once: true },
+      );
+      socket.close(1000, 'client closed');
+    });
+  }
+}
+
+function resolveGlobalWebSocket(): NodeWebSocketCtor {
+  const candidate = (globalThis as { WebSocket?: NodeWebSocketCtor }).WebSocket;
+  if (candidate === undefined) {
+    throw new Error('NodeWsTransport: global WebSocket unavailable (needs Node >= 22)');
+  }
+  return candidate;
+}
+
+function buildWsUrl(baseUrl: string): string {
+  const url = new URL('/api/websocket', baseUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.toString();
+}

--- a/apps/api/src/routes/setup.test.ts
+++ b/apps/api/src/routes/setup.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Config } from '../config';
+import type { HaSetupClient } from '../ha/ha-setup-service';
+import { createSetupRouter } from './setup';
+
+function baseConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    port: 8080,
+    mongodbUri: 'mongodb://localhost:27017',
+    mongodbDb: 'glaon-test',
+    logLevel: 'info',
+    sessionJwtSecret: 'a'.repeat(32),
+    sessionTtlSeconds: 3600,
+    webOrigins: [],
+    supervisorMock: false,
+    buildInfo: { version: '0.0.0-test', commit: 'deadbeef', builtAt: '2026-05-09T00:00:00Z' },
+    ...overrides,
+  };
+}
+
+interface RecordedFrame {
+  readonly type: string;
+  readonly [key: string]: unknown;
+}
+
+/** Fake HaSetupClient: records frames, returns registry ids by type. */
+function fakeClient(opts: {
+  connectError?: Error;
+  failTypes?: Set<string>;
+  sink: RecordedFrame[];
+}): HaSetupClient {
+  return {
+    connect: () => (opts.connectError ? Promise.reject(opts.connectError) : Promise.resolve()),
+    request: <TResult = unknown>(frame: unknown): Promise<TResult> => {
+      const f = frame as RecordedFrame;
+      opts.sink.push(f);
+      if (opts.failTypes?.has(f.type)) {
+        return Promise.reject(new Error(`HA rejected ${f.type}`));
+      }
+      if (f.type === 'config/floor_registry/create') {
+        return Promise.resolve({ floor_id: `floor_${String(f.name)}`, name: f.name } as TResult);
+      }
+      if (f.type === 'config/area_registry/create') {
+        return Promise.resolve({ area_id: `area_${String(f.name)}`, name: f.name } as TResult);
+      }
+      return Promise.resolve({} as TResult);
+    },
+    close: () => Promise.resolve(),
+  };
+}
+
+const FULL_BODY = {
+  latitude: 41.0082,
+  longitude: 28.9784,
+  unitSystem: 'metric' as const,
+  timezone: 'Europe/Istanbul',
+  country: 'TR',
+  locale: 'tr',
+  layout: {
+    floors: [{ name: 'Ground', rooms: [{ name: 'Living' }, { name: 'Kitchen' }] }],
+  },
+};
+
+async function post(
+  router: ReturnType<typeof createSetupRouter>,
+  body: unknown,
+): Promise<Response> {
+  return router.request('/apply-ha', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+describe('setup — unconfigured', () => {
+  it('responds 503 when HA Core URL + token are unset and no client is injected', async () => {
+    const router = createSetupRouter({ config: baseConfig() });
+    const res = await post(router, FULL_BODY);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ error: 'ha-core-not-configured' });
+  });
+});
+
+describe('setup — validation', () => {
+  it('responds 400 on a malformed body without touching HA', async () => {
+    const sink: RecordedFrame[] = [];
+    const clientFactory = vi.fn(() => fakeClient({ sink }));
+    const router = createSetupRouter({ config: baseConfig(), clientFactory });
+    const res = await post(router, 'not-json');
+    expect(res.status).toBe(400);
+    expect(clientFactory).not.toHaveBeenCalled();
+  });
+
+  it('responds 400 when country is not ISO alpha-2', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink }),
+    });
+    const res = await post(router, { ...FULL_BODY, country: 'turkey' });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('setup — happy path', () => {
+  it('sends core update + floor + areas and reports ok=true', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink }),
+    });
+    const res = await post(router, FULL_BODY);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; steps: { step: string; ok: boolean }[] };
+    expect(body.ok).toBe(true);
+    expect(body.steps.map((s) => s.step)).toEqual([
+      'core',
+      'floor:Ground',
+      'area:Living',
+      'area:Kitchen',
+    ]);
+
+    const core = sink.find((f) => f.type === 'config/core/update');
+    expect(core).toMatchObject({
+      latitude: 41.0082,
+      longitude: 28.9784,
+      unit_system: 'metric',
+      time_zone: 'Europe/Istanbul',
+      country: 'TR',
+      language: 'tr',
+    });
+    // Areas carry the floor_id returned by the floor create.
+    const living = sink.find(
+      (f) => f.type === 'config/area_registry/create' && f.name === 'Living',
+    );
+    expect(living).toMatchObject({ floor_id: 'floor_Ground' });
+  });
+});
+
+describe('setup — partial failure', () => {
+  it('degrades gracefully when floor create fails (areas created floor-less, ok=false)', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () =>
+        fakeClient({ sink, failTypes: new Set(['config/floor_registry/create']) }),
+    });
+    const res = await post(router, FULL_BODY);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; steps: { step: string; ok: boolean }[] };
+    expect(body.ok).toBe(false);
+    expect(body.steps.find((s) => s.step === 'floor:Ground')?.ok).toBe(false);
+    // Areas still attempted, and without a floor_id (degrade path).
+    expect(body.steps.find((s) => s.step === 'area:Living')?.ok).toBe(true);
+    const living = sink.find(
+      (f) => f.type === 'config/area_registry/create' && f.name === 'Living',
+    );
+    expect(living).not.toHaveProperty('floor_id');
+  });
+});
+
+describe('setup — unreachable', () => {
+  it('responds 502 when the HA Core connection cannot be established', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink, connectError: new Error('ECONNREFUSED') }),
+    });
+    const res = await post(router, FULL_BODY);
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({ error: 'ha-unreachable' });
+  });
+});

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -1,0 +1,88 @@
+// Setup-wizard → HA config route (#617). The wizard's apply step POSTs
+// the collected home settings here; we translate them into HA Core
+// WebSocket commands (see ha/ha-setup-service.ts) and report per-step
+// results.
+//
+// Authentication: like the hassio-network proxy, this route is **not**
+// gated by `requireSession` — the setup wizard runs before any user
+// account exists. CORS + the dev-only nature of standalone mode are the
+// barriers. Production onboarding does not hit this route (ADR 0029).
+//
+// Responses:
+//   - 200 { ok, steps }   commands attempted; `ok` is true only if all
+//                         succeeded. Partial failure is still 200 — the
+//                         per-step array tells the client what landed.
+//   - 400 invalid-body    Zod rejected the payload.
+//   - 502 ha-unreachable  couldn't open / auth the WS to HA Core.
+//   - 503 not-configured  HA_CORE_URL / HA_CORE_TOKEN unset.
+
+import { Hono } from 'hono';
+
+import { ApplyHaRequestSchema } from '@glaon/core/api-client';
+
+import type { Config } from '../config';
+import type { Logger } from '../observability/logger';
+import {
+  applyHaSetup,
+  createHaCoreClientFactory,
+  HaCoreUnreachableError,
+  type HaSetupClient,
+} from '../ha/ha-setup-service';
+
+interface SetupRouterDeps {
+  readonly config: Config;
+  /** Injectable for tests — defaults to a real HA Core WS client. */
+  readonly clientFactory?: () => HaSetupClient;
+  readonly logger?: Logger;
+}
+
+export function createSetupRouter(deps: SetupRouterDeps): Hono {
+  const router = new Hono();
+  const { haCoreUrl, haCoreToken } = deps.config;
+
+  router.post('/apply-ha', async (c) => {
+    const raw: unknown = await c.req.json().catch(() => null);
+    const parsed = ApplyHaRequestSchema.safeParse(raw);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid-body' }, 400);
+    }
+
+    // A test-injected factory bypasses the env requirement; otherwise we
+    // need the URL + token to build the real client.
+    const factory =
+      deps.clientFactory ??
+      (haCoreUrl !== undefined && haCoreToken !== undefined
+        ? createHaCoreClientFactory(haCoreUrl, haCoreToken)
+        : undefined);
+
+    if (factory === undefined) {
+      return c.json(
+        {
+          error: 'ha-core-not-configured',
+          hint: 'Set HA_CORE_URL + HA_CORE_TOKEN (a long-lived access token). See docs/dev-supervisor.md.',
+        },
+        503,
+      );
+    }
+
+    try {
+      const result = await applyHaSetup(parsed.data, {
+        clientFactory: factory,
+        ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
+      });
+      return c.json(result, 200);
+    } catch (err) {
+      if (err instanceof HaCoreUnreachableError) {
+        deps.logger?.error({ event: 'setup.apply-ha.unreachable', message: err.message });
+        return c.json({ error: 'ha-unreachable' }, 502);
+      }
+      deps.logger?.error({
+        event: 'setup.apply-ha.failed',
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+      return c.json({ error: 'internal' }, 500);
+    }
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -18,16 +18,15 @@
 
 import { Hono } from 'hono';
 
-import { ApplyHaRequestSchema } from '@glaon/core/api-client';
-
 import type { Config } from '../config';
-import type { Logger } from '../observability/logger';
 import {
   applyHaSetup,
   createHaCoreClientFactory,
   HaCoreUnreachableError,
   type HaSetupClient,
 } from '../ha/ha-setup-service';
+import type { Logger } from '../observability/logger';
+import { ApplyHaRequestSchema } from '../schemas';
 
 interface SetupRouterDeps {
   readonly config: Config;

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -8,6 +8,7 @@
 // request validators are surfaced here.
 
 export {
+  ApplyHaRequestSchema,
   AuthExchangeRequestSchema,
   AuthRefreshRequestSchema,
   HaPasswordGrantRequestSchema,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -17,6 +17,7 @@ import { createAuthRouter } from './routes/auth';
 import { createHassioNetworkRouter, probeSupervisor } from './routes/hassio-network';
 import { createLayoutsRouter } from './routes/layouts';
 import { createMeRouter } from './routes/me';
+import { createSetupRouter } from './routes/setup';
 
 export interface ServerDeps {
   readonly db: Db;
@@ -86,6 +87,19 @@ export function createServer(deps: ServerDeps): Hono {
     createHassioNetworkRouter({
       config: deps.config,
       ...(deps.fetchImpl !== undefined ? { fetchImpl: deps.fetchImpl } : {}),
+      logger,
+    }),
+  );
+
+  // Setup-wizard → HA config push (#617). The wizard's apply step POSTs
+  // the collected home settings; we translate them into HA Core
+  // WebSocket commands. Unauthenticated by design (wizard is pre-login),
+  // same posture as /hassio. Dev-first — production onboarding routes
+  // through the relay / add-on, not this route (ADR 0029).
+  app.route(
+    '/setup',
+    createSetupRouter({
+      config: deps.config,
       logger,
     }),
   );

--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -53,6 +53,15 @@ async function mockSupervisorNetworkScan(page: Page): Promise<void> {
   await page.route('**/api/hassio/network/wlan0/update', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: '{"result":"ok"}' });
   });
+  // #617 — the apply step pushes home settings to HA Core before the
+  // Wi-Fi handoff. Mock a clean success so the commit ceremony proceeds.
+  await page.route('**/api/setup/apply-ha', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, steps: [] }),
+    });
+  });
 }
 
 test.describe('setup wizard @smoke', () => {

--- a/apps/web/src/features/setup/apply/apply-step.test.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.test.tsx
@@ -56,6 +56,33 @@ const sampleSupervisorPayload = {
   },
 };
 
+/** Default success response for the HA-settings push (#617). */
+const haApplyOk = { ok: true, steps: [] };
+
+/**
+ * URL-aware default mock: the wizard's commit fires two POSTs —
+ * `/api/setup/apply-ha` (HA config push) then the supervisor wifi
+ * update — plus the GET network scan. Route each so one doesn't get the
+ * other's payload.
+ */
+function defaultFetch(url: unknown): Promise<Response> {
+  const u = String(url);
+  if (u.includes('/api/setup/apply-ha')) {
+    return Promise.resolve(mockFetchResponse({ json: haApplyOk }));
+  }
+  return Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }));
+}
+
+/** Find the supervisor wifi-update POST specifically (not the apply-ha POST). */
+function findWifiPost(): unknown[] | undefined {
+  const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+  return calls.find(
+    ([url, init]) =>
+      (init as { method?: string } | undefined)?.method === 'POST' &&
+      String(url).includes('/hassio/'),
+  );
+}
+
 const reloadSpy = vi.fn();
 
 beforeEach(() => {
@@ -66,7 +93,7 @@ beforeEach(() => {
   reloadSpy.mockReset();
   vi.stubGlobal(
     'fetch',
-    vi.fn(() => Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }))),
+    vi.fn((url: unknown) => defaultFetch(url)),
   );
 });
 
@@ -143,10 +170,7 @@ describe('ApplyStep — populated mode', () => {
     await waitFor(() => {
       expect(reloadSpy).toHaveBeenCalledTimes(1);
     });
-    const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    const postCall = calls.find(
-      ([, init]) => (init as { method?: string } | undefined)?.method === 'POST',
-    );
+    const postCall = findWifiPost();
     expect(postCall).toBeDefined();
     const body = JSON.parse((postCall?.[1] as { body: string }).body) as {
       wifi: { auth: string };
@@ -190,10 +214,7 @@ describe('ApplyStep — populated mode', () => {
     const persistedCipher = persisted?.wifi?.passwordCipher ?? '';
     expect(isWrapped(persistedCipher)).toBe(true);
     expect(persistedCipher).not.toBe('fresh-secret');
-    const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    const postCall = calls.find(
-      ([, init]) => (init as { method?: string } | undefined)?.method === 'POST',
-    );
+    const postCall = findWifiPost();
     const body = JSON.parse((postCall?.[1] as { body: string }).body) as {
       wifi: { auth: string; psk: string };
     };
@@ -202,16 +223,18 @@ describe('ApplyStep — populated mode', () => {
   });
 
   it('surfaces a Toast and stays on the apply step when the Supervisor commit fails', async () => {
-    // Scan succeeds; the network-update POST fails.
-    let callCount = 0;
+    // Scan + HA-settings push succeed; the supervisor wifi-update POST fails.
     vi.stubGlobal(
       'fetch',
-      vi.fn(() => {
-        callCount += 1;
-        if (callCount === 1) {
-          return Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }));
+      vi.fn((url: unknown, init?: { method?: string }) => {
+        const u = String(url);
+        if (u.includes('/api/setup/apply-ha')) {
+          return Promise.resolve(mockFetchResponse({ json: haApplyOk }));
         }
-        return Promise.resolve(mockFetchResponse({ ok: false, status: 500 }));
+        if (init?.method === 'POST' && u.includes('/hassio/')) {
+          return Promise.resolve(mockFetchResponse({ ok: false, status: 500 }));
+        }
+        return Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }));
       }),
     );
     const { findByText, getByRole, findByRole } = render(
@@ -221,6 +244,34 @@ describe('ApplyStep — populated mode', () => {
     fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
     expect(await findByRole('status')).toBeInTheDocument();
     expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it('aborts before the wifi handoff and toasts when the HA-settings push fails', async () => {
+    // HA-settings push reports a partial failure; the wizard must not
+    // switch wifi (no /hassio/ POST) and must stay on the apply step.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: unknown) => {
+        const u = String(url);
+        if (u.includes('/api/setup/apply-ha')) {
+          return Promise.resolve(
+            mockFetchResponse({
+              json: { ok: false, steps: [{ step: 'core', ok: false, error: 'boom' }] },
+            }),
+          );
+        }
+        return Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }));
+      }),
+    );
+    const { findByText, getByRole, findByRole } = render(
+      wrap(<ApplyStep collected={baseCollected} />),
+    );
+    fireEvent.click(await findByText('Guest'));
+    fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
+    expect(await findByRole('status')).toBeInTheDocument();
+    expect(reloadSpy).not.toHaveBeenCalled();
+    // Crucially, the destructive wifi switch never fired.
+    expect(findWifiPost()).toBeUndefined();
   });
 });
 

--- a/apps/web/src/features/setup/apply/apply-step.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.tsx
@@ -36,6 +36,7 @@ import { Button, PasswordInput, useToast } from '@glaon/ui';
 import { useCallback, useEffect, useId, useMemo, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { ApplyHaResponse } from '@glaon/core/api-client';
 import type { DeviceConfigInput, Layout } from '@glaon/core/config';
 
 import { useDeviceConfig } from '../../../config/config-provider';
@@ -58,6 +59,10 @@ interface ApplyStepProps {
 const SUPERVISOR_NETWORK_INTERFACE = 'wlan0';
 const SUPERVISOR_NETWORK_UPDATE = `/api/hassio/network/${SUPERVISOR_NETWORK_INTERFACE}/update`;
 const SUPERVISOR_NETWORK_INFO = '/api/hassio/network/info';
+
+// #617 — apps/api endpoint that pushes the collected home settings into
+// HA Core (config/core/update + floor/area registry) over WebSocket.
+const HA_APPLY_SETTINGS = '/api/setup/apply-ha';
 
 // Hard-coded URL the QR code encodes. The mDNS responder advertises
 // the device under `glaon.local` on the home network (addon-side
@@ -133,6 +138,58 @@ async function pushWifiToSupervisor({ ssid, password, secured }: PushWifiArgs): 
   if (!response.ok) {
     throw new Error(`Supervisor responded ${String(response.status)}`);
   }
+}
+
+/**
+ * Outcome of pushing the collected home settings into HA Core (#617).
+ *   - `ok`       every command landed.
+ *   - `skipped`  apps/api has no HA Core configured (503) — expected in
+ *                dev when HA_CORE_* is unset; not a user-facing error.
+ *   - `partial`  some commands failed (HA reachable, rejected a step).
+ *   - `error`    couldn't reach apps/api / HA, or a malformed response.
+ */
+type HaApplyOutcome =
+  | { readonly kind: 'ok' }
+  | { readonly kind: 'skipped' }
+  | { readonly kind: 'partial' }
+  | { readonly kind: 'error' };
+
+/**
+ * POST the wizard's home settings to apps/api, which pushes them into HA
+ * Core over WebSocket. The room/floor extras (ids, room `type`) ride
+ * along — apps/api's Zod schema strips anything it doesn't consume.
+ * Non-blocking by contract: callers decide what a non-`ok`/`skipped`
+ * outcome means for the commit ceremony.
+ */
+async function pushSettingsToHa(collected: DeviceConfigInput): Promise<HaApplyOutcome> {
+  const body: Record<string, unknown> = {};
+  if (collected.latitude !== undefined) body.latitude = collected.latitude;
+  if (collected.longitude !== undefined) body.longitude = collected.longitude;
+  if (collected.unitSystem !== undefined) body.unitSystem = collected.unitSystem;
+  if (collected.timezone !== undefined) body.timezone = collected.timezone;
+  if (collected.country !== undefined) body.country = collected.country;
+  if (collected.locale !== undefined) body.locale = collected.locale;
+  if (collected.layout !== undefined) body.layout = collected.layout;
+
+  // Nothing collected that maps to HA → no-op success.
+  if (Object.keys(body).length === 0) return { kind: 'ok' };
+
+  let response: Response;
+  try {
+    response = await fetch(HA_APPLY_SETTINGS, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return { kind: 'error' };
+  }
+  if (response.status === 503) return { kind: 'skipped' };
+  if (!response.ok) return { kind: 'error' };
+  const json = (await response.json().catch(() => null)) as ApplyHaResponse | null;
+  if (json === null) return { kind: 'error' };
+  return json.ok ? { kind: 'ok' } : { kind: 'partial' };
 }
 
 // =============================================================
@@ -218,6 +275,26 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
 
   async function runCommit(secureWifiPassword: string): Promise<void> {
     setHandoffPhase('committing');
+
+    // Push home settings to HA *before* the Wi-Fi handoff (#617). This
+    // step is non-destructive and the network is still stable, so a
+    // failure can abort cleanly before we switch Wi-Fi. A `skipped`
+    // outcome (apps/api has no HA Core configured — dev) is fine and
+    // proceeds silently; only a hard failure / partial apply stops the
+    // ceremony so the user can retry without a half-applied home.
+    if (!isStandaloneMode()) {
+      const haOutcome = await pushSettingsToHa(collected);
+      if (haOutcome.kind === 'error' || haOutcome.kind === 'partial') {
+        setHandoffPhase(passwordRequired ? 'confirming' : 'idle');
+        toast.show({
+          intent: 'danger',
+          title: t('setup.apply.haSettingsFailed.title'),
+          description: t('setup.apply.haSettingsFailed.description'),
+        });
+        return;
+      }
+    }
+
     try {
       // The plaintext password lives in the modal's confirm field
       // (`secureWifiPassword`) — used as-is for the supervisor POST

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -216,6 +216,10 @@
         "title": "Couldn't complete setup",
         "description": "Home Assistant didn't accept the configuration. Check the connection and try again."
       },
+      "haSettingsFailed": {
+        "title": "Couldn't save settings to Home Assistant",
+        "description": "We didn't switch your Wi-Fi yet. Some home settings couldn't be applied — check the connection and try again."
+      },
       "actions": {
         "save": "Save and switch network"
       }

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -216,6 +216,10 @@
         "title": "Kurulum tamamlanamadı",
         "description": "Home Assistant ayarları kabul etmedi. Bağlantıyı kontrol edip tekrar dene."
       },
+      "haSettingsFailed": {
+        "title": "Ayarlar Home Assistant'a kaydedilemedi",
+        "description": "Wi-Fi henüz değiştirilmedi. Bazı ev ayarları uygulanamadı — bağlantıyı kontrol edip tekrar dene."
+      },
       "actions": {
         "save": "Kaydet ve ağa geç"
       }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -105,6 +105,16 @@ export default defineConfig(({ command, mode }) => {
           changeOrigin: true,
           rewrite: (path: string) => path.replace(/^\/api/, ''),
         },
+        // #617 — the apply step also POSTs the collected home settings
+        // to `/api/setup/apply-ha`; apps/api pushes them into HA Core
+        // over WebSocket. Same `/api` strip → apps/api mounts at
+        // `/setup`. Production add-on bypasses this (onboarding routes
+        // through the relay / add-on, not apps/api — ADR 0029).
+        '/api/setup': {
+          target: env.VITE_API_BASE_URL ?? 'http://localhost:8080',
+          changeOrigin: true,
+          rewrite: (path: string) => path.replace(/^\/api/, ''),
+        },
       },
     },
     build: {

--- a/docs/adr/0029-apps-api-ha-core-direct-ws.md
+++ b/docs/adr/0029-apps-api-ha-core-direct-ws.md
@@ -1,0 +1,70 @@
+# ADR 0029 — Setup wizard ayar push'u: apps/api → HA Core doğrudan WebSocket (dev-first)
+
+- **Durum:** Accepted
+- **Karar tarihi:** 2026-05-28
+- **Karar verenler:** @toss-cengiz
+- **İlgili konular:** [ADR 0016](0016-ha-ws-transport.md), [ADR 0026](0026-apps-api-delivery-hosted.md), [ADR 0028](0028-device-config-state.md), [issue #617](https://github.com/Glaon-Smart/glaon/issues/617), [issue #602](https://github.com/Glaon-Smart/glaon/issues/602), [issue #607](https://github.com/Glaon-Smart/glaon/issues/607)
+
+## Bağlam
+
+Setup wizard'ın apply step'i (#597) kullanıcının evini tarif eden ayarları topluyor: konum (lat/lon), saat dilimi, ölçü sistemi, ülke, dil ve çok katlı layout (floors/rooms). Wi-Fi handoff'u (#594/#607) artık gerçek HA Supervisor'a iniyor, ama geri kalan ayarlar yalnızca tarayıcının `localStorage`'ında (`glaon.device-config`, [ADR 0028](0028-device-config-state.md)) duruyordu — Home Assistant'a hiç ulaşmıyorlardı. Wizard'da tarif edilen ev, HA tarafında yapılandırılmıyordu.
+
+Bu ayarları HA'ya yazmak için iki teknik kısıt var:
+
+1. **HA Core config + registry yazımları WebSocket-only.** `config/core/update`, `config/floor_registry/create`, `config/area_registry/create` komutlarının REST karşılığı yok.
+2. **Supervisor REST proxy (`/api/hassio/*`) user LLT kabul etmiyor** (#602) — yalnızca add-on'a inject edilen Supervisor token'ı geçerli. Ama **HA Core'un kendi WebSocket auth'u LLT kabul ediyor** (HA Core `/api/` LLT ile 200 dönüyor).
+
+[ADR 0026](0026-apps-api-delivery-hosted.md) `apps/api`'ı hosted servis olarak konumlandırdı; HA'ya **cloud relay** üzerinden bağlanması bekleniyor, doğrudan değil. Dolayısıyla "apps/api → HA Core doğrudan WS" yeni bir desen ve ADR 0026'nın production modelinden sapıyor.
+
+Göz önünde bulundurulan alternatifler:
+
+- **Seçenek A — Tarayıcı (apps/web) HaClient + DirectWsTransport ile doğrudan HA'ya yazar.** Reddedildi: wizard login-öncesi çalışıyor; standalone modda tarayıcının HA WS token'ı yok, Ingress modda token ephemeral ve cookie-bağımlı. Kullanıcı da "API yapsın" dedi.
+- **Seçenek B — apps/api'ı add-on container'ı içinde çalıştırıp Supervisor token ile yaz.** Reddedildi: ADR 0026 apps/api'ı hosted tutuyor; Mongo + Node'u add-on'a paketlemek ağır ve frozen kararla çelişiyor.
+- **Seçenek C — Production relay yolu.** Doğru uzun-vade modeli ama relay backend henüz hazır değil (#345 ailesi); dev döngüsünü bloklar.
+- **Seçenek D (seçilen) — apps/api HA Core'a doğrudan WS açar, LLT ile auth olur. Dev-first.**
+
+## Karar
+
+**Setup ayar push'u, dev/standalone runtime'da `apps/api`'ın HA Core'a doğrudan WebSocket açıp long-lived access token ile auth olarak `config/*` komutlarını göndermesiyle yapılır.** Bu bilinçli olarak dev-first bir capability'dir; production onboarding'i relay / add-on üzerinden gider (ayrı epic) ve bu doğrudan-WS yolu production modeli olarak görülmez.
+
+Teknik detaylar:
+
+- **Mapping `@glaon/core`'da, pure.** `ha/setup-commands.ts` device-config alt kümesini sıralı bir plana çevirir (`buildHaSetupPlan`). `imperial → us_customary`, locale → HA `language` primary subtag dönüşümleri burada. WS frame tipleri (`config/core/update`, `config/{floor,area}_registry/create`) `HaOutboundFrame` union'ına eklendi.
+- **HaClient yeniden kullanılır (ADR 0016).** Transport-agnostic client + auth handshake + id korelasyonu hazır. apps/api Node-tarafı bir transport sağlar (`apps/api/src/ha/node-ws-transport.ts`, Node 22 global `WebSocket`), çünkü core'un `DirectWsTransport`'u DOM tipleri (`MessageEvent<T>`, `CloseEvent`) kullanıyor ve Node tsconfig'inde yok. Bu, package-boundary kuralına uyar: platform-spesifik transport `apps/*`'ta yaşar. `DirectWsTransport` artık `@glaon/core/ha` barrel'ından değil, `@glaon/core/ha/direct-ws` subpath'inden import edilir — Node tüketicisi DOM bağımlılığı miras almaz.
+- **Route `POST /setup/apply-ha`, unauthenticated.** Wizard login-öncesi olduğu için hassio-network proxy'siyle aynı duruş: `requireSession` yok, CORS + dev-only mod bariyer. `HA_CORE_URL` + `HA_CORE_TOKEN` set değilse 503; WS açılamazsa 502; per-step sonuç (`{ ok, steps }`).
+- **Best-effort, per-step.** Her komut, önceki başarısız olsa bile çalışır. Floor-create başarısızsa room'lar yine yaratılır (floor'suz — eski HA'da floor registry yoksa graceful degrade). Tarayıcı tarafı: HA push **Wi-Fi handoff'tan ÖNCE** (non-destructive sırada) çalışır; hard failure'da ceremony abort edilir ve Wi-Fi switch hiç tetiklenmez.
+- **Konfigürasyon.** `HA_CORE_URL` (HA Core HTTP base, scheme ws/wss'e çevrilir) + `HA_CORE_TOKEN` (LLT). `HA_SUPERVISOR_URL` (add-on proxy) ile ayrı.
+
+## Sonuçlar
+
+### Olumlu
+
+- Wizard'ın topladığı ayarlar artık gerçek HA'ya iniyor — "evi gerçekten yapılandırma" hikayesi tamam.
+- HA Core WS auth LLT kabul ettiği için dev box'tan doğrudan çalışır; add-on bounce gerekmez (Wi-Fi push'un aksine).
+- HaClient + transport-agnostic mimari (ADR 0016) gerçek bir ikinci tüketiciyle (Node) doğrulandı; `request()`'in distributive-Omit tip hatası bu sırada düzeltildi.
+- Mapping pure + unit-test'li; route fake client ile test'li.
+
+### Olumsuz / ödenecek bedel
+
+- ADR 0026'nın "apps/api HA'ya relay üzerinden bağlanır" modelinden sapan ikinci bir yol var. Bu sapma dev-first olarak işaretli ama yanlış anlaşılma riski taşıyor — bu yüzden bu ADR yazıldı.
+- Production onboarding için ayar push'u **henüz çözülmedi**; relay/add-on yolu ayrı bir epic.
+- apps/api artık (dev'de) HA Core'a giden bir LLT tutuyor — Supervisor proxy'sinin placeholder token'ından farklı, gerçek bir secret. `.env`'de, asla commit edilmez.
+
+### Etkileri
+
+- **Kod organizasyonu:** Node WS transport `apps/api`'da; core'un ha barrel'ı Node-safe oldu (DirectWsTransport subpath'e taşındı).
+- **CI/build:** Ek bağımlılık yok (Node 22 global WebSocket). Üç pakette test eklendi.
+- **Göç:** Production relay yolu geldiğinde `applyHaSetup`'ın transport/client factory'si değişir; mapping + route contract aynı kalır.
+
+## Tekrar değerlendirme tetikleyicileri
+
+- Cloud relay backend (#345 ailesi) production'a hazır olduğunda: ayar push'u relay üzerinden yapılacak; bu doğrudan-WS yolu dev-only'ye sıkışır veya kaldırılır — yeni ADR.
+- HA base image s6-overlay/WebSocket davranışı değişirse veya `@types/node` global `WebSocket`/`MessageEvent`/`CloseEvent` tiplerini eklerse: `node-ws-transport.ts`'in local tip declaration'ı sadeleşebilir.
+
+## Referanslar
+
+- [ADR 0016 — HaClient transport mimarisi](0016-ha-ws-transport.md)
+- [ADR 0026 — apps/api delivery: hosted](0026-apps-api-delivery-hosted.md)
+- [ADR 0028 — device-config state](0028-device-config-state.md)
+- [docs/dev-supervisor.md](../dev-supervisor.md) — HA Core WS env + dev kurulum
+- HA WebSocket API: <https://developers.home-assistant.io/docs/api/websocket>

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,36 +45,37 @@ Deprecated durumu, kararı yapılacak işin dışına çıkarttığımızda kull
 
 ## Index
 
-| #    | Başlık                                                                                  | Durum              | Tarih      |
-| ---- | --------------------------------------------------------------------------------------- | ------------------ | ---------- |
-| 0001 | [Turborepo + pnpm workspaces](0001-turborepo-pnpm-workspaces.md)                        | Accepted           | 2026-04-20 |
-| 0002 | [Vite + React 19 (web)](0002-vite-react-19-web.md)                                      | Accepted           | 2026-04-20 |
-| 0003 | [Expo SDK + new architecture (mobile)](0003-expo-new-architecture-mobile.md)            | Accepted           | 2026-04-20 |
-| 0004 | [`@glaon/core` platform-agnostic paylaşım paketi](0004-glaon-core-platform-agnostic.md) | Accepted           | 2026-04-20 |
-| 0005 | [OAuth2 Authorization Code + PKCE (tek auth yöntemi)](0005-oauth2-pkce-only-auth.md)    | Superseded by 0017 | 2026-04-20 |
-| 0006 | [Token storage — in-memory + httpOnly / SecureStore](0006-token-storage.md)             | Accepted           | 2026-04-20 |
-| 0007 | [Sentry observability backend olarak](0007-sentry-observability.md)                     | Accepted           | 2026-04-20 |
-| 0008 | [Chromatic tek görsel regresyon aracı](0008-chromatic-visual-regression.md)             | Accepted           | 2026-04-21 |
-| 0009 | [HA Add-on + Ingress teslim kanalı](0009-ha-addon-ingress-delivery.md)                  | Accepted           | 2026-04-20 |
-| 0010 | [Figma tasarım kaynağı + plugin bridge](0010-figma-source-of-truth.md)                  | Accepted           | 2026-04-22 |
-| 0011 | [Untitled UI React kit + CLI source-based delivery](0011-untitled-ui-react-kit.md)      | Accepted           | 2026-04-27 |
-| 0012 | [Tailwind CSS for `@glaon/ui`](0012-tailwind-css-for-glaon-ui.md)                       | Superseded by 0013 | 2026-04-27 |
-| 0013 | [Tailwind v4 + Untitled UI theme.css](0013-tailwind-v4-uui-theme.md)                    | Accepted           | 2026-04-27 |
-| 0014 | [`apps/api` ayrı backend service (Next.js geçişi yerine)](0014-apps-api-over-nextjs.md) | Accepted           | 2026-05-06 |
-| 0015 | [State yönetimi — Zustand + Immer + TanStack Query](0015-state-management.md)           | Accepted           | 2026-05-07 |
-| 0016 | [HA WebSocket transport mimarisi](0016-ha-ws-transport.md)                              | Accepted           | 2026-05-07 |
-| 0017 | [Dual-mode auth — local HA OAuth + cloud-relay (Clerk)](0017-dual-mode-auth.md)         | Accepted           | 2026-05-07 |
-| 0018 | [Cloud relay topology + wire protocol](0018-cloud-relay-topology.md)                    | Accepted           | 2026-05-07 |
-| 0019 | [Identity provider — Clerk (cloud mod için)](0019-identity-provider-clerk.md)           | Accepted           | 2026-05-07 |
-| 0020 | [Cloud hosting platform — CF Workers + Durable Objects](0020-cloud-hosting-platform.md) | Accepted           | 2026-05-07 |
-| 0021 | [Pairing protocol + relay credential lifecycle](0021-pairing-and-relay-credentials.md)  | Accepted           | 2026-05-07 |
-| 0022 | [Cloud deployment + secrets pipeline](0022-cloud-deployment-secrets.md)                 | Accepted           | 2026-05-07 |
-| 0023 | [i18n library + file format + RTL strategy](0023-i18n-library-format-rtl.md)            | Accepted           | 2026-05-07 |
-| 0024 | [Lokal keşif: HA hostname'ine bağ kal](0024-local-discovery-rely-on-ha-hostname.md)     | Accepted           | 2026-05-08 |
-| 0025 | [apps/api stack pick — Hono + native MongoDB + Zod](0025-apps-api-stack.md)             | Accepted           | 2026-05-09 |
-| 0026 | [apps/api delivery: Glaon-managed hosted](0026-apps-api-delivery-hosted.md)             | Accepted           | 2026-05-10 |
-| 0027 | [HA `login_flow` password-grant proxy (cloud-side)](0027-ha-login-flow-proxy.md)        | Accepted           | 2026-05-10 |
-| 0028 | [Cihaz konfigürasyon state'i (first-run setup wizard)](0028-device-config-state.md)     | Accepted           | 2026-05-17 |
+| #    | Başlık                                                                                         | Durum              | Tarih      |
+| ---- | ---------------------------------------------------------------------------------------------- | ------------------ | ---------- |
+| 0001 | [Turborepo + pnpm workspaces](0001-turborepo-pnpm-workspaces.md)                               | Accepted           | 2026-04-20 |
+| 0002 | [Vite + React 19 (web)](0002-vite-react-19-web.md)                                             | Accepted           | 2026-04-20 |
+| 0003 | [Expo SDK + new architecture (mobile)](0003-expo-new-architecture-mobile.md)                   | Accepted           | 2026-04-20 |
+| 0004 | [`@glaon/core` platform-agnostic paylaşım paketi](0004-glaon-core-platform-agnostic.md)        | Accepted           | 2026-04-20 |
+| 0005 | [OAuth2 Authorization Code + PKCE (tek auth yöntemi)](0005-oauth2-pkce-only-auth.md)           | Superseded by 0017 | 2026-04-20 |
+| 0006 | [Token storage — in-memory + httpOnly / SecureStore](0006-token-storage.md)                    | Accepted           | 2026-04-20 |
+| 0007 | [Sentry observability backend olarak](0007-sentry-observability.md)                            | Accepted           | 2026-04-20 |
+| 0008 | [Chromatic tek görsel regresyon aracı](0008-chromatic-visual-regression.md)                    | Accepted           | 2026-04-21 |
+| 0009 | [HA Add-on + Ingress teslim kanalı](0009-ha-addon-ingress-delivery.md)                         | Accepted           | 2026-04-20 |
+| 0010 | [Figma tasarım kaynağı + plugin bridge](0010-figma-source-of-truth.md)                         | Accepted           | 2026-04-22 |
+| 0011 | [Untitled UI React kit + CLI source-based delivery](0011-untitled-ui-react-kit.md)             | Accepted           | 2026-04-27 |
+| 0012 | [Tailwind CSS for `@glaon/ui`](0012-tailwind-css-for-glaon-ui.md)                              | Superseded by 0013 | 2026-04-27 |
+| 0013 | [Tailwind v4 + Untitled UI theme.css](0013-tailwind-v4-uui-theme.md)                           | Accepted           | 2026-04-27 |
+| 0014 | [`apps/api` ayrı backend service (Next.js geçişi yerine)](0014-apps-api-over-nextjs.md)        | Accepted           | 2026-05-06 |
+| 0015 | [State yönetimi — Zustand + Immer + TanStack Query](0015-state-management.md)                  | Accepted           | 2026-05-07 |
+| 0016 | [HA WebSocket transport mimarisi](0016-ha-ws-transport.md)                                     | Accepted           | 2026-05-07 |
+| 0017 | [Dual-mode auth — local HA OAuth + cloud-relay (Clerk)](0017-dual-mode-auth.md)                | Accepted           | 2026-05-07 |
+| 0018 | [Cloud relay topology + wire protocol](0018-cloud-relay-topology.md)                           | Accepted           | 2026-05-07 |
+| 0019 | [Identity provider — Clerk (cloud mod için)](0019-identity-provider-clerk.md)                  | Accepted           | 2026-05-07 |
+| 0020 | [Cloud hosting platform — CF Workers + Durable Objects](0020-cloud-hosting-platform.md)        | Accepted           | 2026-05-07 |
+| 0021 | [Pairing protocol + relay credential lifecycle](0021-pairing-and-relay-credentials.md)         | Accepted           | 2026-05-07 |
+| 0022 | [Cloud deployment + secrets pipeline](0022-cloud-deployment-secrets.md)                        | Accepted           | 2026-05-07 |
+| 0023 | [i18n library + file format + RTL strategy](0023-i18n-library-format-rtl.md)                   | Accepted           | 2026-05-07 |
+| 0024 | [Lokal keşif: HA hostname'ine bağ kal](0024-local-discovery-rely-on-ha-hostname.md)            | Accepted           | 2026-05-08 |
+| 0025 | [apps/api stack pick — Hono + native MongoDB + Zod](0025-apps-api-stack.md)                    | Accepted           | 2026-05-09 |
+| 0026 | [apps/api delivery: Glaon-managed hosted](0026-apps-api-delivery-hosted.md)                    | Accepted           | 2026-05-10 |
+| 0027 | [HA `login_flow` password-grant proxy (cloud-side)](0027-ha-login-flow-proxy.md)               | Accepted           | 2026-05-10 |
+| 0028 | [Cihaz konfigürasyon state'i (first-run setup wizard)](0028-device-config-state.md)            | Accepted           | 2026-05-17 |
+| 0029 | [Setup wizard ayar push'u: apps/api → HA Core doğrudan WS](0029-apps-api-ha-core-direct-ws.md) | Accepted           | 2026-05-28 |
 
 ## Konvansiyonlar
 

--- a/docs/dev-supervisor.md
+++ b/docs/dev-supervisor.md
@@ -69,6 +69,29 @@ curl http://localhost:8080/hassio/network/info | jq '.data.interfaces[0].accessp
 
 Security trade-off: anything on the LAN can hit `http://homeassistant.local:8099/api/hassio/network/*` and commit Wi-Fi changes. Dev-only, trusted-LAN posture. Production add-on (`addon/`) doesn't expose any LAN port.
 
+#### Wizard settings → HA Core (`config/*`, #617)
+
+The Wi-Fi handoff above is only one half of "apply". The wizard also collects location, timezone, unit-system, country, language, and the floors/rooms layout — these get pushed into HA Core via `POST /api/setup/apply-ha`, which apps/api translates into HA Core **WebSocket** commands (`config/core/update`, `config/{floor,area}_registry/create` — WS-only, no REST).
+
+Unlike the Supervisor `/api/hassio/*` proxy, HA Core's WebSocket auth **accepts an LLT** (#602). So this path works directly from a dev box against HA Core — no add-on bounce. Set it alongside the supervisor vars:
+
+```bash
+# apps/api/.env on the dev box
+HA_CORE_URL=http://homeassistant.local:8123
+HA_CORE_TOKEN=<long-lived-access-token>   # HA UI → profile → Security
+```
+
+```bash
+# verify the push end-to-end (after walking the wizard, or by hand)
+curl -X POST http://localhost:8080/setup/apply-ha \
+  -H 'Content-Type: application/json' \
+  -d '{"timezone":"Europe/Istanbul","unitSystem":"metric","country":"TR",
+       "layout":{"floors":[{"name":"Ground","rooms":[{"name":"Living"}]}]}}'
+# { "ok": true, "steps": [ { "step": "core", "ok": true }, ... ] }
+```
+
+Then check HA UI → Settings → System → General (location/timezone/unit-system) and Settings → Areas (the floors/rooms). Both unset → `POST /setup/apply-ha` responds 503. This is a **dev-first** capability ([ADR 0029](adr/0029-apps-api-ha-core-direct-ws.md)); production onboarding routes the same settings through the relay / add-on, not a direct apps/api → HA Core WS.
+
 ### Path 2 — UTM HA OS on macOS (browser wizard only)
 
 Use this when you don't have a Pi handy and need to test the browser wizard against a real Supervisor. **apps/api integration via this path is broken** (LLT 401 against `/api/hassio/*`, see the box above); browser path works because HA Ingress generates session-bound tokens for it.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "./auth": "./src/auth/index.ts",
     "./config": "./src/config/index.ts",
     "./ha": "./src/ha/index.ts",
+    "./ha/direct-ws": "./src/ha/transports/direct-ws.ts",
     "./i18n": "./src/i18n/index.ts",
     "./observability": "./src/observability/index.ts",
     "./protocol": "./src/protocol/index.ts",

--- a/packages/core/src/api-client/index.ts
+++ b/packages/core/src/api-client/index.ts
@@ -48,3 +48,11 @@ export {
   type UserPreferences,
   type UserPreferencesUpdate,
 } from './me';
+export {
+  ApplyHaRequestSchema,
+  ApplyHaResponseSchema,
+  ApplyHaStepResultSchema,
+  type ApplyHaRequest,
+  type ApplyHaResponse,
+  type ApplyHaStepResult,
+} from './setup';

--- a/packages/core/src/api-client/setup.ts
+++ b/packages/core/src/api-client/setup.ts
@@ -1,0 +1,64 @@
+// Setup-wizard → HA config push (#617). The request is the subset of
+// the device-config the wizard collects that maps onto HA Core config +
+// the area/floor registry. apps/web POSTs it to apps/api's
+// `POST /setup/apply-ha`; apps/api translates it (via @glaon/core's
+// `buildHaSetupPlan`) into HA WebSocket `config/*` commands.
+//
+// The field names mirror `DeviceConfig` (config/types.ts) so the wizard
+// can forward its `collected` blob almost verbatim. The shape is also
+// structurally assignable to `HaSetupInput` (ha/setup-commands.ts) — the
+// mapper's input type — so apps/api hands the parsed body straight to
+// the mapper.
+
+import { z } from 'zod';
+
+const ApplyHaRoomSchema = z.object({
+  name: z.string().min(1).max(64),
+});
+
+const ApplyHaFloorSchema = z.object({
+  name: z.string().min(1).max(64),
+  rooms: z.array(ApplyHaRoomSchema).max(50),
+});
+
+export const ApplyHaRequestSchema = z.object({
+  latitude: z.number().min(-90).max(90).optional(),
+  longitude: z.number().min(-180).max(180).optional(),
+  unitSystem: z.union([z.literal('metric'), z.literal('imperial')]).optional(),
+  /** IANA TZ name (e.g. `Europe/Istanbul`). */
+  timezone: z.string().min(1).optional(),
+  /** ISO 3166-1 alpha-2, uppercase. */
+  country: z
+    .string()
+    .regex(/^[A-Z]{2}$/, 'country must be ISO 3166-1 alpha-2 uppercase')
+    .optional(),
+  /** BCP-47 locale tag (e.g. `tr`, `en-US`). */
+  locale: z.string().min(1).optional(),
+  layout: z
+    .object({
+      floors: z.array(ApplyHaFloorSchema).min(1).max(10),
+    })
+    .optional(),
+});
+export type ApplyHaRequest = z.infer<typeof ApplyHaRequestSchema>;
+
+/**
+ * Per-command outcome. `step` is a stable label —
+ * `core` | `floor:<name>` | `area:<name>` — so the client can map a
+ * failure back to a specific section if it wants. apps/api runs every
+ * step even when an earlier one fails (best-effort), so the array
+ * always reflects the full attempted set.
+ */
+export const ApplyHaStepResultSchema = z.object({
+  step: z.string().min(1),
+  ok: z.boolean(),
+  error: z.string().optional(),
+});
+export type ApplyHaStepResult = z.infer<typeof ApplyHaStepResultSchema>;
+
+export const ApplyHaResponseSchema = z.object({
+  /** True only when every attempted step succeeded. */
+  ok: z.boolean(),
+  steps: z.array(ApplyHaStepResultSchema),
+});
+export type ApplyHaResponse = z.infer<typeof ApplyHaResponseSchema>;

--- a/packages/core/src/ha/client.ts
+++ b/packages/core/src/ha/client.ts
@@ -19,6 +19,15 @@ import type { HaEntityState } from '../types';
 
 export type ConnectionState = 'connecting' | 'open' | 'closed' | 'reconnecting';
 
+/** `Omit` that distributes over a union, preserving each member's discriminant. */
+type DistributiveOmit<T, K extends keyof never> = T extends unknown ? Omit<T, K> : never;
+
+/**
+ * Accepted shape for `HaClient.request`: every numbered outbound frame with
+ * its auto-stamped `id` removed, as a union (not collapsed to common keys).
+ */
+type OutboundRequestFrame = DistributiveOmit<Extract<HaOutboundFrame, { id: number }>, 'id'>;
+
 export interface HaClientOptions {
   /** Returns the current HA access token. Called on each (re)auth. */
   readonly getAccessToken: () => Promise<string>;
@@ -177,10 +186,14 @@ export class HaClient {
    * Send a typed request and resolve with the HA `result` payload. Rejects with
    * `HaConnectionLostError` if the WS drops mid-flight or `HaServiceError` if HA
    * surfaces an error response.
+   *
+   * The frame param uses a *distributive* Omit (`OutboundRequestFrame`) so the
+   * parameter stays a union of each frame-minus-id rather than collapsing to the
+   * union members' common keys. Without that, a frame with a required
+   * non-common property (e.g. `config/area_registry/create`'s `name`) would be
+   * rejected by excess-property checking on an inline object literal.
    */
-  request<TResult = unknown>(
-    frame: Omit<Extract<HaOutboundFrame, { id: number }>, 'id'>,
-  ): Promise<TResult> {
+  request<TResult = unknown>(frame: OutboundRequestFrame): Promise<TResult> {
     if (this.transport === null || this.connectionState !== 'open') {
       return Promise.reject(new HaConnectionLostError());
     }

--- a/packages/core/src/ha/index.ts
+++ b/packages/core/src/ha/index.ts
@@ -1,11 +1,20 @@
 export * from './client';
 export * from './transport';
-export * from './transports/direct-ws';
 export * from './services';
+export * from './setup-commands';
+// NOTE: DirectWsTransport is intentionally NOT re-exported here. It is
+// written against DOM `WebSocket` / `MessageEvent` / `CloseEvent` types,
+// which a Node consumer (apps/api, #617) doesn't have in its tsconfig
+// `lib`. Keeping it out of the barrel lets Node code import the
+// transport-agnostic `HaClient` + protocol types from `@glaon/core/ha`
+// without inheriting a DOM dependency. Browser / RN consumers import it
+// from the dedicated subpath: `@glaon/core/ha/direct-ws`.
 export type {
   HaInboundFrame,
   HaOutboundFrame,
   HaResultFrame,
   HaEventFrame,
   HaStateChangedEvent,
+  HaAreaRegistryEntry,
+  HaFloorRegistryEntry,
 } from './protocol/messages';

--- a/packages/core/src/ha/protocol/messages.ts
+++ b/packages/core/src/ha/protocol/messages.ts
@@ -109,6 +109,69 @@ export interface HaGetStatesFrame {
   readonly type: 'get_states';
 }
 
+/* ---------- Config writes (setup wizard → HA, #617) ---------- */
+
+/**
+ * `config/core/update` — sets HA Core's home location + locale prefs.
+ * Every field is optional; HA leaves anything omitted untouched.
+ *
+ * `unit_system` takes HA's enum values (`metric` / `us_customary`),
+ * NOT Glaon's `imperial` — the setup-commands mapper translates.
+ */
+export interface HaConfigCoreUpdateFrame {
+  readonly id: number;
+  readonly type: 'config/core/update';
+  readonly latitude?: number;
+  readonly longitude?: number;
+  readonly elevation?: number;
+  readonly unit_system?: 'metric' | 'us_customary';
+  readonly time_zone?: string;
+  readonly currency?: string;
+  /** ISO 3166-1 alpha-2 (uppercase). */
+  readonly country?: string;
+  /** BCP-47 language tag HA recognises (e.g. `en`, `tr`). */
+  readonly language?: string;
+}
+
+/**
+ * `config/floor_registry/create` — creates a floor. Returns the created
+ * floor (incl. `floor_id`) in the result frame. `level` orders floors
+ * vertically in the HA UI; optional.
+ */
+export interface HaFloorRegistryCreateFrame {
+  readonly id: number;
+  readonly type: 'config/floor_registry/create';
+  readonly name: string;
+  readonly level?: number;
+  readonly icon?: string;
+}
+
+/** Shape of the `result` payload from `config/floor_registry/create`. */
+export interface HaFloorRegistryEntry {
+  readonly floor_id: string;
+  readonly name: string;
+  readonly level?: number | null;
+}
+
+/**
+ * `config/area_registry/create` — creates an area (room). `floor_id`
+ * links it to a floor created earlier in the same run; omit it for the
+ * graceful-degrade path on HA builds without a floor registry.
+ */
+export interface HaAreaRegistryCreateFrame {
+  readonly id: number;
+  readonly type: 'config/area_registry/create';
+  readonly name: string;
+  readonly floor_id?: string;
+}
+
+/** Shape of the `result` payload from `config/area_registry/create`. */
+export interface HaAreaRegistryEntry {
+  readonly area_id: string;
+  readonly name: string;
+  readonly floor_id?: string | null;
+}
+
 /* ---------- frontend/get_translations (i18n-D / #426) ---------- */
 
 /**
@@ -153,4 +216,7 @@ export type HaOutboundFrame =
   | HaUnsubscribeEventsFrame
   | HaCallServiceFrame
   | HaGetStatesFrame
-  | HaGetTranslationsFrame;
+  | HaGetTranslationsFrame
+  | HaConfigCoreUpdateFrame
+  | HaFloorRegistryCreateFrame
+  | HaAreaRegistryCreateFrame;

--- a/packages/core/src/ha/setup-commands.test.ts
+++ b/packages/core/src/ha/setup-commands.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildHaSetupPlan, type HaSetupInput } from './setup-commands';
+
+describe('buildHaSetupPlan — core config', () => {
+  it('maps every collected core field into config/core/update', () => {
+    const input: HaSetupInput = {
+      latitude: 41.0082,
+      longitude: 28.9784,
+      unitSystem: 'metric',
+      timezone: 'Europe/Istanbul',
+      country: 'TR',
+      locale: 'tr',
+    };
+    const plan = buildHaSetupPlan(input);
+    expect(plan.coreUpdate).toEqual({
+      latitude: 41.0082,
+      longitude: 28.9784,
+      unit_system: 'metric',
+      time_zone: 'Europe/Istanbul',
+      country: 'TR',
+      language: 'tr',
+    });
+  });
+
+  it('translates imperial → us_customary', () => {
+    const plan = buildHaSetupPlan({ unitSystem: 'imperial' });
+    expect(plan.coreUpdate).toEqual({ unit_system: 'us_customary' });
+  });
+
+  it('takes the primary subtag of a region locale for language', () => {
+    const plan = buildHaSetupPlan({ locale: 'pt-BR' });
+    expect(plan.coreUpdate).toEqual({ language: 'pt' });
+  });
+
+  it('omits fields the wizard did not collect (HA leaves them untouched)', () => {
+    const plan = buildHaSetupPlan({ latitude: 1, longitude: 2 });
+    expect(plan.coreUpdate).toEqual({ latitude: 1, longitude: 2 });
+  });
+
+  it('returns coreUpdate=null when no core field is present', () => {
+    const plan = buildHaSetupPlan({});
+    expect(plan.coreUpdate).toBeNull();
+  });
+
+  it('treats empty-string timezone / country as absent', () => {
+    const plan = buildHaSetupPlan({ timezone: '', country: '' });
+    expect(plan.coreUpdate).toBeNull();
+  });
+});
+
+describe('buildHaSetupPlan — floors + rooms', () => {
+  it('maps floors to ordered plans with index-derived levels', () => {
+    const input: HaSetupInput = {
+      layout: {
+        floors: [
+          { name: 'Ground', rooms: [{ name: 'Living' }, { name: 'Kitchen' }] },
+          { name: 'Upstairs', rooms: [{ name: 'Bedroom' }] },
+        ],
+      },
+    };
+    const plan = buildHaSetupPlan(input);
+    expect(plan.floors).toEqual([
+      { name: 'Ground', level: 0, rooms: [{ name: 'Living' }, { name: 'Kitchen' }] },
+      { name: 'Upstairs', level: 1, rooms: [{ name: 'Bedroom' }] },
+    ]);
+  });
+
+  it('keeps a floor with no rooms (e.g. attic)', () => {
+    const plan = buildHaSetupPlan({ layout: { floors: [{ name: 'Attic', rooms: [] }] } });
+    expect(plan.floors).toEqual([{ name: 'Attic', level: 0, rooms: [] }]);
+  });
+
+  it('returns an empty floor list when no layout is present', () => {
+    const plan = buildHaSetupPlan({ latitude: 1 });
+    expect(plan.floors).toEqual([]);
+  });
+});

--- a/packages/core/src/ha/setup-commands.ts
+++ b/packages/core/src/ha/setup-commands.ts
@@ -1,0 +1,130 @@
+// Setup-wizard → HA config mapping (#617). Pure translation from the
+// subset of the device-config the wizard collects into the ordered set
+// of HA WebSocket `config/*` commands that materialise it in Home
+// Assistant. No I/O here — the apps/api `ha-setup-service` executes the
+// plan over a live `HaClient`, threading the floor_id results into the
+// area-create calls (a data dependency a flat frame list can't express,
+// hence the structured plan).
+//
+// Why a structured plan rather than a flat `HaOutboundFrame[]`:
+//   - `config/area_registry/create` needs the `floor_id` returned by
+//     the matching `config/floor_registry/create` — a runtime value
+//     not knowable at mapping time.
+//   - Keeping the mapping pure (DeviceConfig subset → plan) makes it
+//     unit-testable without a WS, and lets the service own the one
+//     imperative concern (id threading + graceful degrade).
+
+/**
+ * The wizard-collected fields this mapper reads. Structurally a subset
+ * of `DeviceConfigInput` (config/types.ts) — kept as a standalone shape
+ * so the `ha/` module doesn't take a hard dependency on the `config/`
+ * schema. The api-client `ApplyHaRequest` is assignable to this.
+ */
+// Optional fields carry an explicit `| undefined`: this type is the
+// bridge for the api-client `ApplyHaRequest` (Zod `.optional()` infers
+// `T | undefined`), and under `exactOptionalPropertyTypes` a bare `T?`
+// would reject that. The mapper guards every field on `!== undefined`,
+// so explicit-undefined is semantically a no-op.
+export interface HaSetupInput {
+  readonly latitude?: number | undefined;
+  readonly longitude?: number | undefined;
+  /** Glaon's unit system; mapped to HA's `metric` / `us_customary`. */
+  readonly unitSystem?: 'metric' | 'imperial' | undefined;
+  /** IANA TZ name (e.g. `Europe/Istanbul`). */
+  readonly timezone?: string | undefined;
+  /** ISO 3166-1 alpha-2 (uppercase). */
+  readonly country?: string | undefined;
+  /** BCP-47 locale tag; forwarded to HA `language` best-effort. */
+  readonly locale?: string | undefined;
+  readonly layout?:
+    | {
+        readonly floors: readonly {
+          readonly name: string;
+          readonly rooms: readonly { readonly name: string }[];
+        }[];
+      }
+    | undefined;
+}
+
+/** `config/core/update` payload (frame fields minus `id`/`type`). */
+export interface HaCoreUpdatePayload {
+  readonly latitude?: number;
+  readonly longitude?: number;
+  readonly unit_system?: 'metric' | 'us_customary';
+  readonly time_zone?: string;
+  readonly country?: string;
+  readonly language?: string;
+}
+
+export interface HaFloorPlan {
+  readonly name: string;
+  /** Vertical ordering hint for HA's UI; derived from floor index. */
+  readonly level: number;
+  readonly rooms: readonly { readonly name: string }[];
+}
+
+export interface HaSetupPlan {
+  /** `null` when the wizard collected no core-config fields. */
+  readonly coreUpdate: HaCoreUpdatePayload | null;
+  readonly floors: readonly HaFloorPlan[];
+}
+
+/**
+ * Translate the wizard subset into an ordered HA setup plan. Pure.
+ *
+ * Core-config fields are only included when present, so HA leaves any
+ * field the user didn't touch untouched. `coreUpdate` is `null` (rather
+ * than an empty object) when nothing maps, letting the service skip the
+ * command entirely.
+ */
+export function buildHaSetupPlan(input: HaSetupInput): HaSetupPlan {
+  const core: {
+    latitude?: number;
+    longitude?: number;
+    unit_system?: 'metric' | 'us_customary';
+    time_zone?: string;
+    country?: string;
+    language?: string;
+  } = {};
+
+  if (input.latitude !== undefined) core.latitude = input.latitude;
+  if (input.longitude !== undefined) core.longitude = input.longitude;
+  if (input.unitSystem !== undefined) core.unit_system = mapUnitSystem(input.unitSystem);
+  if (input.timezone !== undefined && input.timezone !== '') core.time_zone = input.timezone;
+  if (input.country !== undefined && input.country !== '') core.country = input.country;
+  const language = mapLanguage(input.locale);
+  if (language !== undefined) core.language = language;
+
+  const coreUpdate = Object.keys(core).length > 0 ? core : null;
+
+  const floors: HaFloorPlan[] = (input.layout?.floors ?? []).map((floor, index) => ({
+    name: floor.name,
+    level: index,
+    rooms: floor.rooms.map((room) => ({ name: room.name })),
+  }));
+
+  return { coreUpdate, floors };
+}
+
+/**
+ * Glaon's `imperial` is HA's `us_customary`; `metric` is shared. Kept
+ * as a function (not a record) so an unexpected value fails the type
+ * check at the call site rather than silently producing `undefined`.
+ */
+function mapUnitSystem(unit: 'metric' | 'imperial'): 'metric' | 'us_customary' {
+  return unit === 'imperial' ? 'us_customary' : 'metric';
+}
+
+/**
+ * Forward the locale's primary subtag as HA's `language` (HA expects a
+ * short language code like `en` / `tr`, not a full BCP-47 region tag).
+ * Returns `undefined` for empty / missing input so the caller omits the
+ * field. HA still validates against its supported set — an unsupported
+ * code surfaces as that single command's failure, not the whole run's.
+ */
+function mapLanguage(locale: string | undefined): string | undefined {
+  if (locale === undefined || locale === '') return undefined;
+  const primary = locale.split('-')[0];
+  if (primary === undefined || primary === '') return undefined;
+  return primary.toLowerCase();
+}


### PR DESCRIPTION
## Summary

The wizard apply step (#597) now pushes the home settings it collects — location, timezone, unit-system, country, language, and the floors/rooms layout — into **Home Assistant**, not just localStorage. The Wi-Fi handoff already reached real HA (#607/#615); this closes the gap for everything else.

HA Core config + registry writes are **WebSocket-only** (`config/core/update`, `config/{floor,area}_registry/create` — no REST). HA Core's WS auth accepts a long-lived access token (unlike the Supervisor `/api/hassio/*` proxy, #602), so **apps/api opens a direct WS to HA Core** and runs the command sequence.

## Changes

**@glaon/core**
- `HaOutboundFrame` gains `config/core/update`, `config/floor_registry/create`, `config/area_registry/create` + registry result types.
- `ha/setup-commands.ts` — pure `DeviceConfig`-subset → ordered plan mapper (`imperial→us_customary`, `locale→language`, floor levels). Unit-tested.
- `HaClient.request` param → distributive `Omit` so frames with required non-common props (e.g. area `name`) type-check. Latent bug existing common-prop callers never hit.
- `DirectWsTransport` moved off the `@glaon/core/ha` barrel to `@glaon/core/ha/direct-ws` so Node consumers don't inherit its DOM (`MessageEvent`/`CloseEvent`) dependency. **No runtime consumers existed** — comment-only references, zero blast radius.
- api-client: `ApplyHaRequest`/`ApplyHaResponse` schemas (shared contract).

**apps/api**
- `HA_CORE_URL` + `HA_CORE_TOKEN` config.
- `NodeWsTransport` (Node 22 global `WebSocket`) implementing `HaTransport` — platform transport lives in `apps/*` per the boundary rule.
- `ha-setup-service` — connect → run plan → per-step results; best-effort (floor-create failure degrades to floor-less areas); connection failure → 502.
- `POST /setup/apply-ha` — unauthenticated (wizard pre-login, mirrors hassio-network); 503 unconfigured, 400 bad body, 502 unreachable.

**apps/web**
- Apply step POSTs settings to `/api/setup/apply-ha` **before** the Wi-Fi handoff (non-destructive ordering). A hard/partial failure aborts the ceremony with a Toast and never switches Wi-Fi; a 503 (dev, HA Core unconfigured) proceeds silently.
- i18n en/tr; `/api/setup` Vite proxy.

**Docs**
- [ADR 0029](../blob/617-push-wizard-settings-to-ha/docs/adr/0029-apps-api-ha-core-direct-ws.md) — apps/api → HA Core direct-WS (dev-first) vs relay (production).
- `docs/dev-supervisor.md` — HA Core WS env + verification.

## Scope

**In** — listed above.

**Out**
- Production relay path for this onboarding step (separate epic; ADR 0029 references it).
- Persisting settings to Glaon's own Mongo (the option-B fork; separate issue if wanted).
- Reading HA config back into the wizard (one-way push).
- `homeName` / free-text `location` / `currency` (no clean HA Core config target / not collected).

## Test plan

- [x] `@glaon/core` 173 tests (incl. `setup-commands` mapping: full config, missing fields, no-floor-registry degrade).
- [x] `apps/api` 124 tests (incl. `setup` route: 503/400/200 happy/partial-degrade/502).
- [x] `apps/web` apply-step 10 tests (incl. new HA-settings-failure aborts before Wi-Fi).
- [x] type-check + lint (core/api/web), i18n parity, core package-contract (`@glaon/core/ha/direct-ws` subpath).
- [ ] CI green on PR.
- [ ] Manual (Pi): set `HA_CORE_URL` + `HA_CORE_TOKEN`, walk the wizard → HA Settings → System → General shows location/timezone/unit-system; Settings → Areas shows the floors/rooms. _(local-verification, user-driven)_

Closes #617
Refs #602, #607, #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)