### PR TITLE
feat(api): proxy Supervisor hostname + accept IPv4/IPv6 interface config

### DIFF
--- a/apps/api/src/routes/hassio-network.test.ts
+++ b/apps/api/src/routes/hassio-network.test.ts
@@ -60,6 +60,61 @@ describe('hassio-network — mock mode', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ mocked: true });
   });
+
+  it('embeds ipv4/ipv6 blocks per interface on GET /network/info', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
+    const res = await router.request('/network/info');
+    const body = (await res.json()) as {
+      data: { interfaces: { interface: string; ipv4?: { method: string } }[] };
+    };
+    const end0 = body.data.interfaces.find((i) => i.interface === 'end0');
+    expect(end0?.ipv4?.method).toBe('static');
+    const wlan0 = body.data.interfaces.find((i) => i.interface === 'wlan0');
+    expect(wlan0?.ipv4?.method).toBe('auto');
+  });
+
+  it('accepts an ipv4 static payload on POST /network/interface/:iface/update', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
+    const res = await router.request('/network/interface/end0/update', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ipv4: { method: 'static', address: ['192.168.1.50/24'], gateway: '192.168.1.1' },
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ mocked: true });
+  });
+
+  it('returns a hostname on GET /host/info', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
+    const res = await router.request('/host/info');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { hostname: string } };
+    expect(body.data.hostname).toBe('glaon');
+  });
+
+  it('accepts a valid hostname on POST /host/options', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
+    const res = await router.request('/host/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hostname: 'glaon-wall' }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ mocked: true });
+  });
+
+  it('rejects an invalid hostname on POST /host/options with 400', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig({ supervisorMock: true }) });
+    const res = await router.request('/host/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hostname: '-bad_host name' }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: 'invalid-hostname' });
+  });
 });
 
 describe('hassio-network — unconfigured', () => {
@@ -82,6 +137,22 @@ describe('hassio-network — unconfigured', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ wifi: { auth: 'open', ssid: 'X' } }),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 503 on GET /host/info when neither URL nor mock is set', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig() });
+    const res = await router.request('/host/info');
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 503 on POST /host/options (valid hostname) when neither URL nor mock is set', async () => {
+    const router = createHassioNetworkRouter({ config: baseConfig() });
+    const res = await router.request('/host/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hostname: 'glaon' }),
     });
     expect(res.status).toBe(503);
   });
@@ -163,6 +234,54 @@ describe('hassio-network — live proxy', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: 'not-json',
+    });
+    expect(res.status).toBe(400);
+    expect(vi.mocked(fetchImpl)).not.toHaveBeenCalled();
+  });
+
+  it('forwards GET /host/info to the upstream supervisor with the bearer token', async () => {
+    const fetchImpl: typeof fetch = vi.fn(() =>
+      Promise.resolve(mockResponse({ body: { data: { hostname: 'pi-ha' } } })),
+    );
+    const router = createHassioNetworkRouter({ config, fetchImpl });
+    const res = await router.request('/host/info');
+    expect(res.status).toBe(200);
+    const call = vi.mocked(fetchImpl).mock.calls[0];
+    if (call === undefined) throw new Error('expected upstream call');
+    expect(call[0]).toBe('http://supervisor.test/network/host/info');
+    const init = call[1];
+    if (init === undefined) throw new Error('expected init');
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer long-lived-token');
+  });
+
+  it('forwards POST /host/options body to the upstream with the bearer token', async () => {
+    const fetchImpl: typeof fetch = vi.fn(() =>
+      Promise.resolve(mockResponse({ status: 202, body: { result: 'ok' } })),
+    );
+    const router = createHassioNetworkRouter({ config, fetchImpl });
+    const res = await router.request('/host/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hostname: 'glaon-wall' }),
+    });
+    expect(res.status).toBe(202);
+    const call = vi.mocked(fetchImpl).mock.calls[0];
+    if (call === undefined) throw new Error('expected upstream call');
+    expect(call[0]).toBe('http://supervisor.test/network/host/options');
+    const init = call[1];
+    if (init === undefined) throw new Error('expected init');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toMatchObject({ hostname: 'glaon-wall' });
+  });
+
+  it('rejects an invalid hostname on POST /host/options with 400 before touching the supervisor', async () => {
+    const fetchImpl: typeof fetch = vi.fn();
+    const router = createHassioNetworkRouter({ config, fetchImpl });
+    const res = await router.request('/host/options', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ hostname: 'bad host' }),
     });
     expect(res.status).toBe(400);
     expect(vi.mocked(fetchImpl)).not.toHaveBeenCalled();

