### PR TITLE
feat(core): add network config schema to DeviceConfig

### DIFF
--- a/packages/core/src/config/config-store.test.ts
+++ b/packages/core/src/config/config-store.test.ts
@@ -57,6 +57,27 @@ describe('InMemoryConfigStore', () => {
     });
   });
 
+  it('round-trips a network block through setPartial and preserves it across merges', async () => {
+    const store = new InMemoryConfigStore();
+    const network = {
+      hostname: 'glaon-wall',
+      interfaces: [
+        {
+          name: 'end0',
+          ipv4: { method: 'static' as const, address: ['192.168.1.50/24'], gateway: '192.168.1.1' },
+          ipv6: { method: 'auto' as const },
+        },
+      ],
+    };
+    await store.setPartial({ network });
+    await store.setPartial({ homeName: 'Olivia' });
+    expect(await store.get()).toEqual({
+      schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+      network,
+      homeName: 'Olivia',
+    });
+  });
+
   it('markComplete stamps an ISO timestamp and flips isConfigured', async () => {
     const store = new InMemoryConfigStore();
     await store.setPartial({ homeName: 'Olivia' });

--- a/packages/core/src/config/types.test.ts
+++ b/packages/core/src/config/types.test.ts
@@ -4,7 +4,11 @@ import {
   DEVICE_CONFIG_SCHEMA_VERSION,
   DeviceConfigSchema,
   FloorSchema,
+  InterfaceConfigSchema,
+  IpConfigSchema,
+  IpMethodSchema,
   LayoutSchema,
+  NetworkConfigSchema,
   RoomSchema,
   RoomTypeSchema,
   UnitSystemSchema,
@@ -46,6 +50,22 @@ describe('DeviceConfigSchema', () => {
         ],
       },
       wifi: { ssid: 'home', passwordCipher: 'AES-GCM:abc123' },
+      network: {
+        hostname: 'glaon-wall',
+        interfaces: [
+          {
+            name: 'end0',
+            ipv4: {
+              method: 'static' as const,
+              address: ['192.168.1.50/24'],
+              gateway: '192.168.1.1',
+              nameservers: ['1.1.1.1', '8.8.8.8'],
+            },
+            ipv6: { method: 'auto' as const },
+          },
+          { name: 'wlan0', ipv4: { method: 'auto' as const } },
+        ],
+      },
       securityPinHash: 'a'.repeat(64),
       completedAt: '2026-05-17T18:30:00.000Z',
     } as const;
@@ -133,6 +153,40 @@ describe('DeviceConfigSchema', () => {
       }),
     ).toThrow();
   });
