### PR TITLE
fix(addon-dev): proxy /api/hassio/host/* to the Supervisor

### DIFF
--- a/addon-dev/rootfs/etc/nginx/http.d/glaon-dev.conf.template
+++ b/addon-dev/rootfs/etc/nginx/http.d/glaon-dev.conf.template
@@ -48,6 +48,22 @@ server {
         proxy_read_timeout 30s;
     }
 
+    # Host API (#635). The wizard's Network step (#629) reads the device
+    # hostname from `/api/hassio/host/info` and sets it via
+    # `/api/hassio/host/options`. Same prefix-strip + bearer injection as
+    # the network block: `/api/hassio/host/info` → `http://supervisor/host/info`.
+    # Without this block these paths fall through to `location /` (SPA),
+    # so hostname read/seed + apply silently degrade in live add-on dev.
+    location /api/hassio/host/ {
+        proxy_pass http://supervisor/host/;
+        proxy_http_version 1.1;
+        proxy_set_header Host supervisor;
+        proxy_set_header Authorization "Bearer ${SUPERVISOR_TOKEN}";
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_buffering off;
+        proxy_read_timeout 30s;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary

Closes the live-add-on-dev gap found during #629 manual testing: the dev add-on nginx only proxied `/api/hassio/network/`, so the wizard Network step's hostname calls (`GET /api/hassio/host/info`, `POST /api/hassio/host/options`) fell through to the SPA (`GET` → `index.html`, `POST` → nginx `405`). Hostname read/seed + apply silently degraded when `apps/api` runs against the dev add-on LAN port (#615/#616).

Adds a `/api/hassio/host/` location to `glaon-dev.conf.template`, a verbatim mirror of the `/api/hassio/network/` block (same `${SUPERVISOR_TOKEN}` bearer injection + headers + trailing-slash prefix strip): `/api/hassio/host/info` → `http://supervisor/host/info`.

## Scope

**In**
- `addon-dev/rootfs/etc/nginx/http.d/glaon-dev.conf.template` — one `location` block (16 lines).

**Out**
- Production add-on (`addon/.../glaon.conf`) proxies **no** `/api/hassio/*` at all — its wizard-Supervisor story is a separate, larger gap, not in scope.

## Test plan

- [ ] On a Pi running the dev add-on: `curl .../api/hassio/host/info` returns the Supervisor hostname JSON (not SPA HTML); `POST .../api/hassio/host/options {"hostname":"glaon-wall"}` returns a Supervisor 2xx (not nginx 405).
- [ ] Wizard Network step seeds the real hostname; finishing setup applies it.
- [x] Block is a verbatim copy of the validated `/network/` block (only path + `proxy_pass` differ); CI add-on image build is green.

Refs #626
Closes #635