### PR TITLE
feat(ui,core,web): add CurrencySelect + HA core currency

### DIFF
--- a/apps/api/src/routes/setup.test.ts
+++ b/apps/api/src/routes/setup.test.ts
@@ -68,6 +68,7 @@ const FULL_BODY = {
   unitSystem: 'metric' as const,
   timezone: 'Europe/Istanbul',
   country: 'TR',
+  currency: 'TRY',
   locale: 'tr',
   layout: {
     floors: [{ name: 'Ground', rooms: [{ name: 'Living' }, { name: 'Kitchen' }] }],
@@ -140,6 +141,7 @@ describe('setup — happy path', () => {
       unit_system: 'metric',
       time_zone: 'Europe/Istanbul',
       country: 'TR',
+      currency: 'TRY',
       language: 'tr',
     });
     // Areas carry the floor_id returned by the floor create.

--- a/apps/web/src/features/setup/home-overview/home-overview-api.ts
+++ b/apps/web/src/features/setup/home-overview/home-overview-api.ts
@@ -54,6 +54,7 @@ interface HomeSettingsSlice {
   readonly unitSystem?: 'metric' | 'imperial' | undefined;
   readonly timezone?: string | undefined;
   readonly country?: string | undefined;
+  readonly currency?: string | undefined;
   readonly locale?: string | undefined;
 }
 
@@ -69,6 +70,7 @@ export async function saveHomeSettings(slice: HomeSettingsSlice): Promise<SaveHo
   if (slice.unitSystem !== undefined) body.unitSystem = slice.unitSystem;
   if (slice.timezone !== undefined && slice.timezone !== '') body.timezone = slice.timezone;
   if (slice.country !== undefined && slice.country !== '') body.country = slice.country;
+  if (slice.currency !== undefined && slice.currency !== '') body.currency = slice.currency;
   if (slice.locale !== undefined && slice.locale !== '') body.locale = slice.locale;
 
   // Nothing to persist → no-op success.

--- a/apps/web/src/features/setup/home-overview/home-overview-step.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.tsx
@@ -26,6 +26,7 @@
 
 import {
   CountrySelect,
+  CurrencySelect,
   InputBase,
   LocationPicker,
   Radio,
@@ -83,6 +84,7 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
   const homeNameLabelId = useId();
   const countryLabelId = useId();
   const timezoneLabelId = useId();
+  const currencyLabelId = useId();
   const languageLabelId = useId();
 
   const [homeName, setHomeName] = useState<string>(collected.homeName ?? '');
@@ -95,6 +97,7 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
   const [unitSystem, setUnitSystem] = useState<UnitSystem>(collected.unitSystem ?? 'metric');
   const [country, setCountry] = useState<string>(collected.country ?? '');
   const [timezone, setTimezone] = useState<string>(collected.timezone ?? '');
+  const [currency, setCurrency] = useState<string>(collected.currency ?? '');
   const [locale, setLocale] = useState<SupportedLocale>(
     (collected.locale as SupportedLocale | undefined) ?? 'en',
   );
@@ -136,6 +139,9 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
       }
       if (collected.timezone === undefined && seed.timezone !== undefined) {
         setTimezone((prev) => (prev === '' ? (seed.timezone ?? prev) : prev));
+      }
+      if (collected.currency === undefined && seed.currency !== undefined) {
+        setCurrency((prev) => (prev === '' ? (seed.currency ?? prev) : prev));
       }
       if (
         collected.locale === undefined &&
@@ -221,6 +227,7 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
     if (location.longitude !== undefined) partial.longitude = location.longitude;
     if (country !== '') partial.country = country;
     if (timezone !== '') partial.timezone = timezone;
+    if (currency !== '') partial.currency = currency;
 
     // Per-step save (#646): persist the slice to the device before
     // advancing. An `error` outcome keeps the user on this step and
@@ -232,6 +239,7 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
       unitSystem,
       timezone: timezone !== '' ? timezone : undefined,
       country: country !== '' ? country : undefined,
+      currency: currency !== '' ? currency : undefined,
       locale,
     });
     if (outcome === 'error') {
@@ -347,6 +355,20 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
             autoDetect={collected.timezone === undefined && timezone === ''}
             onSelectionChange={(tz) => {
               setTimezone(tz ?? '');
+            }}
+          />
+        </FormRow>
+
+        {/* Currency sits under Timezone (#649). Label-less picker — the
+            form-row label is associated via aria-labelledby. */}
+        <FormRow label={t('setup.homeOverview.currency.label')} labelId={currencyLabelId}>
+          <CurrencySelect
+            aria-labelledby={currencyLabelId}
+            placeholder={t('setup.homeOverview.currency.placeholder')}
+            {...(collected.currency !== undefined ? { defaultValue: collected.currency } : {})}
+            autoDetect={collected.currency === undefined}
+            onSelectionChange={(code) => {
+              setCurrency(code ?? '');
             }}
           />
         </FormRow>

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -79,6 +79,10 @@
         "placeholder": "Select timezone",
         "tooltip": "Used by HA-time displays and automations."
       },
+      "currency": {
+        "label": "Currency",
+        "placeholder": "Select currency"
+      },
       "language": {
         "label": "Language",
         "placeholder": "Select language",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -79,6 +79,10 @@
         "placeholder": "Saat dilimini seç",
         "tooltip": "HA saat görüntülemeleri ve otomasyonları için kullanılır."
       },
+      "currency": {
+        "label": "Para Birimi",
+        "placeholder": "Para birimi seç"
+      },
       "language": {
         "label": "Dil",
         "placeholder": "Dil seç",

--- a/packages/core/src/api-client/setup.ts
+++ b/packages/core/src/api-client/setup.ts
@@ -32,6 +32,11 @@ export const ApplyHaRequestSchema = z.object({
     .string()
     .regex(/^[A-Z]{2}$/, 'country must be ISO 3166-1 alpha-2 uppercase')
     .optional(),
+  /** ISO 4217 currency code, uppercase (e.g. `TRY`, `USD`). */
+  currency: z
+    .string()
+    .regex(/^[A-Z]{3}$/, 'currency must be an ISO 4217 alpha-3 uppercase code')
+    .optional(),
   /** BCP-47 locale tag (e.g. `tr`, `en-US`). */
   locale: z.string().min(1).optional(),
   layout: z

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -138,6 +138,12 @@ export const DeviceConfigSchema = z
       .string()
       .regex(/^[A-Z]{2}$/, 'country must be ISO 3166-1 alpha-2 uppercase')
       .optional(),
+    /** ISO 4217 currency code (e.g. "TRY", "USD"). Uppercase. Collected in
+     *  the wizard's Home Overview step (#649); maps to HA Core `currency`. */
+    currency: z
+      .string()
+      .regex(/^[A-Z]{3}$/, 'currency must be ISO 4217 alpha-3 uppercase')
+      .optional(),
     /**
      * Latitude (WGS84 decimal degrees, −90…+90). Optional companion
      * to `location` — present when the user picked the address via

--- a/packages/core/src/ha/setup-commands.test.ts
+++ b/packages/core/src/ha/setup-commands.test.ts
@@ -16,6 +16,7 @@ describe('buildHaSetupPlan — core config', () => {
       unitSystem: 'metric',
       timezone: 'Europe/Istanbul',
       country: 'TR',
+      currency: 'TRY',
       locale: 'tr',
     };
     const plan = buildHaSetupPlan(input);
@@ -25,6 +26,7 @@ describe('buildHaSetupPlan — core config', () => {
       unit_system: 'metric',
       time_zone: 'Europe/Istanbul',
       country: 'TR',
+      currency: 'TRY',
       language: 'tr',
     });
   });

--- a/packages/core/src/ha/setup-commands.ts
+++ b/packages/core/src/ha/setup-commands.ts
@@ -36,6 +36,8 @@ export interface HaSetupInput {
   readonly timezone?: string | undefined;
   /** ISO 3166-1 alpha-2 (uppercase). */
   readonly country?: string | undefined;
+  /** ISO 4217 currency code (e.g. `TRY`, `USD`). */
+  readonly currency?: string | undefined;
   /** BCP-47 locale tag; forwarded to HA `language` best-effort. */
   readonly locale?: string | undefined;
   readonly layout?:
@@ -55,6 +57,7 @@ export interface HaCoreUpdatePayload {
   readonly unit_system?: 'metric' | 'us_customary';
   readonly time_zone?: string;
   readonly country?: string;
+  readonly currency?: string;
   readonly language?: string;
 }
 
@@ -86,6 +89,7 @@ export function buildHaSetupPlan(input: HaSetupInput): HaSetupPlan {
     unit_system?: 'metric' | 'us_customary';
     time_zone?: string;
     country?: string;
+    currency?: string;
     language?: string;
   } = {};
 
@@ -94,6 +98,7 @@ export function buildHaSetupPlan(input: HaSetupInput): HaSetupPlan {
   if (input.unitSystem !== undefined) core.unit_system = mapUnitSystem(input.unitSystem);
   if (input.timezone !== undefined && input.timezone !== '') core.time_zone = input.timezone;
   if (input.country !== undefined && input.country !== '') core.country = input.country;
+  if (input.currency !== undefined && input.currency !== '') core.currency = input.currency;
   const language = mapLanguage(input.locale);
   if (language !== undefined) core.language = language;
 

--- a/packages/ui/src/components/CurrencySelect/CurrencySelect.controls.ts
+++ b/packages/ui/src/components/CurrencySelect/CurrencySelect.controls.ts
@@ -1,0 +1,116 @@
+// `CurrencySelect.controls.ts` — single source of truth for
+// CurrencySelect's variant matrix. Story (`CurrencySelect.stories.tsx`)
+// imports the spec and spreads it into `meta.args` / `meta.argTypes`;
+// MDX docs (`CurrencySelect.mdx`) reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+const localeOptions = ['', 'tr-TR', 'en-US', 'de-DE', 'fr-FR', 'ar-SA'] as const;
+
+export const currencySelectControls = {
+  label: {
+    type: 'text',
+    default: 'Currency',
+    description:
+      'Visible label rendered above the trigger. Provide this, or an external `aria-label` / `aria-labelledby`, so the control always has an accessible name.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  placeholder: {
+    type: 'text',
+    default: 'Select a currency',
+    description:
+      'Hint text shown when no option is selected. Never use placeholder as a substitute for the label.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the trigger. Doubles as the error message when `isInvalid` is true.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  autoDetect: {
+    type: 'boolean',
+    default: true,
+    description:
+      "When true (default), preselect the currency of the browser locale's region on mount (Intl Locale Info `getCurrencies`). Ignored when `value` or `defaultValue` is set. One-shot — re-mount to re-detect.",
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  locale: {
+    type: 'select',
+    options: localeOptions,
+    default: '',
+    description:
+      'BCP-47 locale used for the localized currency names + label collation. Leave empty to use the browser default (`navigator.language`).',
+    category: 'Content',
+  } satisfies ControlSpec<(typeof localeOptions)[number]>,
+  defaultValue: {
+    type: 'text',
+    description:
+      'Uncontrolled initial selection — ISO 4217 code (e.g. `TRY`, `USD`). When set, `autoDetect` is ignored.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description: 'Visual scale forwarded to the underlying ComboBox.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description: 'Block all interaction and dim the trigger.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isInvalid: {
+    type: 'boolean',
+    default: false,
+    description:
+      'Surface validation error styling. Auto-clears once the user makes a selection; re-assert by toggling `false → true`.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  isRequired: {
+    type: 'boolean',
+    default: false,
+    description: 'Mark the field as required (forwards `aria-required`).',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  hideRequiredIndicator: {
+    type: 'boolean',
+    default: false,
+    description: 'Hide the visual `*` next to the label even when `isRequired` is true.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  value: {
+    type: 'text',
+    description: 'Controlled selection — ISO 4217 code. Pair with `onSelectionChange`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  onSelectionChange: {
+    type: false,
+    action: 'selection-changed',
+    description:
+      'Fires when the selected currency changes — receives the new ISO 4217 code or `null` when cleared.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  popoverClassName: {
+    type: false,
+    description: 'Tailwind override hook for the popover surface that wraps the option list.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// `aria-label` / `aria-labelledby` are a11y passthroughs for the
+// label-less usage (host renders its own label); not interactive story
+// args, so they're excluded from the controls matrix here.
+export const currencySelectExcludeFromArgs = defineExcludeFromArgs([
+  'aria-label',
+  'aria-labelledby',
+] as const);

--- a/packages/ui/src/components/CurrencySelect/CurrencySelect.mdx
+++ b/packages/ui/src/components/CurrencySelect/CurrencySelect.mdx
@@ -1,0 +1,119 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as CurrencySelectStories from './CurrencySelect.stories';
+
+<Meta of={CurrencySelectStories} />
+
+# CurrencySelect
+
+App-primitive ISO 4217 currency picker. Thin wrap over the kit
+[`<ComboBox>`](?path=/docs/web-primitives-select--docs#withsearch) that
+adds the built-in currency list, locale-aware sorting + names,
+diacritic-insensitive search, and optional one-shot autodetection.
+
+Sister primitive to
+[CountrySelect](?path=/docs/app-primitives-countryselect--docs) and
+[TimezoneSelect](?path=/docs/app-primitives-timezoneselect--docs) — same
+prop contract, same state machine, same polish (auto-clear-error,
+select-all-on-focus). The differences come from the dataset (ISO 4217
+codes) and the detection source (the browser locale's region currency).
+
+## When to use
+
+- Setup wizard's region step — pairs with Country / Timezone to localize
+  energy-cost and billing displays (maps to Home Assistant Core's
+  `currency`).
+- Any setting that drives a money format.
+
+## When NOT to use
+
+- A short curated list of supported currencies — use a plain
+  [Select](?path=/docs/web-primitives-select--docs).
+- Formatting an amount — that's `Intl.NumberFormat` at the call site, not
+  a picker.
+
+## Auto-detection
+
+When `autoDetect` is `true` (default), on mount the picker reads the
+browser locale's region (`new Intl.Locale(navigator.language).region`)
+and preselects that region's currency via the Intl Locale Info
+`getCurrencies()` API. **Pure browser API** — no network call, no geo-IP.
+
+Detection is **one-shot** at mount and **skipped** when `value`,
+`defaultValue`, or `autoDetect={false}` is set. On a runtime without the
+Intl Locale Info API the picker simply starts empty.
+
+```tsx
+// Preselect from the browser region.
+<CurrencySelect onSelectionChange={setCurrency} />
+
+// Always start empty; let the user pick.
+<CurrencySelect autoDetect={false} onSelectionChange={setCurrency} />
+
+// Controlled, hydrated from a device read.
+<CurrencySelect value={device.currency} onSelectionChange={setCurrency} />
+```
+
+## Anatomy
+
+<Canvas of={CurrencySelectStories.WithDefaultValue} />
+
+```tsx
+<CurrencySelect
+  label="Currency"
+  placeholder="Select a currency"
+  onSelectionChange={(code) => setCurrency(code)}
+/>
+```
+
+Each row renders the ISO 4217 code + the localized currency name, e.g.
+`TRY — Turkish Lira`. The emitted value is the bare code (`'TRY'`).
+
+## Dataset and localization
+
+The list comes from `Intl.supportedValuesOf('currency')` — the
+runtime-built-in ISO 4217 set, no shipped table. The `locale` prop drives
+both the localized currency **names** (`Intl.DisplayNames`) and the sort
+order (`Intl.Collator`), so the same list renders correctly in any locale
+the browser supports.
+
+## Search behaviour
+
+The filter is **diacritic-insensitive** and matches the displayed label
+(code + name). The input **selects-all on focus** so the next keystroke
+replaces the current label cleanly.
+
+## Error UX
+
+`isInvalid` styling **clears automatically** when the user makes a
+selection. Toggle `isInvalid` `false → true` after re-validation to force
+it back on.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Pass a visible `label`, **or** associate a host-rendered label via
+  `aria-labelledby` (id of the external label), **or** supply an
+  `aria-label`. One of the three must be present so the ComboBox always
+  has an accessible name.
+- The popover is keyboard-navigable (Arrow up/down, Enter to select, Esc
+  to dismiss) and the search input is a real `<input>` with
+  `aria-autocomplete="list"`.
+- Pair `isInvalid` with a descriptive `hint` — the kit wires
+  `aria-invalid` + `aria-describedby` automatically.
+
+## Related components
+
+- [CountrySelect](?path=/docs/app-primitives-countryselect--docs) —
+  sister primitive for ISO 3166-1 countries.
+- [TimezoneSelect](?path=/docs/app-primitives-timezoneselect--docs) —
+  sister primitive for IANA timezones.
+- [FormField](?path=/docs/app-primitives-formfield--docs) — wrapper for
+  label + control + error in compound forms.

--- a/packages/ui/src/components/CurrencySelect/CurrencySelect.stories.tsx
+++ b/packages/ui/src/components/CurrencySelect/CurrencySelect.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { CurrencySelect } from './CurrencySelect';
+import { currencySelectControls, currencySelectExcludeFromArgs } from './CurrencySelect.controls';
+
+const { args, argTypes } = defineControls(currencySelectControls);
+
+// Explicit `Meta<typeof CurrencySelect>` annotation (vs `satisfies`)
+// keeps the kit's deep RAC generic chains out of the exported `meta`
+// signature — `tsc --noEmit` runs with `declaration: true`.
+//
+// `tags: ['autodocs']` omitted because `CurrencySelect.mdx` replaces the
+// docs tab.
+const meta: Meta<typeof CurrencySelect> = {
+  title: 'App Primitives/CurrencySelect',
+  component: CurrencySelect,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=app-primitives-currency-select',
+    },
+  },
+  args,
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CurrencySelect>;
+
+export const excludeFromArgs = currencySelectExcludeFromArgs;
+
+/**
+ * Default — auto-detect on. On a browser whose locale region resolves to
+ * a currency (e.g. `tr-TR` → `TRY`) the picker opens with it preselected.
+ */
+export const Default: Story = {};
+
+/**
+ * Explicit `defaultValue`. The auto-detect path is skipped when the host
+ * provides a default; the picker starts with the host's choice.
+ */
+export const WithDefaultValue: Story = {
+  args: { defaultValue: 'TRY', autoDetect: false },
+};
+
+/**
+ * Auto-detect off — the picker starts empty regardless of the runtime's
+ * region. Use when the host owns the state lifecycle (e.g. a form that
+ * hydrates from the server).
+ */
+export const AutoDetectOff: Story = {
+  args: { autoDetect: false },
+};
+
+/** US Dollar — the most common reserve currency. */
+export const UsDollar: Story = {
+  args: { defaultValue: 'USD', autoDetect: false },
+};
+
+/**
+ * Turkish locale — same dataset, Turkish collation order and localized
+ * currency names (`TRY — Türk Lirası`).
+ */
+export const TurkishLocale: Story = {
+  args: {
+    locale: 'tr-TR',
+    autoDetect: false,
+    defaultValue: 'TRY',
+    label: 'Para birimi',
+  },
+};
+
+/**
+ * Arabic locale — exercises the RTL render path; the decorator wraps the
+ * field in `dir="rtl"` so the popover + alignment mirror correctly.
+ */
+export const ArabicRtl: Story = {
+  args: {
+    locale: 'ar-SA',
+    autoDetect: false,
+    defaultValue: 'SAR',
+    label: 'العملة',
+  },
+  decorators: [
+    (Story) => (
+      <div dir="rtl" style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+/** Disabled — trigger is dimmed, popover does not open. */
+export const Disabled: Story = {
+  args: { defaultValue: 'EUR', autoDetect: false, isDisabled: true },
+};
+
+/** Invalid + hint — error styling with descriptive copy below. Picking a
+ *  currency auto-clears the styling. */
+export const WithError: Story = {
+  args: {
+    autoDetect: false,
+    isInvalid: true,
+    hint: 'Currency is required.',
+  },
+};
+
+/** Helper text under the trigger when the field is valid. */
+export const WithHint: Story = {
+  args: {
+    autoDetect: false,
+    hint: 'Used for energy-cost and billing displays.',
+  },
+};
+
+/** Size matrix — `sm`, `md`, `lg`. */
+export const Sizes: Story = {
+  parameters: { controls: { exclude: ['size', 'label'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {(['sm', 'md', 'lg'] as const).map((size) => (
+        <CurrencySelect
+          key={size}
+          {...args}
+          size={size}
+          label={`Size: ${size}`}
+          autoDetect={false}
+          defaultValue="TRY"
+        />
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/CurrencySelect/CurrencySelect.tsx
+++ b/packages/ui/src/components/CurrencySelect/CurrencySelect.tsx
@@ -1,0 +1,189 @@
+// Glaon CurrencySelect — searchable ISO 4217 currency picker that wraps
+// the kit `<ComboBox>` (`packages/ui/src/components/base/select/combobox.tsx`).
+//
+// Sister primitive to `CountrySelect` / `TimezoneSelect` — same wrap
+// pattern, same state machine, same polish (auto-clear-error,
+// select-all-on-focus, diacritic-insensitive filter):
+//
+//   - Built-in list from `Intl.supportedValuesOf('currency')`, no shipped
+//     database, no extra dependency.
+//   - Labels combine the code + localized currency name
+//     (`'TRY — Turkish Lira'`) via `Intl.DisplayNames`.
+//   - Optional one-shot autodetection from the browser locale's region
+//     (`Intl.Locale.getCurrencies()`).
+//   - `Coins01` glyph (`@untitledui/icons`) as the trigger leading icon.
+//
+// Per CLAUDE.md's UUI Source Rule + Component Data-Fetching Boundary: the
+// visual + popover + RAC plumbing come from the kit; this wrapper adds the
+// prop API + dataset + detection. No network call here.
+
+import { useCallback, useEffect, useMemo, useState, type FocusEvent, type ReactNode } from 'react';
+import { Coins01 } from '@untitledui/icons';
+import type { Key } from 'react-aria-components';
+
+import { ComboBox, SelectItem, type SelectItemType } from '../Select';
+import {
+  buildCurrencyItems,
+  detectBrowserCurrency,
+  diacriticInsensitiveFilter,
+} from './currencies';
+
+// Types stay un-exported per memory note `feedback_knip_props_interfaces.md`.
+type CurrencySelectSize = 'sm' | 'md' | 'lg';
+
+interface CurrencySelectProps {
+  /**
+   * Controlled selection — ISO 4217 code (e.g. `'TRY'`, `'USD'`). Pair
+   * with `onSelectionChange`. When set, `defaultValue` + `autoDetect` are
+   * ignored.
+   */
+  value?: string;
+  /** Uncontrolled initial selection — ISO 4217 code. Ignores `autoDetect`. */
+  defaultValue?: string;
+  /** Fires on selection change. Receives the ISO 4217 code, or `null`. */
+  onSelectionChange?: (currency: string | null) => void;
+  /**
+   * When `true` (default), preselect the currency of the browser locale's
+   * region on mount. Ignored when `value` / `defaultValue` is set.
+   * One-shot — re-mount to re-detect. @default true
+   */
+  autoDetect?: boolean;
+  /** BCP-47 locale used for currency names + label collation. */
+  locale?: string;
+  /** Field label rendered above the trigger. */
+  label?: string;
+  /** Accessible name when no visible `label` is rendered; forwarded to
+   *  the ComboBox. */
+  'aria-label'?: string;
+  /** Id of an external visible label; forwarded as `aria-labelledby`. */
+  'aria-labelledby'?: string;
+  /** Placeholder text shown when no option is selected. */
+  placeholder?: string;
+  /** Helper text under the trigger; doubles as the error message when
+   *  `isInvalid` is true. */
+  hint?: ReactNode;
+  /** Block all interaction and dim the trigger. */
+  isDisabled?: boolean;
+  /** Surface validation error styling. Auto-clears on selection. */
+  isInvalid?: boolean;
+  /** Mark the field as required. */
+  isRequired?: boolean;
+  /** Hide the visual `*` even when `isRequired` is true. */
+  hideRequiredIndicator?: boolean;
+  /** Visual scale of the underlying ComboBox. @default 'md' */
+  size?: CurrencySelectSize;
+  /** Tailwind override hook for the outer wrapper. */
+  className?: string;
+  /** Tailwind override hook for the popover surface. */
+  popoverClassName?: string;
+}
+
+export function CurrencySelect({
+  value,
+  defaultValue,
+  onSelectionChange,
+  autoDetect = true,
+  locale,
+  label,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  placeholder,
+  hint,
+  isDisabled,
+  isInvalid,
+  isRequired,
+  hideRequiredIndicator,
+  size = 'md',
+  className,
+  popoverClassName,
+}: CurrencySelectProps) {
+  const resolvedLocale = useResolvedLocale(locale);
+  const items = useMemo(() => buildCurrencyItems(resolvedLocale), [resolvedLocale]);
+
+  const isHostControlled = value !== undefined;
+  const [internalKey, setInternalKey] = useState<string | null>(defaultValue ?? null);
+
+  useEffect(() => {
+    if (isHostControlled) return;
+    if (defaultValue !== undefined) return;
+    if (!autoDetect) return;
+    const detected = detectBrowserCurrency();
+    if (detected !== null) setInternalKey(detected);
+    // One-shot mount detection — explicit empty dep array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const effectiveKey = isHostControlled ? value : internalKey;
+
+  const [suppressInvalid, setSuppressInvalid] = useState(false);
+  useEffect(() => {
+    setSuppressInvalid(false);
+  }, [isInvalid]);
+
+  const handleSelectionChange = (key: Key | null) => {
+    const next = key === null ? null : String(key);
+    if (!isHostControlled) setInternalKey(next);
+    setSuppressInvalid(true);
+    onSelectionChange?.(next);
+  };
+
+  const handleFocusCapture = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.disabled || target.readOnly) return;
+    requestAnimationFrame(() => {
+      try {
+        target.select();
+      } catch {
+        // Input may have unmounted between the focus event and the rAF tick.
+      }
+    });
+  }, []);
+
+  const effectiveInvalid = isInvalid === true && !suppressInvalid;
+
+  const comboProps: Record<string, unknown> = {
+    items,
+    size,
+    selectedKey: effectiveKey ?? null,
+    onSelectionChange: handleSelectionChange,
+    defaultFilter: diacriticInsensitiveFilter,
+    shortcut: false,
+    icon: Coins01,
+  };
+
+  if (label !== undefined) comboProps.label = label;
+  if (ariaLabel !== undefined) comboProps['aria-label'] = ariaLabel;
+  if (ariaLabelledby !== undefined) comboProps['aria-labelledby'] = ariaLabelledby;
+  if (placeholder !== undefined) comboProps.placeholder = placeholder;
+  if (hint !== undefined) comboProps.hint = hint;
+  if (isDisabled === true) comboProps.isDisabled = true;
+  if (effectiveInvalid) comboProps.isInvalid = true;
+  if (isRequired === true) comboProps.isRequired = true;
+  if (hideRequiredIndicator === true) comboProps.hideRequiredIndicator = true;
+  if (className !== undefined) comboProps.className = className;
+  if (popoverClassName !== undefined) comboProps.popoverClassName = popoverClassName;
+
+  return (
+    <div onFocusCapture={handleFocusCapture}>
+      <ComboBox {...comboProps}>
+        {(item: SelectItemType) => <SelectItem id={item.id} label={item.label ?? ''} />}
+      </ComboBox>
+    </div>
+  );
+}
+
+/**
+ * Resolve the locale for currency names + collation. Reads
+ * `navigator.language` lazily so SSR builds don't crash on a missing
+ * `navigator`. Falls back to `'en'`.
+ */
+function useResolvedLocale(locale: string | undefined): string {
+  return useMemo(() => {
+    if (locale !== undefined && locale.length > 0) return locale;
+    if (typeof navigator !== 'undefined' && navigator.language) {
+      return navigator.language;
+    }
+    return 'en';
+  }, [locale]);
+}

--- a/packages/ui/src/components/CurrencySelect/currencies.ts
+++ b/packages/ui/src/components/CurrencySelect/currencies.ts
@@ -1,0 +1,106 @@
+// CurrencySelect data + helpers.
+//
+// The ISO 4217 currency list comes from `Intl.supportedValuesOf('currency')`
+// (Chrome 99+, Firefox 93+, Safari 15.4+). On a runtime without the API we
+// fall back to a small common set so the picker surfaces something rather
+// than erroring — every supported browser meets the threshold.
+//
+// Display labels combine the code and the localized currency name via
+// `Intl.DisplayNames(locale, { type: 'currency' })`, e.g.
+// `'TRY — Turkish Lira'`. No shipped translation tables, no extra
+// dependency — same runtime-locale approach as CountrySelect/TimezoneSelect.
+
+import type { SelectItemType } from '../base/select/select-shared';
+
+const FALLBACK_CURRENCIES = ['USD', 'EUR', 'GBP', 'TRY', 'JPY'] as const;
+
+/**
+ * Resolve the ISO 4217 currency codes exposed by the runtime. Built-in
+ * via `Intl.supportedValuesOf('currency')` on modern engines; falls back
+ * to a small common set on engines that predate the API.
+ */
+function getCurrencyList(): readonly string[] {
+  try {
+    const intlWithSupported = Intl as typeof Intl & {
+      supportedValuesOf?: (key: 'currency') => string[];
+    };
+    if (typeof intlWithSupported.supportedValuesOf === 'function') {
+      const codes = intlWithSupported.supportedValuesOf('currency');
+      if (codes.length > 0) return codes;
+    }
+  } catch {
+    // Fall through to the static fallback.
+  }
+  return FALLBACK_CURRENCIES;
+}
+
+/** Localized currency name for a code, e.g. `'TRY'` → `'Turkish Lira'`. */
+function currencyName(code: string, locale: string): string {
+  try {
+    const dn = new Intl.DisplayNames([locale], { type: 'currency' });
+    const name = dn.of(code);
+    return name ?? code;
+  } catch {
+    return code;
+  }
+}
+
+/**
+ * Build a `{ id, label }` list of currencies sorted by the localized
+ * label using `Intl.Collator`. `id` is the ISO 4217 code (e.g. `'TRY'`),
+ * the canonical value persisted to HA Core's `currency`.
+ */
+export function buildCurrencyItems(locale: string): SelectItemType[] {
+  const codes = getCurrencyList();
+  const collator = new Intl.Collator(locale, { sensitivity: 'base' });
+  return codes
+    .map((code) => ({ id: code, label: `${code} — ${currencyName(code, locale)}` }))
+    .sort((a, b) => collator.compare(a.label, b.label));
+}
+
+/**
+ * Detect the user's currency from their locale's region via the Intl
+ * Locale Info `getCurrencies()` API. Returns the ISO 4217 code (e.g.
+ * `'TRY'`) or `null` when the runtime lacks the API or the region has no
+ * single currency. Pure browser API — no network call, SSR-safe.
+ */
+export function detectBrowserCurrency(): string | null {
+  if (typeof Intl === 'undefined' || typeof navigator === 'undefined') return null;
+  try {
+    const tag = navigator.language;
+    if (!tag) return null;
+    const locale = new Intl.Locale(tag) as unknown as {
+      region?: string;
+      getCurrencies?: () => string[];
+    };
+    if (locale.region === undefined || locale.region === '') return null;
+    const regional = new Intl.Locale('und', { region: locale.region }) as unknown as {
+      getCurrencies?: () => string[];
+      currencies?: string[];
+    };
+    const list =
+      typeof regional.getCurrencies === 'function' ? regional.getCurrencies() : regional.currencies;
+    const first = Array.isArray(list) ? list[0] : undefined;
+    return typeof first === 'string' && first.length > 0 ? first : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Diacritic-insensitive substring filter for the ComboBox's
+ * `defaultFilter` prop — mirrors the helper in `TimezoneSelect/timezones.ts`
+ * and `CountrySelect/countries.ts`. Duplicated rather than extracted to
+ * keep this PR scoped; #589 tracks pulling the copies into a shared
+ * `_internal` module.
+ */
+export function diacriticInsensitiveFilter(textValue: string, inputValue: string): boolean {
+  if (!inputValue) return true;
+  return normaliseForSearch(textValue).includes(normaliseForSearch(inputValue));
+}
+
+const COMBINING_MARKS_RE = /[̀-ͯ]/g;
+
+function normaliseForSearch(s: string): string {
+  return s.normalize('NFD').replace(COMBINING_MARKS_RE, '').toLowerCase();
+}

--- a/packages/ui/src/components/CurrencySelect/index.ts
+++ b/packages/ui/src/components/CurrencySelect/index.ts
@@ -1,0 +1,9 @@
+// Per memory note `feedback_knip_props_interfaces.md`: keep prop /
+// utility types un-exported until an external consumer needs them. The
+// component is re-exported via the package barrel
+// (`packages/ui/src/index.ts`) and reachable as `@glaon/ui`'s
+// `CurrencySelect`. Helpers (`buildCurrencyItems`, `detectBrowserCurrency`,
+// `diacriticInsensitiveFilter`) ship in the same module — add named
+// exports here when an app feature imports them.
+
+export { CurrencySelect } from './CurrencySelect';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,6 +17,7 @@ export * from './components/Calendar';
 export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/CountrySelect';
+export * from './components/CurrencySelect';
 export * from './components/DatePicker';
 export * from './components/DateRangePicker';
 export * from './components/Drawer';

--- a/tools/figma-plugin/scripts/07-currencyselect-frame.js
+++ b/tools/figma-plugin/scripts/07-currencyselect-frame.js
@@ -1,0 +1,166 @@
+// Glaon — 07 CurrencySelect frame (#649)
+//
+// Creates the "App Primitives/CurrencySelect" COMPONENT in the Design
+// System Figma file: a search-select trigger (leading coins glyph,
+// "Currency" label, "Select a currency" placeholder, trailing chevron) —
+// the sister of TimezoneSelect / CountrySelect. The component description
+// carries `storybook-id: app-primitives-currency-select` (Chromatic
+// Figma-diff contract; see docs/figma.md).
+//
+// Usage:
+//   1. Copy this file's contents into tools/figma-plugin/code.js.
+//   2. Open the Design System Figma file (Inter installed; else falls back
+//      to the default font).
+//   3. Run plugin (Plugins → Development → Glaon) → review dry-run.
+//   4. Flip CONFIRM = true → re-run → report the node id for the PR body.
+//   5. git restore tools/figma-plugin/code.js
+//
+// Idempotent: if "App Primitives/CurrencySelect" exists, the script skips
+// creation and reports its id (adding the storybook-id description if
+// missing).
+
+const CONFIRM = false;
+
+const COMPONENT_NAME = 'App Primitives/CurrencySelect';
+const STORYBOOK_ID = 'app-primitives-currency-select';
+const FRAME_WIDTH = 360;
+
+const TOKENS = {
+  surface: { var: 'surface/default', hex: '#FFFFFF' },
+  border: { var: 'border/subtle', hex: '#E4E7EC' },
+  textPrimary: { var: 'text/primary', hex: '#181D27' },
+  textMuted: { var: 'text/muted', hex: '#717680' },
+};
+
+function hexToRgb(hex) {
+  const h = hex.replace('#', '');
+  return {
+    r: parseInt(h.slice(0, 2), 16) / 255,
+    g: parseInt(h.slice(2, 4), 16) / 255,
+    b: parseInt(h.slice(4, 6), 16) / 255,
+  };
+}
+
+(async () => {
+  try {
+    const existing = (await figma.root.findAllWithCriteria({ types: ['COMPONENT'] })).find(
+      (n) => n.name === COMPONENT_NAME,
+    );
+    if (existing) {
+      if (CONFIRM && !existing.description.includes(`storybook-id: ${STORYBOOK_ID}`)) {
+        existing.description =
+          (existing.description ? existing.description + '\n' : '') +
+          `storybook-id: ${STORYBOOK_ID}`;
+      }
+      figma.notify(`${CONFIRM ? '✅' : '🔍'} CurrencySelect already exists — id: ${existing.id}`, {
+        timeout: 12000,
+      });
+      console.log('[Glaon CurrencySelect] existing node id:', existing.id);
+      figma.closePlugin();
+      return;
+    }
+
+    const vars = await figma.variables.getLocalVariablesAsync();
+    const byName = new Map(vars.map((v) => [v.name, v]));
+    const fill = (key) => {
+      const t = TOKENS[key];
+      const paint = { type: 'SOLID', color: hexToRgb(t.hex) };
+      const v = byName.get(t.var);
+      return v ? figma.variables.setBoundVariableForPaint(paint, 'color', v) : paint;
+    };
+
+    if (!CONFIRM) {
+      figma.notify(
+        '🔍 DRY-RUN — would create "App Primitives/CurrencySelect" (360px): label + select trigger (coins glyph, placeholder, chevron). Flip CONFIRM to build.',
+        { timeout: 12000 },
+      );
+      figma.closePlugin();
+      return;
+    }
+
+    const FAMILY = 'Inter';
+    let fontReg = { family: FAMILY, style: 'Regular' };
+    let fontMed = { family: FAMILY, style: 'Medium' };
+    try {
+      await figma.loadFontAsync(fontReg);
+      await figma.loadFontAsync(fontMed);
+    } catch {
+      const fb = { family: 'Roboto', style: 'Regular' };
+      await figma.loadFontAsync(fb);
+      fontReg = fb;
+      fontMed = fb;
+    }
+
+    const text = (chars, font, size, colorKey) => {
+      const t = figma.createText();
+      t.fontName = font;
+      t.fontSize = size;
+      t.characters = chars;
+      t.fills = [fill(colorKey)];
+      return t;
+    };
+
+    const root = figma.createComponent();
+    root.name = COMPONENT_NAME;
+    root.description = `Glaon ISO 4217 currency picker (sister of TimezoneSelect / CountrySelect).\nstorybook-id: ${STORYBOOK_ID}`;
+    root.layoutMode = 'VERTICAL';
+    root.itemSpacing = 6;
+    root.fills = [];
+    root.resize(FRAME_WIDTH, 10);
+    root.primaryAxisSizingMode = 'AUTO';
+    root.counterAxisSizingMode = 'FIXED';
+
+    root.appendChild(text('Currency', fontMed, 14, 'textPrimary'));
+
+    const trigger = figma.createFrame();
+    trigger.name = 'trigger';
+    trigger.layoutMode = 'HORIZONTAL';
+    trigger.itemSpacing = 8;
+    trigger.counterAxisAlignItems = 'CENTER';
+    trigger.paddingLeft = 12;
+    trigger.paddingRight = 12;
+    trigger.paddingTop = 10;
+    trigger.paddingBottom = 10;
+    trigger.cornerRadius = 8;
+    trigger.fills = [fill('surface')];
+    trigger.strokes = [fill('border')];
+    trigger.strokeWeight = 1;
+    trigger.layoutAlign = 'STRETCH';
+    trigger.counterAxisSizingMode = 'AUTO';
+
+    // Leading "coins" glyph — two overlapping circles as a simple mark.
+    const coin1 = figma.createEllipse();
+    coin1.resize(14, 14);
+    coin1.fills = [];
+    coin1.strokes = [fill('textMuted')];
+    coin1.strokeWeight = 1.5;
+    trigger.appendChild(coin1);
+
+    const placeholder = text('Select a currency', fontReg, 16, 'textMuted');
+    placeholder.layoutGrow = 1;
+    trigger.appendChild(placeholder);
+
+    // Trailing chevron-down (a small rotated square reads as a caret).
+    const chevron = figma.createText();
+    chevron.fontName = fontReg;
+    chevron.fontSize = 14;
+    chevron.characters = '⌄';
+    chevron.fills = [fill('textMuted')];
+    trigger.appendChild(chevron);
+
+    root.appendChild(trigger);
+
+    root.x = Math.round(figma.viewport.center.x - FRAME_WIDTH / 2);
+    root.y = Math.round(figma.viewport.center.y - 40);
+    figma.currentPage.appendChild(root);
+    figma.viewport.scrollAndZoomIntoView([root]);
+
+    figma.notify(`✅ Created "${COMPONENT_NAME}" — node id: ${root.id}`, { timeout: 15000 });
+    console.log('[Glaon CurrencySelect] created node id:', root.id);
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();


### PR DESCRIPTION
## Summary

Sub-issue D of #645. New **CurrencySelect** app-primitive + `currency` wired end-to-end:

- **CurrencySelect** mirrors TimezoneSelect: searchable ISO 4217 list from `Intl.supportedValuesOf('currency')`, localized names via `Intl.DisplayNames`, region autodetect via `Intl.Locale.getCurrencies()`, diacritic-insensitive search, `Coins01` glyph. Ships story + controls + MDX, and an `aria-labelledby`/`aria-label` passthrough for label-less use.
- **`currency` plumbing:** added to `DeviceConfig` + `ApplyHaRequest` (ISO 4217 validation), `buildHaSetupPlan` → `config/core/update`, and surfaced by the `get_config` seed (already returned `currency`).
- **Home Overview:** a **Currency row under Timezone**, seeded from the device and saved per-step (label-less, FormRow label associated via `aria-labelledby`).

## Scope

**In:** CurrencySelect primitive (+ story/controls/MDX), core/api `currency` schemas + mapping, Home Overview wiring + i18n keys (`setup.homeOverview.currency.*`), Figma plugin script `tools/figma-plugin/scripts/07-currencyselect-frame.js`.

**Out:** LanguageSelect (#650), Security (#651). Built on `origin/development` — if #656 (sub-issue C) merges first, the Home Overview Timezone/Currency region rebases trivially.

## Figma (Design-System Fidelity Rule)

⚠️ **Figma node ID: pending.** The matching Design System frame is created by the committed plugin script `scripts/07` (carries `storybook-id: app-primitives-currency-select`). Run it, then the node ID is added here before merge. (Until then Chromatic's Figma-diff shows the story as `Not implemented` — a signal, not a failing check; the story's visual snapshot still runs.)

## Test plan

- [x] core `buildHaSetupPlan` maps `currency`; api `apply-ha` forwards it (17 core + 14 api).
- [x] UI unit project incl. F6 prop-coverage gate covers CurrencySelect (162).
- [x] Home Overview seed/save still green (8); `type-check`, `lint`, `knip`, `i18n:check` green.
- [ ] Storybook story-tests + a11y + Chromatic (CI).
- [ ] Manual: Currency seeds from device, persists on Next; autodetect picks region currency.

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)