### PR TITLE
fix(api,web,addon-dev): scan Wi-Fi from the right endpoint + role

### DIFF
--- a/addon-dev/config.yaml
+++ b/addon-dev/config.yaml
@@ -17,12 +17,18 @@ panel_title: Glaon (dev)
 # The production add-on (`addon/`) keeps this `false` per ADR 0026; this
 # manifest is dev-only and never ships to the HA Add-on store.
 #
-# We deliberately do NOT set `hassio_role` — the default role (which is
-# what the Supervisor assigns when the field is omitted) already permits
-# the /network/* endpoints we proxy. Setting `hassio_role: default`
-# explicitly is redundant noise; setting it to anything else widens
-# privilege past what the proxy actually exposes.
+# `hassio_role: admin` is REQUIRED for the network scan + update endpoints
+# (#622). The Supervisor SecurityMiddleware gates `/network/.+` behind
+# ROLE_MANAGER (admin matches every path); the implicit default role only
+# grants `GET /network/info`, so `/network/interface/{iface}/accesspoints`
+# and `/network/interface/{iface}/update` returned 403. An earlier commit
+# (#611/#612) dropped `hassio_role` on the wrong assumption that the
+# default role covered all of `/network/*` — it doesn't. This add-on's
+# entire purpose is driving the Wi-Fi handoff, so full network access via
+# admin is the intended grant; it's dev-only, local, behind Ingress + a
+# trusted-LAN port. The production add-on never sets hassio_api/role.
 hassio_api: true
+hassio_role: admin
 homeassistant_api: false
 auth_api: false
 host_network: false

