### PR TITLE
feat(api,core,web): seed Layout step from the device's HA areas

### DIFF
--- a/apps/api/src/ha/ha-setup-service.ts
+++ b/apps/api/src/ha/ha-setup-service.ts
@@ -25,8 +25,10 @@
 import {
   HaClient,
   buildHaSetupPlan,
+  buildLayoutFromRegistries,
   type HaAreaRegistryEntry,
   type HaFloorRegistryEntry,
+  type HaLayoutResult,
   type HaSetupInput,
 } from '@glaon/core/ha';
 import type { ApplyHaResponse, ApplyHaStepResult } from '@glaon/core/api-client';
@@ -123,6 +125,48 @@ export async function applyHaSetup(
   }
 
   return { ok: steps.every((step) => step.ok), steps };
+}
+
+/**
+ * Read the device's existing HA floors + areas and normalize them into a
+ * layout seed for the wizard's Layout step (#638). Connection failure is
+ * fail-loud (`HaCoreUnreachableError` → 502); a per-command failure (e.g.
+ * an older HA with no floor registry) degrades to an empty list so areas
+ * still come through as unassigned rather than failing the whole read.
+ */
+export async function readHaLayout(deps: ReadHaLayoutDeps): Promise<HaLayoutResult> {
+  const client = deps.clientFactory();
+
+  try {
+    await client.connect();
+  } catch (err) {
+    throw new HaCoreUnreachableError(errMessage(err));
+  }
+
+  try {
+    const floors = await client
+      .request<readonly HaFloorRegistryEntry[]>({ type: 'config/floor_registry/list' })
+      .catch((err: unknown) => {
+        deps.logger?.warn({ event: 'ha-layout.floors.failed', error: errMessage(err) });
+        return [] as readonly HaFloorRegistryEntry[];
+      });
+    const areas = await client
+      .request<readonly HaAreaRegistryEntry[]>({ type: 'config/area_registry/list' })
+      .catch((err: unknown) => {
+        deps.logger?.warn({ event: 'ha-layout.areas.failed', error: errMessage(err) });
+        return [] as readonly HaAreaRegistryEntry[];
+      });
+    return buildLayoutFromRegistries(floors, areas);
+  } finally {
+    await client.close().catch(() => {
+      /* ignore */
+    });
+  }
+}
+
+interface ReadHaLayoutDeps {
+  readonly clientFactory: () => HaSetupClient;
+  readonly logger?: Logger;
 }
 
 /**

--- a/apps/api/src/routes/setup.test.ts
+++ b/apps/api/src/routes/setup.test.ts
@@ -24,11 +24,13 @@ interface RecordedFrame {
   readonly [key: string]: unknown;
 }
 
-/** Fake HaSetupClient: records frames, returns registry ids by type. */
+/** Fake HaSetupClient: records frames, returns registry ids/lists by type. */
 function fakeClient(opts: {
   connectError?: Error;
   failTypes?: Set<string>;
   sink: RecordedFrame[];
+  floors?: readonly unknown[];
+  areas?: readonly unknown[];
 }): HaSetupClient {
   return {
     connect: () => (opts.connectError ? Promise.reject(opts.connectError) : Promise.resolve()),
@@ -43,6 +45,12 @@ function fakeClient(opts: {
       }
       if (f.type === 'config/area_registry/create') {
         return Promise.resolve({ area_id: `area_${String(f.name)}`, name: f.name } as TResult);
+      }
+      if (f.type === 'config/floor_registry/list') {
+        return Promise.resolve((opts.floors ?? []) as TResult);
+      }
+      if (f.type === 'config/area_registry/list') {
+        return Promise.resolve((opts.areas ?? []) as TResult);
       }
       return Promise.resolve({} as TResult);
     },
@@ -168,6 +176,70 @@ describe('setup — unreachable', () => {
       clientFactory: () => fakeClient({ sink, connectError: new Error('ECONNREFUSED') }),
     });
     const res = await post(router, FULL_BODY);
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({ error: 'ha-unreachable' });
+  });
+});
+
+describe('setup — ha-layout (#638)', () => {
+  const floors = [
+    { floor_id: 'f-ground', name: 'Ground', level: 0 },
+    { floor_id: 'f-up', name: 'Upstairs', level: 1 },
+  ];
+  const areas = [
+    { area_id: 'a-living', name: 'Living', floor_id: 'f-ground' },
+    { area_id: 'a-bed', name: 'Bedroom', floor_id: 'f-up' },
+    { area_id: 'a-garage', name: 'Garage', floor_id: null },
+  ];
+
+  it('responds 503 when HA Core is not configured', async () => {
+    const router = createSetupRouter({ config: baseConfig() });
+    const res = await router.request('/ha-layout');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({ error: 'ha-core-not-configured' });
+  });
+
+  it('returns the device floors + areas grouped, with floorless areas unassigned', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink, floors, areas }),
+    });
+    const res = await router.request('/ha-layout');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      floors: { id: string; name: string; rooms: { name: string }[] }[];
+      unassigned: { name: string }[];
+    };
+    expect(body.floors.map((f) => f.name)).toEqual(['Ground', 'Upstairs']);
+    expect(body.floors.find((f) => f.id === 'f-ground')?.rooms.map((r) => r.name)).toEqual([
+      'Living',
+    ]);
+    expect(body.unassigned.map((r) => r.name)).toEqual(['Garage']);
+  });
+
+  it('degrades to areas-only when the floor list fails', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () =>
+        fakeClient({ sink, areas, failTypes: new Set(['config/floor_registry/list']) }),
+    });
+    const res = await router.request('/ha-layout');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { floors: unknown[]; unassigned: { name: string }[] };
+    expect(body.floors).toEqual([]);
+    // With no floors, every area is unassigned.
+    expect(body.unassigned.map((r) => r.name)).toEqual(['Living', 'Bedroom', 'Garage']);
+  });
+
+  it('responds 502 when the HA Core connection cannot be established', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink, connectError: new Error('ECONNREFUSED') }),
+    });
+    const res = await router.request('/ha-layout');
     expect(res.status).toBe(502);
     expect(await res.json()).toMatchObject({ error: 'ha-unreachable' });
   });

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -23,6 +23,7 @@ import {
   applyHaSetup,
   createHaCoreClientFactory,
   HaCoreUnreachableError,
+  readHaLayout,
   type HaSetupClient,
 } from '../ha/ha-setup-service';
 import type { Logger } from '../observability/logger';
