### PR TITLE
feat(web): seed admin username from device, optional password change

### DIFF
--- a/apps/web/src/features/setup/security/security-step.test.tsx
+++ b/apps/web/src/features/setup/security/security-step.test.tsx
@@ -1,13 +1,32 @@
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import { type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import {
+  DEVICE_CONFIG_SCHEMA_VERSION,
+  InMemoryConfigStore,
+  type DeviceConfig,
+} from '@glaon/core/config';
 import { ToastProvider } from '@glaon/ui';
 
+import { ConfigProvider } from '../../../config/config-provider';
 import { SecurityStep } from './security-step';
 
-function wrap(node: React.ReactNode) {
-  return <ToastProvider>{node}</ToastProvider>;
+// The step reads the device's stored config via useDeviceConfig (#651) —
+// pass `initialConfig` to simulate an already-configured device.
+function wrap(node: ReactNode, initialConfig: DeviceConfig | null = null) {
+  return (
+    <ConfigProvider configStore={new InMemoryConfigStore()} initialConfig={initialConfig}>
+      <ToastProvider>{node}</ToastProvider>
+    </ConfigProvider>
+  );
 }
+
+const configuredDevice: DeviceConfig = {
+  schemaVersion: DEVICE_CONFIG_SCHEMA_VERSION,
+  adminUsername: 'olivia.admin',
+  securityPinHash: 'a'.repeat(64),
+};
 
 describe('SecurityStep', () => {
   it('renders the title and both password fields', () => {
@@ -100,5 +119,44 @@ describe('SecurityStep', () => {
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('');
     expect(partial.securityPinHash).toBe(expectedHex);
+  });
+
+  it('seeds the admin username from the stored device config (#651)', () => {
+    const { getByTestId } = render(
+      wrap(<SecurityStep collected={{}} onNext={() => undefined} />, configuredDevice),
+    );
+    expect((getByTestId('security-username') as HTMLInputElement).value).toBe('olivia.admin');
+  });
+
+  it('keeps the existing password when both fields are left blank (#651)', async () => {
+    const onNext = vi.fn();
+    const { getByRole } = render(
+      wrap(<SecurityStep collected={{}} onNext={onNext} />, configuredDevice),
+    );
+    // Username is pre-seeded + valid; leave both password fields blank.
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+    const partial = onNext.mock.calls[0]?.[0] as {
+      adminUsername?: string;
+      securityPinHash?: string;
+    };
+    expect(partial.adminUsername).toBe('olivia.admin');
+    // No new hash emitted → the terminal commit's merge keeps the stored one.
+    expect(partial.securityPinHash).toBeUndefined();
+  });
+
+  it('still validates a newly entered password even when one already exists (#651)', () => {
+    const onNext = vi.fn();
+    const { container, getByRole, getByText } = render(
+      wrap(<SecurityStep collected={{}} onNext={onNext} />, configuredDevice),
+    );
+    const inputs = container.querySelectorAll('input[type="password"]');
+    fireEvent.change(inputs[0] as HTMLInputElement, { target: { value: 'short' } });
+    fireEvent.change(inputs[1] as HTMLInputElement, { target: { value: 'short' } });
+    fireEvent.click(getByRole('button', { name: 'Next' }));
+    expect(onNext).not.toHaveBeenCalled();
+    expect(getByText(/use at least/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/setup/security/security-step.tsx
+++ b/apps/web/src/features/setup/security/security-step.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from 'react-i18next';
 
 import type { DeviceConfigInput } from '@glaon/core/config';
 
+import { useDeviceConfig } from '../../../config/config-provider';
 import { WizardBackButton } from '../wizard-back-button';
 
 interface SecurityStepProps {
@@ -51,7 +52,15 @@ type PasswordValidation =
   | { readonly kind: 'mismatch' }
   | { readonly kind: 'empty' };
 
-function validatePasswords(password: string, confirm: string): PasswordValidation {
+// When `allowEmpty` is true the device already has a password, so leaving
+// both fields blank is valid — it means "keep the current password" (#651).
+// Entering one field still requires both (partial entry is an error).
+function validatePasswords(
+  password: string,
+  confirm: string,
+  allowEmpty: boolean,
+): PasswordValidation {
+  if (password === '' && confirm === '') return allowEmpty ? { kind: 'ok' } : { kind: 'empty' };
   if (password === '' || confirm === '') return { kind: 'empty' };
   if (password.length < MIN_PASSWORD_LENGTH) return { kind: 'too-short' };
   if (password !== confirm) return { kind: 'mismatch' };
@@ -61,13 +70,22 @@ function validatePasswords(password: string, confirm: string): PasswordValidatio
 export function SecurityStep({ collected, onNext, onBack }: SecurityStepProps): ReactNode {
   const { t } = useTranslation();
   const toast = useToast();
+  const { config } = useDeviceConfig();
   const usernameId = useId();
   const passwordId = useId();
   const confirmId = useId();
 
-  // Username is collected-backed, so it pre-fills on a back-navigation
-  // (#637) — unlike the password, which is never stored in plaintext.
-  const [username, setUsername] = useState<string>(collected.adminUsername ?? '');
+  // The device already has a password when a `securityPinHash` is stored
+  // (re-running setup / editing). Then the password change is optional:
+  // blank fields keep the current password (#651).
+  const hasExistingPassword =
+    config?.securityPinHash !== undefined && config.securityPinHash !== '';
+
+  // Username seeds from the in-run value first (back-navigation, #637),
+  // then the device's stored config (#651). Fresh setup → blank.
+  const [username, setUsername] = useState<string>(
+    collected.adminUsername ?? config?.adminUsername ?? '',
+  );
   const [password, setPassword] = useState<string>('');
   const [confirm, setConfirm] = useState<string>('');
   const [submitted, setSubmitted] = useState<boolean>(false);
@@ -75,7 +93,10 @@ export function SecurityStep({ collected, onNext, onBack }: SecurityStepProps): 
 
   const usernameTrimmed = username.trim();
   const usernameValid = USERNAME_RE.test(usernameTrimmed);
-  const validation = useMemo(() => validatePasswords(password, confirm), [password, confirm]);
+  const validation = useMemo(
+    () => validatePasswords(password, confirm, hasExistingPassword),
+    [password, confirm, hasExistingPassword],
+  );
   const showErrors = submitted && validation.kind !== 'ok';
   const usernameInvalid = submitted && !usernameValid;
   const usernameErrorMessage = usernameInvalid
@@ -88,6 +109,15 @@ export function SecurityStep({ collected, onNext, onBack }: SecurityStepProps): 
     event.preventDefault();
     setSubmitted(true);
     if (!usernameValid || validation.kind !== 'ok') return;
+
+    // No new password entered + the device already has one → keep it.
+    // Emit only the username so the terminal commit's merge leaves the
+    // stored `securityPinHash` untouched (#651).
+    if (password === '') {
+      onNext({ adminUsername: usernameTrimmed });
+      return;
+    }
+
     setIsHashing(true);
     try {
       const hash = await sha256Hex(password);
@@ -156,25 +186,38 @@ export function SecurityStep({ collected, onNext, onBack }: SecurityStepProps): 
           )}
         </FormRow>
 
-        <FormRow label={t('setup.security.password.label')} htmlFor={passwordId} required>
+        <FormRow
+          label={t('setup.security.password.label')}
+          htmlFor={passwordId}
+          required={!hasExistingPassword}
+        >
           <PasswordInput
             id={passwordId}
             value={password}
             onChange={setPassword}
             placeholder={t('setup.security.password.placeholder')}
-            isRequired
+            isRequired={!hasExistingPassword}
             autoComplete="new-password"
             {...(passwordErrorMessage !== undefined ? { error: passwordErrorMessage } : {})}
           />
+          {hasExistingPassword && passwordErrorMessage === undefined && (
+            <p className="pt-1.5 text-sm text-tertiary">
+              {t('setup.security.password.optionalHint')}
+            </p>
+          )}
         </FormRow>
 
-        <FormRow label={t('setup.security.confirm.label')} htmlFor={confirmId} required>
+        <FormRow
+          label={t('setup.security.confirm.label')}
+          htmlFor={confirmId}
+          required={!hasExistingPassword}
+        >
           <PasswordInput
             id={confirmId}
             value={confirm}
             onChange={setConfirm}
             placeholder={t('setup.security.confirm.placeholder')}
-            isRequired
+            isRequired={!hasExistingPassword}
             autoComplete="new-password"
             {...(confirmErrorMessage !== undefined ? { error: confirmErrorMessage } : {})}
           />

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -181,7 +181,8 @@
         "label": "Password",
         "placeholder": "At least 8 characters",
         "required": "Password is required.",
-        "tooShort": "Use at least {min} characters."
+        "tooShort": "Use at least {min} characters.",
+        "optionalHint": "Leave blank to keep your current password."
       },
       "confirm": {
         "label": "Confirm password",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -181,7 +181,8 @@
         "label": "Şifre",
         "placeholder": "En az 8 karakter",
         "required": "Şifre zorunludur.",
-        "tooShort": "En az {min} karakter kullan."
+        "tooShort": "En az {min} karakter kullan.",
+        "optionalHint": "Mevcut şifreni korumak için boş bırak."
       },
       "confirm": {
         "label": "Şifreyi tekrar gir",


### PR DESCRIPTION
## Summary

Sub-issue F of #645. The Device Security step now reads the device's stored Glaon config (`useDeviceConfig`):

- **Admin username seeds from the device** — pre-fills from a previously saved `adminUsername` (precedence: in-run value → stored config → blank). Fresh setup has no stored config, so it stays blank for the user to type.
- **Password change is optional when one already exists** — if the device has a `securityPinHash`, leaving both password fields blank keeps the current password (only `adminUsername` is emitted, so the terminal commit's `setPartial` merge leaves the stored hash untouched). The required `*` drops and a "leave blank to keep your current password" hint shows. A newly entered password is still validated (min 8 + match).
- **Fresh setup unchanged** — no stored config ⇒ password required, exactly as before.

## Decision

"Admin username from device" = Glaon's **own persisted config** (there's no HA owner-username readable pre-auth). Confirmed with the team; fresh-device seed is intentionally blank.

## Scope

**In:** `security-step.tsx` (read config, seed username, optional-password logic), tests, i18n key `setup.security.password.optionalHint`.
**Out:** No HA read added; no visual restructure (logic + one hint line), so no new Figma frame.

## Test plan

- [x] Fresh device: password required; min-length + mismatch + username validation unchanged.
- [x] Configured device: username seeds from stored config; blank password ⇒ `onNext({ adminUsername })` with **no** `securityPinHash`; a newly typed short password still errors (9 tests).
- [x] `type-check`, `lint`, `knip`, `i18n:check` green; full setup suite (100) passes.
- [ ] Playwright @smoke + Chromatic (CI).

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)