--- a/apps/api/src/routes/hassio-network.test.ts
+++ b/apps/api/src/routes/hassio-network.test.ts
@@ -27,19 +27,32 @@ function mockResponse(init: { status?: number; body: unknown; contentType?: stri
 }
 
 describe('hassio-network — mock mode', () => {
-  it('returns a canned access-point list on GET /network/info', async () => {
+  it('returns interfaces (no embedded accesspoints) on GET /network/info', async () => {
     const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
     const res = await router.request('/network/info');
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      data: { interfaces: { accesspoints: { ssid: string }[] }[] };
+      data: { interfaces: { interface: string; type: string }[] };
     };
-    expect(body.data.interfaces[0]?.accesspoints.length).toBeGreaterThan(0);
+    const wireless = body.data.interfaces.find((i) => i.type === 'wireless');
+    expect(wireless?.interface).toBe('wlan0');
+    // /network/info carries interfaces only — APs come from the
+    // accesspoints endpoint (#622).
+    expect(body.data.interfaces[0]).not.toHaveProperty('accesspoints');
   });
 
-  it('accepts any POST /network/:iface/update with 200 + { mocked: true }', async () => {
+  it('returns a canned AP list on GET /network/interface/:iface/accesspoints', async () => {
     const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
-    const res = await router.request('/network/wlan0/update', {
+    const res = await router.request('/network/interface/wlan0/accesspoints');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { accesspoints: { ssid: string }[] } };
+    expect(body.data.accesspoints.length).toBeGreaterThan(0);
+    expect(body.data.accesspoints[0]?.ssid).toBe('GlaonDev-Home');
+  });
+
+  it('accepts any POST /network/interface/:iface/update with 200 + { mocked: true }', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
+    const res = await router.request('/network/interface/wlan0/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ wifi: { mode: 'infrastructure', auth: 'open', ssid: 'X' } }),
@@ -50,16 +63,22 @@ describe('hassio-network — mock mode', () => {
 });
 
 describe('hassio-network — unconfigured', () => {
-  it('returns 503 on GET when neither URL nor mock is set', async () => {
+  it('returns 503 on GET /network/info when neither URL nor mock is set', async () => {
     const router = createHassioNetworkRouter({ config: baseConfig() });
     const res = await router.request('/network/info');
     expect(res.status).toBe(503);
     expect(await res.json()).toMatchObject({ error: 'supervisor-not-configured' });
   });
 
-  it('returns 503 on POST when neither URL nor mock is set', async () => {
+  it('returns 503 on GET accesspoints when neither URL nor mock is set', async () => {
     const router = createHassioNetworkRouter({ config: baseConfig() });
-    const res = await router.request('/network/wlan0/update', {
+    const res = await router.request('/network/interface/wlan0/accesspoints');
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 503 on POST update when neither URL nor mock is set', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig() });
+    const res = await router.request('/network/interface/wlan0/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ wifi: { auth: 'open', ssid: 'X' } }),
@@ -91,13 +110,29 @@ describe('hassio-network — live proxy', () => {
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer long-lived-token');
   });
 
-  it('forwards POST body verbatim, preserves status, and re-emits content-type', async () => {
+  it('forwards GET accesspoints to the canonical /interface/ path with the bearer token', async () => {
+    const fetchImpl: typeof fetch = vi.fn(() =>
+      Promise.resolve(mockResponse({ body: { data: { accesspoints: [{ ssid: 'Doyran' }] } } })),
+    );
+    const router = createHassioNetworkRouter({ config, fetchImpl });
+    const res = await router.request('/network/interface/wlan0/accesspoints');
+    expect(res.status).toBe(200);
+    const call = vi.mocked(fetchImpl).mock.calls[0];
+    if (call === undefined) throw new Error('expected upstream call');
+    expect(call[0]).toBe('http://supervisor.test/network/network/interface/wlan0/accesspoints');
+    const init = call[1];
+    if (init === undefined) throw new Error('expected init');
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer long-lived-token');
+  });
+
+  it('forwards POST body verbatim to the canonical /interface/ update path', async () => {
     const upstreamBody = { result: 'ok' };
     const fetchImpl: typeof fetch = vi.fn(() =>
       Promise.resolve(mockResponse({ status: 202, body: upstreamBody })),
     );
     const router = createHassioNetworkRouter({ config, fetchImpl });
-    const res = await router.request('/network/wlan0/update', {
+    const res = await router.request('/network/interface/wlan0/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ wifi: { auth: 'wpa-psk', psk: 'secret' } }),
@@ -107,7 +142,7 @@ describe('hassio-network — live proxy', () => {
     const mock = vi.mocked(fetchImpl);
     const call = mock.mock.calls[0];
     if (call === undefined) throw new Error('expected upstream call');
-    expect(call[0]).toBe('http://supervisor.test/network/network/wlan0/update');
+    expect(call[0]).toBe('http://supervisor.test/network/network/interface/wlan0/update');
     const init = call[1];
     if (init === undefined) throw new Error('expected init');
     expect(init.method).toBe('POST');
@@ -124,7 +159,7 @@ describe('hassio-network — live proxy', () => {
   it('rejects malformed POST bodies with 400 before touching the supervisor', async () => {
     const fetchImpl: typeof fetch = vi.fn();
     const router = createHassioNetworkRouter({ config, fetchImpl });
-    const res = await router.request('/network/wlan0/update', {
+    const res = await router.request('/network/interface/wlan0/update', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: 'not-json',

--- a/apps/api/src/routes/hassio-network.ts
+++ b/apps/api/src/routes/hassio-network.ts
@@ -43,19 +43,53 @@ interface HassioNetworkRouterDeps {
   readonly logger?: Logger;
 }
 
+// `/network/info` returns interfaces only — the real Supervisor does NOT
+// embed access points here (#622). The wizard discovers the wireless
+// interface from this list, then scans it via the accesspoints endpoint.
 const MOCK_NETWORK_INFO = {
   data: {
     interfaces: [
+      { interface: 'wlan0', type: 'wireless', enabled: true, connected: false, primary: false },
+      { interface: 'end0', type: 'ethernet', enabled: true, connected: true, primary: true },
+    ],
+  },
+};
+
+// `/network/interface/{iface}/accesspoints` — the real scan results.
+// Shape mirrors HA Supervisor: { mode, ssid, mac, frequency, signal } and
+// crucially NO `auth`/security field (#622).
+const MOCK_ACCESSPOINTS = {
+  data: {
+    accesspoints: [
       {
-        accesspoints: [
-          { ssid: 'GlaonDev-Home', auth: 'wpa-psk' },
-          { ssid: 'GlaonDev-Guest', auth: 'none' },
-          { ssid: 'GlaonDev-Office', auth: 'wpa-psk' },
-        ],
+        mode: 'infrastructure',
+        ssid: 'GlaonDev-Home',
+        mac: '00:11:22:33:44:01',
+        frequency: 2412,
+        signal: 72,
+      },
+      {
+        mode: 'infrastructure',
+        ssid: 'GlaonDev-Guest',
+        mac: '00:11:22:33:44:02',
+        frequency: 5180,
+        signal: 58,
+      },
+      {
+        mode: 'infrastructure',
+        ssid: 'GlaonDev-Office',
+        mac: '00:11:22:33:44:03',
+        frequency: 2437,
+        signal: 41,
       },
     ],
   },
 };
+
+const NOT_CONFIGURED_BODY = {
+  error: 'supervisor-not-configured',
+  hint: 'Set HA_SUPERVISOR_URL + HA_SUPERVISOR_TOKEN, or HA_SUPERVISOR_MOCK=true for a canned payload. See docs/dev-supervisor.md.',
+} as const;
 
 export function createHassioNetworkRouter(deps: HassioNetworkRouterDeps): Hono {
   const router = new Hono();
@@ -67,13 +101,7 @@ export function createHassioNetworkRouter(deps: HassioNetworkRouterDeps): Hono {
       return c.json(MOCK_NETWORK_INFO);
     }
     if (supervisorUrl === undefined || supervisorToken === undefined) {
-      return c.json(
-        {
-          error: 'supervisor-not-configured',
-          hint: 'Set HA_SUPERVISOR_URL + HA_SUPERVISOR_TOKEN, or HA_SUPERVISOR_MOCK=true for a canned payload. See docs/dev-supervisor.md.',
-        },
-        503,
-      );
+      return c.json(NOT_CONFIGURED_BODY, 503);
     }
     try {
       const upstream = await fetchImpl(`${trim(supervisorUrl)}/network/info`, {
@@ -92,7 +120,42 @@ export function createHassioNetworkRouter(deps: HassioNetworkRouterDeps): Hono {
     }
   });
 
-  router.post('/network/:iface/update', async (c) => {
+  // Wi-Fi scan results for a wireless interface (#622). Separate from
+  // /network/info — the Supervisor only exposes access points here.
+  router.get('/network/interface/:iface/accesspoints', async (c) => {
+    const iface = c.req.param('iface');
+    if (supervisorMock) {
+      return c.json(MOCK_ACCESSPOINTS);
+    }
+    if (supervisorUrl === undefined || supervisorToken === undefined) {
+      return c.json(NOT_CONFIGURED_BODY, 503);
+    }
+    try {
+      const upstream = await fetchImpl(
+        `${trim(supervisorUrl)}/network/interface/${encodeURIComponent(iface)}/accesspoints`,
+        { method: 'GET', headers: { Authorization: `Bearer ${supervisorToken}` } },
+      );
+      const text = await upstream.text();
+      deps.logger?.info({
+        event: 'hassio-network.proxy.accesspoints',
+        iface,
+        status: upstream.status,
+      });
+      return passThroughResponse(text, upstream);
+    } catch (err) {
+      deps.logger?.error({
+        event: 'hassio-network.proxy.accesspoints.failed',
+        iface,
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+      return c.json({ error: 'supervisor-unreachable' }, 502);
+    }
+  });
+
+  // Commit a Wi-Fi connection. Canonical Supervisor path carries the
+  // `/interface/` segment (#622) — the earlier `/network/:iface/update`
+  // form 404s against a real Supervisor.
+  router.post('/network/interface/:iface/update', async (c) => {
     const iface = c.req.param('iface');
     const body: unknown = await c.req.json().catch(() => null);
     if (body === null || typeof body !== 'object') {
@@ -102,17 +165,11 @@ export function createHassioNetworkRouter(deps: HassioNetworkRouterDeps): Hono {
       return c.json({ result: 'ok', mocked: true });
     }
     if (supervisorUrl === undefined || supervisorToken === undefined) {
-      return c.json(
-        {
-          error: 'supervisor-not-configured',
-          hint: 'Set HA_SUPERVISOR_URL + HA_SUPERVISOR_TOKEN, or HA_SUPERVISOR_MOCK=true for a canned payload. See docs/dev-supervisor.md.',
-        },
-        503,
-      );
+      return c.json(NOT_CONFIGURED_BODY, 503);
     }
     try {
       const upstream = await fetchImpl(
-        `${trim(supervisorUrl)}/network/${encodeURIComponent(iface)}/update`,
+        `${trim(supervisorUrl)}/network/interface/${encodeURIComponent(iface)}/update`,
         {
           method: 'POST',
           headers: {

--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -39,18 +39,28 @@ import { expect, test, type Page } from '@playwright/test';
 const DEVICE_CONFIG_KEY = 'glaon.device-config';
 
 async function mockSupervisorNetworkScan(page: Page): Promise<void> {
+  // #622 — /network/info carries interfaces only (for wireless-interface
+  // discovery); the AP list comes from the accesspoints endpoint, which
+  // has no `auth` field (signal only).
   await page.route('**/api/hassio/network/info', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        data: {
-          interfaces: [{ accesspoints: [{ ssid: 'PreviewGuest', auth: 'none' }] }],
-        },
+        data: { interfaces: [{ interface: 'wlan0', type: 'wireless', enabled: true }] },
       }),
     });
   });
-  await page.route('**/api/hassio/network/wlan0/update', async (route) => {
+  await page.route('**/api/hassio/network/interface/wlan0/accesspoints', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: { accesspoints: [{ ssid: 'PreviewGuest', mac: 'aa:bb:cc:00:00:01', signal: 64 }] },
+      }),
+    });
+  });
+  await page.route('**/api/hassio/network/interface/wlan0/update', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: '{"result":"ok"}' });
   });
   // #617 — the apply step pushes home settings to HA Core before the

--- a/apps/web/src/features/setup/apply/apply-step.test.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.test.tsx
@@ -43,15 +43,23 @@ const baseCollected = {
   unitSystem: 'metric' as const,
 };
 
-const sampleSupervisorPayload = {
+// #622 — /network/info carries interfaces only (for wireless-interface
+// discovery); the AP list comes from the accesspoints endpoint and has
+// no `auth` field (signal only).
+const sampleNetworkInfo = {
   data: {
     interfaces: [
-      {
-        accesspoints: [
-          { ssid: 'HomeWifi', auth: 'wpa-psk' },
-          { ssid: 'Guest', auth: 'none' },
-        ],
-      },
+      { interface: 'wlan0', type: 'wireless', enabled: true },
+      { interface: 'end0', type: 'ethernet', enabled: true },
+    ],
+  },
+};
+
+const sampleAccessPoints = {
+  data: {
+    accesspoints: [
+      { ssid: 'HomeWifi', mac: 'aa:bb:cc:00:00:01', signal: 70, mode: 'infrastructure' },
+      { ssid: 'Guest', mac: 'aa:bb:cc:00:00:02', signal: 55, mode: 'infrastructure' },
     ],
   },
 };
@@ -59,18 +67,28 @@ const sampleSupervisorPayload = {
 /** Default success response for the HA-settings push (#617). */
 const haApplyOk = { ok: true, steps: [] };
 
+/** Route a GET network request to the right canned payload, else null. */
+function networkScanResponse(url: string): Response | null {
+  if (url.includes('/network/info')) return mockFetchResponse({ json: sampleNetworkInfo });
+  if (url.includes('/accesspoints')) return mockFetchResponse({ json: sampleAccessPoints });
+  return null;
+}
+
 /**
- * URL-aware default mock: the wizard's commit fires two POSTs —
- * `/api/setup/apply-ha` (HA config push) then the supervisor wifi
- * update — plus the GET network scan. Route each so one doesn't get the
- * other's payload.
+ * URL-aware default mock. The wizard's scan is two GETs (/network/info
+ * then /network/interface/wlan0/accesspoints); the commit fires
+ * /api/setup/apply-ha then the supervisor update POST. Route each so one
+ * doesn't get another's payload.
  */
 function defaultFetch(url: unknown): Promise<Response> {
   const u = String(url);
   if (u.includes('/api/setup/apply-ha')) {
     return Promise.resolve(mockFetchResponse({ json: haApplyOk }));
   }
-  return Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }));
+  const scan = networkScanResponse(u);
+  if (scan !== null) return Promise.resolve(scan);
+  // Update POST (or anything else) → ok.
+  return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
 }
 
 /** Find the supervisor wifi-update POST specifically (not the apply-ha POST). */
@@ -127,7 +145,8 @@ describe('ApplyStep — Wi-Fi scan unavailable (503)', () => {
       'fetch',
       vi.fn((url: unknown) => {
         const u = String(url);
-        if (u.includes('/api/hassio/network/info') || u.includes('/api/setup/apply-ha')) {
+        // Every Supervisor + HA-settings path 503s (HA-less env).
+        if (u.includes('/api/hassio/network/') || u.includes('/api/setup/apply-ha')) {
           return Promise.resolve(
             mockFetchResponse({
               ok: false,
@@ -136,7 +155,7 @@ describe('ApplyStep — Wi-Fi scan unavailable (503)', () => {
             }),
           );
         }
-        return Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }));
+        return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
       }),
     );
   });
@@ -250,7 +269,9 @@ describe('ApplyStep — populated mode', () => {
         if (init?.method === 'POST' && u.includes('/hassio/')) {
           return Promise.resolve(mockFetchResponse({ ok: false, status: 500 }));
         }
-        return Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }));
+        const scan = networkScanResponse(u);
+        if (scan !== null) return Promise.resolve(scan);
+        return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
       }),
     );
     const { findByText, getByRole, findByRole } = render(
@@ -276,7 +297,9 @@ describe('ApplyStep — populated mode', () => {
             }),
           );
         }
-        return Promise.resolve(mockFetchResponse({ json: sampleSupervisorPayload }));
+        const scan = networkScanResponse(u);
+        if (scan !== null) return Promise.resolve(scan);
+        return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
       }),
     );
     const { findByText, getByRole, findByRole } = render(

--- a/apps/web/src/features/setup/apply/apply-step.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.tsx
@@ -62,9 +62,16 @@ interface ApplyStepProps {
 // Supervisor wiring (carried over from review-step + wifi-step)
 // =============================================================
 
-const SUPERVISOR_NETWORK_INTERFACE = 'wlan0';
-const SUPERVISOR_NETWORK_UPDATE = `/api/hassio/network/${SUPERVISOR_NETWORK_INTERFACE}/update`;
 const SUPERVISOR_NETWORK_INFO = '/api/hassio/network/info';
+const DEFAULT_WIRELESS_INTERFACE = 'wlan0';
+
+// HA Supervisor's scan results + commit are per-interface and carry the
+// canonical `/interface/` segment (#622). The AP list is NOT in
+// /network/info — it lives on the accesspoints endpoint.
+const networkAccesspointsUrl = (iface: string): string =>
+  `/api/hassio/network/interface/${encodeURIComponent(iface)}/accesspoints`;
+const networkUpdateUrl = (iface: string): string =>
+  `/api/hassio/network/interface/${encodeURIComponent(iface)}/update`;
 
 // #617 — apps/api endpoint that pushes the collected home settings into
 // HA Core (config/core/update + floor/area registry) over WebSocket.
@@ -76,17 +83,15 @@ const HA_APPLY_SETTINGS = '/api/setup/apply-ha';
 // in #594's open questions.
 const DEVICE_URL_AFTER_HANDOFF = 'http://glaon.local';
 
-function isSecuredAuth(auth: string): boolean {
-  return auth !== '' && auth.toLowerCase() !== 'none';
-}
-
 function isSecuredCipher(cipher: string | undefined): boolean {
   return cipher !== undefined && cipher !== '' && cipher !== '(unsecured)';
 }
 
+// Scan results carry no security/auth field (#622) — only signal. We
+// can't tell secured from open networks; the password field decides.
 interface AccessPoint {
   readonly ssid: string;
-  readonly auth: string;
+  readonly signal?: number;
 }
 
 type FetchState =
@@ -98,42 +103,65 @@ type FetchState =
   | { readonly kind: 'unavailable' };
 
 /**
- * Normalise the HA Supervisor `/api/hassio/network/info` response
- * into a flat, deduplicated list of access points. The endpoint
- * returns `{ data: { interfaces: [{ accesspoints: [...] }] } }` —
- * one entry per wireless interface; merge them.
+ * Pick the wireless interface from a `/network/info` payload
+ * (`{ data: { interfaces: [{ interface, type }] } }`). Falls back to
+ * `wlan0` when discovery is inconclusive — matches the device default.
  */
-function parseAccessPoints(json: unknown): readonly AccessPoint[] {
+function findWirelessInterface(json: unknown): string {
   const root = json as
-    | { data?: { interfaces?: readonly { accesspoints?: readonly unknown[] }[] } }
+    | { data?: { interfaces?: readonly { interface?: unknown; type?: unknown }[] } }
     | undefined;
-  const interfaces = root?.data?.interfaces ?? [];
-  const seen = new Set<string>();
-  const out: AccessPoint[] = [];
-  for (const iface of interfaces) {
-    for (const raw of iface.accesspoints ?? []) {
-      const ap = raw as { ssid?: unknown; auth?: unknown };
-      const ssid = typeof ap.ssid === 'string' ? ap.ssid : '';
-      const auth = typeof ap.auth === 'string' ? ap.auth : '';
-      if (ssid === '' || seen.has(ssid)) continue;
-      seen.add(ssid);
-      out.push({ ssid, auth });
+  for (const iface of root?.data?.interfaces ?? []) {
+    if (
+      iface.type === 'wireless' &&
+      typeof iface.interface === 'string' &&
+      iface.interface !== ''
+    ) {
+      return iface.interface;
     }
   }
-  return out;
+  return DEFAULT_WIRELESS_INTERFACE;
+}
+
+/**
+ * Normalise the Supervisor accesspoints response
+ * (`{ data: { accesspoints: [{ ssid, mac, signal, ... }] } }`) into a
+ * deduplicated AP list. Dedup by SSID keeping the strongest signal;
+ * sort strongest-first.
+ */
+function parseAccessPoints(json: unknown): readonly AccessPoint[] {
+  const root = json as { data?: { accesspoints?: readonly unknown[] } } | undefined;
+  const bySsid = new Map<string, AccessPoint>();
+  for (const raw of root?.data?.accesspoints ?? []) {
+    const ap = raw as { ssid?: unknown; signal?: unknown };
+    const ssid = typeof ap.ssid === 'string' ? ap.ssid : '';
+    if (ssid === '') continue;
+    const signal = typeof ap.signal === 'number' ? ap.signal : undefined;
+    const existing = bySsid.get(ssid);
+    if (existing === undefined || (signal ?? -Infinity) > (existing.signal ?? -Infinity)) {
+      bySsid.set(ssid, signal === undefined ? { ssid } : { ssid, signal });
+    }
+  }
+  return [...bySsid.values()].sort((a, b) => (b.signal ?? -Infinity) - (a.signal ?? -Infinity));
 }
 
 interface PushWifiArgs {
+  readonly iface: string;
   readonly ssid: string;
   readonly password: string;
   readonly secured: boolean;
 }
 
-async function pushWifiToSupervisor({ ssid, password, secured }: PushWifiArgs): Promise<void> {
+async function pushWifiToSupervisor({
+  iface,
+  ssid,
+  password,
+  secured,
+}: PushWifiArgs): Promise<void> {
   const body = secured
     ? { wifi: { mode: 'infrastructure', auth: 'wpa-psk', ssid, psk: password } }
     : { wifi: { mode: 'infrastructure', auth: 'open', ssid } };
-  const response = await fetch(SUPERVISOR_NETWORK_UPDATE, {
+  const response = await fetch(networkUpdateUrl(iface), {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
@@ -213,40 +241,65 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
   const [fetchState, setFetchState] = useState<FetchState>({ kind: 'loading' });
   const [selectedSsid, setSelectedSsid] = useState<string>(collected.wifi?.ssid ?? '');
   const [draftPassword, setDraftPassword] = useState<string>('');
+  // Wireless interface discovered from /network/info; used for both the
+  // accesspoints scan and the commit. Defaults to wlan0 until discovered.
+  const [wirelessIface, setWirelessIface] = useState<string>(DEFAULT_WIRELESS_INTERFACE);
+
+  const failScan = useCallback(() => {
+    setFetchState({ kind: 'error' });
+    toast.show({
+      intent: 'danger',
+      title: t('setup.apply.wifi.scanFailed.title'),
+      description: t('setup.apply.wifi.scanFailed.description'),
+    });
+  }, [t, toast]);
 
   const loadNetworks = useCallback(async () => {
     setFetchState({ kind: 'loading' });
-    let response: Response;
+
+    // Step 1: discover the wireless interface from /network/info.
+    let iface = DEFAULT_WIRELESS_INTERFACE;
+    let infoResponse: Response;
     try {
-      response = await fetch(SUPERVISOR_NETWORK_INFO, { credentials: 'include' });
+      infoResponse = await fetch(SUPERVISOR_NETWORK_INFO, { credentials: 'include' });
     } catch {
-      setFetchState({ kind: 'error' });
-      toast.show({
-        intent: 'danger',
-        title: t('setup.apply.wifi.scanFailed.title'),
-        description: t('setup.apply.wifi.scanFailed.description'),
-      });
+      failScan();
       return;
     }
     // 503 = supervisor-not-configured. The scan genuinely can't run in
-    // this environment (e.g. a dev box with no HA). This is an expected,
-    // handled state — render an inline notice, no danger toast.
-    if (response.status === 503) {
+    // this environment (HA-less dev). Expected, handled — inline notice,
+    // no danger toast.
+    if (infoResponse.status === 503) {
       setFetchState({ kind: 'unavailable' });
       return;
     }
-    if (!response.ok) {
-      setFetchState({ kind: 'error' });
-      toast.show({
-        intent: 'danger',
-        title: t('setup.apply.wifi.scanFailed.title'),
-        description: t('setup.apply.wifi.scanFailed.description'),
-      });
+    if (infoResponse.ok) {
+      iface = findWirelessInterface(await infoResponse.json().catch(() => null));
+    }
+    // A non-ok, non-503 /network/info falls through to the wlan0 default
+    // and still attempts the scan — the accesspoints call is the real
+    // signal of whether scanning works.
+    setWirelessIface(iface);
+
+    // Step 2: scan that interface's access points (the real AP list).
+    let apResponse: Response;
+    try {
+      apResponse = await fetch(networkAccesspointsUrl(iface), { credentials: 'include' });
+    } catch {
+      failScan();
       return;
     }
-    const json: unknown = await response.json().catch(() => null);
+    if (apResponse.status === 503) {
+      setFetchState({ kind: 'unavailable' });
+      return;
+    }
+    if (!apResponse.ok) {
+      failScan();
+      return;
+    }
+    const json: unknown = await apResponse.json().catch(() => null);
     setFetchState({ kind: 'success', networks: parseAccessPoints(json) });
-  }, [t, toast]);
+  }, [failScan]);
 
   useEffect(() => {
     void loadNetworks();
@@ -257,8 +310,11 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
     return fetchState.networks.find((n) => n.ssid === selectedSsid) ?? null;
   }, [fetchState, selectedSsid]);
 
-  const passwordRequired = selectedNetwork !== null && isSecuredAuth(selectedNetwork.auth);
   const wifiPicked = selectedNetwork !== null;
+  // Scan results carry no security info (#622), so "secured" is decided
+  // by whether the user typed a password — non-empty → WPA-PSK, empty →
+  // open. The password field is always optional for a picked network.
+  const passwordProvided = draftPassword.trim() !== '';
 
   // ---- Commit ceremony state (carried from review-step.tsx) ----
 
@@ -266,29 +322,26 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
   const isCommitting = handoffPhase === 'committing';
 
   // CTA enablement: when the scan is unavailable (HA-less env) the user
-  // commits without a network change; otherwise wait for a picked
-  // network and (if secured) the inline password.
-  const ctaDisabled =
-    isCommitting ||
-    (fetchState.kind !== 'unavailable' &&
-      (!wifiPicked || (passwordRequired && draftPassword.trim() === '')));
+  // commits without a network change; otherwise just need a picked
+  // network (the password is optional — open networks exist and the scan
+  // can't tell us which is secured).
+  const ctaDisabled = isCommitting || (fetchState.kind !== 'unavailable' && !wifiPicked);
 
   const onApplyClick = (): void => {
     if (ctaDisabled) return;
-    if (passwordRequired) {
-      // Secured wifi → open handoff modal so the user re-confirms the
-      // password and reads the disconnect warning.
+    if (passwordProvided) {
+      // A password was entered → treat as secured: open the handoff modal
+      // so the user re-confirms the password and reads the disconnect
+      // warning.
       setHandoffPhase('confirming');
       return;
     }
-    // Open / no-wifi networks skip the modal (no password to
-    // re-confirm, no AP→home handoff to warn about for the no-wifi
-    // case).
+    // No password → open network (or no-wifi). Commit directly.
     void runCommit('');
   };
 
   const onHandoffConfirm = (password: string): void => {
-    if (passwordRequired && password.trim() === '') return;
+    if (password.trim() === '') return;
     void runCommit(password);
   };
 
@@ -305,7 +358,7 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
     // handling covers the HA-less environment.
     const haOutcome = await pushSettingsToHa(collected);
     if (haOutcome.kind === 'error' || haOutcome.kind === 'partial') {
-      setHandoffPhase(passwordRequired ? 'confirming' : 'idle');
+      setHandoffPhase(secureWifiPassword.trim() !== '' ? 'confirming' : 'idle');
       toast.show({
         intent: 'danger',
         title: t('setup.apply.haSettingsFailed.title'),
@@ -315,19 +368,23 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
     }
 
     try {
-      // The plaintext password lives in the modal's confirm field
+      // The plaintext password comes from the modal's confirm field
       // (`secureWifiPassword`) — used as-is for the supervisor POST
       // (the wire format expects plaintext PSK), then wrapped via
       // Web Crypto AES-GCM before it lands in the persisted blob
       // (#595, Security-First Rule "no plaintext credentials").
-      const secured = passwordRequired;
-      const password = secured ? secureWifiPassword : '';
-      if (secured && password === '') {
-        throw new Error('missing wifi password');
-      }
+      // "secured" is decided by password presence (#622) — the scan
+      // can't tell us the network's security type.
+      const password = secureWifiPassword;
+      const secured = password.trim() !== '';
 
       if (selectedNetwork !== null) {
-        await pushWifiToSupervisor({ ssid: selectedNetwork.ssid, password, secured });
+        await pushWifiToSupervisor({
+          iface: wirelessIface,
+          ssid: selectedNetwork.ssid,
+          password,
+          secured,
+        });
         const persistedCipher = secured ? await wrapPassword(password) : '(unsecured)';
         await setPartial({
           ...collected,
@@ -341,10 +398,10 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
       // future visit to the URL never resurrects this run's state.
       clearWizardScratch();
       clearDeviceKey();
-      // `passwordRequired` already implies `selectedNetwork !== null`
-      // (see its derivation above), so the wifi handoff overlay path
-      // matches the secured-network case 1:1.
-      if (passwordRequired) {
+      // Secured (password-bearing) commits route through the handoff
+      // overlay — that's the AP→home disconnect moment. Open / no-wifi
+      // commits reload straight away.
+      if (secured) {
         setHandoffPhase('switching');
         // Defer the reload by a moment so the user catches a beat of
         // the HandoffOverlay before the page goes away. In practice
@@ -359,7 +416,7 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
       // Secured-wifi failure re-opens the modal so the user can
       // retry / re-enter the password; everything else returns to
       // idle since there's no modal to re-open. Toast fires in both.
-      setHandoffPhase(passwordRequired ? 'confirming' : 'idle');
+      setHandoffPhase(secureWifiPassword.trim() !== '' ? 'confirming' : 'idle');
       toast.show({
         intent: 'danger',
         title: t('setup.apply.commitFailed.title'),
@@ -371,7 +428,7 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
   // ---- Derived summary value for the embedded Wi-Fi row ----
 
   const wifiSummaryValue = wifiPicked
-    ? passwordRequired
+    ? passwordProvided
       ? t('setup.apply.summary.wifiSecured', { ssid: selectedNetwork.ssid })
       : t('setup.apply.summary.wifiUnsecured', { ssid: selectedNetwork.ssid })
     : collected.wifi !== undefined
@@ -459,7 +516,7 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
             ))}
           </ul>
         )}
-        {passwordRequired && (
+        {wifiPicked && (
           <div className="flex max-w-[480px] flex-col gap-1.5">
             <label
               id={passwordLabelId}
@@ -475,7 +532,9 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
               placeholder={t('setup.apply.wifi.password.placeholder')}
               autoComplete="off"
             />
-            <p className="text-xs text-tertiary">{t('setup.apply.wifi.password.hint')}</p>
+            {/* No security info in scan results (#622) — the field is
+                optional; an empty password commits as an open network. */}
+            <p className="text-xs text-tertiary">{t('setup.apply.wifi.password.optionalHint')}</p>
           </div>
         )}
       </section>
@@ -498,7 +557,7 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
           if (!open) setHandoffPhase('idle');
         }}
         ssid={selectedNetwork?.ssid ?? ''}
-        requiresPassword={passwordRequired}
+        requiresPassword={passwordProvided}
         deviceUrl={DEVICE_URL_AFTER_HANDOFF}
         onConfirm={onHandoffConfirm}
         isCommitting={isCommitting}
@@ -524,7 +583,8 @@ interface WifiNetworkRowProps {
 
 function WifiNetworkRow({ network, isSelected, onSelect }: WifiNetworkRowProps): ReactNode {
   const { t } = useTranslation();
-  const secured = isSecuredAuth(network.auth);
+  // Scan results carry no security type (#622); the secondary line shows
+  // signal strength instead, mirroring HA's own network UI.
   return (
     <button
       type="button"
@@ -538,13 +598,15 @@ function WifiNetworkRow({ network, isSelected, onSelect }: WifiNetworkRowProps):
         aria-hidden="true"
         className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset"
       >
-        {secured ? <LockIcon /> : <LockUnlockedIcon />}
+        <WifiIcon />
       </span>
       <span className="flex flex-1 flex-col">
         <span className="text-sm font-medium leading-5 text-secondary">{network.ssid}</span>
-        <span className="text-sm font-normal leading-5 text-tertiary">
-          {secured ? network.auth.toUpperCase() : t('setup.apply.wifi.unsecured')}
-        </span>
+        {network.signal !== undefined && (
+          <span className="text-sm font-normal leading-5 text-tertiary">
+            {t('setup.apply.wifi.signal', { signal: network.signal })}
+          </span>
+        )}
       </span>
       <span
         aria-hidden="true"
@@ -612,7 +674,7 @@ function EmptyNotice({ onRetry }: RetryProps): ReactNode {
   );
 }
 
-function LockIcon(): ReactNode {
+function WifiIcon(): ReactNode {
   return (
     <svg
       width="16"
@@ -625,27 +687,10 @@ function LockIcon(): ReactNode {
       strokeLinejoin="round"
       aria-hidden="true"
     >
-      <rect x="2.667" y="7.333" width="10.667" height="6.667" rx="1.333" />
-      <path d="M4.667 7.333V4.667a3.333 3.333 0 0 1 6.666 0v2.666" />
-    </svg>
-  );
-}
-
-function LockUnlockedIcon(): ReactNode {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <rect x="2.667" y="7.333" width="10.667" height="6.667" rx="1.333" />
-      <path d="M4.667 7.333V4.667a3.333 3.333 0 0 1 6.666 0" />
+      <path d="M1.667 6a9 9 0 0 1 12.666 0" />
+      <path d="M4 8.667a5.333 5.333 0 0 1 8 0" />
+      <path d="M6.333 11.333a2 2 0 0 1 3.334 0" />
+      <path d="M8 14h.007" />
     </svg>
   );
 }

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -194,11 +194,11 @@
         "list": {
           "ariaLabel": "Available Wi-Fi networks"
         },
-        "unsecured": "Unsecured",
+        "signal": "Signal {signal}%",
         "password": {
           "label": "Network password",
           "placeholder": "Type the password",
-          "hint": "We'll ask again in the confirmation dialog so a typo can't lock you out."
+          "optionalHint": "Optional — leave empty for an open network. We'll ask again in the confirmation dialog so a typo can't lock you out."
         },
         "loading": "Looking for nearby Wi-Fi networks…",
         "empty": "No Wi-Fi networks found nearby. Move closer to your router or try again.",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -194,11 +194,11 @@
         "list": {
           "ariaLabel": "Bulunan Wi-Fi ağları"
         },
-        "unsecured": "Şifresiz",
+        "signal": "Sinyal {signal}%",
         "password": {
           "label": "Ağ şifresi",
           "placeholder": "Şifreyi yaz",
-          "hint": "Onay diyalogunda bir kez daha soracağız — yanlış tuş yüzünden cihazdan kilitlenmeyesin diye."
+          "optionalHint": "İsteğe bağlı — açık ağ için boş bırak. Onay diyalogunda bir kez daha soracağız, yanlış tuş yüzünden cihazdan kilitlenmeyesin diye."
         },
         "loading": "Yakındaki Wi-Fi ağları aranıyor…",
         "empty": "Yakında Wi-Fi ağı bulunamadı. Router'a yaklaş ya da tekrar dene.",

--- a/docs/dev-addon-pi.md
+++ b/docs/dev-addon-pi.md
@@ -97,8 +97,16 @@ UI üzerinden:
 
 1. **Glaon (dev)** kartına tıkla → **Install**. İlk install Pi üzerinde Docker image'ı **lokal olarak build eder** (~1-3 dakika; nginx + gettext apk install adımları log'da görünür).
 2. Install bittiğinde **Start** bas.
+3. **Log** sekmesini aç — şunu görmelisin (bashio'nun varsayılan log formatı, `[HH:MM:SS] INFO:` prefix'iyle):
 
-> **Mevcut bir install'ı güncellerken:** sadece rsync + start yetmez; image cache + AppArmor profile değişiklikleri yenilenmez. CLI'dan:
+   ```
+   [hh:mm:ss] INFO: Rendering nginx config with Supervisor token...
+   [hh:mm:ss] INFO: Starting nginx on :8099...
+   ```
+
+   `FATAL: SUPERVISOR_TOKEN is not set` görünürse `config.yaml` içinde `hassio_api: true` doğrulanmamış demektir — manifest'i kontrol et.
+
+> **Mevcut bir install'ı güncellerken:** sadece rsync + start yetmez; image cache, AppArmor profili ve `hassio_role` gibi manifest değişiklikleri yenilenmez. CLI'dan temiz kur:
 >
 > ```bash
 > ha apps uninstall local_glaon_dev    # mevcut container + image atılır
@@ -107,14 +115,7 @@ UI üzerinden:
 > ha apps start local_glaon_dev
 > ```
 >
-> `ha apps rebuild local_glaon_dev` da kullanılabilir ama bazı manifest değişiklikleri (apparmor flag toggle, hassio_api toggle) için uninstall-reinstall daha güvenli. 3. **Log** sekmesini aç — şunu görmelisin (bashio's varsayılan log formatı, `[HH:MM:SS] INFO:` prefix'iyle):
-
-```
-[hh:mm:ss] INFO: Rendering nginx config with Supervisor token...
-[hh:mm:ss] INFO: Starting nginx on :8099...
-```
-
-`FATAL: SUPERVISOR_TOKEN is not set` görünürse `config.yaml` içinde `hassio_api: true` doğrulanmamış demektir — manifest'i kontrol et.
+> `ha apps rebuild local_glaon_dev` da kullanılabilir ama manifest değişikliklerinde (apparmor flag, hassio_api, **hassio_role**) uninstall-reinstall daha güvenli.
 
 ## 5. Open Web UI
 
@@ -125,10 +126,10 @@ HA UI → Add-on sayfasında **OPEN WEB UI** butonuna bas. Wizard, Ingress URL'i
 ## 6. Doğrulama: gerçek Wi-Fi handoff
 
 1. Wizard'ı **Apply** step'ine kadar yürüt (Home Overview → Layout → Security → Apply).
-2. Apply step Wi-Fi network listesini load ederken `/api/hassio/network/info`'ya gider — bu istek dev add-on'un nginx'inden Supervisor'a forward edilir.
-3. **Pi'nin gerçek Wi-Fi tarama sonuçlarını** görmelisin (mock listesi değil — `GlaonDev-*` SSID'ler **görünmemeli**). Pi'ye fiziksel olarak hangi AP'ler erişilebiliyorsa onlar görünür.
-4. Bir SSID seç, password gir, **Save and switch network** bas.
-5. POST `/api/hassio/network/wlan0/update` Supervisor'a forward edilir, NetworkManager yeni connection'ı NM config'ine yazar.
+2. Apply step önce `/api/hassio/network/info`'dan wireless interface'i (wlan0) keşfeder, sonra `/api/hassio/network/interface/wlan0/accesspoints`'ten AP listesini çeker (#622) — ikisi de dev add-on'un nginx'inden Supervisor'a forward edilir.
+3. **Pi'nin gerçek Wi-Fi tarama sonuçlarını** görmelisin (mock listesi değil — `GlaonDev-*` SSID'ler **görünmemeli**). Pi'ye fiziksel olarak hangi AP'ler erişilebiliyorsa onlar sinyal gücüyle görünür.
+4. Bir SSID seç, password gir (açık ağsa boş bırak), **Save and switch network** bas.
+5. POST `/api/hassio/network/interface/wlan0/update` Supervisor'a forward edilir, NetworkManager yeni connection'ı NM config'ine yazar.
 
 ### Pi tarafında doğrulama
 
@@ -144,16 +145,17 @@ Yeni eklenen connection listede görünmeli.
 
 ## Sorun giderme
 
-| Belirti                                                             | Olası neden                                                                                                                                                                                                                                                                                                  |
-| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Local add-ons` bölümünde Glaon (dev) yok                           | `addons/local/glaon_dev/` path'i yanlış (en sık sebep: rsync hedefinde `/local/` segmenti unutulmuş — yukarı bak), slug eşleşmiyor, `ha apps reload` koşulmamış, ya da `config.yaml` parse hatası var. `ha supervisor logs` parse hatalarını gösterir.                                                       |
-| Install başarısız: "BUILD_FROM not found"                           | Pi mimarisi `aarch64` olmalı — `build.yaml` zaten her iki arch için image map'liyor. Pi'de `uname -m` ile doğrula.                                                                                                                                                                                           |
-| Log'da `FATAL: SUPERVISOR_TOKEN is not set`                         | `config.yaml`'da `hassio_api: true` eksik veya yanlış scope. Manifest'i doğrula, add-on'u kaldırıp tekrar install et.                                                                                                                                                                                        |
-| Log'da `/bin/sh: can't open '/init': Permission denied`             | Eski (#609 öncesi, AppArmor on) build'de çıkıyordu. Şimdi `apparmor: false` dev variant'ta — bu hatayı görüyorsan Pi'deki kaynaklar hâlâ eski. `head -1 /addons/local/glaon_dev/rootfs/run.sh` çıktısı `#!/usr/bin/with-contenv bashio` olmalı; değilse rsync hedefini + `ha apps rebuild` adımını tekrarla. |
-| Log'da `/init: exec: line 45: s6-overlay-suexec: Permission denied` | Aynı kök sebep — AppArmor s6-overlay v3 zincirini engelliyor. #611 ile `apparmor: false` yapıldı; eski install'ı silip yeniden install et (`ha apps uninstall local_glaon_dev && ha apps reload && ha apps install local_glaon_dev`). Rebuild tek başına AppArmor profile'ını yenilemiyor.                   |
-| `App glaon_dev does not exist` (CLI)                                | HA CLI local add-on'ları `local_<slug>` prefix'iyle saklıyor. `ha apps rebuild local_glaon_dev` (önekli) doğru komut.                                                                                                                                                                                        |
-| Wi-Fi listesi boş veya mock SSID'ler görünüyor                      | Mock'a düşmüş — apps/web `VITE_APP_MODE=ingress` ile build edilmemiş olabilir. Build script'ini kontrol et (`apps/web/.env.production`).                                                                                                                                                                     |
-| `/api/hassio/network/info` 502                                      | nginx Supervisor'a ulaşamıyor. `ha network info` çalışıyor mu? Çalışmıyorsa Supervisor'ın kendisi sorunlu. Çalışıyorsa add-on'un network ayarları (`host_network: false` doğru) gözden geçirilmeli.                                                                                                          |
+| Belirti                                                             | Olası neden                                                                                                                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Local add-ons` bölümünde Glaon (dev) yok                           | `addons/local/glaon_dev/` path'i yanlış (en sık sebep: rsync hedefinde `/local/` segmenti unutulmuş — yukarı bak), slug eşleşmiyor, `ha apps reload` koşulmamış, ya da `config.yaml` parse hatası var. `ha supervisor logs` parse hatalarını gösterir.                                                                                      |
+| Install başarısız: "BUILD_FROM not found"                           | Pi mimarisi `aarch64` olmalı — `build.yaml` zaten her iki arch için image map'liyor. Pi'de `uname -m` ile doğrula.                                                                                                                                                                                                                          |
+| Log'da `FATAL: SUPERVISOR_TOKEN is not set`                         | `config.yaml`'da `hassio_api: true` eksik veya yanlış scope. Manifest'i doğrula, add-on'u kaldırıp tekrar install et.                                                                                                                                                                                                                       |
+| Log'da `/bin/sh: can't open '/init': Permission denied`             | Eski (#609 öncesi, AppArmor on) build'de çıkıyordu. Şimdi `apparmor: false` dev variant'ta — bu hatayı görüyorsan Pi'deki kaynaklar hâlâ eski. `head -1 /addons/local/glaon_dev/rootfs/run.sh` çıktısı `#!/usr/bin/with-contenv bashio` olmalı; değilse rsync hedefini + `ha apps rebuild` adımını tekrarla.                                |
+| Log'da `/init: exec: line 45: s6-overlay-suexec: Permission denied` | Aynı kök sebep — AppArmor s6-overlay v3 zincirini engelliyor. #611 ile `apparmor: false` yapıldı; eski install'ı silip yeniden install et (`ha apps uninstall local_glaon_dev && ha apps reload && ha apps install local_glaon_dev`). Rebuild tek başına AppArmor profile'ını yenilemiyor.                                                  |
+| `App glaon_dev does not exist` (CLI)                                | HA CLI local add-on'ları `local_<slug>` prefix'iyle saklıyor. `ha apps rebuild local_glaon_dev` (önekli) doğru komut.                                                                                                                                                                                                                       |
+| `403 Forbidden` (gövde `403: Forbidden`) accesspoints/update'te     | Add-on rolü yetersiz (#622). HA Supervisor `/network/.+` endpoint'lerini `manager`/`admin` rolüne kapatıyor; varsayılan rol yalnız `GET /network/info`'ya izin verir. `config.yaml`'da `hassio_role: admin` olduğundan emin ol; manifest değiştiğinde uninstall + reload + install ile yeniden kur (rebuild rol değişikliğini almayabilir). |
+| Wi-Fi listesi boş ama HA UI ağları buluyor                          | Eski (#622 öncesi) build: AP'ler `/network/info`'dan okunuyordu ama Supervisor onları orada döndürmüyor. Düzeldi — tarama artık `/network/interface/{iface}/accesspoints`'ten gelir. Pi'deki kaynakları güncelle + yeniden install et.                                                                                                      |
+| `/api/hassio/network/info` 502                                      | nginx Supervisor'a ulaşamıyor. `ha network info` çalışıyor mu? Çalışmıyorsa Supervisor'ın kendisi sorunlu. Çalışıyorsa add-on'un network ayarları (`host_network: false` doğru) gözden geçirilmeli.                                                                                                                                         |
 
 ## Güvenlik notları
 


### PR DESCRIPTION
## Summary

Two bugs kept the wizard's Wi-Fi list empty against real HA even though HA's own Network UI found access points.

### Bug 1 — add-on role (403)
`GET /network/interface/wlan0/accesspoints` returned `403 Forbidden` (Supervisor's plain `403: Forbidden`). HA Supervisor's SecurityMiddleware gates `/network/.+` behind `ROLE_MANAGER`; our dev add-on dropped `hassio_role` in #611/#612 on the wrong assumption the default role covered it. Default only grants `GET /network/info`.
→ `addon-dev/config.yaml`: `hassio_role: admin`.

### Bug 2 — wrong scan endpoint + no `auth` in scan data
`/network/info` never carries access points (confirmed `hasAccesspoints: false`). The AP list lives on `GET /network/interface/{iface}/accesspoints`, shape `{ data: { accesspoints: [{ ssid, mac, frequency, signal }] } }` — **no `auth`/security field**. The wizard read `interfaces[].accesspoints` and keyed "password required" on the nonexistent `auth`.
- **apps/api**: new `GET /network/interface/:iface/accesspoints` proxy (mock + live + 503); update route corrected to canonical `POST /network/interface/:iface/update` (was missing `/interface/`); mocks now use real shapes.
- **apps/web**: two-step scan — discover the wireless interface from `/network/info`, then fetch its accesspoints; parse `data.accesspoints` (dedup by SSID, strongest signal first). Drop the `auth`-based gate → optional password per picked network (non-empty → `wpa-psk`, empty → `open`). Commit uses the discovered interface + canonical path. Rows show signal strength.
- **i18n** (en/tr): `wifi.unsecured` + `password.hint` → `wifi.signal` + `password.optionalHint`.
- **tests**: apps/api (16) + apps/web (10) + Playwright smoke updated to the two-endpoint shapes.
- **docs/dev-addon-pi.md**: troubleshooting rows for the 403/role + empty-list-despite-HA-UI; corrected verification endpoints.

## Scope

**In** — listed above.

**Out**

- Active-scan triggering / live progress (#620).
- Production relay onboarding path.
- Production `addon/` (never sets `hassio_api`/`hassio_role`).

## Test plan

- [x] apps/api type-check + 127 tests pass (16 hassio-network incl. new accesspoints + canonical update).
- [x] apps/web type-check + lint + 10 apply-step tests (rewritten for two-step scan + password-presence) + i18n parity.
- [ ] CI green on PR.
- [ ] Pi (after add-on rebuilt with `hassio_role: admin`): `curl :8080/hassio/network/interface/wlan0/accesspoints` → real AP list; wizard apply step shows the Pi's real SSIDs with signal; pick + password commits and the device joins. _(local-verification, user-driven)_

Closes #622
Refs #611, #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)