### PR TITLE
fix(web): drive wizard Wi-Fi availability from server, not build flag

### DIFF
--- a/apps/web/src/features/setup/apply/apply-step.test.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.test.tsx
@@ -117,28 +117,44 @@ describe('ApplyStep — summary', () => {
   });
 });
 
-describe('ApplyStep — standalone mode', () => {
+describe('ApplyStep — Wi-Fi scan unavailable (503)', () => {
+  // #619: availability is server-driven, not a build flag. When the
+  // network-info endpoint answers 503 (supervisor-not-configured) the
+  // Wi-Fi block degrades to an informational notice and the user can
+  // commit without a network switch — the HA-less dev environment.
   beforeEach(() => {
-    vi.stubEnv('VITE_APP_MODE', 'standalone');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: unknown) => {
+        const u = String(url);
+        if (u.includes('/api/hassio/network/info') || u.includes('/api/setup/apply-ha')) {
+          return Promise.resolve(
+            mockFetchResponse({
+              ok: false,
+              status: 503,
+              json: { error: 'supervisor-not-configured' },
+            }),
+          );
+        }
+        return Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }));
+      }),
+    );
   });
 
   it('renders the informational notice and commits without a wifi handoff', async () => {
     const configStore = new InMemoryConfigStore();
-    const { getByRole, getByText } = render(
+    const { getByRole, findByText } = render(
       wrap(<ApplyStep collected={baseCollected} />, configStore),
     );
-    expect(getByText(/Wi-Fi setup is only available/i)).toBeInTheDocument();
+    expect(await findByText(/Wi-Fi scanning isn't available/i)).toBeInTheDocument();
     fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
     await waitFor(() => {
       expect(reloadSpy).toHaveBeenCalledTimes(1);
     });
     expect(await configStore.isConfigured()).toBe(true);
-    // No supervisor call in standalone mode — fetch is mocked but
-    // the wifi block short-circuits before posting.
-    const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    expect(
-      calls.some(([, init]) => (init as { method?: string } | undefined)?.method === 'POST'),
-    ).toBe(false);
+    // No supervisor wifi-update POST — the wifi block had nothing to
+    // commit (the HA-settings push 503s to a silent skip).
+    expect(findWifiPost()).toBeUndefined();
   });
 });
 

--- a/apps/web/src/features/setup/apply/apply-step.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.tsx
@@ -22,11 +22,17 @@
 //     is no "step 6" after a successful commit. A terminal step
 //     should look terminal.
 //
-// Wi-Fi enumeration still goes through the HA Supervisor's
-// `/api/hassio/network/info` endpoint. In standalone mode
-// (`VITE_APP_MODE === 'standalone'`) the wifi block collapses to an
-// informational placeholder and the CTA commits without a network
-// change — same dev affordance #546 shipped with.
+// Wi-Fi enumeration goes through `/api/hassio/network/info`. Whether a
+// scan is possible is decided at runtime by the *server*, not a build
+// flag (#619): apps/api (or the add-on's nginx) proxies the request to
+// a real HA Supervisor. The apply step always attempts the scan and
+// reacts to the response — 200 shows networks, 503
+// (`supervisor-not-configured`) means this environment genuinely can't
+// scan (an HA-less dev box) so the Wi-Fi step degrades to an
+// informational notice and the CTA commits without a network change.
+// There is deliberately no `VITE_APP_MODE` gate here: the end user
+// never perceives Glaon as "an add-on", so availability can't hang off
+// the build target.
 //
 // Per the API Error Toast Rule (CLAUDE.md), commit failures surface
 // through useToast; inline error blocks would mask the cross-section
@@ -70,10 +76,6 @@ const HA_APPLY_SETTINGS = '/api/setup/apply-ha';
 // in #594's open questions.
 const DEVICE_URL_AFTER_HANDOFF = 'http://glaon.local';
 
-function isStandaloneMode(): boolean {
-  return import.meta.env.VITE_APP_MODE === 'standalone';
-}
-
 function isSecuredAuth(auth: string): boolean {
   return auth !== '' && auth.toLowerCase() !== 'none';
 }
@@ -91,7 +93,9 @@ type FetchState =
   | { readonly kind: 'loading' }
   | { readonly kind: 'success'; readonly networks: readonly AccessPoint[] }
   | { readonly kind: 'error' }
-  | { readonly kind: 'standalone' };
+  // Server answered 503 supervisor-not-configured: no scan possible in
+  // this environment (HA-less dev). Informational, not an error.
+  | { readonly kind: 'unavailable' };
 
 /**
  * Normalise the HA Supervisor `/api/hassio/network/info` response
@@ -206,19 +210,15 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
 
   // ---- Wi-Fi enumeration state (carried from wifi-step.tsx) ----
 
-  const [fetchState, setFetchState] = useState<FetchState>(() =>
-    isStandaloneMode() ? { kind: 'standalone' } : { kind: 'loading' },
-  );
+  const [fetchState, setFetchState] = useState<FetchState>({ kind: 'loading' });
   const [selectedSsid, setSelectedSsid] = useState<string>(collected.wifi?.ssid ?? '');
   const [draftPassword, setDraftPassword] = useState<string>('');
 
   const loadNetworks = useCallback(async () => {
     setFetchState({ kind: 'loading' });
+    let response: Response;
     try {
-      const response = await fetch(SUPERVISOR_NETWORK_INFO, { credentials: 'include' });
-      if (!response.ok) throw new Error(`Supervisor responded ${String(response.status)}`);
-      const json: unknown = await response.json();
-      setFetchState({ kind: 'success', networks: parseAccessPoints(json) });
+      response = await fetch(SUPERVISOR_NETWORK_INFO, { credentials: 'include' });
     } catch {
       setFetchState({ kind: 'error' });
       toast.show({
@@ -226,11 +226,29 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
         title: t('setup.apply.wifi.scanFailed.title'),
         description: t('setup.apply.wifi.scanFailed.description'),
       });
+      return;
     }
+    // 503 = supervisor-not-configured. The scan genuinely can't run in
+    // this environment (e.g. a dev box with no HA). This is an expected,
+    // handled state — render an inline notice, no danger toast.
+    if (response.status === 503) {
+      setFetchState({ kind: 'unavailable' });
+      return;
+    }
+    if (!response.ok) {
+      setFetchState({ kind: 'error' });
+      toast.show({
+        intent: 'danger',
+        title: t('setup.apply.wifi.scanFailed.title'),
+        description: t('setup.apply.wifi.scanFailed.description'),
+      });
+      return;
+    }
+    const json: unknown = await response.json().catch(() => null);
+    setFetchState({ kind: 'success', networks: parseAccessPoints(json) });
   }, [t, toast]);
 
   useEffect(() => {
-    if (isStandaloneMode()) return;
     void loadNetworks();
   }, [loadNetworks]);
 
@@ -247,11 +265,12 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
   const [handoffPhase, setHandoffPhase] = useState<HandoffPhase>('idle');
   const isCommitting = handoffPhase === 'committing';
 
-  // CTA enablement: standalone mode commits without wifi; otherwise
-  // wait for a picked network and (if secured) the inline password.
+  // CTA enablement: when the scan is unavailable (HA-less env) the user
+  // commits without a network change; otherwise wait for a picked
+  // network and (if secured) the inline password.
   const ctaDisabled =
     isCommitting ||
-    (fetchState.kind !== 'standalone' &&
+    (fetchState.kind !== 'unavailable' &&
       (!wifiPicked || (passwordRequired && draftPassword.trim() === '')));
 
   const onApplyClick = (): void => {
@@ -279,20 +298,20 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
     // Push home settings to HA *before* the Wi-Fi handoff (#617). This
     // step is non-destructive and the network is still stable, so a
     // failure can abort cleanly before we switch Wi-Fi. A `skipped`
-    // outcome (apps/api has no HA Core configured — dev) is fine and
-    // proceeds silently; only a hard failure / partial apply stops the
-    // ceremony so the user can retry without a half-applied home.
-    if (!isStandaloneMode()) {
-      const haOutcome = await pushSettingsToHa(collected);
-      if (haOutcome.kind === 'error' || haOutcome.kind === 'partial') {
-        setHandoffPhase(passwordRequired ? 'confirming' : 'idle');
-        toast.show({
-          intent: 'danger',
-          title: t('setup.apply.haSettingsFailed.title'),
-          description: t('setup.apply.haSettingsFailed.description'),
-        });
-        return;
-      }
+    // outcome (apps/api has no HA Core configured — dev, 503) is fine
+    // and proceeds silently; only a hard failure / partial apply stops
+    // the ceremony so the user can retry without a half-applied home.
+    // No build-flag guard (#619): pushSettingsToHa's own 503→skipped
+    // handling covers the HA-less environment.
+    const haOutcome = await pushSettingsToHa(collected);
+    if (haOutcome.kind === 'error' || haOutcome.kind === 'partial') {
+      setHandoffPhase(passwordRequired ? 'confirming' : 'idle');
+      toast.show({
+        intent: 'danger',
+        title: t('setup.apply.haSettingsFailed.title'),
+        description: t('setup.apply.haSettingsFailed.description'),
+      });
+      return;
     }
 
     try {
@@ -418,7 +437,7 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
           <p className="text-sm text-tertiary">{t('setup.apply.wifi.subtitle')}</p>
         </div>
 
-        {fetchState.kind === 'standalone' && <StandaloneNotice />}
+        {fetchState.kind === 'unavailable' && <UnavailableNotice />}
         {fetchState.kind === 'loading' && <LoadingNotice />}
         {fetchState.kind === 'error' && <ErrorRetry onRetry={() => void loadNetworks()} />}
         {fetchState.kind === 'success' && fetchState.networks.length === 0 && (
@@ -539,11 +558,11 @@ function WifiNetworkRow({ network, isSelected, onSelect }: WifiNetworkRowProps):
   );
 }
 
-function StandaloneNotice(): ReactNode {
+function UnavailableNotice(): ReactNode {
   const { t } = useTranslation();
   return (
     <div className="rounded-lg border border-secondary bg-secondary/50 p-4 text-sm text-tertiary">
-      {t('setup.apply.wifi.standalone')}
+      {t('setup.apply.wifi.unavailable')}
     </div>
   );
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -202,7 +202,7 @@
         },
         "loading": "Looking for nearby Wi-Fi networks…",
         "empty": "No Wi-Fi networks found nearby. Move closer to your router or try again.",
-        "standalone": "Wi-Fi setup is only available when Glaon runs as the Home Assistant add-on. We'll skip the network switch.",
+        "unavailable": "Wi-Fi scanning isn't available in this environment, so we'll skip the network switch. Your other settings will still be saved.",
         "scanFailed": {
           "title": "Couldn't scan Wi-Fi networks",
           "description": "Home Assistant didn't respond to the network scan. Check that the add-on is running and try again.",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -202,7 +202,7 @@
         },
         "loading": "Yakındaki Wi-Fi ağları aranıyor…",
         "empty": "Yakında Wi-Fi ağı bulunamadı. Router'a yaklaş ya da tekrar dene.",
-        "standalone": "Wi-Fi ayarı yalnız Glaon Home Assistant add-on olarak çalışırken kullanılabilir. Ağ değişimi atlanır.",
+        "unavailable": "Bu ortamda Wi-Fi taraması yapılamıyor, bu yüzden ağ değişimi atlanacak. Diğer ayarların yine de kaydedilir.",
         "scanFailed": {
           "title": "Wi-Fi taraması başarısız",
           "description": "Home Assistant ağ taramasına cevap vermedi. Add-on çalışıyor mu kontrol et ve tekrar dene.",


### PR DESCRIPTION
## Summary

- `apply-step.tsx`: remove `isStandaloneMode()` entirely. The Wi-Fi picker no longer hangs off `VITE_APP_MODE`; the apply step always attempts the scan and reacts to the server's response.
- New `'unavailable'` fetch state driven by a **503 `supervisor-not-configured`** response — renders an honest informational notice (HA-less dev), no danger toast. 200 → real networks; transport error → retry.
- CTA allows commit-without-Wi-Fi in `'unavailable'`; requires a picked network in `'success'`.
- `runCommit` drops the build-flag guard around the HA-settings push (#617) — `pushSettingsToHa`'s own 503→skipped already covers the HA-less case.
- i18n (en/tr): `setup.apply.wifi.standalone` → `.unavailable`, dropping the "only works as an add-on" wording.
- apply-step unit test: the old "standalone mode" block becomes a "Wi-Fi scan unavailable (503)" block driving the new path.

## Why

In standalone builds the apply step showed:

> "Wi-Fi ayarı yalnız Glaon Home Assistant add-on olarak çalışırken kullanılabilir. Ağ değişimi atlanır."

That's a product dead-end — the end user never perceives Glaon as "an add-on", and the gate predates apps/api being able to proxy the Wi-Fi scan to a real Supervisor (#615/616). Availability should be decided by the **server** at runtime, not a build target.

This makes the first-run AP-mode flow (#594) work in the **standalone-on-device** topology (device serves the wizard + runs apps/api with local Supervisor access) without the add-on harness. Add-on Ingress, standalone-on-device, and dev-with-Pi all now scan; only a genuinely HA-less dev box degrades — honestly.

## Scope

**In** — listed in Summary.

**Out**

- Live scan progress over WebSocket — split to #620.
- apps/api `/hassio/network/*` proxy (already correct).
- `VITE_APP_MODE` itself (setup-gate still uses it for the ingress skip; only the apply-step Wi-Fi gate is removed).

## Test plan

- [x] `pnpm --filter @glaon/web type-check` + `lint` clean.
- [x] apply-step unit tests pass (10), including the new 503→unavailable path.
- [x] `i18n:check` green (unavailable key present in en + tr; standalone removed).
- [ ] CI green on PR.
- [ ] Manual (Pi, standalone apps/api): walk the wizard apply step → real Pi networks render (no "add-on" placeholder); committing applies the chosen network. _(local-verification, user-driven)_
- [ ] Manual (dev laptop, no HA): apply step shows the "scanning unavailable, skipping" notice and still completes the wizard. _(local-verification, user-driven)_

Closes #619
Refs #594, #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)