### PR TITLE
ci: raise lighthouse startServerReadyTimeout to fix cold-start flake

### DIFF
--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -6,6 +6,12 @@ module.exports = {
     collect: {
       startServerCommand: 'pnpm --filter @glaon/web preview -- --port 4173 --strictPort',
       startServerReadyPattern: 'Local:',
+      // LHCI's default ready-timeout is 10s; on a loaded runner `vite
+      // preview` can take longer to print `Local:`, so LHCI gave up
+      // waiting and the first of 3 runs measured a cold server — the
+      // intermittent "Timed out waiting for the server to start
+      // listening" flake (#658). 60s gives the server room to warm up.
+      startServerReadyTimeout: 60000,
       url: ['http://localhost:4173/'],
       numberOfRuns: 3,
       settings: {

--- a/.lighthouserc.mobile.cjs
+++ b/.lighthouserc.mobile.cjs
@@ -5,6 +5,12 @@ module.exports = {
     collect: {
       startServerCommand: 'pnpm --filter @glaon/web preview -- --port 4173 --strictPort',
       startServerReadyPattern: 'Local:',
+      // LHCI's default ready-timeout is 10s; on a loaded runner `vite
+      // preview` can take longer to print `Local:`, so LHCI gave up
+      // waiting and the first of 3 runs measured a cold server — the
+      // intermittent "Timed out waiting for the server to start
+      // listening" flake (#658). 60s gives the server room to warm up.
+      startServerReadyTimeout: 60000,
       url: ['http://localhost:4173/'],
       numberOfRuns: 3,
       settings: {


### PR DESCRIPTION
## Summary

Fixes the recurring `lighthouse (mobile)` flake (#655, #656, #657): LHCI's default 10s `startServerReadyTimeout` is too short on loaded GitHub runners, so `vite preview` sometimes prints `Local:` after LHCI stops waiting ("Timed out waiting for the server to start listening"). The first of 3 runs then measures a cold server, producing marginal misses (LCP ~5061ms, perf score 0.59) — not real regressions (`size-check` stays green; the desktop preset on the same server passes).

Sets an explicit **60s `startServerReadyTimeout`** on both `.lighthouserc.cjs` and `.lighthouserc.mobile.cjs` so LHCI waits for the `Local:` ready signal before collecting.

## Scope

**In:** `startServerReadyTimeout: 60000` on both LHCI presets.
**Out:** No metric/budget thresholds changed (LCP, perf score, TBT, CLS untouched).

## Test plan

- [ ] Both `lighthouse (desktop)` and `lighthouse (mobile)` pass on this PR.
- [ ] No threshold values changed — diff is only the new timeout (+ comment).

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)