### PR TITLE
feat(web,ui): wizard back-navigation (rail jump + Back button)

### DIFF
--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -148,6 +148,23 @@ test.describe('setup wizard @smoke', () => {
     expect(persisted.completedAt).toBeDefined();
   });
 
+  test('supports back-navigation via Back button + rail jump, preserving data (#637)', async ({
+    page,
+  }) => {
+    await walkToNetworkStep(page);
+    await expect(page.getByRole('heading', { level: 1, name: 'Network' })).toBeVisible();
+
+    // Back button → previous step (Device Security).
+    await page.getByTestId('wizard-back').click();
+    await expect(page.getByRole('heading', { level: 1, name: 'Device Security' })).toBeVisible();
+
+    // Rail jump back to a visited step (Home Overview) — data entered
+    // earlier is retained (home name is collected-backed).
+    await page.getByRole('button', { name: /Home Overview/i }).click();
+    await expect(page.getByRole('heading', { level: 1, name: 'Home Overview' })).toBeVisible();
+    await expect(page.getByLabel('Home Name')).toHaveValue('Olivia');
+  });
+
   test('reload after completion never re-runs the wizard', async ({ page }) => {
     await walkToNetworkStep(page);
     await page.getByRole('button', { name: /PreviewGuest/i }).click();

--- a/apps/web/src/features/setup/apply/apply-step.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.tsx
@@ -38,12 +38,15 @@ import {
 import { HandoffModal } from '../wifi/handoff-modal';
 import { HandoffOverlay } from '../wifi/handoff-overlay';
 import { clearDeviceKey, unwrapPassword } from '../wifi/wifi-crypto';
+import { WizardBackButton } from '../wizard-back-button';
 
 interface ApplyStepProps {
   /** Final accumulated partial from prior steps. */
   readonly collected: DeviceConfigInput;
   /** Hint from the wizard route that this is the last step (unused — the apply step owns its CTA copy). */
   readonly onNext?: (partial: DeviceConfigInput) => void;
+  /** Go back to the Network step (#637). Undefined would hide Back, but apply is never first. */
+  readonly onBack?: () => void;
 }
 
 // #617 — apps/api endpoint that pushes the collected home settings into
@@ -117,7 +120,7 @@ async function discoverWirelessInterface(): Promise<string> {
 
 type HandoffPhase = 'idle' | 'confirming' | 'committing' | 'switching';
 
-export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
+export function ApplyStep({ collected, onBack }: ApplyStepProps): ReactNode {
   const { t } = useTranslation();
   const toast = useToast();
   const { setPartial, markComplete } = useDeviceConfig();
@@ -294,7 +297,8 @@ export function ApplyStep({ collected }: ApplyStepProps): ReactNode {
         </ReviewCard>
       </div>
 
-      <div className="mt-4 flex justify-end gap-3 border-t border-secondary py-6">
+      <div className="mt-4 flex items-center justify-between gap-3 border-t border-secondary py-6">
+        {onBack !== undefined ? <WizardBackButton onBack={onBack} /> : <span />}
         <Button
           size="md"
           color="primary"

--- a/apps/web/src/features/setup/layout/layout-step.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.tsx
@@ -28,6 +28,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { DeviceConfigInput } from '@glaon/core/config';
 
+import { WizardBackButton } from '../wizard-back-button';
 import { FloorTabs } from './floor-tabs';
 import { RoomGrid } from './room-grid';
 import { useLayoutState } from './use-layout-state';
@@ -37,12 +38,14 @@ interface LayoutStepProps {
   readonly collected: DeviceConfigInput;
   /** Merge the form's output into `collected` and advance to the next step. */
   readonly onNext: (partial: DeviceConfigInput) => void;
+  /** Go back one step (#637). */
+  readonly onBack?: () => void;
 }
 
 const MAX_FLOORS = 10;
 const MAX_ROOMS_PER_FLOOR = 50;
 
-export function LayoutStep({ collected, onNext }: LayoutStepProps): ReactNode {
+export function LayoutStep({ collected, onNext, onBack }: LayoutStepProps): ReactNode {
   const { t } = useTranslation();
 
   const { state, actions, toLayout } = useLayoutState({
@@ -109,7 +112,8 @@ export function LayoutStep({ collected, onNext }: LayoutStepProps): ReactNode {
           />
         )}
 
-        <div className="flex justify-end gap-3 border-t border-secondary pt-6">
+        <div className="flex items-center justify-between gap-3 border-t border-secondary pt-6">
+          {onBack !== undefined ? <WizardBackButton onBack={onBack} /> : <span />}
           <button
             type="submit"
             className="inline-flex items-center gap-2 rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white shadow-xs-skeuomorphic hover:bg-brand-solid_hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"

--- a/apps/web/src/features/setup/network/network-step.tsx
+++ b/apps/web/src/features/setup/network/network-step.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from 'react-i18next';
 import type { DeviceConfigInput, InterfaceConfig, IpConfig, IpMethod } from '@glaon/core/config';
 
 import { wrapPassword } from '../wifi/wifi-crypto';
+import { WizardBackButton } from '../wizard-back-button';
 import { CollapsibleSection } from './collapsible-section';
 import {
   DEFAULT_WIRELESS_INTERFACE,
@@ -54,6 +55,7 @@ import {
 interface NetworkStepProps {
   readonly collected: DeviceConfigInput;
   readonly onNext: (partial: DeviceConfigInput) => void;
+  readonly onBack?: () => void;
 }
 
 // ---- per-family form state (text fields; converted to IpConfig on submit) ----
@@ -108,7 +110,7 @@ type WifiState =
   | { readonly kind: 'error' }
   | { readonly kind: 'unavailable' };
 
-export function NetworkStep({ collected, onNext }: NetworkStepProps): ReactNode {
+export function NetworkStep({ collected, onNext, onBack }: NetworkStepProps): ReactNode {
   const { t } = useTranslation();
   const toast = useToast();
   const hostnameLabelId = useId();
@@ -433,7 +435,8 @@ export function NetworkStep({ collected, onNext }: NetworkStepProps): ReactNode 
         </div>
       )}
 
-      <div className="mt-4 flex justify-end gap-3 border-t border-secondary py-6">
+      <div className="mt-4 flex items-center justify-between gap-3 border-t border-secondary py-6">
+        {onBack !== undefined ? <WizardBackButton onBack={onBack} /> : <span />}
         <button
           type="button"
           onClick={() => void handleNext()}

--- a/apps/web/src/features/setup/security/security-step.tsx
+++ b/apps/web/src/features/setup/security/security-step.tsx
@@ -21,11 +21,15 @@ import { useTranslation } from 'react-i18next';
 
 import type { DeviceConfigInput } from '@glaon/core/config';
 
+import { WizardBackButton } from '../wizard-back-button';
+
 interface SecurityStepProps {
   /** Partial DeviceConfig collected from earlier steps in this run. */
   readonly collected: DeviceConfigInput;
   /** Merge the form's output into `collected` and advance to the next step. */
   readonly onNext: (partial: DeviceConfigInput) => void;
+  /** Go back one step (#637). */
+  readonly onBack?: () => void;
 }
 
 const MIN_PASSWORD_LENGTH = 8;
@@ -51,7 +55,11 @@ function validatePasswords(password: string, confirm: string): PasswordValidatio
   return { kind: 'ok' };
 }
 
-export function SecurityStep({ collected: _collected, onNext }: SecurityStepProps): ReactNode {
+export function SecurityStep({
+  collected: _collected,
+  onNext,
+  onBack,
+}: SecurityStepProps): ReactNode {
   const { t } = useTranslation();
   const toast = useToast();
   const passwordId = useId();
@@ -138,7 +146,8 @@ export function SecurityStep({ collected: _collected, onNext }: SecurityStepProp
           />
         </FormRow>
 
-        <div className="flex justify-end gap-3 border-t border-secondary py-6">
+        <div className="flex items-center justify-between gap-3 border-t border-secondary py-6">
+          {onBack !== undefined ? <WizardBackButton onBack={onBack} /> : <span />}
           <Button type="submit" size="md" isLoading={isHashing}>
             {t('setup.security.actions.next')}
           </Button>

--- a/apps/web/src/features/setup/setup-route.test.tsx
+++ b/apps/web/src/features/setup/setup-route.test.tsx
@@ -82,4 +82,33 @@ describe('SetupRoute', () => {
     // apply"); the body title is the same i18n string in this case.
     expect(activeRail?.textContent).toContain('Save and apply');
   });
+
+  // --- back-navigation (#637) ---
+
+  it('jumps back to a prior step when its rail row is clicked', () => {
+    const { container, getByRole } = renderRoute('network');
+    expect(container.querySelector('h1')?.textContent).toBe('Network');
+    // Layout (index 1) is before Network (index 3) → navigable rail button.
+    fireEvent.click(getByRole('button', { name: /Layout Setup/i }));
+    expect(container.querySelector('h1')?.textContent).toBe('Layout Setup');
+  });
+
+  it('goes back one step via the Back button', () => {
+    const { container, getByTestId } = renderRoute('network');
+    fireEvent.click(getByTestId('wizard-back'));
+    expect(container.querySelector('h1')?.textContent).toBe('Device Security');
+  });
+
+  it('hides the Back button on the first step', () => {
+    const { container, queryByTestId } = renderRoute();
+    expect(container.querySelector('h1')?.textContent).toBe('Home Overview');
+    expect(queryByTestId('wizard-back')).toBeNull();
+  });
+
+  it('does not make future steps clickable in the rail', () => {
+    // At Security (index 2), Network + Apply are future → rendered as
+    // non-interactive rows, not jump buttons.
+    const { queryByRole } = renderRoute('security');
+    expect(queryByRole('button', { name: /Save and apply/i })).toBeNull();
+  });
 });

--- a/apps/web/src/features/setup/setup-route.tsx
+++ b/apps/web/src/features/setup/setup-route.tsx
@@ -51,6 +51,11 @@ interface WizardStepProps {
   readonly collected: DeviceConfigInput;
   /** Merge `partial` into `collected` and advance to the next step. */
   readonly onNext: (partial: DeviceConfigInput) => void;
+  /**
+   * Go back one step (#637). `undefined` on the first step so the step
+   * hides its Back affordance. Navigating back keeps `collected` intact.
+   */
+  readonly onBack?: () => void;
   /** Step-level cancel affordance. v1 hides it; the prop is plumbed for future use. */
   readonly onCancel: () => void;
   /** True when this is the last step — the active step component owns the commit ceremony (#548). */
@@ -106,16 +111,32 @@ const HomeOverviewStepAdapter = (props: WizardStepProps): ReactNode => (
   <HomeOverviewStep collected={props.collected} onNext={props.onNext} />
 );
 const LayoutStepAdapter = (props: WizardStepProps): ReactNode => (
-  <LayoutStep collected={props.collected} onNext={props.onNext} />
+  <LayoutStep
+    collected={props.collected}
+    onNext={props.onNext}
+    {...(props.onBack !== undefined ? { onBack: props.onBack } : {})}
+  />
 );
 const SecurityStepAdapter = (props: WizardStepProps): ReactNode => (
-  <SecurityStep collected={props.collected} onNext={props.onNext} />
+  <SecurityStep
+    collected={props.collected}
+    onNext={props.onNext}
+    {...(props.onBack !== undefined ? { onBack: props.onBack } : {})}
+  />
 );
 const NetworkStepAdapter = (props: WizardStepProps): ReactNode => (
-  <NetworkStep collected={props.collected} onNext={props.onNext} />
+  <NetworkStep
+    collected={props.collected}
+    onNext={props.onNext}
+    {...(props.onBack !== undefined ? { onBack: props.onBack } : {})}
+  />
 );
 const ApplyStepAdapter = (props: WizardStepProps): ReactNode => (
-  <ApplyStep collected={props.collected} onNext={props.onNext} />
+  <ApplyStep
+    collected={props.collected}
+    onNext={props.onNext}
+    {...(props.onBack !== undefined ? { onBack: props.onBack } : {})}
+  />
 );
 
 const SETUP_STEPS: readonly WizardStepRegistration[] = [
@@ -207,6 +228,37 @@ export function SetupRoute({ initialStepId }: SetupRouteProps = {}): ReactNode {
     // affordance.
   }, []);
 
+  // Back-navigation (#637). `onBack` steps one back; `onSelectStep` jumps
+  // to any already-reached step from the rail. Forward jumps are blocked
+  // (the Next button is the only way forward, so each step re-validates).
+  // `collected` persists across both, so entered data survives.
+  const onBack = useCallback(() => {
+    const prevStep = SETUP_STEPS[activeIndex - 1];
+    if (prevStep !== undefined) {
+      setActiveStepId(prevStep.id);
+    }
+  }, [activeIndex, setActiveStepId]);
+
+  const onSelectStep = useCallback(
+    (id: string) => {
+      const targetIndex = SETUP_STEPS.findIndex((step) => step.id === id);
+      // Only allow jumping to the current step or earlier — never skipping
+      // ahead past unvisited steps.
+      const target = SETUP_STEPS[targetIndex];
+      if (target !== undefined && targetIndex <= activeIndex) {
+        setActiveStepId(target.id);
+      }
+    },
+    [activeIndex, setActiveStepId],
+  );
+
+  // Steps the user can jump to from the rail: the active step and every
+  // step before it. Future steps stay non-interactive.
+  const navigableStepIds = useMemo<readonly string[]>(
+    () => SETUP_STEPS.slice(0, activeIndex + 1).map((step) => step.id),
+    [activeIndex],
+  );
+
   const navSteps = useMemo<readonly SetupLayoutStep[]>(
     () =>
       SETUP_STEPS.map((step) => ({
@@ -248,11 +300,14 @@ export function SetupRoute({ initialStepId }: SetupRouteProps = {}): ReactNode {
       steps={navSteps}
       activeStepId={activeStepId}
       completedStepIds={completedStepIds}
+      onSelectStep={onSelectStep}
+      navigableStepIds={navigableStepIds}
       controlsSlot={<WizardLocaleSwitcher onLocaleChange={onLocaleChange} />}
     >
       <ActiveStepComponent
         collected={collected}
         onNext={onNext}
+        {...(activeIndex > 0 ? { onBack } : {})}
         onCancel={onCancel}
         isLastStep={isLastStep}
       />

--- a/apps/web/src/features/setup/wizard-back-button.tsx
+++ b/apps/web/src/features/setup/wizard-back-button.tsx
@@ -1,0 +1,38 @@
+// Shared secondary "Back" CTA for wizard steps (#637). Steps render it in
+// their footer next to the primary action when `onBack` is provided
+// (i.e. on every step except the first). Going back keeps `collected`
+// intact — the wizard route owns that.
+
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface WizardBackButtonProps {
+  readonly onBack: () => void;
+}
+
+export function WizardBackButton({ onBack }: WizardBackButtonProps): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={onBack}
+      className="inline-flex items-center gap-2 rounded-lg border border-secondary bg-primary px-4 py-2 text-sm font-semibold text-secondary shadow-xs-skeuomorphic hover:bg-secondary"
+      data-testid="wizard-back"
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 20 20"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M15.833 10H4.167m0 0L10 15.833M4.167 10 10 4.167" />
+      </svg>
+      <span>{t('setup.actions.back')}</span>
+    </button>
+  );
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -267,6 +267,9 @@
       "actions": {
         "save": "Save and switch network"
       }
+    },
+    "actions": {
+      "back": "Back"
     }
   }
 }

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -267,6 +267,9 @@
       "actions": {
         "save": "Kaydet ve ağa geç"
       }
+    },
+    "actions": {
+      "back": "Geri"
     }
   }
 }

--- a/packages/ui/src/components/SetupLayout/SetupLayout.controls.ts
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.controls.ts
@@ -21,6 +21,7 @@ export const setupLayoutExcludeFromArgs = defineExcludeFromArgs([
   'steps',
   'completedStepIds',
   'onSelectStep',
+  'navigableStepIds',
   'logoSlot',
   'controlsSlot',
   'footerSlot',

--- a/packages/ui/src/components/SetupLayout/SetupLayout.tsx
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.tsx
@@ -47,6 +47,12 @@ export interface SetupLayoutProps {
    */
   onSelectStep?: (id: string) => void;
   /**
+   * Restricts which rail rows are clickable when `onSelectStep` is set.
+   * Forwarded to SetupStepNav as `navigableStepIds`. The wizard passes the
+   * already-reached steps so the user can jump back but not skip ahead.
+   */
+  navigableStepIds?: readonly string[];
+  /**
    * Override for the brand logo at the top-left of the sidebar. Defaults
    * to `<Logo size={133} />` (matches Figma's 133×60 wordmark). Pass
    * `null` to suppress.
@@ -80,6 +86,7 @@ export function SetupLayout({
   activeStepId,
   completedStepIds,
   onSelectStep,
+  navigableStepIds,
   logoSlot,
   controlsSlot,
   footerSlot,
@@ -105,6 +112,7 @@ export function SetupLayout({
             activeStepId={activeStepId}
             {...(completedStepIds === undefined ? {} : { completedStepIds })}
             {...(onSelectStep === undefined ? {} : { onSelect: onSelectStep })}
+            {...(navigableStepIds === undefined ? {} : { navigableStepIds })}
           />
         </div>
         <div className="flex flex-col">

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.controls.ts
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.controls.ts
@@ -1,7 +1,7 @@
 // `SetupStepNav.controls.ts` — Storybook control spec for SetupStepNav.
-// `steps`, `completedStepIds`, `onSelect`, `className` live in
-// `excludeFromArgs` because they carry ReactNode / callable / array
-// values that don't render through the controls panel.
+// `steps`, `completedStepIds`, `onSelect`, `navigableStepIds`, `className`
+// live in `excludeFromArgs` because they carry ReactNode / callable /
+// array values that don't render through the controls panel.
 
 import type { ControlSpec } from '../_internal/controls';
 import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
@@ -20,5 +20,6 @@ export const setupStepNavExcludeFromArgs = defineExcludeFromArgs([
   'steps',
   'completedStepIds',
   'onSelect',
+  'navigableStepIds',
   'className',
 ] as const);

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.mdx
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.mdx
@@ -37,8 +37,10 @@ threshold, so this primitive uses a token-based downshift instead.
   activeStepId="wifi"
   // optional — every step before activeStepId is completed by default
   completedStepIds={['home-overview', 'layout']}
-  // optional — interactive click-to-jump variant; v1 wizard omits it
+  // optional — interactive click-to-jump variant
   onSelect={(id) => router.jumpTo(id)}
+  // optional — restricts which rows are clickable (e.g. reached steps only)
+  navigableStepIds={['home-overview', 'layout', 'wifi']}
 />
 ```
 

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.stories.tsx
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.stories.tsx
@@ -146,6 +146,26 @@ export const WithOnSelect: Story = {
   },
 };
 
+// `navigableStepIds` gates which rows are clickable when `onSelect` is
+// set — the wizard passes only the reached steps (active + earlier) so
+// the user can jump back but not skip ahead (#637). Here the user is on
+// `wifi`, so only the first three rows render as buttons.
+export const WithNavigableSteps: Story = {
+  args: { activeStepId: 'wifi' },
+  render: (args) => (
+    <SetupStepNav
+      {...args}
+      steps={wizardSteps}
+      onSelect={fn()}
+      navigableStepIds={['home-overview', 'layout', 'wifi']}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const buttons = canvasElement.querySelectorAll('button');
+    await expect(buttons.length).toBe(3);
+  },
+};
+
 const singleStepFixture: SetupStepNavStep[] = [
   {
     id: 'home-overview',

--- a/packages/ui/src/components/SetupStepNav/SetupStepNav.tsx
+++ b/packages/ui/src/components/SetupStepNav/SetupStepNav.tsx
@@ -52,13 +52,19 @@ export interface SetupStepNavProps {
    */
   completedStepIds?: readonly string[];
   /**
-   * Optional click handler. When provided each row becomes a
-   * `<button>` so the nav is interactive (click-to-jump). When
-   * undefined, rows render as non-interactive `<li>` content — the v1
-   * first-run wizard locks the order, so SetupLayout passes no
-   * handler.
+   * Optional click handler. When provided a row becomes a `<button>` so
+   * the nav is interactive (click-to-jump). When undefined, rows render
+   * as non-interactive `<li>` content.
    */
   onSelect?: (id: string) => void;
+  /**
+   * Restricts which rows are clickable when `onSelect` is provided. A row
+   * is interactive only if its id is in this list (e.g. the wizard passes
+   * the steps the user has already reached, so they can jump back but not
+   * skip ahead). When omitted, every row is clickable — the default for
+   * an unconstrained click-to-jump nav.
+   */
+  navigableStepIds?: readonly string[];
   /** Optional class hook for the outer `<nav>`. */
   className?: string;
 }
@@ -92,24 +98,28 @@ export function SetupStepNav({
   activeStepId,
   completedStepIds,
   onSelect,
+  navigableStepIds,
   className,
 }: SetupStepNavProps) {
   const completedSet = new Set(completedStepIds ?? defaultCompletedIds(steps, activeStepId));
+  const navigableSet = navigableStepIds === undefined ? undefined : new Set(navigableStepIds);
   return (
     <nav aria-label="Wizard progress" className={className ?? 'w-[320px]'}>
       <ol className="flex flex-col">
         {steps.map((step, index) => {
           const state = resolveStepState(step.id, activeStepId, completedSet);
           const isLast = index === steps.length - 1;
-          return onSelect === undefined ? (
-            <SetupStepNavItem key={step.id} step={step} state={state} isLast={isLast} />
-          ) : (
+          // A row is interactive only when a handler is supplied AND the
+          // step is navigable (no restriction list → all navigable).
+          const interactive =
+            onSelect !== undefined && (navigableSet === undefined || navigableSet.has(step.id));
+          return (
             <SetupStepNavItem
               key={step.id}
               step={step}
               state={state}
               isLast={isLast}
-              onSelect={onSelect}
+              {...(interactive ? { onSelect } : {})}
             />
           );
         })}


### PR DESCRIPTION
## Summary

The setup wizard was forward-only. This adds two ways to go back (#637):

1. **Rail jump** — clicking an already-reached step in the left rail navigates to it.
2. **Per-step Back** — a Back button in each step's footer (hidden on the first step).

Forward navigation stays the **Next** button only — the rail blocks jumping ahead past unvisited steps, so each step still re-validates on the way forward.

The primitives already had the hook (`SetupLayout.onSelectStep` → `SetupStepNav.onSelect`); the missing piece was gating *which* rows are clickable. Added a backward-compatible `navigableStepIds` prop (omitted → all clickable, as before).

## Scope

**In**
- **@glaon/ui** `SetupStepNav` + `SetupLayout`: new `navigableStepIds` prop — a row is interactive only if its id is listed (when `onSelect`/`onSelectStep` is set). Story (`WithNavigableSteps`), controls `excludeFromArgs`, and MDX updated.
- **apps/web** `setup-route.tsx`: `onSelectStep` (jump to index ≤ active), `onBack` (one step back), `navigableStepIds` (active + earlier); `onBack` threaded to steps (undefined on first).
- New `wizard-back-button.tsx` (shared secondary CTA, `data-testid="wizard-back"`); rendered in layout/security/network/apply footers.
- i18n `setup.actions.back` (en/tr).
- Tests: `setup-route.test.tsx` (rail jump back, Back button, first-step hides Back, future steps not clickable); E2E (`@smoke`) back-nav + data-retention walk.

**Out**
- Exiting the wizard entirely.
- Pre-filling the **Security** step's password on back — only the hash is in `collected`, never the plaintext, so the password field resets (re-entry on the way forward). Expected for a credential field.

## Test plan

- [x] `pnpm --filter @glaon/ui test` — 150 passing (incl. new `WithNavigableSteps` play test).
- [x] `pnpm --filter @glaon/web test src/features/setup` — 78 passing (4 new back-nav cases).
- [x] `pnpm type-check` (11) + `pnpm lint` (10) + `pnpm i18n:check` + knip clean.
- [ ] CI green (watching); Playwright back-nav `@smoke` + Chromatic reviewed.

Refs #626
Closes #637