--- a/apps/api/src/routes/hassio-network.ts
+++ b/apps/api/src/routes/hassio-network.ts
@@ -46,12 +46,57 @@ interface HassioNetworkRouterDeps {
 // `/network/info` returns interfaces only — the real Supervisor does NOT
 // embed access points here (#622). The wizard discovers the wireless
 // interface from this list, then scans it via the accesspoints endpoint.
+//
+// Each interface carries `ipv4`/`ipv6` blocks matching the Supervisor
+// shape (`{ method, address, gateway, nameservers, ready }`) so the
+// Network step (#629) has real config to render in mock / HA-less dev.
+// `end0` is a static ethernet, `wlan0` an auto/DHCP wireless — two shapes
+// to exercise the UI's static vs. DHCP branches.
 const MOCK_NETWORK_INFO = {
   data: {
     interfaces: [
-      { interface: 'wlan0', type: 'wireless', enabled: true, connected: false, primary: false },
-      { interface: 'end0', type: 'ethernet', enabled: true, connected: true, primary: true },
+      {
+        interface: 'wlan0',
+        type: 'wireless',
+        enabled: true,
+        connected: false,
+        primary: false,
+        ipv4: { method: 'auto', address: [], gateway: null, nameservers: [], ready: false },
+        ipv6: { method: 'auto', address: [], gateway: null, nameservers: [], ready: false },
+      },
+      {
+        interface: 'end0',
+        type: 'ethernet',
+        enabled: true,
+        connected: true,
+        primary: true,
+        ipv4: {
+          method: 'static',
+          address: ['192.168.1.50/24'],
+          gateway: '192.168.1.1',
+          nameservers: ['192.168.1.1', '1.1.1.1'],
+          ready: true,
+        },
+        ipv6: {
+          method: 'auto',
+          address: ['fe80::5c7d:aeff:fec1:7ff8/64'],
+          gateway: null,
+          nameservers: [],
+          ready: true,
+        },
+      },
     ],
+  },
+};
+
+// `/host/info` — device host metadata. The wizard's Network step (#629)
+// seeds its hostname field from `data.hostname`.
+const MOCK_HOST_INFO = {
+  data: {
+    hostname: 'glaon',
+    operating_system: 'Home Assistant OS 12.0',
+    kernel: '6.6.0',
+    chassis: 'embedded',
   },
 };
 
@@ -199,7 +244,86 @@ export function createHassioNetworkRouter(deps: HassioNetworkRouterDeps): Hono {
     }
   });
 
