### PR TITLE
feat(web): add wizard Network step + move Wi-Fi out of apply

### DIFF
--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -1,57 +1,79 @@
-// Setup wizard @smoke spec (#549 — epic #533, updated for the
-// step-collapse in #597). Drives the first-run device setup wizard
-// end-to-end:
+// Setup wizard @smoke spec (#549 — epic #533; updated for #597's step
+// collapse and #629's Network step). Drives the first-run device setup
+// wizard end-to-end:
 //
 //   1. clear `glaon.device-config` so SetupGate routes to the wizard
 //      (the shared fixture in `support/test.ts` seeds a completedAt
 //      blob by default — we have to opt out).
-//   2. mock the HA Supervisor network endpoints. The preview build
-//      isn't started with `VITE_APP_MODE=standalone`, so the apply
-//      step takes the populated wifi branch and tries to scan; mocked
-//      fetch lets the test pick an unsecured `PreviewGuest` AP and
-//      the commit POST round-trips cleanly.
-//   3. walk all 4 steps filling the minimum required fields:
+//   2. mock the HA Supervisor endpoints. The Network step (#629) reads
+//      /network/info (interfaces + IPv4/IPv6) and /host/info (hostname),
+//      scans Wi-Fi via the accesspoints endpoint, and the commit pushes
+//      hostname (/host/options) + per-interface IP/Wi-Fi (/network/
+//      interface/*/update) before the handoff.
+//   3. walk all 5 steps filling the minimum required fields:
 //        - Home Overview → set the home name + advance
 //        - Layout Setup → advance (single default floor, no required field)
 //        - Device Security → password + confirm + advance
-//        - Apply → assert summary contains the typed home name, pick
-//          the mocked unsecured AP, click "Save and switch network".
-//          No handoff modal opens (the AP is unsecured) so the commit
-//          fires immediately; `window.location.reload()` lands the
-//          user on mode-select or login (either is post-wizard
-//          surface).
-//   4. second test confirms the reload-after-completion path: a
-//      second visit never re-renders the wizard.
+//        - Network → pick the mocked unsecured `PreviewGuest` AP + advance
+//        - Apply → assert summary contains the typed home name, click
+//          "Save and switch network". The AP is unsecured, so no handoff
+//          modal opens; the commit fires immediately and
+//          `window.location.reload()` lands the user on mode-select /
+//          login.
+//   4. second test confirms the reload-after-completion path: a second
+//      visit never re-renders the wizard.
 //
 // Tagged `@smoke` so the CI matrix runs it on every PR.
 
 import { expect, test, type Page } from '@playwright/test';
 
-// Bypass the shared `support/test.ts` fixture deliberately: the fixture
-// runs an init script on every navigation that seeds
-// `glaon.device-config.completedAt`. After this spec's wizard
-// completes and reloads, that init script would overwrite the blob
-// the user just persisted — so SetupGate would still see "configured"
-// thanks to the seed but the test couldn't observe the wizard's own
-// write. Using the raw `@playwright/test` import keeps localStorage
-// untouched between navigations, matching real first-run behaviour.
+// Bypass the shared `support/test.ts` fixture deliberately (see #549) so
+// localStorage stays untouched between navigations, matching real
+// first-run behaviour.
 
 const DEVICE_CONFIG_KEY = 'glaon.device-config';
 
-async function mockSupervisorNetworkScan(page: Page): Promise<void> {
-  // #622 — /network/info carries interfaces only (for wireless-interface
-  // discovery); the AP list comes from the accesspoints endpoint, which
-  // has no `auth` field (signal only).
+async function mockSupervisorNetwork(page: Page): Promise<void> {
+  // /network/info — interfaces with IPv4/IPv6 blocks (#629). wlan0 first
+  // so it's the default tab and the Wi-Fi picker shows immediately.
   await page.route('**/api/hassio/network/info', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        data: { interfaces: [{ interface: 'wlan0', type: 'wireless', enabled: true }] },
+        data: {
+          interfaces: [
+            {
+              interface: 'wlan0',
+              type: 'wireless',
+              enabled: true,
+              ipv4: { method: 'auto' },
+              ipv6: { method: 'auto' },
+            },
+            {
+              interface: 'end0',
+              type: 'ethernet',
+              enabled: true,
+              ipv4: { method: 'auto' },
+              ipv6: { method: 'auto' },
+            },
+          ],
+        },
       }),
     });
   });
-  await page.route('**/api/hassio/network/interface/wlan0/accesspoints', async (route) => {
+  // /host/info — seeds the hostname field.
+  await page.route('**/api/hassio/host/info', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: { hostname: 'glaon' } }),
+    });
+  });
+  await page.route('**/api/hassio/host/options', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{"result":"ok"}' });
+  });
+  await page.route('**/api/hassio/network/interface/*/accesspoints', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -60,11 +82,11 @@ async function mockSupervisorNetworkScan(page: Page): Promise<void> {
       }),
     });
   });
-  await page.route('**/api/hassio/network/interface/wlan0/update', async (route) => {
+  await page.route('**/api/hassio/network/interface/*/update', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: '{"result":"ok"}' });
   });
   // #617 — the apply step pushes home settings to HA Core before the