+
+  it('accepts a network block with hostname + static/auto interfaces', () => {
+    const network = {
+      hostname: 'glaon-wall',
+      interfaces: [
+        {
+          name: 'end0',
+          ipv4: { method: 'static' as const, address: ['10.0.0.5/24'], gateway: '10.0.0.1' },
+        },
+        { name: 'wlan0', ipv4: { method: 'auto' as const } },
+      ],
+    };
+    expect(
+      DeviceConfigSchema.parse({ schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION, network }),
+    ).toEqual({ schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION, network });
+  });
+
+  it('rejects an invalid hostname (leading hyphen)', () => {
+    expect(() =>
+      DeviceConfigSchema.parse({
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        network: { hostname: '-glaon' },
+      }),
+    ).toThrow(/RFC 1123/);
+  });
+
+  it('rejects a network interface with an empty name', () => {
+    expect(() =>
+      DeviceConfigSchema.parse({
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        network: { interfaces: [{ name: '', ipv4: { method: 'auto' } }] },
+      }),
+    ).toThrow();
+  });
 });
 
 describe('LayoutSchema', () => {
@@ -197,5 +251,71 @@ describe('WifiConfigSchema', () => {
       ssid: 'home',
       passwordCipher: 'x',
     });
+  });
+});
+
+describe('IpMethodSchema', () => {
+  it('accepts auto, static, and disabled', () => {
+    expect(IpMethodSchema.parse('auto')).toBe('auto');
+    expect(IpMethodSchema.parse('static')).toBe('static');
+    expect(IpMethodSchema.parse('disabled')).toBe('disabled');
+  });
+
+  it('rejects anything else', () => {
+    expect(() => IpMethodSchema.parse('dhcp')).toThrow();
+  });
+});
+
+describe('IpConfigSchema', () => {
+  it('accepts a bare auto entry', () => {
+    expect(IpConfigSchema.parse({ method: 'auto' })).toEqual({ method: 'auto' });
+  });
+
+  it('round-trips a full static entry', () => {
+    const entry = {
+      method: 'static' as const,
+      address: ['192.168.1.50/24'],
+      gateway: '192.168.1.1',
+      nameservers: ['1.1.1.1'],
+    };
+    expect(IpConfigSchema.parse(entry)).toEqual(entry);
+  });
+
+  it('requires a method', () => {
+    expect(() => IpConfigSchema.parse({ address: ['10.0.0.1/24'] })).toThrow();
+  });
+
+  it('rejects an empty address string', () => {
+    expect(() => IpConfigSchema.parse({ method: 'static', address: [''] })).toThrow();
+  });
+});
+
+describe('InterfaceConfigSchema', () => {
+  it('accepts an interface with only a name', () => {
+    expect(InterfaceConfigSchema.parse({ name: 'end0' })).toEqual({ name: 'end0' });
+  });
+
+  it('rejects an empty interface name', () => {
+    expect(() => InterfaceConfigSchema.parse({ name: '' })).toThrow();
+  });
+});
+
+describe('NetworkConfigSchema', () => {
+  it('accepts an empty block', () => {
+    expect(NetworkConfigSchema.parse({})).toEqual({});
+  });
+
+  it('accepts a 63-char hostname but rejects 64', () => {
+    expect(NetworkConfigSchema.parse({ hostname: 'a'.repeat(63) })).toBeDefined();
+    expect(() => NetworkConfigSchema.parse({ hostname: 'a'.repeat(64) })).toThrow(/RFC 1123/);
+  });
+
+  it('rejects a hostname with an underscore or space', () => {
+    expect(() => NetworkConfigSchema.parse({ hostname: 'glaon_wall' })).toThrow(/RFC 1123/);
+    expect(() => NetworkConfigSchema.parse({ hostname: 'glaon wall' })).toThrow(/RFC 1123/);
+  });
+
+  it('rejects a trailing hyphen', () => {
+    expect(() => NetworkConfigSchema.parse({ hostname: 'glaon-' })).toThrow(/RFC 1123/);
   });
 });

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -67,6 +67,67 @@ export const WifiConfigSchema = z.object({
 });
 export type WifiConfig = z.infer<typeof WifiConfigSchema>;
 