@@ -39,6 +40,44 @@ export function createSetupRouter(deps: SetupRouterDeps): Hono {
   const router = new Hono();
   const { haCoreUrl, haCoreToken } = deps.config;
 
+  // A test-injected factory bypasses the env requirement; otherwise we
+  // need the URL + token to build the real client. `undefined` → the
+  // caller returns 503 ha-core-not-configured.
+  const resolveFactory = (): (() => HaSetupClient) | undefined =>
+    deps.clientFactory ??
+    (haCoreUrl !== undefined && haCoreToken !== undefined
+      ? createHaCoreClientFactory(haCoreUrl, haCoreToken)
+      : undefined);
+
+  const notConfigured = {
+    error: 'ha-core-not-configured',
+    hint: 'Set HA_CORE_URL + HA_CORE_TOKEN (a long-lived access token). See docs/dev-supervisor.md.',
+  } as const;
+
+  // Read the device's existing HA floors + areas to seed the wizard's
+  // Layout step (#638). Same auth posture + config-gating as /apply-ha.
+  router.get('/ha-layout', async (c) => {
+    const factory = resolveFactory();
+    if (factory === undefined) return c.json(notConfigured, 503);
+    try {
+      const layout = await readHaLayout({
+        clientFactory: factory,
+        ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
+      });
+      return c.json(layout, 200);
+    } catch (err) {
+      if (err instanceof HaCoreUnreachableError) {
+        deps.logger?.error({ event: 'setup.ha-layout.unreachable', message: err.message });
+        return c.json({ error: 'ha-unreachable' }, 502);
+      }
+      deps.logger?.error({
+        event: 'setup.ha-layout.failed',
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+      return c.json({ error: 'internal' }, 500);
+    }
+  });
+
   router.post('/apply-ha', async (c) => {
     const raw: unknown = await c.req.json().catch(() => null);
     const parsed = ApplyHaRequestSchema.safeParse(raw);
@@ -46,22 +85,9 @@ export function createSetupRouter(deps: SetupRouterDeps): Hono {
       return c.json({ error: 'invalid-body' }, 400);
     }
 
-    // A test-injected factory bypasses the env requirement; otherwise we
-    // need the URL + token to build the real client.
-    const factory =
-      deps.clientFactory ??
-      (haCoreUrl !== undefined && haCoreToken !== undefined
-        ? createHaCoreClientFactory(haCoreUrl, haCoreToken)
-        : undefined);
-
+    const factory = resolveFactory();
     if (factory === undefined) {
-      return c.json(
-        {
-          error: 'ha-core-not-configured',
-          hint: 'Set HA_CORE_URL + HA_CORE_TOKEN (a long-lived access token). See docs/dev-supervisor.md.',
-        },
-        503,
-      );
+      return c.json(notConfigured, 503);
     }
 
     try {

--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -85,6 +85,16 @@ async function mockSupervisorNetwork(page: Page): Promise<void> {
   await page.route('**/api/hassio/network/interface/*/update', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: '{"result":"ok"}' });
   });
+  // #638 — the Layout step reads the device's HA floors/areas to pre-fill.
+  // Mock 503 (HA Core not configured) so the step degrades to a blank
+  // default floor — deterministic and independent of seed content.
+  await page.route('**/api/setup/ha-layout', async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'ha-core-not-configured' }),
+    });
+  });
   // #617 — the apply step pushes home settings to HA Core before the
   // network commit. Mock a clean success so the ceremony proceeds.
   await page.route('**/api/setup/apply-ha', async (route) => {

--- a/apps/web/src/features/setup/layout/layout-step.test.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.test.tsx
@@ -1,28 +1,86 @@
 // Smoke-level UI coverage. The reducer's correctness is tested
-// exhaustively in `use-layout-state.test.ts`; here we just verify
-// the default state renders, the add-floor / add-room affordances
-// dispatch into the reducer, and the form submit emits the new
-// structured `layout` blob (not a free-text string).
+// exhaustively in `use-layout-state.test.ts`; here we verify the step
+// seeds from the device HA layout (#638), the default state renders, the
+// add-floor / add-room affordances dispatch into the reducer, and submit
+// emits the structured `layout` blob.
 
-import { fireEvent, render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ToastProvider } from '@glaon/ui';
 
 import type { Layout } from '@glaon/core/config';
 
 import { LayoutStep } from './layout-step';
 
+function wrap(node: React.ReactNode) {
+  return <ToastProvider>{node}</ToastProvider>;
+}
+
+function mockResponse(init: { ok?: boolean; status?: number; json?: unknown }): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: () => Promise.resolve(init.json),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  // Default: HA Core not configured (503) → the step degrades silently to
+  // a blank default floor. Tests that exercise seeding override this.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(mockResponse({ ok: false, status: 503, json: {} }))),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('LayoutStep', () => {
-  it('renders the title and the default single floor', () => {
-    const { container, getByText } = render(<LayoutStep collected={{}} onNext={() => undefined} />);
+  it('renders the title and the default single floor when the device has none', async () => {
+    const { container, findByText } = render(
+      wrap(<LayoutStep collected={{}} onNext={() => undefined} />),
+    );
     expect(container.querySelector('h1')?.textContent).toBe('Layout Setup');
-    // The default floor name comes from the EN locale string.
-    expect(getByText('Ground Floor')).toBeInTheDocument();
+    // After the 503, the editor seeds the EN default floor name.
+    expect(await findByText('Ground Floor')).toBeInTheDocument();
   });
 
-  it('submits the default single-floor layout on Next', () => {
+  it('seeds floors + rooms from the device HA layout (#638)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          mockResponse({
+            json: {
+              floors: [{ id: 'f1', name: 'Garage Floor', rooms: [{ id: 'r1', name: 'Workshop' }] }],
+              unassigned: [{ id: 'r2', name: 'Patio' }],
+            },
+          }),
+        ),
+      ),
+    );
     const onNext = vi.fn();
-    const { getByRole } = render(<LayoutStep collected={{}} onNext={onNext} />);
+    const { findByText, getByRole, getByDisplayValue } = render(
+      wrap(<LayoutStep collected={{}} onNext={onNext} />),
+    );
+    // The device floor pill + its room (in an input) render after the seed.
+    expect(await findByText('Garage Floor')).toBeInTheDocument();
+    expect(getByDisplayValue('Workshop')).toBeInTheDocument();
+    // Submitting carries both the device floor and the unassigned area
+    // (under the default-named floor).
     fireEvent.click(getByRole('button', { name: 'Next' }));
+    const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
+    expect(partial.layout?.floors.map((f) => f.name)).toEqual(['Garage Floor', 'Ground Floor']);
+    expect(partial.layout?.floors[1]?.rooms.map((r) => r.name)).toEqual(['Patio']);
+  });
+
+  it('submits the default single-floor layout on Next', async () => {
+    const onNext = vi.fn();
+    const { findByRole } = render(wrap(<LayoutStep collected={{}} onNext={onNext} />));
+    fireEvent.click(await findByRole('button', { name: 'Next' }));
     expect(onNext).toHaveBeenCalledTimes(1);
     const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
     expect(partial.layout?.floors).toHaveLength(1);
@@ -30,32 +88,29 @@ describe('LayoutStep', () => {
     expect(partial.layout?.floors[0]?.rooms).toEqual([]);
   });
 
-  it('adds a second floor via the "Add floor" pill', () => {
+  it('adds a second floor via the "Add floor" pill', async () => {
     const onNext = vi.fn();
-    const { getByRole } = render(<LayoutStep collected={{}} onNext={onNext} />);
-    fireEvent.click(getByRole('button', { name: /Add floor/i }));
+    const { findByRole, getByRole } = render(wrap(<LayoutStep collected={{}} onNext={onNext} />));
+    fireEvent.click(await findByRole('button', { name: /Add floor/i }));
     fireEvent.click(getByRole('button', { name: 'Next' }));
     const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
     expect(partial.layout?.floors).toHaveLength(2);
-    // Second floor seeded with an empty rooms list. Name comes
-    // from the locale template; we don't assert the exact label
-    // because ICU interpolation isn't deterministic across the
-    // vitest setup permutations.
     expect(partial.layout?.floors[1]?.rooms).toEqual([]);
   });
 
-  it('adds a room via the empty-state CTA on the default floor', () => {
+  it('adds a room via the empty-state CTA on the default floor', async () => {
     const onNext = vi.fn();
-    const { getByRole } = render(<LayoutStep collected={{}} onNext={onNext} />);
-    fireEvent.click(getByRole('button', { name: /Add your first room/i }));
+    const { findByRole, getByRole } = render(wrap(<LayoutStep collected={{}} onNext={onNext} />));
+    fireEvent.click(await findByRole('button', { name: /Add your first room/i }));
     fireEvent.click(getByRole('button', { name: 'Next' }));
     const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
     expect(partial.layout?.floors[0]?.rooms).toHaveLength(1);
-    expect(typeof partial.layout?.floors[0]?.rooms[0]?.name).toBe('string');
     expect((partial.layout?.floors[0]?.rooms[0]?.name ?? '').length).toBeGreaterThan(0);
   });
 
-  it('hydrates from a previously collected layout', () => {
+  it('reuses a previously collected layout and skips the device read', async () => {
+    const fetchSpy = vi.fn(() => Promise.resolve(mockResponse({ json: {} })));
+    vi.stubGlobal('fetch', fetchSpy);
     const layout: Layout = {
       floors: [
         {
@@ -66,12 +121,13 @@ describe('LayoutStep', () => {
       ],
     };
     const { container, getByDisplayValue } = render(
-      <LayoutStep collected={{ layout }} onNext={() => undefined} />,
+      wrap(<LayoutStep collected={{ layout }} onNext={() => undefined} />),
     );
-    // The floor name renders as the active-tab pill button text.
     expect(container.textContent ?? '').toMatch(/Penthouse/);
-    // The room name lands inside an `<input>` — assert via the
-    // value, not the text content.
     expect(getByDisplayValue('Solarium')).toBeInTheDocument();
+    // collected.layout present → no device read.
+    await waitFor(() => {
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/features/setup/layout/layout-step.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.tsx
@@ -1,32 +1,28 @@
 // Layout Setup wizard step — second step in the device setup wizard
 // (epic #533, ADR 0028). Multi-floor + rooms editor (#592).
 //
-// Replaces the v1 free-text placeholder from #545. The previous
-// single-string `layout?: string` field is gone — the schema now
-// carries a structured `layout?: { floors: Floor[] }` blob. Phase 2
-// has no production blobs that wrote the old shape so the swap is
-// direct (see types.ts comment for the rationale).
+// On entry the step seeds its editor from the device's existing HA
+// floors + areas (#638): `GET /api/setup/ha-layout` returns the current
+// registries normalized into floors-with-rooms (+ floorless areas under
+// `unassigned`), which we map into the editor's initial state. The user
+// then adds / edits on top. When the wizard already collected a layout
+// (re-entry / back-navigation), that takes precedence and the device
+// read is skipped. A 503 (HA Core not configured — HA-less dev) is
+// expected and degrades silently to a blank default floor; a real fetch
+// failure surfaces a Toast (API Error Toast Rule) and also degrades.
 //
 // UX:
-//   - Tab strip of floors at the top; the active tab's rooms render
-//     below.
-//   - Rooms render as a responsive card grid (1 column on phones,
-//     2 on tablets, 3 on desktop).
-//   - Each room card carries an emoji glyph driven by `RoomType`,
-//     editable name, type selector, and a ×-on-hover remove.
-//   - Empty floor: centred CTA with a 🏠 glyph and "Add your first
-//     room" copy.
-//   - Default state seeded by `useLayoutState`: one floor named per
-//     i18n (`Ground Floor` / `Zemin Kat`), empty rooms list.
-//
-// Per the API Error Toast Rule (CLAUDE.md), per-field validation
-// is inline / inline-only; nothing here goes through Toast because
-// nothing leaves the device.
+//   - Tab strip of floors at the top; the active tab's rooms render below.
+//   - Rooms render as a responsive card grid.
+//   - Per-field validation is inline; only the device-read failure uses
+//     Toast (it's a cross-section, network-level signal).
 
-import type { ReactNode, SubmitEvent } from 'react';
+import { useToast } from '@glaon/ui';
+import { useCallback, useEffect, useState, type ReactNode, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import type { DeviceConfigInput } from '@glaon/core/config';
+import { HaLayoutResponseSchema, type HaLayoutResponse } from '@glaon/core/api-client';
+import type { DeviceConfigInput, Layout } from '@glaon/core/config';
 
 import { WizardBackButton } from '../wizard-back-button';
 import { FloorTabs } from './floor-tabs';
@@ -44,13 +40,124 @@ interface LayoutStepProps {
 
 const MAX_FLOORS = 10;
 const MAX_ROOMS_PER_FLOOR = 50;
+const HA_LAYOUT_URL = '/api/setup/ha-layout';
+
+/**
+ * Map the device's HA floors/areas into the editor's seed `Layout`.
+ * Floorless areas go under a default-named floor (naming is the UI's
+ * job). Caps to the editor's floor/room maxima so the seed stays
+ * schema-valid. Returns `undefined` when there's nothing to seed, letting
+ * `useLayoutState` create its single blank floor.
+ */
+function mapHaLayoutToSeed(resp: HaLayoutResponse, defaultFloorName: string): Layout | undefined {
+  const floors: Layout['floors'][number][] = resp.floors.slice(0, MAX_FLOORS).map((floor) => ({
+    id: floor.id,
+    name: floor.name,
+    rooms: floor.rooms
+      .slice(0, MAX_ROOMS_PER_FLOOR)
+      .map((room) => ({ id: room.id, name: room.name })),
+  }));
+  if (resp.unassigned.length > 0 && floors.length < MAX_FLOORS) {
+    floors.push({
+      id: crypto.randomUUID(),
+      name: defaultFloorName,
+      rooms: resp.unassigned.slice(0, MAX_ROOMS_PER_FLOOR).map((room) => ({
+        id: room.id,
+        name: room.name,
+      })),
+    });
+  }
+  return floors.length > 0 ? { floors } : undefined;
+}
 
 export function LayoutStep({ collected, onNext, onBack }: LayoutStepProps): ReactNode {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const defaultFloorName = t('setup.layoutSetup.defaultFloorName');
+
+  // `collected.layout` present → reuse it (re-entry / back-nav) and skip
+  // the device read; absent → fetch the device's HA layout to pre-fill.
+  const [phase, setPhase] = useState<'loading' | 'ready'>(
+    collected.layout !== undefined ? 'ready' : 'loading',
+  );
+  const [seed, setSeed] = useState<Layout | undefined>(collected.layout);
+
+  const showLoadError = useCallback(() => {
+    toast.show({
+      intent: 'danger',
+      title: t('setup.layoutSetup.loadFailed.title'),
+      description: t('setup.layoutSetup.loadFailed.description'),
+    });
+  }, [t, toast]);
+
+  useEffect(() => {
+    if (collected.layout !== undefined) return;
+    // No unmount guard needed: this effect runs once (collected.layout is
+    // stable while on the step), and a setState after unmount is a no-op
+    // in React 19.
+    void (async () => {
+      try {
+        const res = await fetch(HA_LAYOUT_URL, { credentials: 'include' });
+        if (res.ok) {
+          const parsed = HaLayoutResponseSchema.safeParse(await res.json().catch(() => null));
+          if (parsed.success) {
+            setSeed(mapHaLayoutToSeed(parsed.data, defaultFloorName));
+          }
+        } else if (res.status !== 503) {
+          // 503 = HA Core not configured (HA-less dev): expected, silent.
+          // Any other non-ok is a real failure worth surfacing.
+          showLoadError();
+        }
+      } catch {
+        showLoadError();
+      } finally {
+        setPhase('ready');
+      }
+    })();
+  }, [collected.layout, defaultFloorName, showLoadError]);
+
+  if (phase === 'loading') {
+    return (
+      <div className="flex flex-col p-8 lg:p-12">
+        <LayoutHeader />
+        <p role="status" className="pt-2 text-sm text-tertiary">
+          {t('setup.layoutSetup.loading')}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <LayoutEditor
+      initialLayout={seed}
+      onNext={onNext}
+      {...(onBack !== undefined ? { onBack } : {})}
+    />
+  );
+}
+
+function LayoutHeader(): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <header className="flex flex-col gap-1 pb-6">
+      <h1 className="text-display-xs font-semibold text-primary">{t('setup.layoutSetup.title')}</h1>
+      <p className="text-sm text-tertiary">{t('setup.layoutSetup.subtitle')}</p>
+    </header>
+  );
+}
+
+interface LayoutEditorProps {
+  readonly initialLayout: Layout | undefined;
+  readonly onNext: (partial: DeviceConfigInput) => void;
+  readonly onBack?: () => void;
+}
+
+function LayoutEditor({ initialLayout, onNext, onBack }: LayoutEditorProps): ReactNode {
   const { t } = useTranslation();
 
   const { state, actions, toLayout } = useLayoutState({
     defaultFloorName: t('setup.layoutSetup.defaultFloorName'),
-    ...(collected.layout !== undefined ? { initial: collected.layout } : {}),
+    ...(initialLayout !== undefined ? { initial: initialLayout } : {}),
   });
 
   const activeFloor =
@@ -77,12 +184,7 @@ export function LayoutStep({ collected, onNext, onBack }: LayoutStepProps): Reac
 
   return (
     <div className="flex flex-col p-8 lg:p-12">
-      <header className="flex flex-col gap-1 pb-6">
-        <h1 className="text-display-xs font-semibold text-primary">
-          {t('setup.layoutSetup.title')}
-        </h1>
-        <p className="text-sm text-tertiary">{t('setup.layoutSetup.subtitle')}</p>
-      </header>
+      <LayoutHeader />
 
       <form onSubmit={onSubmit} noValidate className="flex flex-col gap-6">
         <FloorTabs

--- a/apps/web/src/features/setup/setup-route.test.tsx
+++ b/apps/web/src/features/setup/setup-route.test.tsx
@@ -45,13 +45,14 @@ describe('SetupRoute', () => {
     expect(heading?.textContent).toBe('Home Overview');
   });
 
-  it('advances to the next step when the placeholder Next button is clicked', () => {
-    // Start at the Layout step so we exercise the placeholder Next
-    // path; Home Overview's own form validation is covered in
-    // `home-overview-step.test.tsx`.
-    const { container, getByRole } = renderRoute('layout');
-    const next = getByRole('button', { name: 'Next' });
-    fireEvent.click(next);
+  it('advances to the next step when Next is clicked', async () => {
+    // Start at the Layout step so we exercise the Next path; Home
+    // Overview's own form validation is covered in
+    // `home-overview-step.test.tsx`. The Layout step now seeds from the
+    // device first (#638) — the stubbed fetch rejects, so it settles to
+    // the blank editor; await its Next button before clicking.
+    const { container, findByRole } = renderRoute('layout');
+    fireEvent.click(await findByRole('button', { name: 'Next' }));
     expect(container.querySelector('h1')?.textContent).toBe('Device Security');
   });
 

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -127,6 +127,11 @@
       },
       "actions": {
         "next": "Next"
+      },
+      "loading": "Loading your current layout…",
+      "loadFailed": {
+        "title": "Couldn't load the current layout",
+        "description": "Starting with a blank layout — add floors and rooms below."
       }
     },
     "wifi": {

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -127,6 +127,11 @@
       },
       "actions": {
         "next": "İleri"
+      },
+      "loading": "Mevcut yerleşimin yükleniyor…",
+      "loadFailed": {
+        "title": "Mevcut yerleşim yüklenemedi",
+        "description": "Boş bir yerleşimle başlıyoruz — aşağıdan kat ve oda ekleyebilirsin."
       }
     },
     "wifi": {

--- a/packages/core/src/api-client/index.ts
+++ b/packages/core/src/api-client/index.ts
@@ -52,7 +52,9 @@ export {
   ApplyHaRequestSchema,
   ApplyHaResponseSchema,
   ApplyHaStepResultSchema,
+  HaLayoutResponseSchema,
   type ApplyHaRequest,
   type ApplyHaResponse,
   type ApplyHaStepResult,
+  type HaLayoutResponse,
 } from './setup';

--- a/packages/core/src/api-client/setup.ts
+++ b/packages/core/src/api-client/setup.ts
@@ -62,3 +62,25 @@ export const ApplyHaResponseSchema = z.object({
   steps: z.array(ApplyHaStepResultSchema),
 });
 export type ApplyHaResponse = z.infer<typeof ApplyHaResponseSchema>;
+
+/**
+ * Response from `GET /setup/ha-layout` (#638): the device's existing HA
+ * floors + areas, normalized so the wizard's Layout step can pre-fill its
+ * editor. `unassigned` holds areas with no floor — the step buckets them
+ * under a default-named floor. Structurally matches `HaLayoutResult`
+ * (ha/setup-commands.ts), the pure mapper apps/api builds it from.
+ */
+const HaLayoutRoomSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+const HaLayoutFloorSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  rooms: z.array(HaLayoutRoomSchema),
+});
+export const HaLayoutResponseSchema = z.object({
+  floors: z.array(HaLayoutFloorSchema),
+  unassigned: z.array(HaLayoutRoomSchema),
+});
+export type HaLayoutResponse = z.infer<typeof HaLayoutResponseSchema>;

--- a/packages/core/src/ha/protocol/messages.ts
+++ b/packages/core/src/ha/protocol/messages.ts
@@ -154,6 +154,26 @@ export interface HaFloorRegistryEntry {
 }
 
 /**
+ * `config/floor_registry/list` — reads the existing floors so the wizard
+ * can pre-fill its layout editor from the device (#638). Result is a
+ * `HaFloorRegistryEntry[]`.
+ */
+export interface HaFloorRegistryListFrame {
+  readonly id: number;
+  readonly type: 'config/floor_registry/list';
+}
+
+/**
+ * `config/area_registry/list` — reads the existing areas. Result is a
+ * `HaAreaRegistryEntry[]`; each entry's `floor_id` links it to a floor
+ * (null/absent → the area has no floor).
+ */
+export interface HaAreaRegistryListFrame {
+  readonly id: number;
+  readonly type: 'config/area_registry/list';
+}
+
+/**
  * `config/area_registry/create` — creates an area (room). `floor_id`
  * links it to a floor created earlier in the same run; omit it for the
  * graceful-degrade path on HA builds without a floor registry.
@@ -219,4 +239,6 @@ export type HaOutboundFrame =
   | HaGetTranslationsFrame
   | HaConfigCoreUpdateFrame
   | HaFloorRegistryCreateFrame
-  | HaAreaRegistryCreateFrame;
+  | HaFloorRegistryListFrame
+  | HaAreaRegistryCreateFrame
+  | HaAreaRegistryListFrame;

--- a/packages/core/src/ha/setup-commands.test.ts
+++ b/packages/core/src/ha/setup-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildHaSetupPlan, type HaSetupInput } from './setup-commands';
+import type { HaAreaRegistryEntry, HaFloorRegistryEntry } from './protocol/messages';
+import { buildHaSetupPlan, buildLayoutFromRegistries, type HaSetupInput } from './setup-commands';
 
 describe('buildHaSetupPlan — core config', () => {
   it('maps every collected core field into config/core/update', () => {
@@ -74,5 +75,45 @@ describe('buildHaSetupPlan — floors + rooms', () => {
   it('returns an empty floor list when no layout is present', () => {
     const plan = buildHaSetupPlan({ latitude: 1 });
     expect(plan.floors).toEqual([]);
+  });
+});
+
+describe('buildLayoutFromRegistries — device layout seed (#638)', () => {
+  const floors: HaFloorRegistryEntry[] = [
+    { floor_id: 'f-up', name: 'Upstairs', level: 1 },
+    { floor_id: 'f-ground', name: 'Ground', level: 0 },
+  ];
+  const areas: HaAreaRegistryEntry[] = [
+    { area_id: 'a-living', name: 'Living', floor_id: 'f-ground' },
+    { area_id: 'a-kitchen', name: 'Kitchen', floor_id: 'f-ground' },
+    { area_id: 'a-bed', name: 'Bedroom', floor_id: 'f-up' },
+    { area_id: 'a-garage', name: 'Garage', floor_id: null },
+    { area_id: 'a-attic', name: 'Attic' },
+  ];
+
+  it('groups areas under their floors, ordered by level', () => {
+    const result = buildLayoutFromRegistries(floors, areas);
+    expect(result.floors.map((f) => f.name)).toEqual(['Ground', 'Upstairs']);
+    const ground = result.floors.find((f) => f.id === 'f-ground');
+    expect(ground?.rooms.map((r) => r.name)).toEqual(['Living', 'Kitchen']);
+    const up = result.floors.find((f) => f.id === 'f-up');
+    expect(up?.rooms.map((r) => r.name)).toEqual(['Bedroom']);
+  });
+
+  it('collects floorless / unknown-floor areas as unassigned', () => {
+    const result = buildLayoutFromRegistries(floors, areas);
+    expect(result.unassigned.map((r) => r.name)).toEqual(['Garage', 'Attic']);
+  });
+
+  it('treats an area pointing at a missing floor as unassigned', () => {
+    const result = buildLayoutFromRegistries(floors, [
+      { area_id: 'a-x', name: 'Mystery', floor_id: 'f-nonexistent' },
+    ]);
+    expect(result.floors.flatMap((f) => f.rooms)).toEqual([]);
+    expect(result.unassigned.map((r) => r.name)).toEqual(['Mystery']);
+  });
+
+  it('returns empty floors + unassigned for empty registries', () => {
+    expect(buildLayoutFromRegistries([], [])).toEqual({ floors: [], unassigned: [] });
   });
 });

--- a/packages/core/src/ha/setup-commands.ts
+++ b/packages/core/src/ha/setup-commands.ts
@@ -14,6 +14,8 @@
 //     unit-testable without a WS, and lets the service own the one
 //     imperative concern (id threading + graceful degrade).
 
+import type { HaAreaRegistryEntry, HaFloorRegistryEntry } from './protocol/messages';
+
 /**
  * The wizard-collected fields this mapper reads. Structurally a subset
  * of `DeviceConfigInput` (config/types.ts) — kept as a standalone shape
@@ -104,6 +106,67 @@ export function buildHaSetupPlan(input: HaSetupInput): HaSetupPlan {
   }));
 
   return { coreUpdate, floors };
+}
+
+// ---- Reverse direction: HA registries → wizard layout seed (#638) ----
+
+export interface HaLayoutRoom {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface HaLayoutFloor {
+  readonly id: string;
+  readonly name: string;
+  readonly rooms: readonly HaLayoutRoom[];
+}
+
+/**
+ * Result of reading HA's floor + area registries: floors with their
+ * rooms, plus the areas that have no floor link. The consumer (the
+ * wizard's Layout step) buckets `unassigned` under a default-named floor
+ * — naming stays in the UI layer where i18n lives.
+ */
+export interface HaLayoutResult {
+  readonly floors: readonly HaLayoutFloor[];
+  readonly unassigned: readonly HaLayoutRoom[];
+}
+
+/**
+ * Group HA areas under their floors to seed the wizard's layout editor.
+ * Pure. Floors are ordered by `level` (nullish last, stable otherwise);
+ * areas whose `floor_id` is null/absent/unknown land in `unassigned`.
+ */
+export function buildLayoutFromRegistries(
+  floors: readonly HaFloorRegistryEntry[],
+  areas: readonly HaAreaRegistryEntry[],
+): HaLayoutResult {
+  const knownFloorIds = new Set(floors.map((f) => f.floor_id));
+  const roomsByFloor = new Map<string, HaLayoutRoom[]>();
+  const unassigned: HaLayoutRoom[] = [];
+
+  for (const area of areas) {
+    const room: HaLayoutRoom = { id: area.area_id, name: area.name };
+    const floorId = area.floor_id;
+    if (floorId !== null && floorId !== undefined && floorId !== '' && knownFloorIds.has(floorId)) {
+      const list = roomsByFloor.get(floorId) ?? [];
+      list.push(room);
+      roomsByFloor.set(floorId, list);
+    } else {
+      unassigned.push(room);
+    }
+  }
+
+  const ordered = [...floors].sort(
+    (a, b) => (a.level ?? Number.POSITIVE_INFINITY) - (b.level ?? Number.POSITIVE_INFINITY),
+  );
+  const mappedFloors: HaLayoutFloor[] = ordered.map((floor) => ({
+    id: floor.floor_id,
+    name: floor.name,
+    rooms: roomsByFloor.get(floor.floor_id) ?? [],
+  }));
+
+  return { floors: mappedFloors, unassigned };
 }
 
 /**


### PR DESCRIPTION
## Summary

The Layout Setup step started from a single blank floor. It now **pre-fills from the device's existing Home Assistant floors + areas** (#638); the user adds / edits on top. When the wizard already collected a layout (re-entry / back-navigation), that takes precedence and the device read is skipped.

## Scope

**In**
- **core**: `config/floor_registry/list` + `config/area_registry/list` protocol frames; a pure `buildLayoutFromRegistries(floors, areas)` that groups areas under their floors (ordered by `level`) with floorless / unknown-floor areas in `unassigned`. New `HaLayoutResponse` api-client contract (+ schema).
- **apps/api**: `GET /setup/ha-layout` reads both registries over the HA Core WS and returns the normalized layout. `503` when HA Core unconfigured, `502` when unreachable; a per-registry-list failure degrades to areas-only (older HA without a floor registry).
- **web**: the Layout step fetches the device layout on entry and maps it into the editor's seed; floorless areas land under a **default-named floor**. A real fetch failure surfaces a Toast (API Error Toast Rule) and degrades to the blank default; a `503` degrades silently.

**Out**
- Two-way / live sync — one-shot seed at step entry.
- Area metadata beyond name.

## Test plan

- [x] `pnpm --filter @glaon/core test setup-commands` — 13 passing (grouping by floor/level, floorless → unassigned, unknown-floor → unassigned, empty registries).
- [x] `pnpm --filter @glaon/api test routes/setup` — 10 passing (`GET /ha-layout`: 503 unconfigured, grouped result, floor-list-fail degrade, 502 unreachable).
- [x] `pnpm --filter @glaon/web test src/features/setup` — 83 passing (Layout step seeds 'Garage Floor' + 'Workshop' + unassigned 'Patio' from a mocked device layout; reuses collected.layout without a device read; degrades to blank default on 503).
- [x] `pnpm type-check` (11) + `pnpm lint` (10) + `pnpm i18n:check` + knip clean.
- [ ] CI green (watching). Live HA-Core seeding needs a real HA (covered by the mapper unit test + the route test + the web component test against a mocked response).

Refs #626
Closes #638