-  // Wi-Fi handoff. Mock a clean success so the commit ceremony proceeds.
+  // network commit. Mock a clean success so the ceremony proceeds.
   await page.route('**/api/setup/apply-ha', async (route) => {
     await route.fulfill({
       status: 200,
@@ -74,50 +96,49 @@ async function mockSupervisorNetworkScan(page: Page): Promise<void> {
   });
 }
 
+async function walkToNetworkStep(page: Page): Promise<void> {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { level: 1, name: 'Home Overview' })).toBeVisible();
+  await page.getByLabel('Home Name').fill('Olivia');
+  await page.getByRole('button', { name: 'Next' }).click();
+
+  await expect(page.getByRole('heading', { level: 1, name: 'Layout Setup' })).toBeVisible();
+  await page.getByRole('button', { name: 'Next' }).click();
+
+  await expect(page.getByRole('heading', { level: 1, name: 'Device Security' })).toBeVisible();
+  // The asterisk lives inside the <label>, so getByLabel misses; the
+  // placeholders are unique per field.
+  await page.getByPlaceholder('At least 8 characters').fill('correct-horse');
+  await page.getByPlaceholder('Type the password again').fill('correct-horse');
+  await page.getByRole('button', { name: 'Next' }).click();
+}
+
 test.describe('setup wizard @smoke', () => {
   test.beforeEach(async ({ page }) => {
-    await mockSupervisorNetworkScan(page);
+    await mockSupervisorNetwork(page);
   });
 
-  test('walks all 4 steps and lands on the login screen after commit', async ({ page }) => {
-    await page.goto('/');
+  test('walks all 5 steps and lands on the login screen after commit', async ({ page }) => {
+    await walkToNetworkStep(page);
 
-    // Step 1: Home Overview.
-    await expect(page.getByRole('heading', { level: 1, name: 'Home Overview' })).toBeVisible();
-    await page.getByLabel('Home Name').fill('Olivia');
+    // Step 4: Network. Pick the mocked unsecured AP (Wi-Fi picker moved
+    // here from Apply in #629), then advance. The hostname seeds from
+    // /host/info; the default static-method panels need no input.
+    await expect(page.getByRole('heading', { level: 1, name: 'Network' })).toBeVisible();
+    await page.getByRole('button', { name: /PreviewGuest/i }).click();
     await page.getByRole('button', { name: 'Next' }).click();
 
-    // Step 2: Layout Setup (placeholder; no required field).
-    await expect(page.getByRole('heading', { level: 1, name: 'Layout Setup' })).toBeVisible();
-    await page.getByRole('button', { name: 'Next' }).click();
-
-    // Step 3: Device Security. After #597 the wizard collapses the
-    // old Wi-Fi credentials step + Final Review into the terminal
-    // Apply step, so Security comes immediately after Layout.
-    await expect(page.getByRole('heading', { level: 1, name: 'Device Security' })).toBeVisible();
-    // SecurityStep labels render as "Password *" / "Confirm password *"
-    // (the asterisk lives inside the <label>), so getByLabel with
-    // exact:true misses. Use the placeholder text — unique per field.
-    await page.getByPlaceholder('At least 8 characters').fill('correct-horse');
-    await page.getByPlaceholder('Type the password again').fill('correct-horse');
-    await page.getByRole('button', { name: 'Next' }).click();
-
-    // Step 4: Save and apply. Summary contains the home name, the
-    // wifi picker shows the mocked PreviewGuest AP; clicking it
-    // selects the network. The AP is unsecured, so "Save and switch
-    // network" commits without opening the handoff modal. The reload
-    // lands on mode-select / login.
+    // Step 5: Save and apply. Summary contains the home name; the AP is
+    // unsecured, so "Save and switch network" commits without a handoff
+    // modal. The reload lands on mode-select / login.
     await expect(page.getByRole('heading', { level: 1, name: 'Save and apply' })).toBeVisible();
     await expect(page.getByText('Olivia')).toBeVisible();
-    await page.getByRole('button', { name: /PreviewGuest/i }).click();
     await page.getByRole('button', { name: 'Save and switch network' }).click();
 
     await expect(
       page.getByTestId('mode-select-route').or(page.getByTestId('login-device-form')),
     ).toBeVisible({ timeout: 10_000 });
 
-    // The persisted blob now has `completedAt` so a second visit
-    // never shows the wizard again.
     const persistedRaw = await page.evaluate(
       (key) => window.localStorage.getItem(key),
       DEVICE_CONFIG_KEY,
@@ -128,18 +149,9 @@ test.describe('setup wizard @smoke', () => {
   });
 
   test('reload after completion never re-runs the wizard', async ({ page }) => {
-    // First run: walk the wizard end-to-end (compressed assertions).
-    await page.goto('/');
-    await page.getByLabel('Home Name').fill('Olivia');
-    await page.getByRole('button', { name: 'Next' }).click(); // Home → Layout
-    await page.getByRole('button', { name: 'Next' }).click(); // Layout → Security
-    // SecurityStep labels render as "Password *" / "Confirm password *"
-    // (the asterisk lives inside the <label>), so getByLabel with
-    // exact:true misses. Use the placeholder text — unique per field.
-    await page.getByPlaceholder('At least 8 characters').fill('correct-horse');
-    await page.getByPlaceholder('Type the password again').fill('correct-horse');
-    await page.getByRole('button', { name: 'Next' }).click(); // Security → Apply
+    await walkToNetworkStep(page);
     await page.getByRole('button', { name: /PreviewGuest/i }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
     await page.getByRole('button', { name: 'Save and switch network' }).click();
     await expect(
       page.getByTestId('mode-select-route').or(page.getByTestId('login-device-form')),

--- a/apps/web/src/features/setup/apply/apply-step.test.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.test.tsx
@@ -1,9 +1,9 @@
-// Combined smoke for the merged Apply step (#597). Folds the
-// previous wifi-step and review-step test coverage into one file
-// since the two screens collapsed into one. The handoff modal +
-// overlay sit under `wifi/handoff-*.tsx` and are exercised end-to-
-// end here (the modal opens after the user clicks Save and the
-// network is secured).
+// Apply step smoke (#597, #629). After #629 the Wi-Fi scan + picker
+// moved to the Network step; the apply step now reads everything from
+// `collected` and runs the commit ceremony: HA-settings push → hostname
+// → per-interface IP → Wi-Fi handoff. The handoff modal + overlay sit
+// under `wifi/handoff-*.tsx` and are exercised here (the modal opens
+// after Save when the collected Wi-Fi is secured).
 
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,7 +12,7 @@ import { InMemoryConfigStore } from '@glaon/core/config';
 import { ToastProvider } from '@glaon/ui';
 
 import { ConfigProvider } from '../../../config/config-provider';
-import { isWrapped } from '../wifi/wifi-crypto';
+import { isWrapped, wrapPassword } from '../wifi/wifi-crypto';
 import { ApplyStep } from './apply-step';
 
 interface MockResponseInit {
@@ -43,9 +43,7 @@ const baseCollected = {
   unitSystem: 'metric' as const,
 };
 
-// #622 — /network/info carries interfaces only (for wireless-interface
-// discovery); the AP list comes from the accesspoints endpoint and has
-// no `auth` field (signal only).
+// /network/info — used by the commit's wireless-interface discovery.
 const sampleNetworkInfo = {
   data: {
     interfaces: [
@@ -55,55 +53,36 @@ const sampleNetworkInfo = {
   },
 };
 
-const sampleAccessPoints = {
-  data: {
-    accesspoints: [
-      { ssid: 'HomeWifi', mac: 'aa:bb:cc:00:00:01', signal: 70, mode: 'infrastructure' },
-      { ssid: 'Guest', mac: 'aa:bb:cc:00:00:02', signal: 55, mode: 'infrastructure' },
-    ],
-  },
-};
-
-/** Default success response for the HA-settings push (#617). */
 const haApplyOk = { ok: true, steps: [] };
 
-/** Route a GET network request to the right canned payload, else null. */
-function networkScanResponse(url: string): Response | null {
-  if (url.includes('/network/info')) return mockFetchResponse({ json: sampleNetworkInfo });
-  if (url.includes('/accesspoints')) return mockFetchResponse({ json: sampleAccessPoints });
-  return null;
-}
-
-/**
- * URL-aware default mock. The wizard's scan is two GETs (/network/info
- * then /network/interface/wlan0/accesspoints); the commit fires
- * /api/setup/apply-ha then the supervisor update POST. Route each so one
- * doesn't get another's payload.
- */
+/** Default URL-aware mock: apply-ha + network/info GET + any POST → ok. */
 function defaultFetch(url: unknown): Promise<Response> {
   const u = String(url);
   if (u.includes('/api/setup/apply-ha')) {
     return Promise.resolve(mockFetchResponse({ json: haApplyOk }));
   }
-  const scan = networkScanResponse(u);
-  if (scan !== null) return Promise.resolve(scan);
-  // Update POST (or anything else) → ok.
+  if (u.includes('/network/info'))
+    return Promise.resolve(mockFetchResponse({ json: sampleNetworkInfo }));
   return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
 }
 
-/** Find the supervisor wifi-update POST specifically (not the apply-ha POST). */
-function findWifiPost(): unknown[] | undefined {
+/** Find a POST call whose URL contains `substr` (not the apply-ha POST). */
+function findPost(substr: string): unknown[] | undefined {
   const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls;
   return calls.find(
     ([url, init]) =>
-      (init as { method?: string } | undefined)?.method === 'POST' &&
-      String(url).includes('/hassio/'),
+      (init as { method?: string } | undefined)?.method === 'POST' && String(url).includes(substr),
   );
+}
+
+function postBody(call: unknown[] | undefined): Record<string, unknown> {
+  return JSON.parse((call?.[1] as { body: string }).body) as Record<string, unknown>;
 }
 
 const reloadSpy = vi.fn();
 
 beforeEach(() => {
+  localStorage.clear();
   Object.defineProperty(window, 'location', {
     configurable: true,
     value: { reload: reloadSpy },
@@ -118,6 +97,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
+  localStorage.clear();
 });
 
 describe('ApplyStep — summary', () => {
@@ -129,109 +109,85 @@ describe('ApplyStep — summary', () => {
     expect(getByText('Metric')).toBeInTheDocument();
   });
 
+  it('shows the hostname + Wi-Fi from collected network config', () => {
+    const collected = {
+      ...baseCollected,
+      network: { hostname: 'glaon-wall' },
+      wifi: { ssid: 'HomeWifi', passwordCipher: 'AES-GCM:abc' },
+    };
+    const { getByText } = render(wrap(<ApplyStep collected={collected} />));
+    expect(getByText('glaon-wall')).toBeInTheDocument();
+    // wifiSecured renders the "(secured)" summary variant (vs. the not-set
+    // glyph) — robust to whether i18n interpolation runs in the test env.
+    expect(getByText(/secured/)).toBeInTheDocument();
+  });
+
   it('marks empty fields with the not-set glyph', () => {
     const { getAllByText } = render(wrap(<ApplyStep collected={{}} />));
     expect(getAllByText('—').length).toBeGreaterThan(0);
   });
 });
 
-describe('ApplyStep — Wi-Fi scan unavailable (503)', () => {
-  // #619: availability is server-driven, not a build flag. When the
-  // network-info endpoint answers 503 (supervisor-not-configured) the
-  // Wi-Fi block degrades to an informational notice and the user can
-  // commit without a network switch — the HA-less dev environment.
-  beforeEach(() => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((url: unknown) => {
-        const u = String(url);
-        // Every Supervisor + HA-settings path 503s (HA-less env).
-        if (u.includes('/api/hassio/network/') || u.includes('/api/setup/apply-ha')) {
-          return Promise.resolve(
-            mockFetchResponse({
-              ok: false,
-              status: 503,
-              json: { error: 'supervisor-not-configured' },
-            }),
-          );
-        }
-        return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
-      }),
-    );
-  });
-
-  it('renders the informational notice and commits without a wifi handoff', async () => {
+describe('ApplyStep — commit', () => {
+  it('commits home settings with no network/Wi-Fi and reloads (no handoff)', async () => {
     const configStore = new InMemoryConfigStore();
-    const { getByRole, findByText } = render(
-      wrap(<ApplyStep collected={baseCollected} />, configStore),
-    );
-    expect(await findByText(/Wi-Fi scanning isn't available/i)).toBeInTheDocument();
+    const { getByRole } = render(wrap(<ApplyStep collected={baseCollected} />, configStore));
     fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
     await waitFor(() => {
       expect(reloadSpy).toHaveBeenCalledTimes(1);
     });
     expect(await configStore.isConfigured()).toBe(true);
-    // No supervisor wifi-update POST — the wifi block had nothing to
-    // commit (the HA-settings push 503s to a silent skip).
-    expect(findWifiPost()).toBeUndefined();
-  });
-});
-
-describe('ApplyStep — populated mode', () => {
-  beforeEach(() => {
-    vi.stubEnv('VITE_APP_MODE', 'ingress');
+    expect(findPost('/host/options')).toBeUndefined();
+    expect(findPost('/network/interface/')).toBeUndefined();
   });
 
-  it('renders one card per SSID returned by the scan', async () => {
-    const { findByText } = render(wrap(<ApplyStep collected={baseCollected} />));
-    expect(await findByText('HomeWifi')).toBeInTheDocument();
-    expect(await findByText('Guest')).toBeInTheDocument();
-  });
-
-  it('blocks Save until a network is picked', async () => {
-    const { findByText, getByRole } = render(wrap(<ApplyStep collected={baseCollected} />));
-    await findByText('HomeWifi');
-    const cta = getByRole('button', { name: 'Save and switch network' }) as HTMLButtonElement;
-    expect(cta.disabled).toBe(true);
-  });
-
-  it('commits an unsecured network without opening the handoff modal', async () => {
-    const configStore = new InMemoryConfigStore();
-    const { findByText, getByRole } = render(
-      wrap(<ApplyStep collected={baseCollected} />, configStore),
-    );
-    fireEvent.click(await findByText('Guest'));
+  it('pushes the hostname and a static IPv4 config, then reloads', async () => {
+    const collected = {
+      ...baseCollected,
+      network: {
+        hostname: 'glaon-wall',
+        interfaces: [
+          {
+            name: 'end0',
+            ipv4: {
+              method: 'static' as const,
+              address: ['192.168.1.50/24'],
+              gateway: '192.168.1.1',
+            },
+            ipv6: { method: 'auto' as const },
+          },
+        ],
+      },
+    };
+    const { getByRole } = render(wrap(<ApplyStep collected={collected} />));
     fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
     await waitFor(() => {
       expect(reloadSpy).toHaveBeenCalledTimes(1);
     });
-    const postCall = findWifiPost();
-    expect(postCall).toBeDefined();
-    const body = JSON.parse((postCall?.[1] as { body: string }).body) as {
-      wifi: { auth: string };
-    };
-    expect(body.wifi.auth).toBe('open');
+    expect(postBody(findPost('/host/options'))).toMatchObject({ hostname: 'glaon-wall' });
+    const ifaceBody = postBody(findPost('/network/interface/end0/update'));
+    expect(ifaceBody).toMatchObject({ ipv4: { method: 'static', address: ['192.168.1.50/24'] } });
   });
 
-  it('opens the HandoffModal for a secured network and commits after Switch network now', async () => {
-    const configStore = new InMemoryConfigStore();
-    const { findByText, getByRole } = render(
-      wrap(<ApplyStep collected={baseCollected} />, configStore),
-    );
-    fireEvent.click(await findByText('HomeWifi'));
-    // Inline password input below the wifi list.
-    const inlinePassword = document.body.querySelector('input[type="password"]');
-    if (inlinePassword === null) throw new Error('expected inline password input');
-    fireEvent.change(inlinePassword, { target: { value: 'inline-pass' } });
+  it('commits an unsecured Wi-Fi without opening the handoff modal', async () => {
+    const collected = { ...baseCollected, wifi: { ssid: 'Guest', passwordCipher: '(unsecured)' } };
+    const { getByRole } = render(wrap(<ApplyStep collected={collected} />));
     fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
-    // Modal opens; the "Switch network now" button is the confirm.
+    await waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+    const body = postBody(findPost('/network/interface/wlan0/update'));
+    expect(body).toMatchObject({ wifi: { auth: 'open', ssid: 'Guest' } });
+  });
+
+  it('opens the handoff modal for a secured Wi-Fi and commits the unwrapped PSK', async () => {
+    const passwordCipher = await wrapPassword('secret');
+    const collected = { ...baseCollected, wifi: { ssid: 'HomeWifi', passwordCipher } };
+    const configStore = new InMemoryConfigStore();
+    const { getByRole } = render(wrap(<ApplyStep collected={collected} />, configStore));
+    fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
     const switchBtn = await waitFor(() => getByRole('button', { name: 'Switch network now' }));
-    expect((switchBtn as HTMLButtonElement).disabled).toBe(true);
-    // Re-type the password in the modal (typo guard).
-    const modalPassword = document.body.querySelectorAll('input[type="password"]')[1];
-    if (modalPassword === undefined) throw new Error('expected modal password input');
-    fireEvent.change(modalPassword, { target: { value: 'fresh-secret' } });
-    fireEvent.click(getByRole('button', { name: 'Switch network now' }));
+    fireEvent.click(switchBtn);
     // Secured path defers the reload by 1500ms.
     await waitFor(
       () => {
@@ -239,26 +195,14 @@ describe('ApplyStep — populated mode', () => {
       },
       { timeout: 3000 },
     );
-    const persisted = await configStore.get();
-    // #595 — the persisted cipher is AES-GCM wrapped, not the
-    // raw modal password. Asserting on the wrap shape only because
-    // the apply step's post-commit cleanup intentionally drops the
-    // wrap key from storage; an unwrap here would race a fresh key
-    // and fail. The wrap → unwrap round-trip is exhaustively
-    // covered by `wifi-crypto.test.ts`.
-    const persistedCipher = persisted?.wifi?.passwordCipher ?? '';
+    const body = postBody(findPost('/network/interface/wlan0/update'));
+    expect(body).toMatchObject({ wifi: { auth: 'wpa-psk', psk: 'secret', ssid: 'HomeWifi' } });
+    // The persisted cipher stays wrapped (#595); plaintext never lands in the blob.
+    const persistedCipher = (await configStore.get())?.wifi?.passwordCipher ?? '';
     expect(isWrapped(persistedCipher)).toBe(true);
-    expect(persistedCipher).not.toBe('fresh-secret');
-    const postCall = findWifiPost();
-    const body = JSON.parse((postCall?.[1] as { body: string }).body) as {
-      wifi: { auth: string; psk: string };
-    };
-    expect(body.wifi.auth).toBe('wpa-psk');
-    expect(body.wifi.psk).toBe('fresh-secret');
   });
 
-  it('surfaces a Toast and stays on the apply step when the Supervisor commit fails', async () => {
-    // Scan + HA-settings push succeed; the supervisor wifi-update POST fails.
+  it('surfaces a Toast and stays put when the Supervisor commit fails', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn((url: unknown, init?: { method?: string }) => {
@@ -266,26 +210,23 @@ describe('ApplyStep — populated mode', () => {
         if (u.includes('/api/setup/apply-ha')) {
           return Promise.resolve(mockFetchResponse({ json: haApplyOk }));
         }
-        if (init?.method === 'POST' && u.includes('/hassio/')) {
+        if (init?.method === 'POST' && u.includes('/network/interface/')) {
           return Promise.resolve(mockFetchResponse({ ok: false, status: 500 }));
         }
-        const scan = networkScanResponse(u);
-        if (scan !== null) return Promise.resolve(scan);
+        if (u.includes('/network/info')) {
+          return Promise.resolve(mockFetchResponse({ json: sampleNetworkInfo }));
+        }
         return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
       }),
     );
-    const { findByText, getByRole, findByRole } = render(
-      wrap(<ApplyStep collected={baseCollected} />),
-    );
-    fireEvent.click(await findByText('Guest'));
+    const collected = { ...baseCollected, wifi: { ssid: 'Guest', passwordCipher: '(unsecured)' } };
+    const { getByRole, findByRole } = render(wrap(<ApplyStep collected={collected} />));
     fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
     expect(await findByRole('status')).toBeInTheDocument();
     expect(reloadSpy).not.toHaveBeenCalled();
   });
 
-  it('aborts before the wifi handoff and toasts when the HA-settings push fails', async () => {
-    // HA-settings push reports a partial failure; the wizard must not
-    // switch wifi (no /hassio/ POST) and must stay on the apply step.
+  it('aborts before the network push and toasts when the HA-settings push fails', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn((url: unknown) => {
@@ -297,37 +238,39 @@ describe('ApplyStep — populated mode', () => {
             }),
           );
         }
-        const scan = networkScanResponse(u);
-        if (scan !== null) return Promise.resolve(scan);
         return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
       }),
     );
-    const { findByText, getByRole, findByRole } = render(
-      wrap(<ApplyStep collected={baseCollected} />),
-    );
-    fireEvent.click(await findByText('Guest'));
+    const collected = { ...baseCollected, wifi: { ssid: 'Guest', passwordCipher: '(unsecured)' } };
+    const { getByRole, findByRole } = render(wrap(<ApplyStep collected={collected} />));
     fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
     expect(await findByRole('status')).toBeInTheDocument();
     expect(reloadSpy).not.toHaveBeenCalled();
-    // Crucially, the destructive wifi switch never fired.
-    expect(findWifiPost()).toBeUndefined();
+    // The destructive network push never fired.
+    expect(findPost('/network/interface/')).toBeUndefined();
   });
 });
 
-describe('ApplyStep — error path', () => {
-  beforeEach(() => {
-    vi.stubEnv('VITE_APP_MODE', 'ingress');
-  });
-
-  it('surfaces a Toast when the network scan fails and renders an inline retry', async () => {
+describe('ApplyStep — HA-less environment', () => {
+  it('still completes setup when apply-ha is 503 (no HA Core configured)', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(() => Promise.reject(new TypeError('network down'))),
+      vi.fn((url: unknown) => {
+        const u = String(url);
+        if (u.includes('/api/setup/apply-ha')) {
+          return Promise.resolve(
+            mockFetchResponse({ ok: false, status: 503, json: { error: 'no-ha' } }),
+          );
+        }
+        return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
+      }),
     );
-    const { findByRole, findByText } = render(wrap(<ApplyStep collected={baseCollected} />));
-    await waitFor(async () => {
-      expect(await findByRole('status')).toBeInTheDocument();
+    const configStore = new InMemoryConfigStore();
+    const { getByRole } = render(wrap(<ApplyStep collected={baseCollected} />, configStore));
+    fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
+    await waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
     });
-    expect(await findByText(/We couldn't reach the Home Assistant/i)).toBeInTheDocument();
+    expect(await configStore.isConfigured()).toBe(true);
   });
 });

--- a/apps/web/src/features/setup/apply/apply-step.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.tsx
@@ -1,45 +1,25 @@
-// Apply — terminal wizard step (#597). Collapses what used to be
-// the Wi-Fi (#546) and Final Review (#548) steps into a single
-// surface that:
+// Apply — terminal wizard step (#597, #629). A read-only review of
+// everything collected in steps 1–4, then the single commit ceremony:
 //
-//   1. Shows the user a read-only summary of everything they
-//      entered in steps 1–3.
-//   2. Lets them pick their home Wi-Fi network + password right
-//      below the summary (the old wifi-step UI, embedded here).
-//   3. Commits everything in one ceremony at click-time —
-//      HandoffModal opens, user re-confirms password, HandoffOverlay
-//      takes over while the device drops AP and joins the home
-//      network. After the reload the user lands on /login.
+//   1. Push the home settings into HA Core (#617).
+//   2. Push the device hostname + per-interface IPv4/IPv6 to the
+//      Supervisor (collected in the Network step, #629).
+//   3. Join the home Wi-Fi network — the destructive handoff: HandoffModal
+//      confirms, HandoffOverlay takes over while the device drops its AP
+//      and joins the home network, then the page reloads to /login.
 //
-// Why one step instead of two:
-//
-//   - The user's commitment moment IS the network switch. Splitting
-//     "pick network" and "review + commit" across two screens put
-//     the destructive action three steps after the decision, hiding
-//     it behind a Review headline that read like an informational
-//     summary.
-//   - The wizard ends at the network handoff in every flow — there
-//     is no "step 6" after a successful commit. A terminal step
-//     should look terminal.
-//
-// Wi-Fi enumeration goes through `/api/hassio/network/info`. Whether a
-// scan is possible is decided at runtime by the *server*, not a build
-// flag (#619): apps/api (or the add-on's nginx) proxies the request to
-// a real HA Supervisor. The apply step always attempts the scan and
-// reacts to the response — 200 shows networks, 503
-// (`supervisor-not-configured`) means this environment genuinely can't
-// scan (an HA-less dev box) so the Wi-Fi step degrades to an
-// informational notice and the CTA commits without a network change.
-// There is deliberately no `VITE_APP_MODE` gate here: the end user
-// never perceives Glaon as "an add-on", so availability can't hang off
-// the build target.
+// Wi-Fi credentials + network config are collected earlier (Network step,
+// #629) and arrive here via `collected`; this step no longer scans or
+// prompts for them — it reads them and commits. The handoff stays
+// terminal because the network switch is still the user's commitment
+// moment (#597 rationale preserved).
 //
 // Per the API Error Toast Rule (CLAUDE.md), commit failures surface
 // through useToast; inline error blocks would mask the cross-section
 // nature of the failure.
 
-import { Button, PasswordInput, useToast } from '@glaon/ui';
-import { useCallback, useEffect, useId, useMemo, useState, type ReactNode } from 'react';
+import { Button, useToast } from '@glaon/ui';
+import { useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ApplyHaResponse } from '@glaon/core/api-client';
@@ -47,9 +27,17 @@ import type { DeviceConfigInput, Layout } from '@glaon/core/config';
 
 import { useDeviceConfig } from '../../../config/config-provider';
 import { clearWizardScratch } from '../../../setup/use-wizard-state';
+import {
+  DEFAULT_WIRELESS_INTERFACE,
+  NETWORK_INFO_URL,
+  findWirelessInterface,
+  pushHostname,
+  pushInterfaceUpdate,
+  toSupervisorIpBlock,
+} from '../network/network-api';
 import { HandoffModal } from '../wifi/handoff-modal';
 import { HandoffOverlay } from '../wifi/handoff-overlay';
-import { clearDeviceKey, wrapPassword } from '../wifi/wifi-crypto';
+import { clearDeviceKey, unwrapPassword } from '../wifi/wifi-crypto';
 
 interface ApplyStepProps {
   /** Final accumulated partial from prior steps. */
@@ -58,118 +46,16 @@ interface ApplyStepProps {
   readonly onNext?: (partial: DeviceConfigInput) => void;
 }
 
-// =============================================================
-// Supervisor wiring (carried over from review-step + wifi-step)
-// =============================================================
-
-const SUPERVISOR_NETWORK_INFO = '/api/hassio/network/info';
-const DEFAULT_WIRELESS_INTERFACE = 'wlan0';
-
-// HA Supervisor's scan results + commit are per-interface and carry the
-// canonical `/interface/` segment (#622). The AP list is NOT in
-// /network/info — it lives on the accesspoints endpoint.
-const networkAccesspointsUrl = (iface: string): string =>
-  `/api/hassio/network/interface/${encodeURIComponent(iface)}/accesspoints`;
-const networkUpdateUrl = (iface: string): string =>
-  `/api/hassio/network/interface/${encodeURIComponent(iface)}/update`;
-
 // #617 — apps/api endpoint that pushes the collected home settings into
 // HA Core (config/core/update + floor/area registry) over WebSocket.
 const HA_APPLY_SETTINGS = '/api/setup/apply-ha';
 
-// Hard-coded URL the QR code encodes. The mDNS responder advertises
-// the device under `glaon.local` on the home network (addon-side
-// concern). Per-device hostnames (`glaon-<serial>.local`) are tracked
-// in #594's open questions.
+// Hard-coded URL the QR code encodes. The mDNS responder advertises the
+// device under `glaon.local` on the home network (addon-side concern).
 const DEVICE_URL_AFTER_HANDOFF = 'http://glaon.local';
 
 function isSecuredCipher(cipher: string | undefined): boolean {
   return cipher !== undefined && cipher !== '' && cipher !== '(unsecured)';
-}
-
-// Scan results carry no security/auth field (#622) — only signal. We
-// can't tell secured from open networks; the password field decides.
-interface AccessPoint {
-  readonly ssid: string;
-  readonly signal?: number;
-}
-
-type FetchState =
-  | { readonly kind: 'loading' }
-  | { readonly kind: 'success'; readonly networks: readonly AccessPoint[] }
-  | { readonly kind: 'error' }
-  // Server answered 503 supervisor-not-configured: no scan possible in
-  // this environment (HA-less dev). Informational, not an error.
-  | { readonly kind: 'unavailable' };
-
-/**
- * Pick the wireless interface from a `/network/info` payload
- * (`{ data: { interfaces: [{ interface, type }] } }`). Falls back to
- * `wlan0` when discovery is inconclusive — matches the device default.
- */
-function findWirelessInterface(json: unknown): string {
-  const root = json as
-    | { data?: { interfaces?: readonly { interface?: unknown; type?: unknown }[] } }
-    | undefined;
-  for (const iface of root?.data?.interfaces ?? []) {
-    if (
-      iface.type === 'wireless' &&
-      typeof iface.interface === 'string' &&
-      iface.interface !== ''
-    ) {
-      return iface.interface;
-    }
-  }
-  return DEFAULT_WIRELESS_INTERFACE;
-}
-
-/**
- * Normalise the Supervisor accesspoints response
- * (`{ data: { accesspoints: [{ ssid, mac, signal, ... }] } }`) into a
- * deduplicated AP list. Dedup by SSID keeping the strongest signal;
- * sort strongest-first.
- */
-function parseAccessPoints(json: unknown): readonly AccessPoint[] {
-  const root = json as { data?: { accesspoints?: readonly unknown[] } } | undefined;
-  const bySsid = new Map<string, AccessPoint>();
-  for (const raw of root?.data?.accesspoints ?? []) {
-    const ap = raw as { ssid?: unknown; signal?: unknown };
-    const ssid = typeof ap.ssid === 'string' ? ap.ssid : '';
-    if (ssid === '') continue;
-    const signal = typeof ap.signal === 'number' ? ap.signal : undefined;
-    const existing = bySsid.get(ssid);
-    if (existing === undefined || (signal ?? -Infinity) > (existing.signal ?? -Infinity)) {
-      bySsid.set(ssid, signal === undefined ? { ssid } : { ssid, signal });
-    }
-  }
-  return [...bySsid.values()].sort((a, b) => (b.signal ?? -Infinity) - (a.signal ?? -Infinity));
-}
-
-interface PushWifiArgs {
-  readonly iface: string;
-  readonly ssid: string;
-  readonly password: string;
-  readonly secured: boolean;
-}
-
-async function pushWifiToSupervisor({
-  iface,
-  ssid,
-  password,
-  secured,
-}: PushWifiArgs): Promise<void> {
-  const body = secured
-    ? { wifi: { mode: 'infrastructure', auth: 'wpa-psk', ssid, psk: password } }
-    : { wifi: { mode: 'infrastructure', auth: 'open', ssid } };
-  const response = await fetch(networkUpdateUrl(iface), {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  if (!response.ok) {
-    throw new Error(`Supervisor responded ${String(response.status)}`);
-  }
 }
 
 /**
@@ -186,13 +72,6 @@ type HaApplyOutcome =
   | { readonly kind: 'partial' }
   | { readonly kind: 'error' };
 
-/**
- * POST the wizard's home settings to apps/api, which pushes them into HA
- * Core over WebSocket. The room/floor extras (ids, room `type`) ride
- * along — apps/api's Zod schema strips anything it doesn't consume.
- * Non-blocking by contract: callers decide what a non-`ok`/`skipped`
- * outcome means for the commit ceremony.
- */
 async function pushSettingsToHa(collected: DeviceConfigInput): Promise<HaApplyOutcome> {
   const body: Record<string, unknown> = {};
   if (collected.latitude !== undefined) body.latitude = collected.latitude;
@@ -224,9 +103,17 @@ async function pushSettingsToHa(collected: DeviceConfigInput): Promise<HaApplyOu
   return json.ok ? { kind: 'ok' } : { kind: 'partial' };
 }
 
-// =============================================================
-// Apply step
-// =============================================================
+/** Discover the wireless interface so the Wi-Fi handoff targets the right
+ * one. Best-effort: defaults to wlan0 if /network/info can't be reached. */
+async function discoverWirelessInterface(): Promise<string> {
+  try {
+    const response = await fetch(NETWORK_INFO_URL, { credentials: 'include' });
+    if (response.ok) return findWirelessInterface(await response.json().catch(() => null));
+  } catch {
+    // fall through to the default
+  }
+  return DEFAULT_WIRELESS_INTERFACE;
+}
 
 type HandoffPhase = 'idle' | 'confirming' | 'committing' | 'switching';
 
@@ -234,131 +121,65 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
   const { t } = useTranslation();
   const toast = useToast();
   const { setPartial, markComplete } = useDeviceConfig();
-  const passwordLabelId = useId();
-
-  // ---- Wi-Fi enumeration state (carried from wifi-step.tsx) ----
-
-  const [fetchState, setFetchState] = useState<FetchState>({ kind: 'loading' });
-  const [selectedSsid, setSelectedSsid] = useState<string>(collected.wifi?.ssid ?? '');
-  const [draftPassword, setDraftPassword] = useState<string>('');
-  // Wireless interface discovered from /network/info; used for both the
-  // accesspoints scan and the commit. Defaults to wlan0 until discovered.
-  const [wirelessIface, setWirelessIface] = useState<string>(DEFAULT_WIRELESS_INTERFACE);
-
-  const failScan = useCallback(() => {
-    setFetchState({ kind: 'error' });
-    toast.show({
-      intent: 'danger',
-      title: t('setup.apply.wifi.scanFailed.title'),
-      description: t('setup.apply.wifi.scanFailed.description'),
-    });
-  }, [t, toast]);
-
-  const loadNetworks = useCallback(async () => {
-    setFetchState({ kind: 'loading' });
-
-    // Step 1: discover the wireless interface from /network/info.
-    let iface = DEFAULT_WIRELESS_INTERFACE;
-    let infoResponse: Response;
-    try {
-      infoResponse = await fetch(SUPERVISOR_NETWORK_INFO, { credentials: 'include' });
-    } catch {
-      failScan();
-      return;
-    }
-    // 503 = supervisor-not-configured. The scan genuinely can't run in
-    // this environment (HA-less dev). Expected, handled — inline notice,
-    // no danger toast.
-    if (infoResponse.status === 503) {
-      setFetchState({ kind: 'unavailable' });
-      return;
-    }
-    if (infoResponse.ok) {
-      iface = findWirelessInterface(await infoResponse.json().catch(() => null));
-    }
-    // A non-ok, non-503 /network/info falls through to the wlan0 default
-    // and still attempts the scan — the accesspoints call is the real
-    // signal of whether scanning works.
-    setWirelessIface(iface);
-
-    // Step 2: scan that interface's access points (the real AP list).
-    let apResponse: Response;
-    try {
-      apResponse = await fetch(networkAccesspointsUrl(iface), { credentials: 'include' });
-    } catch {
-      failScan();
-      return;
-    }
-    if (apResponse.status === 503) {
-      setFetchState({ kind: 'unavailable' });
-      return;
-    }
-    if (!apResponse.ok) {
-      failScan();
-      return;
-    }
-    const json: unknown = await apResponse.json().catch(() => null);
-    setFetchState({ kind: 'success', networks: parseAccessPoints(json) });
-  }, [failScan]);
-
-  useEffect(() => {
-    void loadNetworks();
-  }, [loadNetworks]);
-
-  const selectedNetwork = useMemo<AccessPoint | null>(() => {
-    if (fetchState.kind !== 'success') return null;
-    return fetchState.networks.find((n) => n.ssid === selectedSsid) ?? null;
-  }, [fetchState, selectedSsid]);
-
-  const wifiPicked = selectedNetwork !== null;
-  // Scan results carry no security info (#622), so "secured" is decided
-  // by whether the user typed a password — non-empty → WPA-PSK, empty →
-  // open. The password field is always optional for a picked network.
-  const passwordProvided = draftPassword.trim() !== '';
-
-  // ---- Commit ceremony state (carried from review-step.tsx) ----
 
   const [handoffPhase, setHandoffPhase] = useState<HandoffPhase>('idle');
   const isCommitting = handoffPhase === 'committing';
 
-  // CTA enablement: when the scan is unavailable (HA-less env) the user
-  // commits without a network change; otherwise just need a picked
-  // network (the password is optional — open networks exist and the scan
-  // can't tell us which is secured).
-  const ctaDisabled = isCommitting || (fetchState.kind !== 'unavailable' && !wifiPicked);
+  const wifi = collected.wifi;
+  const wifiSecured = wifi !== undefined && isSecuredCipher(wifi.passwordCipher);
+
+  const wifiSummaryValue =
+    wifi !== undefined
+      ? wifiSecured
+        ? t('setup.apply.summary.wifiSecured', { ssid: wifi.ssid })
+        : t('setup.apply.summary.wifiUnsecured', { ssid: wifi.ssid })
+      : undefined;
 
   const onApplyClick = (): void => {
-    if (ctaDisabled) return;
-    if (passwordProvided) {
-      // A password was entered → treat as secured: open the handoff modal
-      // so the user re-confirms the password and reads the disconnect
-      // warning.
+    if (isCommitting) return;
+    // A secured network routes through the confirmation modal (the
+    // disconnect warning); open / no-Wi-Fi commits go straight through.
+    if (wifiSecured) {
       setHandoffPhase('confirming');
       return;
     }
-    // No password → open network (or no-wifi). Commit directly.
     void runCommit('');
   };
 
-  const onHandoffConfirm = (password: string): void => {
-    if (password.trim() === '') return;
-    void runCommit(password);
+  const onHandoffConfirm = (): void => {
+    void confirmAndCommit();
   };
 
-  async function runCommit(secureWifiPassword: string): Promise<void> {
+  async function confirmAndCommit(): Promise<void> {
+    // The plaintext PSK for the Supervisor comes from unwrapping the
+    // cipher the Network step persisted (#629) — the user doesn't re-type
+    // it. A failed unwrap (missing/rotated device key) aborts cleanly.
+    let plaintext = '';
+    if (wifi !== undefined) {
+      try {
+        plaintext = await unwrapPassword(wifi.passwordCipher);
+      } catch {
+        setHandoffPhase('idle');
+        toast.show({
+          intent: 'danger',
+          title: t('setup.apply.commitFailed.title'),
+          description: t('setup.apply.commitFailed.description'),
+        });
+        return;
+      }
+    }
+    void runCommit(plaintext);
+  }
+
+  async function runCommit(wifiPassword: string): Promise<void> {
     setHandoffPhase('committing');
 
-    // Push home settings to HA *before* the Wi-Fi handoff (#617). This
-    // step is non-destructive and the network is still stable, so a
-    // failure can abort cleanly before we switch Wi-Fi. A `skipped`
-    // outcome (apps/api has no HA Core configured — dev, 503) is fine
-    // and proceeds silently; only a hard failure / partial apply stops
-    // the ceremony so the user can retry without a half-applied home.
-    // No build-flag guard (#619): pushSettingsToHa's own 503→skipped
-    // handling covers the HA-less environment.
+    // Push home settings to HA *before* touching the network — non-
+    // destructive, network still stable, so a failure aborts cleanly. A
+    // `skipped` outcome (no HA Core configured — dev 503) proceeds.
     const haOutcome = await pushSettingsToHa(collected);
     if (haOutcome.kind === 'error' || haOutcome.kind === 'partial') {
-      setHandoffPhase(secureWifiPassword.trim() !== '' ? 'confirming' : 'idle');
+      setHandoffPhase(wifiSecured ? 'confirming' : 'idle');
       toast.show({
         intent: 'danger',
         title: t('setup.apply.haSettingsFailed.title'),
@@ -368,44 +189,46 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
     }
 
     try {
-      // The plaintext password comes from the modal's confirm field
-      // (`secureWifiPassword`) — used as-is for the supervisor POST
-      // (the wire format expects plaintext PSK), then wrapped via
-      // Web Crypto AES-GCM before it lands in the persisted blob
-      // (#595, Security-First Rule "no plaintext credentials").
-      // "secured" is decided by password presence (#622) — the scan
-      // can't tell us the network's security type.
-      const password = secureWifiPassword;
-      const secured = password.trim() !== '';
-
-      if (selectedNetwork !== null) {
-        await pushWifiToSupervisor({
-          iface: wirelessIface,
-          ssid: selectedNetwork.ssid,
-          password,
-          secured,
-        });
-        const persistedCipher = secured ? await wrapPassword(password) : '(unsecured)';
-        await setPartial({
-          ...collected,
-          wifi: { ssid: selectedNetwork.ssid, passwordCipher: persistedCipher },
-        });
-      } else {
-        await setPartial(collected);
+      // Hostname first — cheap and non-destructive.
+      if (collected.network?.hostname !== undefined) {
+        await pushHostname(collected.network.hostname);
       }
+
+      // Per-interface IP config. The wireless interface's update folds in
+      // the Wi-Fi credentials so the home-network join is one request.
+      const wirelessIface = wifi !== undefined ? await discoverWirelessInterface() : undefined;
+      const interfaces = collected.network?.interfaces ?? [];
+      const wifiBody = wifiSecured
+        ? { mode: 'infrastructure', auth: 'wpa-psk', ssid: wifi.ssid, psk: wifiPassword }
+        : { mode: 'infrastructure', auth: 'open', ssid: wifi?.ssid };
+
+      for (const iface of interfaces) {
+        const body: Record<string, unknown> = {};
+        if (iface.ipv4 !== undefined) body.ipv4 = toSupervisorIpBlock(iface.ipv4);
+        if (iface.ipv6 !== undefined) body.ipv6 = toSupervisorIpBlock(iface.ipv6);
+        if (iface.name === wirelessIface && wifi !== undefined) body.wifi = wifiBody;
+        if (Object.keys(body).length > 0) await pushInterfaceUpdate(iface.name, body);
+      }
+
+      // Edge: Wi-Fi was chosen but the Network step never collected an
+      // interface list (it degraded to "unavailable") — push Wi-Fi on its
+      // own to the discovered wireless interface.
+      const wirelessInList = interfaces.some((i) => i.name === wirelessIface);
+      if (wifi !== undefined && !wirelessInList) {
+        await pushInterfaceUpdate(wirelessIface ?? DEFAULT_WIRELESS_INTERFACE, { wifi: wifiBody });
+      }
+
+      await setPartial(collected);
       await markComplete();
-      // Wizard is complete — drop the scratch entry + wrap key so a
-      // future visit to the URL never resurrects this run's state.
+      // Wizard complete — drop the scratch entry + wrap key so a future
+      // visit never resurrects this run's state.
       clearWizardScratch();
       clearDeviceKey();
-      // Secured (password-bearing) commits route through the handoff
-      // overlay — that's the AP→home disconnect moment. Open / no-wifi
-      // commits reload straight away.
-      if (secured) {
+
+      // Secured commits route through the handoff overlay — the AP→home
+      // disconnect moment. Open / no-Wi-Fi commits reload straight away.
+      if (wifiSecured) {
         setHandoffPhase('switching');
-        // Defer the reload by a moment so the user catches a beat of
-        // the HandoffOverlay before the page goes away. In practice
-        // the addon drops the AP first.
         setTimeout(() => {
           window.location.reload();
         }, 1500);
@@ -413,10 +236,7 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
         window.location.reload();
       }
     } catch {
-      // Secured-wifi failure re-opens the modal so the user can
-      // retry / re-enter the password; everything else returns to
-      // idle since there's no modal to re-open. Toast fires in both.
-      setHandoffPhase(secureWifiPassword.trim() !== '' ? 'confirming' : 'idle');
+      setHandoffPhase(wifiSecured ? 'confirming' : 'idle');
       toast.show({
         intent: 'danger',
         title: t('setup.apply.commitFailed.title'),
@@ -425,18 +245,6 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
     }
   }
 
-  // ---- Derived summary value for the embedded Wi-Fi row ----
-
-  const wifiSummaryValue = wifiPicked
-    ? passwordProvided
-      ? t('setup.apply.summary.wifiSecured', { ssid: selectedNetwork.ssid })
-      : t('setup.apply.summary.wifiUnsecured', { ssid: selectedNetwork.ssid })
-    : collected.wifi !== undefined
-      ? isSecuredCipher(collected.wifi.passwordCipher)
-        ? t('setup.apply.summary.wifiSecured', { ssid: collected.wifi.ssid })
-        : t('setup.apply.summary.wifiUnsecured', { ssid: collected.wifi.ssid })
-      : undefined;
-
   return (
     <div className="flex flex-col p-8 lg:p-12">
       <header className="flex flex-col gap-1 pb-6">
@@ -444,7 +252,6 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
         <p className="text-sm text-tertiary">{t('setup.apply.subtitle')}</p>
       </header>
 
-      {/* === Summary === */}
       <section aria-labelledby="apply-summary-heading" className="flex flex-col">
         <h2
           id="apply-summary-heading"
@@ -467,6 +274,10 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
             }
           />
           <LayoutSummaryRow layout={collected.layout} />
+          <SummaryRow
+            label={t('setup.network.hostname.label')}
+            value={collected.network?.hostname}
+          />
           <SummaryRow label={t('setup.apply.summary.wifi')} value={wifiSummaryValue} />
           <SummaryRow
             label={t('setup.apply.summary.adminPassword')}
@@ -479,73 +290,13 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
         </dl>
       </section>
 
-      {/* === Wi-Fi picker === */}
-      <section
-        aria-labelledby="apply-wifi-heading"
-        className="mt-8 flex flex-col gap-4 border-t border-secondary pt-6"
-      >
-        <div className="flex flex-col gap-1">
-          <h2
-            id="apply-wifi-heading"
-            className="text-sm font-semibold uppercase tracking-wide text-tertiary"
-          >
-            {t('setup.apply.wifi.heading')}
-          </h2>
-          <p className="text-sm text-tertiary">{t('setup.apply.wifi.subtitle')}</p>
-        </div>
-
-        {fetchState.kind === 'unavailable' && <UnavailableNotice />}
-        {fetchState.kind === 'loading' && <LoadingNotice />}
-        {fetchState.kind === 'error' && <ErrorRetry onRetry={() => void loadNetworks()} />}
-        {fetchState.kind === 'success' && fetchState.networks.length === 0 && (
-          <EmptyNotice onRetry={() => void loadNetworks()} />
-        )}
-        {fetchState.kind === 'success' && fetchState.networks.length > 0 && (
-          <ul className="flex flex-col gap-3" aria-label={t('setup.apply.wifi.list.ariaLabel')}>
-            {fetchState.networks.map((network) => (
-              <li key={network.ssid}>
-                <WifiNetworkRow
-                  network={network}
-                  isSelected={network.ssid === selectedSsid}
-                  onSelect={() => {
-                    setSelectedSsid(network.ssid);
-                    setDraftPassword('');
-                  }}
-                />
-              </li>
-            ))}
-          </ul>
-        )}
-        {wifiPicked && (
-          <div className="flex max-w-[480px] flex-col gap-1.5">
-            <label
-              id={passwordLabelId}
-              className="text-sm font-semibold text-secondary"
-              htmlFor={`${passwordLabelId}-input`}
-            >
-              {t('setup.apply.wifi.password.label')}
-            </label>
-            <PasswordInput
-              id={`${passwordLabelId}-input`}
-              value={draftPassword}
-              onChange={setDraftPassword}
-              placeholder={t('setup.apply.wifi.password.placeholder')}
-              autoComplete="off"
-            />
-            {/* No security info in scan results (#622) — the field is
-                optional; an empty password commits as an open network. */}
-            <p className="text-xs text-tertiary">{t('setup.apply.wifi.password.optionalHint')}</p>
-          </div>
-        )}
-      </section>
-
-      <div className="flex justify-end gap-3 border-t border-secondary py-6 mt-4">
+      <div className="mt-4 flex justify-end gap-3 border-t border-secondary py-6">
         <Button
           size="md"
           color="primary"
           onClick={onApplyClick}
           isLoading={isCommitting}
-          isDisabled={ctaDisabled}
+          isDisabled={isCommitting}
         >
           {t('setup.apply.actions.save')}
         </Button>
@@ -556,147 +307,22 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
         onOpenChange={(open) => {
           if (!open) setHandoffPhase('idle');
         }}
-        ssid={selectedNetwork?.ssid ?? ''}
-        requiresPassword={passwordProvided}
+        ssid={wifi?.ssid ?? ''}
+        requiresPassword={false}
         deviceUrl={DEVICE_URL_AFTER_HANDOFF}
         onConfirm={onHandoffConfirm}
         isCommitting={isCommitting}
       />
 
       {handoffPhase === 'switching' && (
-        <HandoffOverlay ssid={selectedNetwork?.ssid ?? ''} deviceUrl={DEVICE_URL_AFTER_HANDOFF} />
+        <HandoffOverlay ssid={wifi?.ssid ?? ''} deviceUrl={DEVICE_URL_AFTER_HANDOFF} />
       )}
     </div>
   );
 }
 
 // =============================================================
-// Sub-components — kept inline (private to this step) until a
-// second consumer arrives.
-// =============================================================
-
-interface WifiNetworkRowProps {
-  readonly network: AccessPoint;
-  readonly isSelected: boolean;
-  readonly onSelect: () => void;
-}
-
-function WifiNetworkRow({ network, isSelected, onSelect }: WifiNetworkRowProps): ReactNode {
-  const { t } = useTranslation();
-  // Scan results carry no security type (#622); the secondary line shows
-  // signal strength instead, mirroring HA's own network UI.
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-pressed={isSelected}
-      className={`flex w-full items-start gap-4 rounded-xl border border-secondary p-4 text-left transition-colors hover:bg-secondary ${
-        isSelected ? 'bg-[var(--glaon-light-grey)]' : 'bg-primary'
-      }`}
-    >
-      <span
-        aria-hidden="true"
-        className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset"
-      >
-        <WifiIcon />
-      </span>
-      <span className="flex flex-1 flex-col">
-        <span className="text-sm font-medium leading-5 text-secondary">{network.ssid}</span>
-        {network.signal !== undefined && (
-          <span className="text-sm font-normal leading-5 text-tertiary">
-            {t('setup.apply.wifi.signal', { signal: network.signal })}
-          </span>
-        )}
-      </span>
-      <span
-        aria-hidden="true"
-        className={`mt-1 inline-flex size-4 shrink-0 items-center justify-center rounded-full border ${
-          isSelected ? 'border-brand-solid bg-brand-solid' : 'border-secondary bg-primary'
-        }`}
-      >
-        {isSelected && <span className="block size-1.5 rounded-full bg-primary" />}
-      </span>
-    </button>
-  );
-}
-
-function UnavailableNotice(): ReactNode {
-  const { t } = useTranslation();
-  return (
-    <div className="rounded-lg border border-secondary bg-secondary/50 p-4 text-sm text-tertiary">
-      {t('setup.apply.wifi.unavailable')}
-    </div>
-  );
-}
-
-function LoadingNotice(): ReactNode {
-  const { t } = useTranslation();
-  return (
-    <div role="status" className="text-sm text-tertiary">
-      {t('setup.apply.wifi.loading')}
-    </div>
-  );
-}
-
-interface RetryProps {
-  readonly onRetry: () => void;
-}
-
-function ErrorRetry({ onRetry }: RetryProps): ReactNode {
-  const { t } = useTranslation();
-  return (
-    <div className="flex flex-col gap-3 rounded-lg border border-secondary bg-primary p-4 text-sm text-tertiary">
-      <p>{t('setup.apply.wifi.scanFailed.body')}</p>
-      <button
-        type="button"
-        onClick={onRetry}
-        className="inline-flex w-fit items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-1.5 text-sm font-semibold text-secondary shadow-xs-skeuomorphic"
-      >
-        {t('setup.apply.wifi.actions.retry')}
-      </button>
-    </div>
-  );
-}
-
-function EmptyNotice({ onRetry }: RetryProps): ReactNode {
-  const { t } = useTranslation();
-  return (
-    <div className="flex flex-col gap-3 rounded-lg border border-secondary bg-primary p-4 text-sm text-tertiary">
-      <p>{t('setup.apply.wifi.empty')}</p>
-      <button
-        type="button"
-        onClick={onRetry}
-        className="inline-flex w-fit items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-1.5 text-sm font-semibold text-secondary shadow-xs-skeuomorphic"
-      >
-        {t('setup.apply.wifi.actions.retry')}
-      </button>
-    </div>
-  );
-}
-
-function WifiIcon(): ReactNode {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M1.667 6a9 9 0 0 1 12.666 0" />
-      <path d="M4 8.667a5.333 5.333 0 0 1 8 0" />
-      <path d="M6.333 11.333a2 2 0 0 1 3.334 0" />
-      <path d="M8 14h.007" />
-    </svg>
-  );
-}
-
-// =============================================================
-// Summary rows (carried from review-step.tsx)
+// Summary rows
 // =============================================================
 
 interface SummaryRowProps {

--- a/apps/web/src/features/setup/network/collapsible-section.tsx
+++ b/apps/web/src/features/setup/network/collapsible-section.tsx
@@ -1,0 +1,73 @@
+// Accessible expand/collapse panel for the Network step's IPv4 / IPv6
+// blocks (#629). Feature-local on purpose: @glaon/ui ships no
+// Accordion/Disclosure primitive yet, and this is wizard-step composition
+// (like apply-step's own private sub-components), not a reusable base
+// primitive. If a second consumer appears it graduates to @glaon/ui as a
+// UUI-wrapped primitive. Uses native button + aria-expanded/aria-controls
+// so it's keyboard- and screen-reader-correct without a library.
+
+import { useId, useState, type ReactNode } from 'react';
+
+interface CollapsibleSectionProps {
+  readonly title: string;
+  /** Secondary line shown under the title (e.g. the current method). */
+  readonly summary?: string;
+  readonly defaultOpen?: boolean;
+  readonly children: ReactNode;
+}
+
+export function CollapsibleSection({
+  title,
+  summary,
+  defaultOpen = false,
+  children,
+}: CollapsibleSectionProps): ReactNode {
+  const [open, setOpen] = useState<boolean>(defaultOpen);
+  const panelId = useId();
+
+  return (
+    <div className="rounded-xl border border-secondary bg-primary">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => {
+          setOpen((prev) => !prev);
+        }}
+        className="flex w-full items-center justify-between gap-3 rounded-xl px-4 py-3 text-left transition-colors hover:bg-secondary"
+      >
+        <span className="flex flex-col">
+          <span className="text-sm font-semibold text-secondary">{title}</span>
+          {summary !== undefined && (
+            <span className="text-sm font-normal text-tertiary">{summary}</span>
+          )}
+        </span>
+        <ChevronIcon open={open} />
+      </button>
+      {open && (
+        <div id={panelId} className="flex flex-col gap-4 border-t border-secondary px-4 py-4">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChevronIcon({ open }: { open: boolean }): ReactNode {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={`shrink-0 text-tertiary transition-transform ${open ? 'rotate-180' : ''}`}
+    >
+      <path d="M6 9l6 6 6-6" />
+    </svg>
+  );
+}

--- a/apps/web/src/features/setup/network/index.ts
+++ b/apps/web/src/features/setup/network/index.ts
@@ -1,0 +1,1 @@
+export { NetworkStep } from './network-step';

--- a/apps/web/src/features/setup/network/network-api.ts
+++ b/apps/web/src/features/setup/network/network-api.ts
@@ -1,0 +1,189 @@
+// Supervisor HTTP + response parsing for the wizard's Network step (#629)
+// and the terminal commit (#629/#597). Whether a call succeeds is decided
+// at runtime by the *server* (apps/api or the add-on's nginx proxying a
+// real HA Supervisor) — see docs/dev-supervisor.md. A 503
+// (`supervisor-not-configured`) means this environment genuinely can't
+// reach a Supervisor (HA-less dev); callers degrade gracefully.
+
+import type { IpConfig, IpMethod } from '@glaon/core/config';
+
+export const NETWORK_INFO_URL = '/api/hassio/network/info';
+export const HOST_INFO_URL = '/api/hassio/host/info';
+export const HOST_OPTIONS_URL = '/api/hassio/host/options';
+export const DEFAULT_WIRELESS_INTERFACE = 'wlan0';
+
+export const accesspointsUrl = (iface: string): string =>
+  `/api/hassio/network/interface/${encodeURIComponent(iface)}/accesspoints`;
+export const interfaceUpdateUrl = (iface: string): string =>
+  `/api/hassio/network/interface/${encodeURIComponent(iface)}/update`;
+
+// Scan results carry no security/auth field (#622) — only signal. We
+// can't tell secured from open networks; the password field decides.
+export interface AccessPoint {
+  readonly ssid: string;
+  readonly signal?: number;
+}
+
+/** A `/network/info` interface entry, narrowed to what the step renders. */
+export interface InterfaceInfo {
+  readonly name: string;
+  readonly type: string;
+  readonly ipv4: IpConfig;
+  readonly ipv6: IpConfig;
+}
+
+function asIpMethod(value: unknown): IpMethod {
+  return value === 'static' || value === 'disabled' ? value : 'auto';
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+/** Normalise a Supervisor `ipv4`/`ipv6` block into a core `IpConfig`. */
+function parseIpFamily(raw: unknown): IpConfig {
+  if (raw === null || typeof raw !== 'object') return { method: 'auto' };
+  const block = raw as {
+    method?: unknown;
+    address?: unknown;
+    gateway?: unknown;
+    nameservers?: unknown;
+  };
+  const address = asStringArray(block.address);
+  const nameservers = asStringArray(block.nameservers);
+  const gateway =
+    typeof block.gateway === 'string' && block.gateway !== '' ? block.gateway : undefined;
+  return {
+    method: asIpMethod(block.method),
+    ...(address.length > 0 ? { address } : {}),
+    ...(gateway !== undefined ? { gateway } : {}),
+    ...(nameservers.length > 0 ? { nameservers } : {}),
+  };
+}
+
+/**
+ * Parse the `/network/info` payload
+ * (`{ data: { interfaces: [{ interface, type, ipv4, ipv6 }] } }`) into the
+ * interfaces the step renders. Each interface always carries an `ipv4` +
+ * `ipv6` (defaulting to `{ method: 'auto' }`) so the form has a value to
+ * seed every panel.
+ */
+export function parseInterfaces(json: unknown): InterfaceInfo[] {
+  const root = json as
+    | {
+        data?: {
+          interfaces?: readonly {
+            interface?: unknown;
+            type?: unknown;
+            ipv4?: unknown;
+            ipv6?: unknown;
+          }[];
+        };
+      }
+    | undefined;
+  const result: InterfaceInfo[] = [];
+  for (const iface of root?.data?.interfaces ?? []) {
+    if (typeof iface.interface !== 'string' || iface.interface === '') continue;
+    result.push({
+      name: iface.interface,
+      type: typeof iface.type === 'string' ? iface.type : 'unknown',
+      ipv4: parseIpFamily(iface.ipv4),
+      ipv6: parseIpFamily(iface.ipv6),
+    });
+  }
+  return result;
+}
+
+/** First wireless interface from a `/network/info` payload, or wlan0. */
+export function findWirelessInterface(json: unknown): string {
+  for (const iface of parseInterfaces(json)) {
+    if (iface.type === 'wireless') return iface.name;
+  }
+  return DEFAULT_WIRELESS_INTERFACE;
+}
+
+/**
+ * Normalise the Supervisor accesspoints response
+ * (`{ data: { accesspoints: [{ ssid, signal, ... }] } }`) into a
+ * deduplicated AP list — dedup by SSID keeping the strongest signal, then
+ * sort strongest-first.
+ */
+export function parseAccessPoints(json: unknown): AccessPoint[] {
+  const root = json as { data?: { accesspoints?: readonly unknown[] } } | undefined;
+  const bySsid = new Map<string, AccessPoint>();
+  for (const raw of root?.data?.accesspoints ?? []) {
+    const ap = raw as { ssid?: unknown; signal?: unknown };
+    const ssid = typeof ap.ssid === 'string' ? ap.ssid : '';
+    if (ssid === '') continue;
+    const signal = typeof ap.signal === 'number' ? ap.signal : undefined;
+    const existing = bySsid.get(ssid);
+    if (existing === undefined || (signal ?? -Infinity) > (existing.signal ?? -Infinity)) {
+      bySsid.set(ssid, signal === undefined ? { ssid } : { ssid, signal });
+    }
+  }
+  return [...bySsid.values()].sort((a, b) => (b.signal ?? -Infinity) - (a.signal ?? -Infinity));
+}
+
+/** Device hostname from a `/host/info` payload, if present. */
+export function parseHostname(json: unknown): string | undefined {
+  const root = json as { data?: { hostname?: unknown } } | undefined;
+  const hostname = root?.data?.hostname;
+  return typeof hostname === 'string' && hostname !== '' ? hostname : undefined;
+}
+
+/** Push the device hostname to the Supervisor host API. Throws on non-ok. */
+export async function pushHostname(hostname: string): Promise<void> {
+  const response = await fetch(HOST_OPTIONS_URL, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ hostname }),
+  });
+  if (!response.ok) {
+    throw new Error(`Supervisor host/options responded ${String(response.status)}`);
+  }
+}
+
+/** A Supervisor `ipv4`/`ipv6` update block (only meaningful keys included). */
+export interface SupervisorIpBlock {
+  readonly method: IpMethod;
+  readonly address?: string[];
+  readonly gateway?: string;
+  readonly nameservers?: string[];
+}
+
+/** Map a collected `IpConfig` to the Supervisor update wire shape. */
+export function toSupervisorIpBlock(config: IpConfig): SupervisorIpBlock {
+  if (config.method !== 'static') return { method: config.method };
+  return {
+    method: 'static',
+    ...(config.address !== undefined && config.address.length > 0
+      ? { address: config.address }
+      : {}),
+    ...(config.gateway !== undefined ? { gateway: config.gateway } : {}),
+    ...(config.nameservers !== undefined && config.nameservers.length > 0
+      ? { nameservers: config.nameservers }
+      : {}),
+  };
+}
+
+/**
+ * POST an interface update — IP config and/or Wi-Fi credentials. The
+ * Supervisor accepts `ipv4`/`ipv6`/`wifi` in one call, so the terminal
+ * commit can fold the wireless interface's IP config into the same
+ * request that joins the home network. Throws on non-ok.
+ */
+export async function pushInterfaceUpdate(
+  iface: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const response = await fetch(interfaceUpdateUrl(iface), {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`Supervisor interface update responded ${String(response.status)}`);
+  }
+}

--- a/apps/web/src/features/setup/network/network-api.ts
+++ b/apps/web/src/features/setup/network/network-api.ts
@@ -9,12 +9,12 @@ import type { IpConfig, IpMethod } from '@glaon/core/config';
 
 export const NETWORK_INFO_URL = '/api/hassio/network/info';
 export const HOST_INFO_URL = '/api/hassio/host/info';
-export const HOST_OPTIONS_URL = '/api/hassio/host/options';
+const HOST_OPTIONS_URL = '/api/hassio/host/options';
 export const DEFAULT_WIRELESS_INTERFACE = 'wlan0';
 
 export const accesspointsUrl = (iface: string): string =>
   `/api/hassio/network/interface/${encodeURIComponent(iface)}/accesspoints`;
-export const interfaceUpdateUrl = (iface: string): string =>
+const interfaceUpdateUrl = (iface: string): string =>
   `/api/hassio/network/interface/${encodeURIComponent(iface)}/update`;
 
 // Scan results carry no security/auth field (#622) — only signal. We
@@ -145,7 +145,7 @@ export async function pushHostname(hostname: string): Promise<void> {
 }
 
 /** A Supervisor `ipv4`/`ipv6` update block (only meaningful keys included). */
-export interface SupervisorIpBlock {
+interface SupervisorIpBlock {
   readonly method: IpMethod;
   readonly address?: string[];
   readonly gateway?: string;

--- a/apps/web/src/features/setup/network/network-step.test.tsx
+++ b/apps/web/src/features/setup/network/network-step.test.tsx
@@ -1,0 +1,145 @@
+// Network step smoke (#629). Drives the load → render path and the
+// hostname validation gate. The Select-driven static-IP reveal +
+// per-field IP validation are unit-covered in `validation.test.ts` and
+// walked end-to-end in the Playwright wizard smoke (react-aria's Select
+// popup isn't reliably driveable in jsdom).
+
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ToastProvider } from '@glaon/ui';
+
+import { NetworkStep } from './network-step';
+
+interface MockResponseInit {
+  readonly ok?: boolean;
+  readonly status?: number;
+  readonly json?: unknown;
+}
+
+function mockFetchResponse({ ok = true, status = 200, json }: MockResponseInit): Response {
+  return { ok, status, json: () => Promise.resolve(json) } as unknown as Response;
+}
+
+const sampleNetworkInfo = {
+  data: {
+    interfaces: [
+      { interface: 'wlan0', type: 'wireless', ipv4: { method: 'auto' }, ipv6: { method: 'auto' } },
+      {
+        interface: 'end0',
+        type: 'ethernet',
+        ipv4: { method: 'static', address: ['192.168.1.50/24'], gateway: '192.168.1.1' },
+        ipv6: { method: 'auto' },
+      },
+    ],
+  },
+};
+
+const sampleAccessPoints = {
+  data: {
+    accesspoints: [
+      { ssid: 'HomeWifi', mac: 'aa:bb:cc:00:00:01', signal: 70 },
+      { ssid: 'Guest', mac: 'aa:bb:cc:00:00:02', signal: 55 },
+    ],
+  },
+};
+
+function readyFetch(url: unknown): Promise<Response> {
+  const u = String(url);
+  if (u.includes('/network/info'))
+    return Promise.resolve(mockFetchResponse({ json: sampleNetworkInfo }));
+  if (u.includes('/host/info')) {
+    return Promise.resolve(mockFetchResponse({ json: { data: { hostname: 'glaon' } } }));
+  }
+  if (u.includes('/accesspoints')) {
+    return Promise.resolve(mockFetchResponse({ json: sampleAccessPoints }));
+  }
+  return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
+}
+
+function renderStep(onNext = vi.fn()) {
+  return {
+    onNext,
+    ...render(
+      <ToastProvider>
+        <NetworkStep collected={{}} onNext={onNext} />
+      </ToastProvider>,
+    ),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('NetworkStep — ready', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: unknown) => readyFetch(url)),
+    );
+  });
+
+  it('seeds the hostname and renders an interface tab per interface', async () => {
+    const { findByTestId, getByRole } = renderStep();
+    const hostname = (await findByTestId('network-hostname')) as HTMLInputElement;
+    expect(hostname.value).toBe('glaon');
+    expect(getByRole('tab', { name: 'wlan0' })).toBeInTheDocument();
+    expect(getByRole('tab', { name: 'end0' })).toBeInTheDocument();
+  });
+
+  it('lists scanned Wi-Fi networks under the wireless interface', async () => {
+    const { findByText } = renderStep();
+    expect(await findByText('HomeWifi')).toBeInTheDocument();
+    expect(await findByText('Guest')).toBeInTheDocument();
+  });
+
+  it('advances with the collected network config when valid', async () => {
+    const { onNext, findByTestId, getByTestId } = renderStep();
+    await findByTestId('network-hostname');
+    fireEvent.click(getByTestId('network-next'));
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+    const partial = onNext.mock.calls[0]?.[0] as {
+      network?: { hostname?: string; interfaces?: { name: string }[] };
+    };
+    expect(partial.network?.hostname).toBe('glaon');
+    expect(partial.network?.interfaces?.map((i) => i.name)).toEqual(['wlan0', 'end0']);
+  });
+
+  it('blocks Next and shows an inline error for an invalid hostname', async () => {
+    const { onNext, findByTestId, getByTestId, findByText } = renderStep();
+    const hostname = await findByTestId('network-hostname');
+    fireEvent.change(hostname, { target: { value: 'bad host' } });
+    fireEvent.click(getByTestId('network-next'));
+    expect(await findByText(/1–63 letters/i)).toBeInTheDocument();
+    expect(onNext).not.toHaveBeenCalled();
+  });
+});
+
+describe('NetworkStep — supervisor unavailable', () => {
+  it('shows the unavailable notice and still advances on Next', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: unknown) => {
+        if (String(url).includes('/network/info')) {
+          return Promise.resolve(
+            mockFetchResponse({
+              ok: false,
+              status: 503,
+              json: { error: 'supervisor-not-configured' },
+            }),
+          );
+        }
+        return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
+      }),
+    );
+    const { onNext, findByText, getByTestId } = renderStep();
+    expect(await findByText(/Network configuration isn't available/i)).toBeInTheDocument();
+    fireEvent.click(getByTestId('network-next'));
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledWith({});
+    });
+  });
+});

--- a/apps/web/src/features/setup/network/network-step.tsx
+++ b/apps/web/src/features/setup/network/network-step.tsx
@@ -1,0 +1,829 @@
+// Network — wizard step between Security and Review (#629). Mirrors HA's
+// Supervisor "Network" screen: a device hostname, per-interface tabs
+// (end0 / wlan0), collapsible IPv4 + IPv6 panels (method + static
+// address / gateway / DNS), and the Wi-Fi picker (moved here from the
+// old terminal apply step).
+//
+// Collect-only by contract: everything the user enters is merged into the
+// wizard's `collected` state via `onNext`. The destructive network
+// handoff + the actual Supervisor push stay in the terminal Review step
+// (#626 decision) — the user's commitment moment is still the network
+// switch, not this screen.
+//
+// Per the API Error Toast Rule (CLAUDE.md), the Wi-Fi scan failure routes
+// through useToast; per-field validation (bad hostname / IP) renders
+// inline on the field.
+
+import {
+  InputBase,
+  PasswordInput,
+  Select,
+  SelectItem,
+  Tabs,
+  TextField,
+  useToast,
+  type SelectItemType,
+} from '@glaon/ui';
+import { useCallback, useEffect, useId, useMemo, useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { DeviceConfigInput, InterfaceConfig, IpConfig, IpMethod } from '@glaon/core/config';
+
+import { wrapPassword } from '../wifi/wifi-crypto';
+import { CollapsibleSection } from './collapsible-section';
+import {
+  DEFAULT_WIRELESS_INTERFACE,
+  HOST_INFO_URL,
+  NETWORK_INFO_URL,
+  accesspointsUrl,
+  findWirelessInterface,
+  parseAccessPoints,
+  parseHostname,
+  parseInterfaces,
+  type AccessPoint,
+  type InterfaceInfo,
+} from './network-api';
+import {
+  areNameserversValid,
+  isCidr,
+  isHostnameLabel,
+  isPlainIp,
+  splitNameservers,
+} from './validation';
+
+interface NetworkStepProps {
+  readonly collected: DeviceConfigInput;
+  readonly onNext: (partial: DeviceConfigInput) => void;
+}
+
+// ---- per-family form state (text fields; converted to IpConfig on submit) ----
+
+type Family = 'ipv4' | 'ipv6';
+
+interface IpFormState {
+  readonly method: IpMethod;
+  readonly address: string;
+  readonly gateway: string;
+  readonly nameservers: string;
+}
+
+type InterfaceForms = Record<string, { ipv4: IpFormState; ipv6: IpFormState }>;
+
+const EMPTY_FORM: IpFormState = { method: 'auto', address: '', gateway: '', nameservers: '' };
+
+function seedIpForm(config: IpConfig): IpFormState {
+  return {
+    method: config.method,
+    address: config.address?.[0] ?? '',
+    gateway: config.gateway ?? '',
+    nameservers: config.nameservers?.join(', ') ?? '',
+  };
+}
+
+function ipFormToConfig(form: IpFormState): IpConfig {
+  if (form.method !== 'static') return { method: form.method };
+  const address = form.address.trim();
+  const gateway = form.gateway.trim();
+  const nameservers = splitNameservers(form.nameservers);
+  return {
+    method: 'static',
+    ...(address !== '' ? { address: [address] } : {}),
+    ...(gateway !== '' ? { gateway } : {}),
+    ...(nameservers.length > 0 ? { nameservers } : {}),
+  };
+}
+
+interface FamilyErrors {
+  readonly address?: string;
+  readonly gateway?: string;
+  readonly nameservers?: string;
+}
+
+type LoadState = 'loading' | 'ready' | 'unavailable' | 'error';
+
+type WifiState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'success'; readonly networks: readonly AccessPoint[] }
+  | { readonly kind: 'error' }
+  | { readonly kind: 'unavailable' };
+
+export function NetworkStep({ collected, onNext }: NetworkStepProps): ReactNode {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const hostnameLabelId = useId();
+
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [interfaces, setInterfaces] = useState<readonly InterfaceInfo[]>([]);
+  const [interfaceForms, setInterfaceForms] = useState<InterfaceForms>({});
+  const [wirelessIface, setWirelessIface] = useState<string>(DEFAULT_WIRELESS_INTERFACE);
+
+  const [hostname, setHostname] = useState<string>(collected.network?.hostname ?? '');
+  const [submitted, setSubmitted] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+
+  // Wi-Fi picker (moved from apply-step).
+  const [wifiState, setWifiState] = useState<WifiState>({ kind: 'idle' });
+  const [selectedSsid, setSelectedSsid] = useState<string>(collected.wifi?.ssid ?? '');
+  const [draftPassword, setDraftPassword] = useState<string>('');
+
+  // Seed interface IP forms: prefer what the wizard already collected on a
+  // re-entry, else the live Supervisor values from /network/info.
+  const seedForms = useCallback(
+    (live: readonly InterfaceInfo[]): InterfaceForms => {
+      const collectedByName = new Map<string, InterfaceConfig>(
+        (collected.network?.interfaces ?? []).map((iface) => [iface.name, iface]),
+      );
+      const forms: InterfaceForms = {};
+      for (const iface of live) {
+        const prior = collectedByName.get(iface.name);
+        forms[iface.name] = {
+          ipv4: seedIpForm(prior?.ipv4 ?? iface.ipv4),
+          ipv6: seedIpForm(prior?.ipv6 ?? iface.ipv6),
+        };
+      }
+      return forms;
+    },
+    [collected.network?.interfaces],
+  );
+
+  const loadWifi = useCallback(
+    async (iface: string) => {
+      setWifiState({ kind: 'loading' });
+      let response: Response;
+      try {
+        response = await fetch(accesspointsUrl(iface), { credentials: 'include' });
+      } catch {
+        setWifiState({ kind: 'error' });
+        toast.show({
+          intent: 'danger',
+          title: t('setup.network.wifi.scanFailed.title'),
+          description: t('setup.network.wifi.scanFailed.description'),
+        });
+        return;
+      }
+      if (response.status === 503) {
+        setWifiState({ kind: 'unavailable' });
+        return;
+      }
+      if (!response.ok) {
+        setWifiState({ kind: 'error' });
+        toast.show({
+          intent: 'danger',
+          title: t('setup.network.wifi.scanFailed.title'),
+          description: t('setup.network.wifi.scanFailed.description'),
+        });
+        return;
+      }
+      setWifiState({
+        kind: 'success',
+        networks: parseAccessPoints(await response.json().catch(() => null)),
+      });
+    },
+    [t, toast],
+  );
+
+  const load = useCallback(async () => {
+    setLoadState('loading');
+    let infoResponse: Response;
+    try {
+      infoResponse = await fetch(NETWORK_INFO_URL, { credentials: 'include' });
+    } catch {
+      setLoadState('error');
+      return;
+    }
+    // 503 = supervisor-not-configured: this environment can't configure
+    // the network (HA-less dev). Informational, not an error — the step
+    // degrades to a notice and the user advances without network config.
+    if (infoResponse.status === 503) {
+      setLoadState('unavailable');
+      return;
+    }
+    if (!infoResponse.ok) {
+      setLoadState('error');
+      return;
+    }
+    const infoJson: unknown = await infoResponse.json().catch(() => null);
+    const live = parseInterfaces(infoJson);
+    const iface = findWirelessInterface(infoJson);
+    setInterfaces(live);
+    setInterfaceForms(seedForms(live));
+    setWirelessIface(iface);
+
+    // Seed hostname from the host API only when the wizard hasn't already
+    // collected one (re-entry keeps the user's edit).
+    if (collected.network?.hostname === undefined) {
+      try {
+        const hostResponse = await fetch(HOST_INFO_URL, { credentials: 'include' });
+        if (hostResponse.ok) {
+          const parsed = parseHostname(await hostResponse.json().catch(() => null));
+          if (parsed !== undefined) setHostname(parsed);
+        }
+      } catch {
+        // Hostname is a nicety; a failed /host/info shouldn't block the step.
+      }
+    }
+
+    setLoadState('ready');
+    void loadWifi(iface);
+  }, [collected.network?.hostname, loadWifi, seedForms]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const updateForm = useCallback((name: string, family: Family, next: IpFormState) => {
+    setInterfaceForms((prev) => {
+      const existing = prev[name] ?? { ipv4: EMPTY_FORM, ipv6: EMPTY_FORM };
+      return { ...prev, [name]: { ...existing, [family]: next } };
+    });
+  }, []);
+
+  // ---- validation ----
+
+  const hostnameTrimmed = hostname.trim();
+  const hostnameInvalid = submitted && hostnameTrimmed !== '' && !isHostnameLabel(hostnameTrimmed);
+  const hostnameError = hostnameInvalid ? t('setup.network.hostname.invalid') : undefined;
+
+  const familyErrors = useCallback(
+    (form: IpFormState | undefined, family: Family): FamilyErrors => {
+      if (!submitted || form?.method !== 'static') return {};
+      const address = form.address.trim();
+      const gateway = form.gateway.trim();
+      const addressError =
+        address === ''
+          ? t('setup.network.address.required')
+          : !isCidr(address, family)
+            ? t('setup.network.address.invalid')
+            : undefined;
+      const gatewayError =
+        gateway !== '' && !isPlainIp(gateway, family)
+          ? t('setup.network.gateway.invalid')
+          : undefined;
+      const nameserversError = !areNameserversValid(form.nameservers, family)
+        ? t('setup.network.dns.invalid')
+        : undefined;
+      return {
+        ...(addressError !== undefined ? { address: addressError } : {}),
+        ...(gatewayError !== undefined ? { gateway: gatewayError } : {}),
+        ...(nameserversError !== undefined ? { nameservers: nameserversError } : {}),
+      };
+    },
+    [submitted, t],
+  );
+
+  const hasErrors = useMemo(() => {
+    if (hostnameTrimmed !== '' && !isHostnameLabel(hostnameTrimmed)) return true;
+    return interfaces.some((iface) => {
+      const form = interfaceForms[iface.name];
+      for (const family of ['ipv4', 'ipv6'] as const) {
+        const f = form?.[family];
+        if (f?.method !== 'static') continue;
+        if (f.address.trim() === '' || !isCidr(f.address.trim(), family)) return true;
+        if (f.gateway.trim() !== '' && !isPlainIp(f.gateway.trim(), family)) return true;
+        if (!areNameserversValid(f.nameservers, family)) return true;
+      }
+      return false;
+    });
+  }, [hostnameTrimmed, interfaces, interfaceForms]);
+
+  const selectedNetwork = useMemo<AccessPoint | null>(() => {
+    if (wifiState.kind !== 'success') return null;
+    return wifiState.networks.find((n) => n.ssid === selectedSsid) ?? null;
+  }, [wifiState, selectedSsid]);
+
+  const handleNext = useCallback(async () => {
+    if (loadState !== 'ready') {
+      onNext({});
+      return;
+    }
+    setSubmitted(true);
+    if (hasErrors) return;
+
+    const partial: DeviceConfigInput = {};
+
+    const network: NonNullable<DeviceConfigInput['network']> = {};
+    if (hostnameTrimmed !== '') network.hostname = hostnameTrimmed;
+    const interfaceConfigs: InterfaceConfig[] = interfaces.map((iface) => {
+      const form = interfaceForms[iface.name];
+      return {
+        name: iface.name,
+        ipv4: ipFormToConfig(form?.ipv4 ?? EMPTY_FORM),
+        ipv6: ipFormToConfig(form?.ipv6 ?? EMPTY_FORM),
+      };
+    });
+    if (interfaceConfigs.length > 0) network.interfaces = interfaceConfigs;
+    if (network.hostname !== undefined || network.interfaces !== undefined)
+      partial.network = network;
+
+    if (selectedNetwork !== null) {
+      setIsSubmitting(true);
+      const password = draftPassword.trim();
+      const passwordCipher = password !== '' ? await wrapPassword(password) : '(unsecured)';
+      partial.wifi = { ssid: selectedNetwork.ssid, passwordCipher };
+    }
+
+    onNext(partial);
+  }, [
+    draftPassword,
+    hasErrors,
+    hostnameTrimmed,
+    interfaceForms,
+    interfaces,
+    loadState,
+    onNext,
+    selectedNetwork,
+  ]);
+
+  return (
+    <div className="flex flex-col p-8 lg:p-12">
+      <header className="flex flex-col gap-1 pb-6">
+        <h1 className="text-display-xs font-semibold text-primary">{t('setup.network.title')}</h1>
+        <p className="text-sm text-tertiary">{t('setup.network.subtitle')}</p>
+      </header>
+
+      {loadState === 'loading' && (
+        <p role="status" className="text-sm text-tertiary">
+          {t('setup.network.loading')}
+        </p>
+      )}
+      {loadState === 'error' && <ErrorRetry onRetry={() => void load()} />}
+      {loadState === 'unavailable' && (
+        <div className="rounded-lg border border-secondary bg-secondary/50 p-4 text-sm text-tertiary">
+          {t('setup.network.unavailable')}
+        </div>
+      )}
+
+      {loadState === 'ready' && (
+        <div className="flex flex-col">
+          <FormRow label={t('setup.network.hostname.label')} labelId={hostnameLabelId}>
+            <TextField
+              value={hostname}
+              onChange={setHostname}
+              isInvalid={hostnameInvalid}
+              aria-labelledby={hostnameLabelId}
+            >
+              <InputBase
+                type="text"
+                placeholder={t('setup.network.hostname.placeholder')}
+                autoComplete="off"
+                data-testid="network-hostname"
+              />
+            </TextField>
+            <p className="text-xs text-tertiary">{t('setup.network.hostname.hint')}</p>
+            {hostnameError !== undefined && <InlineError>{hostnameError}</InlineError>}
+          </FormRow>
+
+          <section
+            aria-labelledby="network-interfaces-heading"
+            className="flex flex-col gap-4 border-t border-secondary py-5"
+          >
+            <h2
+              id="network-interfaces-heading"
+              className="text-sm font-semibold uppercase tracking-wide text-tertiary"
+            >
+              {t('setup.network.interfaces.heading')}
+            </h2>
+
+            {interfaces.length > 0 && (
+              <Tabs defaultSelectedKey={interfaces[0]?.name ?? ''}>
+                <Tabs.List>
+                  {interfaces.map((iface) => (
+                    <Tabs.Trigger key={iface.name} id={iface.name} label={iface.name} />
+                  ))}
+                </Tabs.List>
+                {interfaces.map((iface) => (
+                  <Tabs.Content key={iface.name} id={iface.name}>
+                    <div className="flex flex-col gap-4 pt-4">
+                      {iface.type === 'wireless' && iface.name === wirelessIface && (
+                        <WifiPicker
+                          state={wifiState}
+                          selectedSsid={selectedSsid}
+                          draftPassword={draftPassword}
+                          onSelect={(ssid) => {
+                            setSelectedSsid(ssid);
+                            setDraftPassword('');
+                          }}
+                          onPasswordChange={setDraftPassword}
+                          onRetry={() => void loadWifi(iface.name)}
+                        />
+                      )}
+                      <IpFamilyForm
+                        family="ipv4"
+                        form={interfaceForms[iface.name]?.ipv4}
+                        errors={familyErrors(interfaceForms[iface.name]?.ipv4, 'ipv4')}
+                        onChange={(next) => {
+                          updateForm(iface.name, 'ipv4', next);
+                        }}
+                      />
+                      <IpFamilyForm
+                        family="ipv6"
+                        form={interfaceForms[iface.name]?.ipv6}
+                        errors={familyErrors(interfaceForms[iface.name]?.ipv6, 'ipv6')}
+                        onChange={(next) => {
+                          updateForm(iface.name, 'ipv6', next);
+                        }}
+                      />
+                    </div>
+                  </Tabs.Content>
+                ))}
+              </Tabs>
+            )}
+          </section>
+        </div>
+      )}
+
+      <div className="mt-4 flex justify-end gap-3 border-t border-secondary py-6">
+        <button
+          type="button"
+          onClick={() => void handleNext()}
+          disabled={isSubmitting}
+          className="inline-flex items-center gap-2 rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white shadow-xs-skeuomorphic hover:bg-brand-solid_hover disabled:opacity-60"
+          data-testid="network-next"
+        >
+          <span>{t('setup.network.actions.next')}</span>
+          <NextArrowIcon />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================
+// IP family form (one of IPv4 / IPv6), collapsible
+// =============================================================
+
+interface IpFamilyFormProps {
+  readonly family: Family;
+  readonly form: IpFormState | undefined;
+  readonly errors: FamilyErrors;
+  readonly onChange: (next: IpFormState) => void;
+}
+
+function IpFamilyForm({ family, form, errors, onChange }: IpFamilyFormProps): ReactNode {
+  const { t } = useTranslation();
+  const addressId = useId();
+  const gatewayId = useId();
+  const dnsId = useId();
+  const methodId = useId();
+
+  const current: IpFormState = form ?? {
+    method: 'auto',
+    address: '',
+    gateway: '',
+    nameservers: '',
+  };
+
+  const methodItems = useMemo<SelectItemType[]>(
+    () => [
+      { id: 'auto', label: t('setup.network.method.auto') },
+      { id: 'static', label: t('setup.network.method.static') },
+      { id: 'disabled', label: t('setup.network.method.disabled') },
+    ],
+    [t],
+  );
+
+  const title =
+    family === 'ipv4' ? t('setup.network.ipv4.heading') : t('setup.network.ipv6.heading');
+  const summary = t(`setup.network.method.${current.method}`);
+  // Auto-open when the family is statically configured so the user sees
+  // the fields without an extra click.
+  const defaultOpen = current.method === 'static';
+
+  return (
+    <CollapsibleSection title={title} summary={summary} defaultOpen={defaultOpen}>
+      <div className="flex flex-col gap-1.5">
+        <label id={methodId} className="text-sm font-semibold text-secondary">
+          {t('setup.network.method.label')}
+        </label>
+        <Select
+          aria-labelledby={methodId}
+          items={methodItems}
+          value={current.method}
+          onChange={(key) => {
+            if (key === 'auto' || key === 'static' || key === 'disabled') {
+              onChange({ ...current, method: key });
+            }
+          }}
+        >
+          {(item) => <SelectItem key={item.id} id={item.id} label={item.label ?? ''} />}
+        </Select>
+      </div>
+
+      {current.method === 'static' && (
+        <>
+          <IpTextField
+            id={addressId}
+            label={t('setup.network.address.label')}
+            placeholder={family === 'ipv4' ? '192.168.1.50/24' : 'fd00::50/64'}
+            value={current.address}
+            error={errors.address}
+            onChange={(value) => {
+              onChange({ ...current, address: value });
+            }}
+          />
+          <IpTextField
+            id={gatewayId}
+            label={t('setup.network.gateway.label')}
+            placeholder={family === 'ipv4' ? '192.168.1.1' : 'fd00::1'}
+            value={current.gateway}
+            error={errors.gateway}
+            onChange={(value) => {
+              onChange({ ...current, gateway: value });
+            }}
+          />
+          <IpTextField
+            id={dnsId}
+            label={t('setup.network.dns.label')}
+            placeholder={family === 'ipv4' ? '1.1.1.1, 8.8.8.8' : '2606:4700:4700::1111'}
+            value={current.nameservers}
+            error={errors.nameservers}
+            onChange={(value) => {
+              onChange({ ...current, nameservers: value });
+            }}
+          />
+        </>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+interface IpTextFieldProps {
+  readonly id: string;
+  readonly label: string;
+  readonly placeholder: string;
+  readonly value: string;
+  readonly error: string | undefined;
+  readonly onChange: (value: string) => void;
+}
+
+function IpTextField({
+  id,
+  label,
+  placeholder,
+  value,
+  error,
+  onChange,
+}: IpTextFieldProps): ReactNode {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label id={id} className="text-sm font-semibold text-secondary">
+        {label}
+      </label>
+      <TextField
+        value={value}
+        onChange={onChange}
+        isInvalid={error !== undefined}
+        aria-labelledby={id}
+      >
+        <InputBase type="text" placeholder={placeholder} autoComplete="off" />
+      </TextField>
+      {error !== undefined && <InlineError>{error}</InlineError>}
+    </div>
+  );
+}
+
+// =============================================================
+// Wi-Fi picker (moved from apply-step.tsx)
+// =============================================================
+
+interface WifiPickerProps {
+  readonly state: WifiState;
+  readonly selectedSsid: string;
+  readonly draftPassword: string;
+  readonly onSelect: (ssid: string) => void;
+  readonly onPasswordChange: (value: string) => void;
+  readonly onRetry: () => void;
+}
+
+function WifiPicker({
+  state,
+  selectedSsid,
+  draftPassword,
+  onSelect,
+  onPasswordChange,
+  onRetry,
+}: WifiPickerProps): ReactNode {
+  const { t } = useTranslation();
+  const passwordLabelId = useId();
+  const wifiPicked =
+    state.kind === 'success' && state.networks.some((n) => n.ssid === selectedSsid);
+
+  return (
+    <section aria-labelledby="network-wifi-heading" className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <h3
+          id="network-wifi-heading"
+          className="text-sm font-semibold uppercase tracking-wide text-tertiary"
+        >
+          {t('setup.network.wifi.heading')}
+        </h3>
+        <p className="text-sm text-tertiary">{t('setup.network.wifi.subtitle')}</p>
+      </div>
+
+      {state.kind === 'loading' && (
+        <p role="status" className="text-sm text-tertiary">
+          {t('setup.network.wifi.loading')}
+        </p>
+      )}
+      {state.kind === 'unavailable' && (
+        <div className="rounded-lg border border-secondary bg-secondary/50 p-4 text-sm text-tertiary">
+          {t('setup.network.wifi.unavailable')}
+        </div>
+      )}
+      {state.kind === 'error' && (
+        <WifiNotice body={t('setup.network.wifi.scanFailed.body')} onRetry={onRetry} />
+      )}
+      {state.kind === 'success' && state.networks.length === 0 && (
+        <WifiNotice body={t('setup.network.wifi.empty')} onRetry={onRetry} />
+      )}
+      {state.kind === 'success' && state.networks.length > 0 && (
+        <ul className="flex flex-col gap-3" aria-label={t('setup.network.wifi.list.ariaLabel')}>
+          {state.networks.map((network) => (
+            <li key={network.ssid}>
+              <WifiNetworkRow
+                network={network}
+                isSelected={network.ssid === selectedSsid}
+                onSelect={() => {
+                  onSelect(network.ssid);
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {wifiPicked && (
+        <div className="flex max-w-[480px] flex-col gap-1.5">
+          <label
+            id={passwordLabelId}
+            className="text-sm font-semibold text-secondary"
+            htmlFor={`${passwordLabelId}-input`}
+          >
+            {t('setup.network.wifi.password.label')}
+          </label>
+          <PasswordInput
+            id={`${passwordLabelId}-input`}
+            value={draftPassword}
+            onChange={onPasswordChange}
+            placeholder={t('setup.network.wifi.password.placeholder')}
+            autoComplete="off"
+          />
+          <p className="text-xs text-tertiary">{t('setup.network.wifi.password.optionalHint')}</p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface WifiNetworkRowProps {
+  readonly network: AccessPoint;
+  readonly isSelected: boolean;
+  readonly onSelect: () => void;
+}
+
+function WifiNetworkRow({ network, isSelected, onSelect }: WifiNetworkRowProps): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={isSelected}
+      className={`flex w-full items-start gap-4 rounded-xl border border-secondary p-4 text-left transition-colors hover:bg-secondary ${
+        isSelected ? 'bg-[var(--glaon-light-grey)]' : 'bg-primary'
+      }`}
+    >
+      <span
+        aria-hidden="true"
+        className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary text-secondary shadow-xs-skeuomorphic ring-1 ring-primary ring-inset"
+      >
+        <WifiIcon />
+      </span>
+      <span className="flex flex-1 flex-col">
+        <span className="text-sm font-medium leading-5 text-secondary">{network.ssid}</span>
+        {network.signal !== undefined && (
+          <span className="text-sm font-normal leading-5 text-tertiary">
+            {t('setup.network.wifi.signal', { signal: network.signal })}
+          </span>
+        )}
+      </span>
+      <span
+        aria-hidden="true"
+        className={`mt-1 inline-flex size-4 shrink-0 items-center justify-center rounded-full border ${
+          isSelected ? 'border-brand-solid bg-brand-solid' : 'border-secondary bg-primary'
+        }`}
+      >
+        {isSelected && <span className="block size-1.5 rounded-full bg-primary" />}
+      </span>
+    </button>
+  );
+}
+
+interface WifiNoticeProps {
+  readonly body: string;
+  readonly onRetry: () => void;
+}
+
+function WifiNotice({ body, onRetry }: WifiNoticeProps): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-secondary bg-primary p-4 text-sm text-tertiary">
+      <p>{body}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex w-fit items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-1.5 text-sm font-semibold text-secondary shadow-xs-skeuomorphic"
+      >
+        {t('setup.network.wifi.actions.retry')}
+      </button>
+    </div>
+  );
+}
+
+// =============================================================
+// Shared chrome (mirrors home-overview-step)
+// =============================================================
+
+interface FormRowProps {
+  readonly label: string;
+  readonly labelId?: string;
+  readonly children: ReactNode;
+}
+
+function FormRow({ label, labelId, children }: FormRowProps): ReactNode {
+  return (
+    <div className="grid grid-cols-1 gap-2 border-t border-secondary py-5 sm:grid-cols-[240px_1fr] sm:items-start sm:gap-8">
+      <p id={labelId} className="pt-2 text-sm font-semibold text-secondary">
+        {label}
+      </p>
+      <div className="flex max-w-[480px] flex-col gap-1.5">{children}</div>
+    </div>
+  );
+}
+
+function InlineError({ children }: { children: ReactNode }): ReactNode {
+  return (
+    <p role="alert" className="text-sm text-error-primary">
+      {children}
+    </p>
+  );
+}
+
+interface ErrorRetryProps {
+  readonly onRetry: () => void;
+}
+
+function ErrorRetry({ onRetry }: ErrorRetryProps): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-secondary bg-primary p-4 text-sm text-tertiary">
+      <p>{t('setup.network.loadFailed')}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex w-fit items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-1.5 text-sm font-semibold text-secondary shadow-xs-skeuomorphic"
+      >
+        {t('setup.network.wifi.actions.retry')}
+      </button>
+    </div>
+  );
+}
+
+function WifiIcon(): ReactNode {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M1.667 6a9 9 0 0 1 12.666 0" />
+      <path d="M4 8.667a5.333 5.333 0 0 1 8 0" />
+      <path d="M6.333 11.333a2 2 0 0 1 3.334 0" />
+      <path d="M8 14h.007" />
+    </svg>
+  );
+}
+
+function NextArrowIcon(): ReactNode {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4.167 10h11.666m0 0L10 4.167M15.833 10 10 15.833" />
+    </svg>
+  );
+}

--- a/apps/web/src/features/setup/network/validation.test.ts
+++ b/apps/web/src/features/setup/network/validation.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  areNameserversValid,
+  isCidr,
+  isHostnameLabel,
+  isIpv4,
+  isIpv6,
+  isPlainIp,
+  splitNameservers,
+} from './validation';
+
+describe('isHostnameLabel', () => {
+  it('accepts a plain label and a hyphenated one', () => {
+    expect(isHostnameLabel('glaon')).toBe(true);
+    expect(isHostnameLabel('glaon-wall')).toBe(true);
+    expect(isHostnameLabel('a')).toBe(true);
+    expect(isHostnameLabel('a'.repeat(63))).toBe(true);
+  });
+
+  it('rejects leading/trailing hyphen, bad chars, and over-length', () => {
+    expect(isHostnameLabel('-glaon')).toBe(false);
+    expect(isHostnameLabel('glaon-')).toBe(false);
+    expect(isHostnameLabel('glaon_wall')).toBe(false);
+    expect(isHostnameLabel('glaon wall')).toBe(false);
+    expect(isHostnameLabel('a'.repeat(64))).toBe(false);
+    expect(isHostnameLabel('')).toBe(false);
+  });
+});
+
+describe('isIpv4', () => {
+  it('accepts well-formed addresses', () => {
+    expect(isIpv4('192.168.1.50')).toBe(true);
+    expect(isIpv4('0.0.0.0')).toBe(true);
+    expect(isIpv4('255.255.255.255')).toBe(true);
+  });
+
+  it('rejects out-of-range octets, wrong arity, and leading zeros', () => {
+    expect(isIpv4('256.1.1.1')).toBe(false);
+    expect(isIpv4('192.168.1')).toBe(false);
+    expect(isIpv4('192.168.1.1.1')).toBe(false);
+    expect(isIpv4('192.168.01.1')).toBe(false);
+    expect(isIpv4('192.168.1.x')).toBe(false);
+    expect(isIpv4('')).toBe(false);
+  });
+});
+
+describe('isIpv6', () => {
+  it('accepts full, compressed, and all-zero forms', () => {
+    expect(isIpv6('2001:db8:85a3:0:0:8a2e:370:7334')).toBe(true);
+    expect(isIpv6('fd00::1')).toBe(true);
+    expect(isIpv6('::')).toBe(true);
+    expect(isIpv6('::1')).toBe(true);
+    expect(isIpv6('fe80::5c7d:aeff:fec1:7ff8')).toBe(true);
+  });
+
+  it('rejects double compression, bad groups, and wrong length', () => {
+    expect(isIpv6('2001::db8::1')).toBe(false);
+    expect(isIpv6('gggg::1')).toBe(false);
+    expect(isIpv6('2001:db8:85a3:0:0:8a2e:370')).toBe(false);
+    expect(isIpv6('12345::1')).toBe(false);
+    expect(isIpv6('')).toBe(false);
+  });
+});
+
+describe('isPlainIp', () => {
+  it('dispatches on family', () => {
+    expect(isPlainIp('10.0.0.1', 'ipv4')).toBe(true);
+    expect(isPlainIp('fd00::1', 'ipv4')).toBe(false);
+    expect(isPlainIp('fd00::1', 'ipv6')).toBe(true);
+    expect(isPlainIp('10.0.0.1', 'ipv6')).toBe(false);
+  });
+});
+
+describe('isCidr', () => {
+  it('accepts addresses with and without a valid prefix', () => {
+    expect(isCidr('192.168.1.50/24', 'ipv4')).toBe(true);
+    expect(isCidr('192.168.1.50', 'ipv4')).toBe(true);
+    expect(isCidr('fd00::1/64', 'ipv6')).toBe(true);
+    expect(isCidr('fd00::1', 'ipv6')).toBe(true);
+  });
+
+  it('rejects out-of-range or malformed prefixes', () => {
+    expect(isCidr('192.168.1.50/33', 'ipv4')).toBe(false);
+    expect(isCidr('fd00::1/129', 'ipv6')).toBe(false);
+    expect(isCidr('192.168.1.50/', 'ipv4')).toBe(false);
+    expect(isCidr('192.168.1.50/aa', 'ipv4')).toBe(false);
+    expect(isCidr('not-an-ip/24', 'ipv4')).toBe(false);
+  });
+});
+
+describe('splitNameservers', () => {
+  it('splits on commas and whitespace, trimming empties', () => {
+    expect(splitNameservers('1.1.1.1, 8.8.8.8')).toEqual(['1.1.1.1', '8.8.8.8']);
+    expect(splitNameservers('1.1.1.1   8.8.8.8')).toEqual(['1.1.1.1', '8.8.8.8']);
+    expect(splitNameservers('  ')).toEqual([]);
+    expect(splitNameservers('')).toEqual([]);
+  });
+});
+
+describe('areNameserversValid', () => {
+  it('accepts a list of valid addresses and an empty field', () => {
+    expect(areNameserversValid('1.1.1.1, 8.8.8.8', 'ipv4')).toBe(true);
+    expect(areNameserversValid('', 'ipv4')).toBe(true);
+    expect(areNameserversValid('fd00::1 2606:4700:4700::1111', 'ipv6')).toBe(true);
+  });
+
+  it('rejects when any entry is invalid for the family', () => {
+    expect(areNameserversValid('1.1.1.1, nope', 'ipv4')).toBe(false);
+    expect(areNameserversValid('1.1.1.1', 'ipv6')).toBe(false);
+  });
+});

--- a/apps/web/src/features/setup/network/validation.ts
+++ b/apps/web/src/features/setup/network/validation.ts
@@ -1,0 +1,78 @@
+// Form-level network validation for the wizard's Network step (#629).
+//
+// These check *format* for the per-field inline errors the step shows.
+// @glaon/core's NetworkConfigSchema enforces shape (non-empty strings)
+// only — friendly IP-format feedback lives here in the UI layer, the
+// same split that keeps `country` the lone regex-validated field on
+// DeviceConfig. Pure functions, no DOM: trivially unit-testable.
+
+/** RFC 1123 hostname label: 1–63 chars, letters/digits/hyphen, no edge hyphen. */
+const HOSTNAME_RE = /^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
+
+export function isHostnameLabel(value: string): boolean {
+  return HOSTNAME_RE.test(value);
+}
+
+/** Dotted-quad IPv4, no leading zeros (each octet 0–255). */
+export function isIpv4(value: string): boolean {
+  const octets = value.split('.');
+  if (octets.length !== 4) return false;
+  return octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255 && String(Number(o)) === o);
+}
+
+/**
+ * IPv6 with `::` compression. No embedded-IPv4 or zone-index forms —
+ * uncommon for LAN config and not worth the validator surface. Each
+ * group is 1–4 hex digits; `::` (at most once) stands in for one or more
+ * zero groups.
+ */
+export function isIpv6(value: string): boolean {
+  if (value === '' || (value.match(/::/g)?.length ?? 0) > 1) return false;
+  const groupRe = /^[0-9a-fA-F]{1,4}$/;
+  const hasCompression = value.includes('::');
+  const parts = value.split('::');
+  const head = parts[0] ?? '';
+  const tail = parts[1] ?? '';
+  const headGroups = head === '' ? [] : head.split(':');
+  const tailGroups = tail === '' ? [] : tail.split(':');
+  const groups = [...headGroups, ...tailGroups];
+  if (!groups.every((g) => groupRe.test(g))) return false;
+  // `::` expands to >= 1 zero group, so head+tail must leave room (<= 7);
+  // without compression the address must be exactly 8 groups.
+  return hasCompression ? groups.length <= 7 : groups.length === 8;
+}
+
+/** Plain address of the given family (no prefix). */
+export function isPlainIp(value: string, family: 'ipv4' | 'ipv6'): boolean {
+  return family === 'ipv4' ? isIpv4(value) : isIpv6(value);
+}
+
+/**
+ * Address with an optional CIDR prefix (e.g. `192.168.1.50/24`,
+ * `fd00::1/64`). The prefix is optional but, when present, must be in
+ * range for the family (0–32 for IPv4, 0–128 for IPv6).
+ */
+export function isCidr(value: string, family: 'ipv4' | 'ipv6'): boolean {
+  const slash = value.indexOf('/');
+  if (slash === -1) return isPlainIp(value, family);
+  const addr = value.slice(0, slash);
+  const prefix = value.slice(slash + 1);
+  if (!isPlainIp(addr, family)) return false;
+  if (!/^\d{1,3}$/.test(prefix)) return false;
+  const max = family === 'ipv4' ? 32 : 128;
+  return Number(prefix) <= max;
+}
+
+/** Split a free-text DNS field on commas / whitespace into trimmed entries. */
+export function splitNameservers(value: string): string[] {
+  return value
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s !== '');
+}
+
+/** True when every entry in the DNS field is a valid plain address. */
+export function areNameserversValid(value: string, family: 'ipv4' | 'ipv6'): boolean {
+  const entries = splitNameservers(value);
+  return entries.every((entry) => isPlainIp(entry, family));
+}

--- a/apps/web/src/features/setup/setup-route.test.tsx
+++ b/apps/web/src/features/setup/setup-route.test.tsx
@@ -55,7 +55,15 @@ describe('SetupRoute', () => {
     expect(container.querySelector('h1')?.textContent).toBe('Device Security');
   });
 
-  it('lands on the Apply step after Security in the 4-step order', () => {
+  it('renders the Network step (after Security in the 5-step order)', () => {
+    // #629 inserts Network between Security and Apply. The fetch stub
+    // rejects so the step lands in its error state, but the h1 (rendered
+    // regardless of load state) is the routing signal we assert here.
+    const { container } = renderRoute('network');
+    expect(container.querySelector('h1')?.textContent).toBe('Network');
+  });
+
+  it('lands on the Apply step (terminal, after Network in the 5-step order)', () => {
     const { container } = renderRoute('apply');
     expect(container.querySelector('h1')?.textContent).toBe('Save and apply');
   });

--- a/apps/web/src/features/setup/setup-route.tsx
+++ b/apps/web/src/features/setup/setup-route.tsx
@@ -32,12 +32,15 @@ import { useWizardState } from '../../setup/use-wizard-state';
 import { ApplyStep } from './apply';
 import { HomeOverviewStep } from './home-overview';
 import { LayoutStep } from './layout';
+import { NetworkStep } from './network';
 import { SecurityStep } from './security';
 
 // #597 collapsed the old wifi + review steps into a single terminal
-// "apply" step that hosts the summary + Wi-Fi picker + handoff
-// ceremony.
-export type WizardStepId = 'home-overview' | 'layout' | 'security' | 'apply';
+// "apply" step. #629 adds a dedicated Network step (hostname + per-
+// interface IPv4/IPv6 + Wi-Fi selection) between Security and Apply; the
+// Wi-Fi picker moved out of Apply into Network, the destructive handoff
+// stays terminal.
+export type WizardStepId = 'home-overview' | 'layout' | 'security' | 'network' | 'apply';
 
 // `WizardStepProps`, `SETUP_STEPS`, and `SetupRouteProps` stay unexported
 // here: each subsequent step issue (#540, #545–#548) introduces its own
@@ -69,8 +72,12 @@ const STEP_ICON_PATHS: Record<WizardStepId, string> = {
   'home-overview': 'M9 22V12h6v10M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V9z',
   layout: 'M3 4h18v16H3zM12 4v16',
   security: 'M12 4v16M4 12h16M5.6 5.6l12.8 12.8M18.4 5.6L5.6 18.4',
-  // Wi-Fi bars — same glyph the old wifi step used, kept because
-  // the apply step's destructive action is the network switch.
+  // Globe with meridians — the Network step configures hostname + per-
+  // interface IPv4/IPv6 + Wi-Fi.
+  network:
+    'M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20M2 12h20M12 2a15 15 0 0 1 0 20M12 2a15 15 0 0 0 0 20',
+  // Wi-Fi bars — kept for the apply step because its destructive action
+  // is the network switch.
   apply:
     'M5 12.55a11 11 0 0 1 14 0M1.42 9a16 16 0 0 1 21.16 0M8.53 16.11a6 6 0 0 1 6.95 0M12 20h.01',
 };
@@ -104,6 +111,9 @@ const LayoutStepAdapter = (props: WizardStepProps): ReactNode => (
 const SecurityStepAdapter = (props: WizardStepProps): ReactNode => (
   <SecurityStep collected={props.collected} onNext={props.onNext} />
 );
+const NetworkStepAdapter = (props: WizardStepProps): ReactNode => (
+  <NetworkStep collected={props.collected} onNext={props.onNext} />
+);
 const ApplyStepAdapter = (props: WizardStepProps): ReactNode => (
   <ApplyStep collected={props.collected} onNext={props.onNext} />
 );
@@ -129,6 +139,13 @@ const SETUP_STEPS: readonly WizardStepRegistration[] = [
     description: 'Create a password to protect your smart devices.',
     icon: <StepIcon id="security" />,
     Component: SecurityStepAdapter,
+  },
+  {
+    id: 'network',
+    title: 'Network',
+    description: 'Set the hostname and configure interfaces and Wi-Fi.',
+    icon: <StepIcon id="network" />,
+    Component: NetworkStepAdapter,
   },
   {
     id: 'apply',

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -174,19 +174,48 @@
         "next": "Next"
       }
     },
-    "apply": {
-      "title": "Save and apply",
-      "subtitle": "Double-check your settings, pick your home Wi-Fi, and we'll switch the device over.",
-      "summary": {
-        "heading": "Settings to apply",
-        "wifi": "Wi-Fi",
-        "wifiSecured": "{ssid} (secured)",
-        "wifiUnsecured": "{ssid} (open)",
-        "adminPassword": "Admin password",
-        "passwordSet": "Set",
-        "notSet": "—",
-        "layoutHeadline": "{floorCount} floors · {roomCount} rooms",
-        "layoutEmptyFloor": "no rooms yet"
+    "network": {
+      "title": "Network",
+      "subtitle": "Set this device's hostname and how each interface gets its address, then pick the Wi-Fi network it should join.",
+      "loading": "Loading network configuration…",
+      "loadFailed": "We couldn't load the current network configuration. The Home Assistant add-on may be restarting.",
+      "unavailable": "Network configuration isn't available in this environment, so we'll skip it. Your other settings will still be saved.",
+      "hostname": {
+        "label": "Hostname",
+        "placeholder": "e.g. glaon",
+        "hint": "The name this device uses on your network.",
+        "invalid": "Use 1–63 letters, digits, or hyphens (no leading or trailing hyphen)."
+      },
+      "interfaces": {
+        "heading": "Network interfaces"
+      },
+      "ipv4": {
+        "heading": "IPv4"
+      },
+      "ipv6": {
+        "heading": "IPv6"
+      },
+      "method": {
+        "label": "Method",
+        "auto": "Automatic (DHCP)",
+        "static": "Static",
+        "disabled": "Disabled"
+      },
+      "address": {
+        "label": "IP address",
+        "required": "An IP address is required for a static configuration.",
+        "invalid": "Enter a valid address, optionally with a /prefix (e.g. 192.168.1.50/24)."
+      },
+      "gateway": {
+        "label": "Gateway",
+        "invalid": "Enter a valid gateway address."
+      },
+      "dns": {
+        "label": "DNS servers",
+        "invalid": "Enter valid DNS addresses, separated by commas."
+      },
+      "actions": {
+        "next": "Next"
       },
       "wifi": {
         "heading": "Wi-Fi network",
@@ -211,6 +240,21 @@
         "actions": {
           "retry": "Try again"
         }
+      }
+    },
+    "apply": {
+      "title": "Save and apply",
+      "subtitle": "Double-check your settings, pick your home Wi-Fi, and we'll switch the device over.",
+      "summary": {
+        "heading": "Settings to apply",
+        "wifi": "Wi-Fi",
+        "wifiSecured": "{ssid} (secured)",
+        "wifiUnsecured": "{ssid} (open)",
+        "adminPassword": "Admin password",
+        "passwordSet": "Set",
+        "notSet": "—",
+        "layoutHeadline": "{floorCount} floors · {roomCount} rooms",
+        "layoutEmptyFloor": "no rooms yet"
       },
       "commitFailed": {
         "title": "Couldn't complete setup",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -174,19 +174,48 @@
         "next": "İleri"
       }
     },
-    "apply": {
-      "title": "Kaydet ve uygula",
-      "subtitle": "Ayarları gözden geçir, ev Wi-Fi'nı seç — sonra Glaon cihazı kendi ağına geçirir.",
-      "summary": {
-        "heading": "Uygulanacak ayarlar",
-        "wifi": "Wi-Fi",
-        "wifiSecured": "{ssid} (şifreli)",
-        "wifiUnsecured": "{ssid} (açık)",
-        "adminPassword": "Yönetici şifresi",
-        "passwordSet": "Ayarlandı",
-        "notSet": "—",
-        "layoutHeadline": "{floorCount} kat · {roomCount} oda",
-        "layoutEmptyFloor": "henüz oda yok"
+    "network": {
+      "title": "Ağ",
+      "subtitle": "Bu cihazın ana bilgisayar adını ve her arayüzün adresini nasıl alacağını ayarla, sonra bağlanacağı Wi-Fi ağını seç.",
+      "loading": "Ağ yapılandırması yükleniyor…",
+      "loadFailed": "Mevcut ağ yapılandırması yüklenemedi. Home Assistant add-on’u yeniden başlatılıyor olabilir.",
+      "unavailable": "Bu ortamda ağ yapılandırması yapılamıyor, bu yüzden atlanacak. Diğer ayarların yine de kaydedilir.",
+      "hostname": {
+        "label": "Ana bilgisayar adı",
+        "placeholder": "örn. glaon",
+        "hint": "Bu cihazın ağında kullanacağı ad.",
+        "invalid": "1–63 harf, rakam veya tire kullan (başında veya sonunda tire olmadan)."
+      },
+      "interfaces": {
+        "heading": "Ağ arayüzleri"
+      },
+      "ipv4": {
+        "heading": "IPv4"
+      },
+      "ipv6": {
+        "heading": "IPv6"
+      },
+      "method": {
+        "label": "Yöntem",
+        "auto": "Otomatik (DHCP)",
+        "static": "Statik",
+        "disabled": "Kapalı"
+      },
+      "address": {
+        "label": "IP adresi",
+        "required": "Statik yapılandırma için bir IP adresi gerekli.",
+        "invalid": "Geçerli bir adres gir, isteğe bağlı /önek ile (örn. 192.168.1.50/24)."
+      },
+      "gateway": {
+        "label": "Ağ geçidi",
+        "invalid": "Geçerli bir ağ geçidi adresi gir."
+      },
+      "dns": {
+        "label": "DNS sunucuları",
+        "invalid": "Geçerli DNS adresleri gir, virgülle ayır."
+      },
+      "actions": {
+        "next": "İleri"
       },
       "wifi": {
         "heading": "Wi-Fi ağı",
@@ -211,6 +240,21 @@
         "actions": {
           "retry": "Tekrar dene"
         }
+      }
+    },
+    "apply": {
+      "title": "Kaydet ve uygula",
+      "subtitle": "Ayarları gözden geçir, ev Wi-Fi'nı seç — sonra Glaon cihazı kendi ağına geçirir.",
+      "summary": {
+        "heading": "Uygulanacak ayarlar",
+        "wifi": "Wi-Fi",
+        "wifiSecured": "{ssid} (şifreli)",
+        "wifiUnsecured": "{ssid} (açık)",
+        "adminPassword": "Yönetici şifresi",
+        "passwordSet": "Ayarlandı",
+        "notSet": "—",
+        "layoutHeadline": "{floorCount} kat · {roomCount} oda",
+        "layoutEmptyFloor": "henüz oda yok"
       },
       "commitFailed": {
         "title": "Kurulum tamamlanamadı",


### PR DESCRIPTION
## Summary

Adds the dedicated **Network** wizard step (epic #626), placed between **Device Security** and **Save and apply**, mirroring HA's Supervisor network screen:

- **Hostname** field (seeded from `/api/hassio/host/info`, RFC 1123 inline validation).
- **Per-interface tabs** (`end0` / `wlan0`) from `/api/hassio/network/info`.
- **Collapsible IPv4 + IPv6 panels** per interface — method (DHCP / Static / Disabled); when Static, address (CIDR) / gateway / DNS inputs with inline IP-format validation. Static panels auto-open and seed from the live interface config.
- **Wi-Fi picker** — moved here from the terminal apply step.

The step is **collect-only**: hostname + IP land in `collected.network`, Wi-Fi SSID/password in `collected.wifi` (AES-GCM wrapped). The terminal **apply step** now reads those from `collected` and, at commit, pushes the hostname (`/host/options`) and per-interface IP (`/network/interface/:iface/update`, folding the Wi-Fi credentials into the wireless interface's update) **before** the network handoff — the destructive switch stays terminal (preserves #597's rationale). The handoff modal is now confirmation-only (the password was collected earlier; it's unwrapped from the cipher at commit).

## Design note (Figma deviation)

Per #626, this screen is designed **in code** using HA's network screen as the functional reference — a maintainer-approved deviation from the Design-System Fidelity Rule. Figma reconciliation is a tracked follow-up. No `@glaon/ui` primitive was added: the IPv4/IPv6 collapsible is a feature-local accessible disclosure (native `<button aria-expanded/aria-controls>`), consistent with apply-step's own private sub-components; it graduates to a UUI-wrapped `@glaon/ui` primitive if a second consumer appears.

## Scope

**In**
- `apps/web/src/features/setup/network/`: `network-step.tsx`, `network-api.ts` (Supervisor HTTP + parsing), `validation.ts` (hostname/IPv4/IPv6/CIDR/DNS), `collapsible-section.tsx`, `index.ts`, + tests.
- `setup-route.tsx`: register `network` step (id, adapter, globe icon) before `apply`.
- `apply-step.tsx`: drop the Wi-Fi scan/picker; read Wi-Fi/hostname/IP from `collected`; push hostname + per-interface IP + Wi-Fi at commit. Rewrote `apply-step.test.tsx` for the new flow.
- i18n: moved `setup.apply.wifi.*` → `setup.network.wifi.*`, added the `setup.network.*` subtree (en + tr).
- E2E: `setup-wizard.spec.ts` walks the new 5-step flow (picks Wi-Fi in the Network step).

**Out**
- Review step **redesign** (#630) — this PR leaves the apply summary functional (adds a hostname row) but does not restyle it.
- Mobile parity.

## Test plan

- [x] `pnpm --filter @glaon/web test src/features/setup` — 73 passing (validation 12, network-step render/Wi-Fi/503/hostname-validation, apply commit flows incl. hostname+static-IP push, secured/unsecured Wi-Fi, HA-settings-fail abort, 503 HA-less).
- [x] `pnpm type-check` (all 11) + `pnpm lint` (all) + `pnpm i18n:check` green.
- [x] **Manual browser** (mock Supervisor): Network step renders with hostname seeded `glaon`, `wlan0`/`end0` tabs, Wi-Fi APs listed; `end0` static IPv4 panel auto-opens seeded `192.168.1.50/24` + gateway + DNS; invalid address blocks Next with the inline error.
- [ ] CI green (watching after push); Chromatic reviewed.

Refs #626
Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)