+/**
+ * Supervisor IP-method vocabulary (matches HA's `ipv4`/`ipv6` `method`):
+ * `auto` = DHCP / SLAAC, `static` = manual addressing, `disabled` = no
+ * addressing on this family.
+ */
+export const IpMethodSchema = z.enum(['auto', 'static', 'disabled']);
+export type IpMethod = z.infer<typeof IpMethodSchema>;
+
+/**
+ * Per-family (IPv4 or IPv6) addressing for one interface, mirroring the
+ * HA Supervisor block. `address`/`gateway`/`nameservers` are only
+ * meaningful when `method === 'static'`. The schema enforces *shape*
+ * (non-empty strings), not IP semantics — friendlier per-field IP-format
+ * validation lives in the wizard's form layer, the same split that keeps
+ * `country` the only regex-validated field on DeviceConfig.
+ */
+export const IpConfigSchema = z.object({
+  method: IpMethodSchema,
+  /** CIDR strings, e.g. "192.168.1.50/24". Present for static config. */
+  address: z.array(z.string().min(1)).max(8).optional(),
+  gateway: z.string().min(1).optional(),
+  /** DNS servers, in priority order. */
+  nameservers: z.array(z.string().min(1)).max(8).optional(),
+});
+export type IpConfig = z.infer<typeof IpConfigSchema>;
+
+/**
+ * One network interface's collected IP config. `name` matches the
+ * Supervisor interface id (e.g. "end0", "wlan0"). Wi-Fi credentials stay
+ * on `DeviceConfig.wifi`; this block is wired/wireless addressing only.
+ */
+export const InterfaceConfigSchema = z.object({
+  name: z.string().min(1),
+  ipv4: IpConfigSchema.optional(),
+  ipv6: IpConfigSchema.optional(),
+});
+export type InterfaceConfig = z.infer<typeof InterfaceConfigSchema>;
+
+/**
+ * Device-level network settings collected in the wizard's Network step
+ * (#629): the LAN hostname + per-interface IPv4/IPv6. Fully optional and
+ * additive — blobs written before this field parse clean, so no
+ * `schemaVersion` bump (same reasoning as latitude/longitude/layout).
+ */
+export const NetworkConfigSchema = z.object({
+  /**
+   * RFC 1123 hostname label: 1–63 chars of letters, digits, and hyphens,
+   * with no leading or trailing hyphen. Case is preserved here; the
+   * Supervisor lowercases and re-validates host-side on commit.
+   */
+  hostname: z
+    .string()
+    .regex(
+      /^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/,
+      'hostname must be an RFC 1123 label (1–63 chars: letters, digits, hyphen; no leading/trailing hyphen)',
+    )
+    .optional(),
+  interfaces: z.array(InterfaceConfigSchema).max(16).optional(),
+});
+export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
+
 export const DeviceConfigSchema = z
   .object({
     schemaVersion: z.literal(DEVICE_CONFIG_SCHEMA_VERSION),
@@ -107,6 +168,13 @@ export const DeviceConfigSchema = z
      */
     layout: LayoutSchema.optional(),
     wifi: WifiConfigSchema.optional(),
+    /**
+     * LAN hostname + per-interface IPv4/IPv6 collected in the wizard's
+     * Network step (#629). Optional + additive; see NetworkConfigSchema.
+     * The terminal commit pushes hostname to the Supervisor host API and
+     * the IP config to `/network/interface/{iface}/update`.
+     */
+    network: NetworkConfigSchema.optional(),
     /** SHA-256 hex (64 lowercase hex chars). Plaintext PIN never leaves the device. */
     securityPinHash: z
       .string()


### PR DESCRIPTION
## Summary

Foundation for the wizard Network step (epic #626). Adds an optional `network` block to `DeviceConfigSchema` so the wizard can collect and persist the device LAN **hostname** and **per-interface IPv4/IPv6** addressing.

- `network.hostname` — RFC 1123 label (1–63 chars; letters/digits/hyphen, no leading/trailing hyphen).
- `network.interfaces[]` — `{ name, ipv4?, ipv6? }`, where each `IpConfig` mirrors the HA Supervisor shape: `method` (`auto` / `static` / `disabled`) + `address[]` (CIDR) + `gateway` + `nameservers[]`.
- Schema enforces **shape**, not IP semantics — friendly per-field IP-format validation lives in the wizard form layer (same split that keeps `country` the only regex-validated field).

Fully optional + additive, so blobs written before this field parse clean — **no `schemaVersion` bump** (same reasoning as `latitude`/`longitude`/`layout`). `ConfigStore.setPartial` needs no change: it spreads + parses the full schema, so the new field flows through automatically.

## Scope

**In**
- `packages/core/src/config/types.ts`: `IpMethodSchema`, `IpConfigSchema`, `InterfaceConfigSchema`, `NetworkConfigSchema` (+ inferred types), wired onto `DeviceConfigSchema.network`.
- Tests in `types.test.ts` (schema accept/reject) + `config-store.test.ts` (setPartial round-trip + merge preservation).

**Out**
- apps/api Supervisor proxy for hostname/IP (#627).
- Web wizard Network step UI (#629).
- HA Core / Supervisor commit mapping.

## Test plan

- [x] `pnpm --filter @glaon/core test` — 189 passing (network accept/reject, hostname RFC 1123 edges, IP method enum, setPartial round-trip).
- [x] `pnpm type-check` — all 11 workspace tasks green (no downstream break).
- [x] `pnpm --filter @glaon/core lint` + knip clean (no unused exports flagged).

Refs #626
Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)