### PR TITLE
feat(web): split Network static IP into address + netmask fields

### DIFF
--- a/apps/web/src/features/setup/network/network-step.test.tsx
+++ b/apps/web/src/features/setup/network/network-step.test.tsx
@@ -94,7 +94,7 @@ describe('NetworkStep — ready', () => {
     expect(await findByText('Guest')).toBeInTheDocument();
   });
 
-  it('advances with the collected network config when valid', async () => {
+  it('advances with the collected network config, recombining IP + mask into CIDR', async () => {
     const { onNext, findByTestId, getByTestId } = renderStep();
     await findByTestId('network-hostname');
     fireEvent.click(getByTestId('network-next'));
@@ -102,10 +102,25 @@ describe('NetworkStep — ready', () => {
       expect(onNext).toHaveBeenCalledTimes(1);
     });
     const partial = onNext.mock.calls[0]?.[0] as {
-      network?: { hostname?: string; interfaces?: { name: string }[] };
+      network?: {
+        hostname?: string;
+        interfaces?: { name: string; ipv4?: { address?: string[] } }[];
+      };
     };
     expect(partial.network?.hostname).toBe('glaon');
     expect(partial.network?.interfaces?.map((i) => i.name)).toEqual(['wlan0', 'end0']);
+    // end0's seeded static IP (192.168.1.50) + mask (255.255.255.0, from
+    // the seeded /24) recombine into the CIDR the schema expects (#639).
+    const end0 = partial.network?.interfaces?.find((i) => i.name === 'end0');
+    expect(end0?.ipv4?.address).toEqual(['192.168.1.50/24']);
+  });
+
+  it('splits a seeded CIDR into an IP + dotted subnet mask on a static interface (#639)', async () => {
+    const { findByRole, getByLabelText } = renderStep();
+    // end0's IPv4 is static, so its panel auto-opens; the seeded
+    // 192.168.1.50/24 shows as a plain IP + a dotted mask.
+    fireEvent.click(await findByRole('tab', { name: 'end0' }));
+    expect((getByLabelText('Subnet mask') as HTMLInputElement).value).toBe('255.255.255.0');
   });
 
   it('blocks Next and shows an inline error for an invalid hostname', async () => {

--- a/apps/web/src/features/setup/network/network-step.tsx
+++ b/apps/web/src/features/setup/network/network-step.tsx
@@ -46,9 +46,12 @@ import {
 } from './network-api';
 import {
   areNameserversValid,
-  isCidr,
   isHostnameLabel,
+  isIpv4Netmask,
+  isIpv6Prefix,
   isPlainIp,
+  netmaskToPrefix,
+  prefixToNetmask,
   splitNameservers,
 } from './validation';
 
@@ -64,32 +67,64 @@ type Family = 'ipv4' | 'ipv6';
 
 interface IpFormState {
   readonly method: IpMethod;
+  /** Plain IP address, no prefix (e.g. 192.168.1.50 / fd00::50). */
   readonly address: string;
+  /** IPv4 dotted subnet mask (255.255.255.0), or IPv6 prefix length (64). */
+  readonly netmask: string;
   readonly gateway: string;
   readonly nameservers: string;
 }
 
 type InterfaceForms = Record<string, { ipv4: IpFormState; ipv6: IpFormState }>;
 
-const EMPTY_FORM: IpFormState = { method: 'auto', address: '', gateway: '', nameservers: '' };
+const EMPTY_FORM: IpFormState = {
+  method: 'auto',
+  address: '',
+  netmask: '',
+  gateway: '',
+  nameservers: '',
+};
 
-function seedIpForm(config: IpConfig): IpFormState {
+// `IpConfig.address` is a CIDR string ("ip/prefix"); the form splits it
+// into a plain address + a family-appropriate mask field for display
+// (#639). IPv4 shows a dotted subnet mask; IPv6 shows the prefix length.
+function seedIpForm(config: IpConfig, family: Family): IpFormState {
+  const cidr = config.address?.[0] ?? '';
+  const slash = cidr.indexOf('/');
+  const address = slash === -1 ? cidr : cidr.slice(0, slash);
+  const prefix = slash === -1 ? '' : cidr.slice(slash + 1);
+  const netmask = prefix === '' ? '' : family === 'ipv4' ? prefixToNetmask(Number(prefix)) : prefix;
   return {
     method: config.method,
-    address: config.address?.[0] ?? '',
+    address,
+    netmask,
     gateway: config.gateway ?? '',
     nameservers: config.nameservers?.join(', ') ?? '',
   };
 }
 
-function ipFormToConfig(form: IpFormState): IpConfig {
+// Recombine address + mask into the CIDR string the core schema +
+// Supervisor expect. IPv4's dotted mask converts to a prefix; IPv6's
+// mask is already a prefix length.
+function ipFormToConfig(form: IpFormState, family: Family): IpConfig {
   if (form.method !== 'static') return { method: form.method };
   const address = form.address.trim();
+  const netmask = form.netmask.trim();
   const gateway = form.gateway.trim();
   const nameservers = splitNameservers(form.nameservers);
+  let cidr = '';
+  if (address !== '') {
+    if (netmask === '') {
+      cidr = address;
+    } else if (family === 'ipv4') {
+      cidr = `${address}/${String(netmaskToPrefix(netmask))}`;
+    } else {
+      cidr = `${address}/${netmask}`;
+    }
+  }
   return {
     method: 'static',
-    ...(address !== '' ? { address: [address] } : {}),
+    ...(cidr !== '' ? { address: [cidr] } : {}),
     ...(gateway !== '' ? { gateway } : {}),
     ...(nameservers.length > 0 ? { nameservers } : {}),
   };
@@ -97,6 +132,7 @@ function ipFormToConfig(form: IpFormState): IpConfig {
 
 interface FamilyErrors {
   readonly address?: string;
+  readonly netmask?: string;
   readonly gateway?: string;
   readonly nameservers?: string;
 }
@@ -140,8 +176,8 @@ export function NetworkStep({ collected, onNext, onBack }: NetworkStepProps): Re
       for (const iface of live) {
         const prior = collectedByName.get(iface.name);
         forms[iface.name] = {
-          ipv4: seedIpForm(prior?.ipv4 ?? iface.ipv4),
-          ipv6: seedIpForm(prior?.ipv6 ?? iface.ipv6),
+          ipv4: seedIpForm(prior?.ipv4 ?? iface.ipv4, 'ipv4'),
+          ipv6: seedIpForm(prior?.ipv6 ?? iface.ipv6, 'ipv6'),
         };
       }
       return forms;
@@ -251,12 +287,24 @@ export function NetworkStep({ collected, onNext, onBack }: NetworkStepProps): Re
     (form: IpFormState | undefined, family: Family): FamilyErrors => {
       if (!submitted || form?.method !== 'static') return {};
       const address = form.address.trim();
+      const netmask = form.netmask.trim();
       const gateway = form.gateway.trim();
       const addressError =
         address === ''
           ? t('setup.network.address.required')
-          : !isCidr(address, family)
+          : !isPlainIp(address, family)
             ? t('setup.network.address.invalid')
+            : undefined;
+      const netmaskValid = family === 'ipv4' ? isIpv4Netmask(netmask) : isIpv6Prefix(netmask);
+      const netmaskError =
+        netmask === ''
+          ? t('setup.network.netmask.required')
+          : !netmaskValid
+            ? t(
+                family === 'ipv4'
+                  ? 'setup.network.netmask.maskInvalid'
+                  : 'setup.network.netmask.prefixInvalid',
+              )
             : undefined;
       const gatewayError =
         gateway !== '' && !isPlainIp(gateway, family)
@@ -267,6 +315,7 @@ export function NetworkStep({ collected, onNext, onBack }: NetworkStepProps): Re
         : undefined;
       return {
         ...(addressError !== undefined ? { address: addressError } : {}),
+        ...(netmaskError !== undefined ? { netmask: netmaskError } : {}),
         ...(gatewayError !== undefined ? { gateway: gatewayError } : {}),
         ...(nameserversError !== undefined ? { nameservers: nameserversError } : {}),
       };
@@ -281,7 +330,10 @@ export function NetworkStep({ collected, onNext, onBack }: NetworkStepProps): Re
       for (const family of ['ipv4', 'ipv6'] as const) {
         const f = form?.[family];
         if (f?.method !== 'static') continue;
-        if (f.address.trim() === '' || !isCidr(f.address.trim(), family)) return true;
+        if (f.address.trim() === '' || !isPlainIp(f.address.trim(), family)) return true;
+        const netmask = f.netmask.trim();
+        const netmaskValid = family === 'ipv4' ? isIpv4Netmask(netmask) : isIpv6Prefix(netmask);
+        if (!netmaskValid) return true;
         if (f.gateway.trim() !== '' && !isPlainIp(f.gateway.trim(), family)) return true;
         if (!areNameserversValid(f.nameservers, family)) return true;
       }
@@ -310,8 +362,8 @@ export function NetworkStep({ collected, onNext, onBack }: NetworkStepProps): Re
       const form = interfaceForms[iface.name];
       return {
         name: iface.name,
-        ipv4: ipFormToConfig(form?.ipv4 ?? EMPTY_FORM),
-        ipv6: ipFormToConfig(form?.ipv6 ?? EMPTY_FORM),
+        ipv4: ipFormToConfig(form?.ipv4 ?? EMPTY_FORM, 'ipv4'),
+        ipv6: ipFormToConfig(form?.ipv6 ?? EMPTY_FORM, 'ipv6'),
       };
     });
     if (interfaceConfigs.length > 0) network.interfaces = interfaceConfigs;
@@ -466,6 +518,7 @@ interface IpFamilyFormProps {
 function IpFamilyForm({ family, form, errors, onChange }: IpFamilyFormProps): ReactNode {
   const { t } = useTranslation();
   const addressId = useId();
+  const netmaskId = useId();
   const gatewayId = useId();
   const dnsId = useId();
   const methodId = useId();
@@ -473,6 +526,7 @@ function IpFamilyForm({ family, form, errors, onChange }: IpFamilyFormProps): Re
   const current: IpFormState = form ?? {
     method: 'auto',
     address: '',
+    netmask: '',
     gateway: '',
     nameservers: '',
   };
@@ -518,11 +572,25 @@ function IpFamilyForm({ family, form, errors, onChange }: IpFamilyFormProps): Re
           <IpTextField
             id={addressId}
             label={t('setup.network.address.label')}
-            placeholder={family === 'ipv4' ? '192.168.1.50/24' : 'fd00::50/64'}
+            placeholder={family === 'ipv4' ? '192.168.1.50' : 'fd00::50'}
             value={current.address}
             error={errors.address}
             onChange={(value) => {
               onChange({ ...current, address: value });
+            }}
+          />
+          <IpTextField
+            id={netmaskId}
+            label={
+              family === 'ipv4'
+                ? t('setup.network.netmask.maskLabel')
+                : t('setup.network.netmask.prefixLabel')
+            }
+            placeholder={family === 'ipv4' ? '255.255.255.0' : '64'}
+            value={current.netmask}
+            error={errors.netmask}
+            onChange={(value) => {
+              onChange({ ...current, netmask: value });
             }}
           />
           <IpTextField

--- a/apps/web/src/features/setup/network/validation.test.ts
+++ b/apps/web/src/features/setup/network/validation.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import {
   areNameserversValid,
-  isCidr,
   isHostnameLabel,
   isIpv4,
+  isIpv4Netmask,
   isIpv6,
+  isIpv6Prefix,
   isPlainIp,
+  netmaskToPrefix,
+  prefixToNetmask,
   splitNameservers,
 } from './validation';
 
@@ -72,20 +75,44 @@ describe('isPlainIp', () => {
   });
 });
 
-describe('isCidr', () => {
-  it('accepts addresses with and without a valid prefix', () => {
-    expect(isCidr('192.168.1.50/24', 'ipv4')).toBe(true);
-    expect(isCidr('192.168.1.50', 'ipv4')).toBe(true);
-    expect(isCidr('fd00::1/64', 'ipv6')).toBe(true);
-    expect(isCidr('fd00::1', 'ipv6')).toBe(true);
+describe('isIpv4Netmask', () => {
+  it('accepts contiguous masks', () => {
+    expect(isIpv4Netmask('255.255.255.0')).toBe(true);
+    expect(isIpv4Netmask('255.255.0.0')).toBe(true);
+    expect(isIpv4Netmask('255.255.255.255')).toBe(true);
+    expect(isIpv4Netmask('0.0.0.0')).toBe(true);
+    expect(isIpv4Netmask('255.255.255.240')).toBe(true);
   });
 
-  it('rejects out-of-range or malformed prefixes', () => {
-    expect(isCidr('192.168.1.50/33', 'ipv4')).toBe(false);
-    expect(isCidr('fd00::1/129', 'ipv6')).toBe(false);
-    expect(isCidr('192.168.1.50/', 'ipv4')).toBe(false);
-    expect(isCidr('192.168.1.50/aa', 'ipv4')).toBe(false);
-    expect(isCidr('not-an-ip/24', 'ipv4')).toBe(false);
+  it('rejects non-contiguous or non-IPv4 masks', () => {
+    expect(isIpv4Netmask('255.0.255.0')).toBe(false);
+    expect(isIpv4Netmask('255.255.255.1')).toBe(false);
+    expect(isIpv4Netmask('256.0.0.0')).toBe(false);
+    expect(isIpv4Netmask('24')).toBe(false);
+  });
+});
+
+describe('isIpv6Prefix', () => {
+  it('accepts 0–128, rejects out of range / non-numeric', () => {
+    expect(isIpv6Prefix('64')).toBe(true);
+    expect(isIpv6Prefix('0')).toBe(true);
+    expect(isIpv6Prefix('128')).toBe(true);
+    expect(isIpv6Prefix('129')).toBe(false);
+    expect(isIpv6Prefix('')).toBe(false);
+    expect(isIpv6Prefix('aa')).toBe(false);
+  });
+});
+
+describe('netmaskToPrefix / prefixToNetmask', () => {
+  it('round-trips IPv4 masks ↔ prefixes', () => {
+    expect(netmaskToPrefix('255.255.255.0')).toBe(24);
+    expect(netmaskToPrefix('255.255.0.0')).toBe(16);
+    expect(netmaskToPrefix('255.255.255.255')).toBe(32);
+    expect(netmaskToPrefix('0.0.0.0')).toBe(0);
+    expect(prefixToNetmask(24)).toBe('255.255.255.0');
+    expect(prefixToNetmask(16)).toBe('255.255.0.0');
+    expect(prefixToNetmask(32)).toBe('255.255.255.255');
+    expect(prefixToNetmask(0)).toBe('0.0.0.0');
   });
 });
 

--- a/apps/web/src/features/setup/network/validation.ts
+++ b/apps/web/src/features/setup/network/validation.ts
@@ -47,20 +47,46 @@ export function isPlainIp(value: string, family: 'ipv4' | 'ipv6'): boolean {
   return family === 'ipv4' ? isIpv4(value) : isIpv6(value);
 }
 
+/** Parse a dotted IPv4 string into its unsigned 32-bit value. */
+function ipv4ToInt(value: string): number {
+  return (
+    value.split('.').reduce((acc, octet) => ((acc * 256 + Number(octet)) >>> 0) >>> 0, 0) >>> 0
+  );
+}
+
 /**
- * Address with an optional CIDR prefix (e.g. `192.168.1.50/24`,
- * `fd00::1/64`). The prefix is optional but, when present, must be in
- * range for the family (0–32 for IPv4, 0–128 for IPv6).
+ * Valid IPv4 subnet mask — a dotted quad whose bits are a contiguous run
+ * of high 1s (e.g. 255.255.255.0, 255.255.0.0). Rejects non-contiguous
+ * masks like 255.0.255.0.
  */
-export function isCidr(value: string, family: 'ipv4' | 'ipv6'): boolean {
-  const slash = value.indexOf('/');
-  if (slash === -1) return isPlainIp(value, family);
-  const addr = value.slice(0, slash);
-  const prefix = value.slice(slash + 1);
-  if (!isPlainIp(addr, family)) return false;
-  if (!/^\d{1,3}$/.test(prefix)) return false;
-  const max = family === 'ipv4' ? 32 : 128;
-  return Number(prefix) <= max;
+export function isIpv4Netmask(value: string): boolean {
+  if (!isIpv4(value)) return false;
+  const inv = ~ipv4ToInt(value) >>> 0;
+  // For a contiguous high-bit mask the inverse is all-1s in the low bits,
+  // so `inv & (inv + 1)` clears to zero.
+  return (inv & (inv + 1)) >>> 0 === 0;
+}
+
+/** Valid IPv6 prefix length — an integer 0–128. */
+export function isIpv6Prefix(value: string): boolean {
+  return /^\d{1,3}$/.test(value) && Number(value) <= 128;
+}
+
+/** Bit count of a (valid, contiguous) IPv4 dotted mask → prefix length. */
+export function netmaskToPrefix(mask: string): number {
+  let n = ipv4ToInt(mask);
+  let count = 0;
+  while (n !== 0) {
+    count += n & 1;
+    n >>>= 1;
+  }
+  return count;
+}
+
+/** IPv4 prefix length (0–32) → dotted subnet mask. */
+export function prefixToNetmask(prefix: number): string {
+  const m = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return [(m >>> 24) & 0xff, (m >>> 16) & 0xff, (m >>> 8) & 0xff, m & 0xff].join('.');
 }
 
 /** Split a free-text DNS field on commas / whitespace into trimmed entries. */

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -210,7 +210,14 @@
       "address": {
         "label": "IP address",
         "required": "An IP address is required for a static configuration.",
-        "invalid": "Enter a valid address, optionally with a /prefix (e.g. 192.168.1.50/24)."
+        "invalid": "Enter a valid IP address (e.g. 192.168.1.50)."
+      },
+      "netmask": {
+        "maskLabel": "Subnet mask",
+        "prefixLabel": "Prefix length",
+        "required": "Required for a static configuration.",
+        "maskInvalid": "Enter a valid subnet mask (e.g. 255.255.255.0).",
+        "prefixInvalid": "Enter a prefix length between 0 and 128."
       },
       "gateway": {
         "label": "Gateway",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -210,7 +210,14 @@
       "address": {
         "label": "IP adresi",
         "required": "Statik yapılandırma için bir IP adresi gerekli.",
-        "invalid": "Geçerli bir adres gir, isteğe bağlı /önek ile (örn. 192.168.1.50/24)."
+        "invalid": "Geçerli bir IP adresi gir (örn. 192.168.1.50)."
+      },
+      "netmask": {
+        "maskLabel": "Alt ağ maskesi",
+        "prefixLabel": "Önek uzunluğu",
+        "required": "Statik yapılandırma için gerekli.",
+        "maskInvalid": "Geçerli bir alt ağ maskesi gir (örn. 255.255.255.0).",
+        "prefixInvalid": "0 ile 128 arasında bir önek uzunluğu gir."
       },
       "gateway": {
         "label": "Ağ geçidi",


### PR DESCRIPTION
## Summary

The Network step's static IPv4/IPv6 config used a single CIDR field (`192.168.1.50/24`). It now exposes a separate **IP address** field and a **mask** field (#639):

- **IPv4** → IP address + **dotted subnet mask** (`255.255.255.0`).
- **IPv6** → IP address + **prefix length** (`64`).

On submit the two recombine into the CIDR string the core schema + Supervisor expect; on seed the live CIDR splits back for display. **Core schema unchanged** (`IpConfig.address` stays a `string[]` of CIDR) — the split is purely the form ↔ config mapping.

## Scope

**In**
- `validation.ts`: replace `isCidr` with `isIpv4Netmask` (contiguous-mask check) / `isIpv6Prefix` (0–128) + `netmaskToPrefix` / `prefixToNetmask` converters.
- `network-step.tsx`: address field is now a plain IP; a new netmask field (dotted mask for IPv4, prefix for IPv6) sits below it, each inline-validated. `seedIpForm`/`ipFormToConfig` split/recombine CIDR per family.
- i18n: `setup.network.netmask.*` (en + tr); `address.invalid` reworded (no `/prefix`).

**Out**
- core schema / apps/api / Supervisor wire format (unchanged — still CIDR).

## Test plan

- [x] `pnpm --filter @glaon/web test src/features/setup/network` — 20 passing (netmask validators, mask↔prefix round-trip, seed split shows `255.255.255.0`, submit recombines to `192.168.1.50/24`).
- [x] `pnpm type-check` + `pnpm lint` + `pnpm i18n:check` + knip clean.
- [x] **Manual browser** (mock): end0 static IPv4 panel shows "IP adresi 192.168.1.50" + "Alt ağ maskesi 255.255.255.0" as separate fields (split from the seeded `/24`).
- [ ] CI green (watching); Chromatic reviewed.

Refs #626
Closes #639