### PR TITLE
feat(web,core): add admin username to Device Security step

### DIFF
--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -106,8 +106,9 @@ async function walkToNetworkStep(page: Page): Promise<void> {
   await page.getByRole('button', { name: 'Next' }).click();
 
   await expect(page.getByRole('heading', { level: 1, name: 'Device Security' })).toBeVisible();
-  // The asterisk lives inside the <label>, so getByLabel misses; the
-  // placeholders are unique per field.
+  // Admin username is required (#640); the asterisk lives inside the
+  // <label>, so target the field by its testid / unique placeholders.
+  await page.getByTestId('security-username').fill('admin');
   await page.getByPlaceholder('At least 8 characters').fill('correct-horse');
   await page.getByPlaceholder('Type the password again').fill('correct-horse');
   await page.getByRole('button', { name: 'Next' }).click();

--- a/apps/web/src/features/setup/apply/apply-step.test.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.test.tsx
@@ -109,14 +109,16 @@ describe('ApplyStep — summary', () => {
     expect(getByText('Metric')).toBeInTheDocument();
   });
 
-  it('shows the hostname + Wi-Fi from collected network config', () => {
+  it('shows the hostname, Wi-Fi, and admin username from collected config', () => {
     const collected = {
       ...baseCollected,
+      adminUsername: 'admin-user',
       network: { hostname: 'glaon-wall' },
       wifi: { ssid: 'HomeWifi', passwordCipher: 'AES-GCM:abc' },
     };
     const { getByText } = render(wrap(<ApplyStep collected={collected} />));
     expect(getByText('glaon-wall')).toBeInTheDocument();
+    expect(getByText('admin-user')).toBeInTheDocument();
     // wifiSecured renders the "(secured)" summary variant (vs. the not-set
     // glyph) — robust to whether i18n interpolation runs in the test env.
     expect(getByText(/secured/)).toBeInTheDocument();

--- a/apps/web/src/features/setup/apply/apply-step.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.tsx
@@ -286,6 +286,7 @@ export function ApplyStep({ collected, onBack }: ApplyStepProps): ReactNode {
         </ReviewCard>
 
         <ReviewCard icon={<SecurityGlyph />} title={t('setup.security.title')}>
+          <ReviewRow label={t('setup.security.username.label')} value={collected.adminUsername} />
           <ReviewRow
             label={t('setup.apply.summary.adminPassword')}
             value={

--- a/apps/web/src/features/setup/security/security-step.test.tsx
+++ b/apps/web/src/features/setup/security/security-step.test.tsx
@@ -56,9 +56,27 @@ describe('SecurityStep', () => {
     expect(getByText(/Passwords don't match/i)).toBeInTheDocument();
   });
 
-  it('hashes the password with SHA-256 and emits securityPinHash on Next', async () => {
+  it('blocks submission and shows an error for an invalid username (#640)', () => {
     const onNext = vi.fn();
-    const { container, getByRole } = render(wrap(<SecurityStep collected={{}} onNext={onNext} />));
+    const { container, getByRole, getByTestId, getByText } = render(
+      wrap(<SecurityStep collected={{}} onNext={onNext} />),
+    );
+    // Valid passwords, but an invalid username (contains a space).
+    const pw = container.querySelectorAll('input[type="password"]');
+    fireEvent.change(pw[0] as HTMLInputElement, { target: { value: 'longenough1' } });
+    fireEvent.change(pw[1] as HTMLInputElement, { target: { value: 'longenough1' } });
+    fireEvent.change(getByTestId('security-username'), { target: { value: 'bad name' } });
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    expect(onNext).not.toHaveBeenCalled();
+    expect(getByText(/3–32 characters/i)).toBeInTheDocument();
+  });
+
+  it('emits adminUsername + securityPinHash on a valid Next (#640)', async () => {
+    const onNext = vi.fn();
+    const { container, getByRole, getByTestId } = render(
+      wrap(<SecurityStep collected={{}} onNext={onNext} />),
+    );
+    fireEvent.change(getByTestId('security-username'), { target: { value: 'admin.user' } });
     const inputs = container.querySelectorAll('input[type="password"]');
     fireEvent.change(inputs[0] as HTMLInputElement, { target: { value: 'correct horse battery' } });
     fireEvent.change(inputs[1] as HTMLInputElement, { target: { value: 'correct horse battery' } });
@@ -66,7 +84,11 @@ describe('SecurityStep', () => {
     await waitFor(() => {
       expect(onNext).toHaveBeenCalledTimes(1);
     });
-    const partial = onNext.mock.calls[0]?.[0] as { securityPinHash?: string };
+    const partial = onNext.mock.calls[0]?.[0] as {
+      adminUsername?: string;
+      securityPinHash?: string;
+    };
+    expect(partial.adminUsername).toBe('admin.user');
     expect(partial.securityPinHash).toMatch(/^[0-9a-f]{64}$/);
     // Same input → same hash. Compute the expected hash directly so
     // the test catches any deviation from canonical SHA-256.

--- a/apps/web/src/features/setup/security/security-step.tsx
+++ b/apps/web/src/features/setup/security/security-step.tsx
@@ -15,7 +15,7 @@
 // admin password as required for protected setup. Skip can be added in
 // a follow-up once we know whether kiosk deployments want it.
 
-import { Button, PasswordInput, useToast } from '@glaon/ui';
+import { Button, InputBase, PasswordInput, TextField, useToast } from '@glaon/ui';
 import { useId, useMemo, useState, type ReactNode, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -33,6 +33,9 @@ interface SecurityStepProps {
 }
 
 const MIN_PASSWORD_LENGTH = 8;
+// Admin username (#640): 3–32 chars of letters, digits, dot, underscore,
+// hyphen. Mirrors @glaon/core's DeviceConfig `adminUsername` regex.
+const USERNAME_RE = /^[A-Za-z0-9._-]{3,32}$/;
 
 async function sha256Hex(input: string): Promise<string> {
   const data = new TextEncoder().encode(input);
@@ -55,32 +58,40 @@ function validatePasswords(password: string, confirm: string): PasswordValidatio
   return { kind: 'ok' };
 }
 
-export function SecurityStep({
-  collected: _collected,
-  onNext,
-  onBack,
-}: SecurityStepProps): ReactNode {
+export function SecurityStep({ collected, onNext, onBack }: SecurityStepProps): ReactNode {
   const { t } = useTranslation();
   const toast = useToast();
+  const usernameId = useId();
   const passwordId = useId();
   const confirmId = useId();
 
+  // Username is collected-backed, so it pre-fills on a back-navigation
+  // (#637) — unlike the password, which is never stored in plaintext.
+  const [username, setUsername] = useState<string>(collected.adminUsername ?? '');
   const [password, setPassword] = useState<string>('');
   const [confirm, setConfirm] = useState<string>('');
   const [submitted, setSubmitted] = useState<boolean>(false);
   const [isHashing, setIsHashing] = useState<boolean>(false);
 
+  const usernameTrimmed = username.trim();
+  const usernameValid = USERNAME_RE.test(usernameTrimmed);
   const validation = useMemo(() => validatePasswords(password, confirm), [password, confirm]);
   const showErrors = submitted && validation.kind !== 'ok';
+  const usernameInvalid = submitted && !usernameValid;
+  const usernameErrorMessage = usernameInvalid
+    ? usernameTrimmed === ''
+      ? t('setup.security.username.required')
+      : t('setup.security.username.invalid')
+    : undefined;
 
   const onSubmit = async (event: SubmitEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
     setSubmitted(true);
-    if (validation.kind !== 'ok') return;
+    if (!usernameValid || validation.kind !== 'ok') return;
     setIsHashing(true);
     try {
       const hash = await sha256Hex(password);
-      onNext({ securityPinHash: hash });
+      onNext({ adminUsername: usernameTrimmed, securityPinHash: hash });
     } catch {
       // Web Crypto failure is extremely rare (older browsers without
       // `crypto.subtle`). Surface via Toast per the API Error Toast
@@ -122,6 +133,29 @@ export function SecurityStep({
         noValidate
         className="flex flex-col"
       >
+        <FormRow label={t('setup.security.username.label')} htmlFor={usernameId} required>
+          <TextField
+            value={username}
+            onChange={setUsername}
+            isRequired
+            isInvalid={usernameInvalid}
+            aria-label={t('setup.security.username.label')}
+          >
+            <InputBase
+              id={usernameId}
+              type="text"
+              placeholder={t('setup.security.username.placeholder')}
+              autoComplete="username"
+              data-testid="security-username"
+            />
+          </TextField>
+          {usernameErrorMessage !== undefined && (
+            <p role="alert" className="pt-1.5 text-sm text-error-primary">
+              {usernameErrorMessage}
+            </p>
+          )}
+        </FormRow>
+
         <FormRow label={t('setup.security.password.label')} htmlFor={passwordId} required>
           <PasswordInput
             id={passwordId}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -154,6 +154,12 @@
     "security": {
       "title": "Device Security",
       "subtitle": "Set the admin password for this device. Anyone who needs to change the setup will need it.",
+      "username": {
+        "label": "Admin username",
+        "placeholder": "e.g. admin",
+        "required": "Username is required.",
+        "invalid": "Use 3–32 characters: letters, digits, dot, underscore, hyphen."
+      },
       "password": {
         "label": "Password",
         "placeholder": "At least 8 characters",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -154,6 +154,12 @@
     "security": {
       "title": "Cihaz Güvenliği",
       "subtitle": "Bu cihaz için yönetici şifresi belirle. Kurulumu değiştirecek herkes bu şifreye ihtiyaç duyacak.",
+      "username": {
+        "label": "Yönetici kullanıcı adı",
+        "placeholder": "örn. admin",
+        "required": "Kullanıcı adı gerekli.",
+        "invalid": "3–32 karakter kullan: harf, rakam, nokta, alt çizgi, tire."
+      },
       "password": {
         "label": "Şifre",
         "placeholder": "En az 8 karakter",

--- a/packages/core/src/config/types.test.ts
+++ b/packages/core/src/config/types.test.ts
@@ -103,6 +103,23 @@ describe('DeviceConfigSchema', () => {
     ).toThrow();
   });
 
+  it('accepts a valid adminUsername and rejects malformed ones', () => {
+    expect(
+      DeviceConfigSchema.parse({
+        schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+        adminUsername: 'admin.user-1',
+      }).adminUsername,
+    ).toBe('admin.user-1');
+    for (const bad of ['ab', 'a'.repeat(33), 'bad user', 'nope!', '']) {
+      expect(() =>
+        DeviceConfigSchema.parse({
+          schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+          adminUsername: bad,
+        }),
+      ).toThrow(/adminUsername/);
+    }
+  });
+
   it('rejects a lowercase country code', () => {
     expect(() =>
       DeviceConfigSchema.parse({ schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION, country: 'tr' }),

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -175,6 +175,19 @@ export const DeviceConfigSchema = z
      * the IP config to `/network/interface/{iface}/update`.
      */
     network: NetworkConfigSchema.optional(),
+    /**
+     * Local device admin username (#640), paired with `securityPinHash`
+     * for re-entering setup. A plain identifier, not a secret: 3–32 chars
+     * of letters, digits, dot, underscore, hyphen. Required in the
+     * wizard's Security step; optional here so partial blobs parse.
+     */
+    adminUsername: z
+      .string()
+      .regex(
+        /^[A-Za-z0-9._-]{3,32}$/,
+        'adminUsername must be 3–32 chars: letters, digits, dot, underscore, hyphen',
+      )
+      .optional(),
     /** SHA-256 hex (64 lowercase hex chars). Plaintext PIN never leaves the device. */
     securityPinHash: z
       .string()


### PR DESCRIPTION
## Summary

The Device Security step collected only a password. It now also collects an **admin username** (#640) — a plain identifier paired with the password for re-entering setup.

## Scope

**In**
- **core**: optional `adminUsername` on `DeviceConfig` — RFC-ish identifier, **3–32 chars** of `[A-Za-z0-9._-]`, stored **as-entered** (not hashed; it's not a secret). Additive + optional, no `schemaVersion` bump. Schema tests.
- **web** (`security-step.tsx`): a **required** username field above the password, inline-validated (required + format). Emitted in `onNext` as `adminUsername` alongside `securityPinHash`. Pre-fills on back-navigation since it's collected-backed (unlike the password, which is never stored in plaintext).
- **web** (Review): the redesigned Security card surfaces the username.
- i18n: `setup.security.username.{label,placeholder,required,invalid}` (en + tr).
- E2E: the wizard walk fills the now-required username.

**Out**
- Mapping the username to an HA Core user — the admin is Glaon-local (re-enter setup), not an HA account. Separate issue if wanted.

## Test plan

- [x] `pnpm --filter @glaon/core test config/types` — 38 passing (valid username accepted; too-short / over-long / bad-char / empty rejected).
- [x] `pnpm --filter @glaon/web test src/features/setup` — 79 passing (invalid-username blocks Next + error; valid emits `adminUsername` + `securityPinHash`; Review shows the username).
- [x] `pnpm type-check` (11) + `pnpm lint` + `pnpm i18n:check` + knip clean.
- [ ] CI green (watching); Playwright `@smoke` (fills username) + Chromatic reviewed.

Refs #626
Closes #640