+  // Host metadata — the wizard's Network step (#629) seeds its hostname
+  // field from `data.hostname`. Maps to the Supervisor `/host/info`.
+  router.get('/host/info', async (c) => {
+    if (supervisorMock) {
+      return c.json(MOCK_HOST_INFO);
+    }
+    if (supervisorUrl === undefined || supervisorToken === undefined) {
+      return c.json(NOT_CONFIGURED_BODY, 503);
+    }
+    try {
+      const upstream = await fetchImpl(`${trim(supervisorUrl)}/host/info`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${supervisorToken}` },
+      });
+      const text = await upstream.text();
+      deps.logger?.info({ event: 'hassio-network.proxy.host.get', status: upstream.status });
+      return passThroughResponse(text, upstream);
+    } catch (err) {
+      deps.logger?.error({
+        event: 'hassio-network.proxy.host.get.failed',
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+      return c.json({ error: 'supervisor-unreachable' }, 502);
+    }
+  });
+
+  // Set the device hostname. Maps to the Supervisor `/host/options`.
+  // `hostname`, when present, must be an RFC 1123 label — rejected with
+  // 400 before touching the Supervisor (the host-side validator also
+  // enforces this, but a clear 400 beats a cryptic upstream 4xx).
+  router.post('/host/options', async (c) => {
+    const body: unknown = await c.req.json().catch(() => null);
+    if (body === null || typeof body !== 'object') {
+      return c.json({ error: 'invalid-body' }, 400);
+    }
+    const { hostname } = body as { hostname?: unknown };
+    if (hostname !== undefined && (typeof hostname !== 'string' || !isValidHostname(hostname))) {
+      return c.json({ error: 'invalid-hostname' }, 400);
+    }
+    if (supervisorMock) {
+      return c.json({ result: 'ok', mocked: true });
+    }
+    if (supervisorUrl === undefined || supervisorToken === undefined) {
+      return c.json(NOT_CONFIGURED_BODY, 503);
+    }
+    try {
+      const upstream = await fetchImpl(`${trim(supervisorUrl)}/host/options`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${supervisorToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      const text = await upstream.text();
+      deps.logger?.info({
+        event: 'hassio-network.proxy.host.post',
+        status: upstream.status,
+        hostname,
+      });
+      return passThroughResponse(text, upstream);
+    } catch (err) {
+      deps.logger?.error({
+        event: 'hassio-network.proxy.host.post.failed',
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+      return c.json({ error: 'supervisor-unreachable' }, 502);
+    }
+  });
+
   return router;
+}
+
+// RFC 1123 hostname label: 1–63 chars of letters, digits, and hyphens,
+// no leading/trailing hyphen. Mirrors @glaon/core's NetworkConfigSchema
+// (kept inline so this proxy carries no @glaon/core dependency).
+const HOSTNAME_RE = /^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
+
+function isValidHostname(value: string): boolean {
+  return HOSTNAME_RE.test(value);
 }
 
 // Mirror the upstream supervisor response back to the caller. Returning

--- a/docs/dev-supervisor.md
+++ b/docs/dev-supervisor.md
@@ -1,11 +1,19 @@
 # HA Supervisor proxy — dev guide
 
-The setup wizard's apply step (#597) talks to HA Supervisor at two
-endpoints:
+The setup wizard's Network step (#629) + apply step (#597) talk to HA
+Supervisor at these endpoints:
 
-- `GET /api/hassio/network/info` — enumerate Wi-Fi access points.
-- `POST /api/hassio/network/wlan0/update` — commit the chosen SSID +
-  password (this is the disconnect / handoff moment).
+- `GET /api/hassio/network/info` — enumerate interfaces, each with its
+  `ipv4`/`ipv6` config (`method` / `address` / `gateway` / `nameservers`).
+- `GET /api/hassio/network/interface/{iface}/accesspoints` — Wi-Fi scan.
+- `POST /api/hassio/network/interface/{iface}/update` — commit Wi-Fi
+  credentials and/or `ipv4`/`ipv6` config (the Wi-Fi case is the
+  disconnect / handoff moment).
+- `GET /api/hassio/host/info` — device host metadata; the Network step
+  seeds its hostname field from `data.hostname` (#627).
+- `POST /api/hassio/host/options` — set the device hostname. The proxy
+  validates `hostname` as an RFC 1123 label and rejects bad input with
+  `400 invalid-hostname` before touching the Supervisor (#627).
 
 Two runtime modes:
 
@@ -18,9 +26,12 @@ This doc covers **standalone / dev**.
 
 ## Quick start (mock mode — recommended for daily dev)
 
-Mock mode gives you a canned 3-network payload from `GET /network/info`
-and accepts any `POST /network/:iface/update` with a 200. The wizard's
-apply step walks end-to-end without a real HA running anywhere.
+Mock mode gives you canned payloads: two interfaces with `ipv4`/`ipv6`
+config from `GET /network/info`, a 3-network scan from the accesspoints
+endpoint, a hostname from `GET /host/info`, and a 200 for any
+`POST /network/interface/:iface/update` or `POST /host/options` (a bad
+hostname still gets `400`). The wizard's Network + apply steps walk
+end-to-end without a real HA running anywhere.
 
 ```bash
 cp apps/api/.env.example apps/api/.env


### PR DESCRIPTION
## Summary

Foundation for the wizard Network step (epic #626). Extends the `hassio-network` Supervisor proxy so the wizard can read/set the device hostname and render per-interface IPv4/IPv6 config.

- **`GET /api/hassio/host/info`** — net-new proxy to Supervisor `/host/info`. The Network step seeds its hostname field from `data.hostname`.
- **`POST /api/hassio/host/options`** — net-new proxy to Supervisor `/host/options`. Validates `hostname` as an RFC 1123 label and rejects bad input with `400 invalid-hostname` **before** touching the Supervisor (clear 400 beats a cryptic upstream 4xx). The regex is inlined (no `@glaon/core` dependency on this proxy) but mirrors `NetworkConfigSchema` from #628.
- **Enriched dev mock**: `/network/info` now carries per-interface `ipv4`/`ipv6` blocks (`end0` static, `wlan0` auto) and `/host/info` returns a hostname — so the Network step has real config to render in mock / HA-less dev.
- The existing `POST /network/interface/:iface/update` already passes the body through verbatim, so `ipv4`/`ipv6` payloads already reach a **live** Supervisor; the mock now accepts them too (200).

## Scope

**In**
- `apps/api/src/routes/hassio-network.ts`: `MOCK_HOST_INFO`, enriched `MOCK_NETWORK_INFO`, `GET /host/info`, `POST /host/options`, `isValidHostname`.
- Tests in `hassio-network.test.ts` (mock / unconfigured / live-proxy for the new endpoints + ipv4/ipv6 mock assertions).
- `docs/dev-supervisor.md`: endpoint list + mock-mode description.

**Out**
- `@glaon/core` schema (#628).
- Web wizard Network step UI (#629).
- Hostname/IP push from the wizard commit (#629).

## Test plan

- [x] `pnpm --filter @glaon/api test hassio-network` — 26 passing (host info/options mock, valid/invalid hostname → 200/400, ipv4/ipv6 in mock, live-proxy forwarding + bearer, 503 when unconfigured).
- [x] `pnpm --filter @glaon/api type-check` + `lint` green.
- [ ] CI green (watching after push).

Refs #626
Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)