### PR TITLE
feat(ui,web): add searchable LanguageSelect, drop sidebar switcher

### DIFF
--- a/apps/web/src/features/setup/home-overview/home-overview-step.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.tsx
@@ -28,26 +28,16 @@ import {
   CountrySelect,
   CurrencySelect,
   InputBase,
+  LanguageSelect,
   LocationPicker,
   Radio,
   RadioGroup,
-  Select,
-  SelectItem,
   TextField,
   TimezoneSelect,
   nominatimGeocode,
   useToast,
-  type SelectItemType,
 } from '@glaon/ui';
-import {
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-  type SubmitEvent,
-} from 'react';
+import { useEffect, useId, useRef, useState, type ReactNode, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { SUPPORTED_LOCALES, type SupportedLocale } from '@glaon/core/i18n';
@@ -79,7 +69,7 @@ interface LocationState {
 const DEFAULT_RADIUS_M = 100;
 
 export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): ReactNode {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const toast = useToast();
   const homeNameLabelId = useId();
   const countryLabelId = useId();
@@ -157,15 +147,6 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
     // Seed once on mount; `collected` is read for the initial guard only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const localeItems = useMemo<SelectItemType[]>(
-    () =>
-      SUPPORTED_LOCALES.map((code) => ({
-        id: code,
-        label: t(`setup.locales.${code}`),
-      })),
-    [t],
-  );
 
   const homeNameTrimmed = homeName.trim();
   const homeNameInvalid = showHomeNameError && homeNameTrimmed === '';
@@ -373,23 +354,23 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
           />
         </FormRow>
 
+        {/* Single language control (#650) — the sidebar switcher was
+            removed. Selecting a language live-switches the wizard UI
+            (i18n.changeLanguage) and is saved to HA core `language`. */}
         <FormRow label={t('setup.homeOverview.language.label')} labelId={languageLabelId}>
-          <Select
+          <LanguageSelect
             aria-labelledby={languageLabelId}
-            items={localeItems}
-            placeholder={t('setup.homeOverview.language.placeholder')}
+            options={SUPPORTED_LOCALES}
             value={locale}
-            onChange={(key) => {
-              if (
-                typeof key === 'string' &&
-                (SUPPORTED_LOCALES as readonly string[]).includes(key)
-              ) {
-                setLocale(key as SupportedLocale);
+            placeholder={t('setup.homeOverview.language.placeholder')}
+            autoDetect={false}
+            onSelectionChange={(code) => {
+              if (code !== null && (SUPPORTED_LOCALES as readonly string[]).includes(code)) {
+                setLocale(code as SupportedLocale);
+                void i18n.changeLanguage(code);
               }
             }}
-          >
-            {(item) => <SelectItem key={item.id} id={item.id} label={item.label ?? ''} />}
-          </Select>
+          />
         </FormRow>
 
         <div className="flex justify-end gap-3 border-t border-secondary py-6">

--- a/apps/web/src/features/setup/setup-route.tsx
+++ b/apps/web/src/features/setup/setup-route.tsx
@@ -21,11 +21,8 @@
 // validation land per-step.
 
 import { useCallback, useMemo, useState, type ComponentType, type ReactNode } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import type { DeviceConfigInput } from '@glaon/core/config';
-import { SUPPORTED_LOCALES, isSupportedLocale, type SupportedLocale } from '@glaon/core/i18n';
-import { Select, SelectItem, type SelectItemType } from '@glaon/ui';
 import { SetupLayout, type SetupLayoutStep } from '@glaon/ui';
 
 import { ApplyStep } from './apply';
@@ -278,13 +275,6 @@ export function SetupRoute({ initialStepId }: SetupRouteProps = {}): ReactNode {
     [activeIndex],
   );
 
-  const onLocaleChange = useCallback(
-    (next: SupportedLocale) => {
-      setCollected((prev) => ({ ...prev, locale: next }));
-    },
-    [setCollected],
-  );
-
   if (activeStep === undefined) {
     // SETUP_STEPS is non-empty at module load — this branch exists only
     // to convince TS that ActiveStepComponent below is callable.
@@ -300,7 +290,6 @@ export function SetupRoute({ initialStepId }: SetupRouteProps = {}): ReactNode {
       completedStepIds={completedStepIds}
       onSelectStep={onSelectStep}
       navigableStepIds={navigableStepIds}
-      controlsSlot={<WizardLocaleSwitcher onLocaleChange={onLocaleChange} />}
     >
       <ActiveStepComponent
         collected={collected}
@@ -313,47 +302,7 @@ export function SetupRoute({ initialStepId }: SetupRouteProps = {}): ReactNode {
   );
 }
 
-interface WizardLocaleSwitcherProps {
-  /**
-   * Mirror the chosen locale into the wizard's `collected` state so the
-   * final commit (#548) persists the user's actual choice. Without this,
-   * the user could switch the chrome to Turkish but the post-wizard
-   * `glaon.locale` would stay at whatever Home Overview's Language form
-   * field defaulted to.
-   */
-  readonly onLocaleChange: (next: SupportedLocale) => void;
-}
-
-// In-wizard language switcher (#570). The wizard's chrome embeds this
-// in the sidebar so a user who opened the wizard in the wrong locale
-// can swap to their language without losing the data they've already
-// filled in: route-local `collected` state survives because the wizard
-// route does not unmount when i18next changes the active language.
-// Persistence flows through i18next-browser-languagedetector → the same
-// `glaon.locale` localStorage key the Home Overview step ultimately
-// commits, so the post-wizard reload picks the choice up.
-function WizardLocaleSwitcher({ onLocaleChange }: WizardLocaleSwitcherProps): ReactNode {
-  const { t, i18n } = useTranslation();
-  const active: SupportedLocale = isSupportedLocale(i18n.resolvedLanguage)
-    ? i18n.resolvedLanguage
-    : 'en';
-  const items: SelectItemType[] = SUPPORTED_LOCALES.map((code) => ({
-    id: code,
-    label: t(`languageSwitcher.options.${code}`),
-  }));
-  return (
-    <Select
-      aria-label={t('languageSwitcher.ariaLabel')}
-      items={items}
-      value={active}
-      onChange={(key) => {
-        if (typeof key === 'string' && isSupportedLocale(key)) {
-          void i18n.changeLanguage(key);
-          onLocaleChange(key);
-        }
-      }}
-    >
-      {(item) => <SelectItem key={item.id} id={item.id} label={item.label ?? ''} />}
-    </Select>
-  );
-}
+// The in-wizard sidebar language switcher (#570) was removed in #650: the
+// Home Overview step's LanguageSelect is now the single language control
+// (it live-switches the UI via i18n.changeLanguage and persists to HA +
+// glaon.locale), so a second chrome-level control was redundant.

--- a/packages/ui/src/components/LanguageSelect/LanguageSelect.controls.ts
+++ b/packages/ui/src/components/LanguageSelect/LanguageSelect.controls.ts
@@ -1,0 +1,119 @@
+// `LanguageSelect.controls.ts` — single source of truth for
+// LanguageSelect's variant matrix. Story (`LanguageSelect.stories.tsx`)
+// imports the spec and spreads it into `meta.args` / `meta.argTypes`;
+// MDX docs (`LanguageSelect.mdx`) reads the same spec via `<Controls />`.
+
+import type { ControlSpec } from '../_internal/controls';
+import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
+
+const sizeOptions = ['sm', 'md', 'lg'] as const;
+const localeOptions = ['', 'tr-TR', 'en-US', 'de-DE', 'fr-FR', 'ar-SA'] as const;
+
+export const languageSelectControls = {
+  label: {
+    type: 'text',
+    default: 'Language',
+    description:
+      'Visible label rendered above the trigger. Provide this, or an external `aria-label` / `aria-labelledby`, so the control always has an accessible name.',
+    category: 'A11y',
+  } satisfies ControlSpec<string>,
+  placeholder: {
+    type: 'text',
+    default: 'Select a language',
+    description: 'Hint text shown when no option is selected.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  hint: {
+    type: 'text',
+    description:
+      'Helper text rendered below the trigger. Doubles as the error message when `isInvalid` is true.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  autoDetect: {
+    type: 'boolean',
+    default: true,
+    description:
+      "When true (default), preselect the browser's language on mount if it is one of `options`. Ignored when `value` or `defaultValue` is set. One-shot.",
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  locale: {
+    type: 'select',
+    options: localeOptions,
+    default: '',
+    description:
+      'BCP-47 locale used for the localized language names + label collation. Leave empty to use the browser default (`navigator.language`).',
+    category: 'Content',
+  } satisfies ControlSpec<(typeof localeOptions)[number]>,
+  defaultValue: {
+    type: 'text',
+    description:
+      'Uncontrolled initial selection — a language code from `options` (e.g. `tr`). When set, `autoDetect` is ignored.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  size: {
+    type: 'inline-radio',
+    options: sizeOptions,
+    default: 'md',
+    description: 'Visual scale forwarded to the underlying ComboBox.',
+    category: 'Style',
+  } satisfies ControlSpec<(typeof sizeOptions)[number]>,
+  isDisabled: {
+    type: 'boolean',
+    default: false,
+    description: 'Block all interaction and dim the trigger.',
+    category: 'Behavior',
+  } satisfies ControlSpec<boolean>,
+  isInvalid: {
+    type: 'boolean',
+    default: false,
+    description: 'Surface validation error styling. Auto-clears once the user makes a selection.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  isRequired: {
+    type: 'boolean',
+    default: false,
+    description: 'Mark the field as required (forwards `aria-required`).',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  hideRequiredIndicator: {
+    type: 'boolean',
+    default: false,
+    description: 'Hide the visual `*` next to the label even when `isRequired` is true.',
+    category: 'A11y',
+  } satisfies ControlSpec<boolean>,
+  value: {
+    type: 'text',
+    description:
+      'Controlled selection — a language code from `options`. Pair with `onSelectionChange`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<string>,
+  options: {
+    type: false,
+    description:
+      'Supported language codes (BCP-47 primary subtags, e.g. `["en","tr"]`). When empty, a common fallback list renders.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  onSelectionChange: {
+    type: false,
+    action: 'selection-changed',
+    description: 'Fires when the selected language changes — receives the code or `null`.',
+    category: 'Behavior',
+  } satisfies ControlSpec<unknown>,
+  className: {
+    type: false,
+    description: 'Tailwind override hook for the outer wrapper.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+  popoverClassName: {
+    type: false,
+    description: 'Tailwind override hook for the popover surface that wraps the option list.',
+    category: 'Style',
+  } satisfies ControlSpec<string>,
+} as const;
+
+// `aria-label` / `aria-labelledby` are a11y passthroughs for the
+// label-less usage; not interactive story args, so they're excluded.
+export const languageSelectExcludeFromArgs = defineExcludeFromArgs([
+  'aria-label',
+  'aria-labelledby',
+] as const);

--- a/packages/ui/src/components/LanguageSelect/LanguageSelect.mdx
+++ b/packages/ui/src/components/LanguageSelect/LanguageSelect.mdx
@@ -1,0 +1,90 @@
+import { Meta, Canvas, Stories, Controls } from '@storybook/addon-docs/blocks';
+
+import * as LanguageSelectStories from './LanguageSelect.stories';
+
+<Meta of={LanguageSelectStories} />
+
+# LanguageSelect
+
+App-primitive language picker. Thin wrap over the kit
+[`<ComboBox>`](?path=/docs/web-primitives-select--docs#withsearch) that adds
+localized language names, locale-aware sorting, diacritic-insensitive
+search, and optional one-shot browser autodetection.
+
+Sister to
+[CountrySelect](?path=/docs/app-primitives-countryselect--docs) /
+[TimezoneSelect](?path=/docs/app-primitives-timezoneselect--docs) /
+[CurrencySelect](?path=/docs/app-primitives-currencyselect--docs) — same
+prop contract + polish. The difference: the candidate languages are
+**injected** via `options` (the app's supported set), because "which
+languages the product ships" is app knowledge, not a fixed Intl table.
+Labels come from `Intl.DisplayNames(locale, { type: 'language' })`.
+
+## When to use
+
+- Setup wizard / settings — the UI + Home Assistant language.
+- Any place the user picks an interface language from the supported set.
+
+## Options
+
+Pass the supported codes via `options` (BCP-47 primary subtags, e.g.
+`['en', 'tr']` — Glaon's current set). When `options` is empty a common
+fallback list renders so the primitive works standalone. A future
+HA-driven language list can feed `options` without changing the component.
+
+```tsx
+import { SUPPORTED_LOCALES } from '@glaon/core/i18n';
+
+<LanguageSelect
+  options={SUPPORTED_LOCALES}
+  value={locale}
+  onSelectionChange={setLocale}
+/>;
+```
+
+## Auto-detection
+
+When `autoDetect` is `true` (default), on mount the picker preselects the
+browser's language (primary subtag of `navigator.language`) **if** it is
+one of `options`. Skipped when `value` / `defaultValue` is set, or
+`autoDetect={false}`. Pure browser API — no network call.
+
+## Anatomy
+
+<Canvas of={LanguageSelectStories.WithDefaultValue} />
+
+Each row renders the localized language name (e.g. `Türkçe`, `English`).
+The emitted value is the bare code (`'tr'`).
+
+## Search behaviour
+
+Diacritic-insensitive substring match on the localized label; the input
+selects-all on focus so the next keystroke replaces the current label.
+
+## Error UX
+
+`isInvalid` styling clears when the user makes a selection. Toggle
+`false → true` after re-validation to re-arm it.
+
+## Variants
+
+<Stories includePrimary={false} />
+
+## Props
+
+<Controls />
+
+## Accessibility
+
+- Pass a visible `label`, **or** associate a host-rendered label via
+  `aria-labelledby`, **or** supply an `aria-label`. One must be present so
+  the ComboBox always has an accessible name.
+- The popover is keyboard-navigable (Arrow up/down, Enter, Esc) and the
+  search input is a real `<input>` with `aria-autocomplete="list"`.
+
+## Related components
+
+- [CountrySelect](?path=/docs/app-primitives-countryselect--docs),
+  [TimezoneSelect](?path=/docs/app-primitives-timezoneselect--docs),
+  [CurrencySelect](?path=/docs/app-primitives-currencyselect--docs) — the
+  sister region/locale pickers.

--- a/packages/ui/src/components/LanguageSelect/LanguageSelect.stories.tsx
+++ b/packages/ui/src/components/LanguageSelect/LanguageSelect.stories.tsx
@@ -1,0 +1,100 @@
+import type { Meta, StoryObj } from '@storybook/react-native-web-vite';
+
+import { defineControls } from '../_internal/controls';
+import { LanguageSelect } from './LanguageSelect';
+import { languageSelectControls, languageSelectExcludeFromArgs } from './LanguageSelect.controls';
+
+const { args, argTypes } = defineControls(languageSelectControls);
+
+// Glaon ships en/tr today; stories use that set to mirror the app. The
+// component falls back to a common list when `options` is empty.
+const GLAON_LOCALES = ['en', 'tr'] as const;
+
+const meta: Meta<typeof LanguageSelect> = {
+  title: 'App Primitives/LanguageSelect',
+  component: LanguageSelect,
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/cDLzPUkcsDJtvwqZLWRwrd/Design-System?node-id=app-primitives-language-select',
+    },
+  },
+  args: { ...args, options: [...GLAON_LOCALES] },
+  argTypes,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof LanguageSelect>;
+
+export const excludeFromArgs = languageSelectExcludeFromArgs;
+
+/**
+ * Default — Glaon's supported set (`en`, `tr`), auto-detect on. Labels are
+ * localized via `Intl.DisplayNames` (English in the `en` story locale).
+ */
+export const Default: Story = {};
+
+/** Explicit `defaultValue` — starts on Turkish, auto-detect skipped. */
+export const WithDefaultValue: Story = {
+  args: { defaultValue: 'tr', autoDetect: false },
+};
+
+/** Auto-detect off — starts empty regardless of the browser language. */
+export const AutoDetectOff: Story = {
+  args: { autoDetect: false },
+};
+
+/**
+ * Turkish locale — names render in Turkish (`Türkçe`, `İngilizce`) and
+ * sort with Turkish collation.
+ */
+export const TurkishLocale: Story = {
+  args: { locale: 'tr-TR', autoDetect: false, defaultValue: 'tr', label: 'Dil' },
+};
+
+/**
+ * Wider option set — exercises search across many languages (the
+ * fallback list). Type `por`, `deu`, etc. to filter.
+ */
+export const ManyLanguages: Story = {
+  args: {
+    options: ['en', 'tr', 'de', 'fr', 'es', 'it', 'pt', 'ar', 'ru', 'ja'],
+    autoDetect: false,
+  },
+};
+
+/** Disabled — trigger dimmed, popover does not open. */
+export const Disabled: Story = {
+  args: { defaultValue: 'en', autoDetect: false, isDisabled: true },
+};
+
+/** Invalid + hint — error styling; picking a language clears it. */
+export const WithError: Story = {
+  args: { autoDetect: false, isInvalid: true, hint: 'Language is required.' },
+};
+
+/** Size matrix — `sm`, `md`, `lg`. */
+export const Sizes: Story = {
+  parameters: { controls: { exclude: ['size', 'label'] } },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {(['sm', 'md', 'lg'] as const).map((size) => (
+        <LanguageSelect
+          key={size}
+          {...args}
+          size={size}
+          label={`Size: ${size}`}
+          autoDetect={false}
+          defaultValue="en"
+        />
+      ))}
+    </div>
+  ),
+};

--- a/packages/ui/src/components/LanguageSelect/LanguageSelect.tsx
+++ b/packages/ui/src/components/LanguageSelect/LanguageSelect.tsx
@@ -1,0 +1,184 @@
+// Glaon LanguageSelect — searchable language picker that wraps the kit
+// `<ComboBox>`. Sister to CountrySelect / TimezoneSelect / CurrencySelect
+// (same wrap pattern + polish), differing only in its dataset: the
+// candidate languages are *injected* via `options` (the app's supported
+// set) rather than pulled from a fixed Intl table, since "which languages
+// the product ships" is app knowledge. Labels are localized via
+// `Intl.DisplayNames(locale, { type: 'language' })`.
+//
+// Per CLAUDE.md's UUI Source Rule + Component Data-Fetching Boundary: the
+// visual + popover + RAC plumbing come from the kit; this wrapper adds the
+// prop API + label derivation + detection. No network call here.
+
+import { useCallback, useEffect, useMemo, useState, type FocusEvent, type ReactNode } from 'react';
+import { Translate01 } from '@untitledui/icons';
+import type { Key } from 'react-aria-components';
+
+import { ComboBox, SelectItem, type SelectItemType } from '../Select';
+import { buildLanguageItems, detectBrowserLanguage, diacriticInsensitiveFilter } from './languages';
+
+// Types stay un-exported per memory note `feedback_knip_props_interfaces.md`.
+type LanguageSelectSize = 'sm' | 'md' | 'lg';
+
+interface LanguageSelectProps {
+  /**
+   * Supported language codes (BCP-47 primary subtags, e.g. `['en','tr']`).
+   * The app injects its supported set; when empty a common fallback list
+   * renders so the primitive works in isolation.
+   */
+  options?: readonly string[];
+  /** Controlled selection — a language code from `options`. */
+  value?: string;
+  /** Uncontrolled initial selection. Ignores `autoDetect`. */
+  defaultValue?: string;
+  /** Fires on selection change. Receives the code, or `null`. */
+  onSelectionChange?: (language: string | null) => void;
+  /**
+   * When `true` (default), preselect the browser's language on mount if it
+   * is one of `options`. Ignored when `value` / `defaultValue` is set.
+   * One-shot. @default true
+   */
+  autoDetect?: boolean;
+  /** BCP-47 locale used for the language names + label collation. */
+  locale?: string;
+  /** Field label rendered above the trigger. */
+  label?: string;
+  /** Accessible name when no visible `label` is rendered; forwarded to
+   *  the ComboBox. */
+  'aria-label'?: string;
+  /** Id of an external visible label; forwarded as `aria-labelledby`. */
+  'aria-labelledby'?: string;
+  /** Placeholder text shown when no option is selected. */
+  placeholder?: string;
+  /** Helper text under the trigger; doubles as the error message when
+   *  `isInvalid` is true. */
+  hint?: ReactNode;
+  /** Block all interaction and dim the trigger. */
+  isDisabled?: boolean;
+  /** Surface validation error styling. Auto-clears on selection. */
+  isInvalid?: boolean;
+  /** Mark the field as required. */
+  isRequired?: boolean;
+  /** Hide the visual `*` even when `isRequired` is true. */
+  hideRequiredIndicator?: boolean;
+  /** Visual scale of the underlying ComboBox. @default 'md' */
+  size?: LanguageSelectSize;
+  /** Tailwind override hook for the outer wrapper. */
+  className?: string;
+  /** Tailwind override hook for the popover surface. */
+  popoverClassName?: string;
+}
+
+export function LanguageSelect({
+  options = [],
+  value,
+  defaultValue,
+  onSelectionChange,
+  autoDetect = true,
+  locale,
+  label,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  placeholder,
+  hint,
+  isDisabled,
+  isInvalid,
+  isRequired,
+  hideRequiredIndicator,
+  size = 'md',
+  className,
+  popoverClassName,
+}: LanguageSelectProps) {
+  const resolvedLocale = useResolvedLocale(locale);
+  const items = useMemo(
+    () => buildLanguageItems(options, resolvedLocale),
+    [options, resolvedLocale],
+  );
+
+  const isHostControlled = value !== undefined;
+  const [internalKey, setInternalKey] = useState<string | null>(defaultValue ?? null);
+
+  useEffect(() => {
+    if (isHostControlled) return;
+    if (defaultValue !== undefined) return;
+    if (!autoDetect) return;
+    const detected = detectBrowserLanguage(options);
+    if (detected !== null) setInternalKey(detected);
+    // One-shot mount detection — explicit empty dep array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const effectiveKey = isHostControlled ? value : internalKey;
+
+  const [suppressInvalid, setSuppressInvalid] = useState(false);
+  useEffect(() => {
+    setSuppressInvalid(false);
+  }, [isInvalid]);
+
+  const handleSelectionChange = (key: Key | null) => {
+    const next = key === null ? null : String(key);
+    if (!isHostControlled) setInternalKey(next);
+    setSuppressInvalid(true);
+    onSelectionChange?.(next);
+  };
+
+  const handleFocusCapture = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.disabled || target.readOnly) return;
+    requestAnimationFrame(() => {
+      try {
+        target.select();
+      } catch {
+        // Input may have unmounted between the focus event and the rAF tick.
+      }
+    });
+  }, []);
+
+  const effectiveInvalid = isInvalid === true && !suppressInvalid;
+
+  const comboProps: Record<string, unknown> = {
+    items,
+    size,
+    selectedKey: effectiveKey ?? null,
+    onSelectionChange: handleSelectionChange,
+    defaultFilter: diacriticInsensitiveFilter,
+    shortcut: false,
+    icon: Translate01,
+  };
+
+  if (label !== undefined) comboProps.label = label;
+  if (ariaLabel !== undefined) comboProps['aria-label'] = ariaLabel;
+  if (ariaLabelledby !== undefined) comboProps['aria-labelledby'] = ariaLabelledby;
+  if (placeholder !== undefined) comboProps.placeholder = placeholder;
+  if (hint !== undefined) comboProps.hint = hint;
+  if (isDisabled === true) comboProps.isDisabled = true;
+  if (effectiveInvalid) comboProps.isInvalid = true;
+  if (isRequired === true) comboProps.isRequired = true;
+  if (hideRequiredIndicator === true) comboProps.hideRequiredIndicator = true;
+  if (className !== undefined) comboProps.className = className;
+  if (popoverClassName !== undefined) comboProps.popoverClassName = popoverClassName;
+
+  return (
+    <div onFocusCapture={handleFocusCapture}>
+      <ComboBox {...comboProps}>
+        {(item: SelectItemType) => <SelectItem id={item.id} label={item.label ?? ''} />}
+      </ComboBox>
+    </div>
+  );
+}
+
+/**
+ * Resolve the locale for language names + collation. Reads
+ * `navigator.language` lazily so SSR builds don't crash on a missing
+ * `navigator`. Falls back to `'en'`.
+ */
+function useResolvedLocale(locale: string | undefined): string {
+  return useMemo(() => {
+    if (locale !== undefined && locale.length > 0) return locale;
+    if (typeof navigator !== 'undefined' && navigator.language) {
+      return navigator.language;
+    }
+    return 'en';
+  }, [locale]);
+}

--- a/packages/ui/src/components/LanguageSelect/index.ts
+++ b/packages/ui/src/components/LanguageSelect/index.ts
@@ -1,0 +1,8 @@
+// Per memory note `feedback_knip_props_interfaces.md`: keep prop /
+// utility types un-exported until an external consumer needs them. The
+// component is re-exported via the package barrel
+// (`packages/ui/src/index.ts`) as `@glaon/ui`'s `LanguageSelect`. Helpers
+// (`buildLanguageItems`, `detectBrowserLanguage`, ...) ship in the same
+// module — add named exports here when an app feature imports them.
+
+export { LanguageSelect } from './LanguageSelect';

--- a/packages/ui/src/components/LanguageSelect/languages.ts
+++ b/packages/ui/src/components/LanguageSelect/languages.ts
@@ -1,0 +1,71 @@
+// LanguageSelect data + helpers.
+//
+// Unlike CountrySelect/TimezoneSelect/CurrencySelect, the candidate set
+// isn't a fixed Intl table — it's the app's *supported* languages (Glaon
+// ships en/tr today; HA could supply more later). So the option codes are
+// injected via the `options` prop; this module only turns codes into
+// localized labels (`Intl.DisplayNames(locale, { type: 'language' })`),
+// sorts them, and filters — the same runtime-locale approach as the sister
+// pickers, no shipped translation tables.
+
+import type { SelectItemType } from '../base/select/select-shared';
+
+// Standalone fallback for stories / consumers that don't inject a list.
+// Apps pass their own supported set (e.g. @glaon/core's SUPPORTED_LOCALES).
+const DEFAULT_LANGUAGES = ['en', 'tr', 'de', 'fr', 'es', 'it', 'pt', 'ar', 'ru', 'ja'] as const;
+
+/** Localized language name, e.g. `'tr'` → `'Türkçe'` (in tr) / `'Turkish'` (in en). */
+function languageName(code: string, locale: string): string {
+  try {
+    const dn = new Intl.DisplayNames([locale], { type: 'language' });
+    return dn.of(code) ?? code;
+  } catch {
+    return code;
+  }
+}
+
+/**
+ * Build a `{ id, label }` list from the injected language codes, sorted by
+ * the localized label via `Intl.Collator`. `id` is the BCP-47 code the
+ * consumer persists (e.g. `'tr'`). Falls back to a common set when
+ * `options` is empty so the primitive renders something in isolation.
+ */
+export function buildLanguageItems(options: readonly string[], locale: string): SelectItemType[] {
+  const codes = options.length > 0 ? options : DEFAULT_LANGUAGES;
+  const collator = new Intl.Collator(locale, { sensitivity: 'base' });
+  return codes
+    .map((code) => ({ id: code, label: languageName(code, locale) }))
+    .sort((a, b) => collator.compare(a.label, b.label));
+}
+
+/**
+ * Detect the browser's language (primary subtag of `navigator.language`)
+ * when it's one of the supported `options`. Returns `null` otherwise (or
+ * with no `navigator`), so the caller leaves the field unset. Pure browser
+ * API — no network call, SSR-safe.
+ */
+export function detectBrowserLanguage(options: readonly string[]): string | null {
+  if (typeof navigator === 'undefined') return null;
+  const tag = navigator.language;
+  if (!tag) return null;
+  const primary = tag.split('-')[0]?.toLowerCase();
+  if (primary === undefined || primary === '') return null;
+  const supported = (options.length > 0 ? options : DEFAULT_LANGUAGES).map((c) => c.toLowerCase());
+  return supported.includes(primary) ? primary : null;
+}
+
+/**
+ * Diacritic-insensitive substring filter — mirrors the helper in the
+ * sister pickers. Duplicated to keep this PR scoped; #589 tracks pulling
+ * the copies into a shared `_internal` module.
+ */
+export function diacriticInsensitiveFilter(textValue: string, inputValue: string): boolean {
+  if (!inputValue) return true;
+  return normaliseForSearch(textValue).includes(normaliseForSearch(inputValue));
+}
+
+const COMBINING_MARKS_RE = /[̀-ͯ]/g;
+
+function normaliseForSearch(s: string): string {
+  return s.normalize('NFD').replace(COMBINING_MARKS_RE, '').toLowerCase();
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -24,6 +24,7 @@ export * from './components/Drawer';
 export * from './components/Dropdown';
 export * from './components/FormField';
 export * from './components/Input';
+export * from './components/LanguageSelect';
 export * from './components/List';
 export * from './components/LocationPicker';
 export * from './components/Logo';

--- a/tools/figma-plugin/scripts/08-languageselect-frame.js
+++ b/tools/figma-plugin/scripts/08-languageselect-frame.js
@@ -1,0 +1,156 @@
+// Glaon — 08 LanguageSelect frame (#650)
+//
+// Creates the "App Primitives/LanguageSelect" COMPONENT in the Design
+// System Figma file: a search-select trigger (leading translate glyph,
+// "Language" label, "Select a language" placeholder, trailing chevron) —
+// the sister of CurrencySelect / TimezoneSelect / CountrySelect. The
+// component description carries `storybook-id: app-primitives-language-select`
+// (Chromatic Figma-diff contract; see docs/figma.md).
+//
+// Usage:
+//   1. Copy this file's contents into tools/figma-plugin/code.js.
+//   2. Open the Design System Figma file (Inter installed; else falls back
+//      to the default font).
+//   3. Run plugin (Plugins → Development → Glaon) → review dry-run.
+//   4. Flip CONFIRM = true → re-run → report the node id for the PR body.
+//   5. git restore tools/figma-plugin/code.js
+//
+// Idempotent: if the component exists, the script skips creation and
+// reports its id (adding the storybook-id description if missing).
+
+const CONFIRM = false;
+
+const COMPONENT_NAME = 'App Primitives/LanguageSelect';
+const STORYBOOK_ID = 'app-primitives-language-select';
+const FRAME_WIDTH = 360;
+
+const TOKENS = {
+  surface: { var: 'surface/default', hex: '#FFFFFF' },
+  border: { var: 'border/subtle', hex: '#E4E7EC' },
+  textPrimary: { var: 'text/primary', hex: '#181D27' },
+  textMuted: { var: 'text/muted', hex: '#717680' },
+};
+
+function hexToRgb(hex) {
+  const h = hex.replace('#', '');
+  return {
+    r: parseInt(h.slice(0, 2), 16) / 255,
+    g: parseInt(h.slice(2, 4), 16) / 255,
+    b: parseInt(h.slice(4, 6), 16) / 255,
+  };
+}
+
+(async () => {
+  try {
+    const existing = (await figma.root.findAllWithCriteria({ types: ['COMPONENT'] })).find(
+      (n) => n.name === COMPONENT_NAME,
+    );
+    if (existing) {
+      if (CONFIRM && !existing.description.includes(`storybook-id: ${STORYBOOK_ID}`)) {
+        existing.description =
+          (existing.description ? existing.description + '\n' : '') +
+          `storybook-id: ${STORYBOOK_ID}`;
+      }
+      figma.notify(`${CONFIRM ? '✅' : '🔍'} LanguageSelect already exists — id: ${existing.id}`, {
+        timeout: 12000,
+      });
+      console.log('[Glaon LanguageSelect] existing node id:', existing.id);
+      figma.closePlugin();
+      return;
+    }
+
+    const vars = await figma.variables.getLocalVariablesAsync();
+    const byName = new Map(vars.map((v) => [v.name, v]));
+    const fill = (key) => {
+      const t = TOKENS[key];
+      const paint = { type: 'SOLID', color: hexToRgb(t.hex) };
+      const v = byName.get(t.var);
+      return v ? figma.variables.setBoundVariableForPaint(paint, 'color', v) : paint;
+    };
+
+    if (!CONFIRM) {
+      figma.notify(
+        '🔍 DRY-RUN — would create "App Primitives/LanguageSelect" (360px): label + select trigger (translate glyph, placeholder, chevron). Flip CONFIRM to build.',
+        { timeout: 12000 },
+      );
+      figma.closePlugin();
+      return;
+    }
+
+    const FAMILY = 'Inter';
+    let fontReg = { family: FAMILY, style: 'Regular' };
+    let fontMed = { family: FAMILY, style: 'Medium' };
+    try {
+      await figma.loadFontAsync(fontReg);
+      await figma.loadFontAsync(fontMed);
+    } catch {
+      const fb = { family: 'Roboto', style: 'Regular' };
+      await figma.loadFontAsync(fb);
+      fontReg = fb;
+      fontMed = fb;
+    }
+
+    const text = (chars, font, size, colorKey) => {
+      const t = figma.createText();
+      t.fontName = font;
+      t.fontSize = size;
+      t.characters = chars;
+      t.fills = [fill(colorKey)];
+      return t;
+    };
+
+    const root = figma.createComponent();
+    root.name = COMPONENT_NAME;
+    root.description = `Glaon language picker (sister of CurrencySelect / TimezoneSelect / CountrySelect).\nstorybook-id: ${STORYBOOK_ID}`;
+    root.layoutMode = 'VERTICAL';
+    root.itemSpacing = 6;
+    root.fills = [];
+    root.resize(FRAME_WIDTH, 10);
+    root.primaryAxisSizingMode = 'AUTO';
+    root.counterAxisSizingMode = 'FIXED';
+
+    root.appendChild(text('Language', fontMed, 14, 'textPrimary'));
+
+    const trigger = figma.createFrame();
+    trigger.name = 'trigger';
+    trigger.layoutMode = 'HORIZONTAL';
+    trigger.itemSpacing = 8;
+    trigger.counterAxisAlignItems = 'CENTER';
+    trigger.paddingLeft = 12;
+    trigger.paddingRight = 12;
+    trigger.paddingTop = 10;
+    trigger.paddingBottom = 10;
+    trigger.cornerRadius = 8;
+    trigger.fills = [fill('surface')];
+    trigger.strokes = [fill('border')];
+    trigger.strokeWeight = 1;
+    trigger.layoutAlign = 'STRETCH';
+    trigger.counterAxisSizingMode = 'AUTO';
+
+    // Leading "translate" glyph — a simple "A文" mark.
+    const glyph = text('A文', fontReg, 14, 'textMuted');
+    trigger.appendChild(glyph);
+
+    const placeholder = text('Select a language', fontReg, 16, 'textMuted');
+    placeholder.layoutGrow = 1;
+    trigger.appendChild(placeholder);
+
+    const chevron = text('⌄', fontReg, 14, 'textMuted');
+    trigger.appendChild(chevron);
+
+    root.appendChild(trigger);
+
+    root.x = Math.round(figma.viewport.center.x - FRAME_WIDTH / 2);
+    root.y = Math.round(figma.viewport.center.y - 40);
+    figma.currentPage.appendChild(root);
+    figma.viewport.scrollAndZoomIntoView([root]);
+
+    figma.notify(`✅ Created "${COMPONENT_NAME}" — node id: ${root.id}`, { timeout: 15000 });
+    console.log('[Glaon LanguageSelect] created node id:', root.id);
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();


### PR DESCRIPTION
## Summary

Sub-issue E of #645 — the last picker primitive + the language de-dup:

- **New `LanguageSelect`** app-primitive — searchable picker mirroring the sister selects (CountrySelect/TimezoneSelect/CurrencySelect). Languages are **injected via `options`** (the app's supported set); labels are localized via `Intl.DisplayNames(locale, { type: 'language' })`. Ships story + controls + MDX + `aria-labelledby`/`aria-label` passthrough, with optional browser autodetect.
- **De-dup (2 → 1 language control):** Home Overview's plain language `Select` is replaced by `LanguageSelect`; selecting a language now **live-switches the wizard UI** (`i18n.changeLanguage`) *and* saves to HA core `language`. The redundant **sidebar `WizardLocaleSwitcher` is removed** — one language control, on step 1.

## Scope

**In:** `LanguageSelect` primitive (+ story/controls/MDX), Home Overview wiring, removal of the sidebar switcher in `setup-route.tsx`, Figma plugin script `scripts/08`.
**Out:** Dynamic-from-HA language list deferred — `options` is injectable; today it's `SUPPORTED_LOCALES` (en/tr). Layout reconcile (#652).

## Figma

⚠️ **Figma node ID: pending** — created by committed `scripts/08` (`storybook-id: app-primitives-language-select`).

## Test plan

- [x] UI unit incl. F6 prop-coverage covers LanguageSelect (165); full setup suite (100); type-check/lint/knip/i18n green.
- [ ] Storybook story-tests + a11y + Chromatic (CI).
- [ ] Manual: language live-switches the chrome + persists; one control visible.

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)