### PR TITLE
feat(core,api,web): layout per-step save with registry reconcile

### DIFF
--- a/apps/api/src/ha/ha-setup-service.ts
+++ b/apps/api/src/ha/ha-setup-service.ts
@@ -26,12 +26,15 @@ import {
   HaClient,
   buildHaSetupPlan,
   buildLayoutFromRegistries,
+  buildLayoutReconcilePlan,
   mapHaConfigResult,
+  type FloorRef,
   type HaAreaRegistryEntry,
   type HaConfigSeed,
   type HaFloorRegistryEntry,
   type HaLayoutResult,
   type HaSetupInput,
+  type ReconcileLayoutInput,
 } from '@glaon/core/ha';
 import type { ApplyHaResponse, ApplyHaStepResult } from '@glaon/core/api-client';
 
@@ -169,6 +172,124 @@ export async function readHaLayout(deps: ReadHaLayoutDeps): Promise<HaLayoutResu
 interface ReadHaLayoutDeps {
   readonly clientFactory: () => HaSetupClient;
   readonly logger?: Logger;
+}
+
+/**
+ * Reconcile HA's floor + area registries to the wizard's desired layout
+ * (#652). Reads the current registries, diffs them via the pure
+ * `buildLayoutReconcilePlan`, then executes the plan idempotently:
+ * create floors → create/update (rename + reparent) areas → delete areas
+ * → delete floors. Created floor ids are threaded into the areas that
+ * point at them. Best-effort + per-step (like `applyHaSetup`); connection
+ * failure is fail-loud (`HaCoreUnreachableError` → 502).
+ */
+export async function reconcileHaLayout(
+  desired: ReconcileLayoutInput,
+  deps: ApplyHaSetupDeps,
+): Promise<ApplyHaResponse> {
+  const client = deps.clientFactory();
+  const steps: ApplyHaStepResult[] = [];
+
+  try {
+    await client.connect();
+  } catch (err) {
+    throw new HaCoreUnreachableError(errMessage(err));
+  }
+
+  try {
+    // Read current registries (graceful-degrade to empty on a per-list
+    // failure, same as readHaLayout).
+    const floors = await client
+      .request<readonly HaFloorRegistryEntry[]>({ type: 'config/floor_registry/list' })
+      .catch(() => [] as readonly HaFloorRegistryEntry[]);
+    const areas = await client
+      .request<readonly HaAreaRegistryEntry[]>({ type: 'config/area_registry/list' })
+      .catch(() => [] as readonly HaAreaRegistryEntry[]);
+    const existing = buildLayoutFromRegistries(floors, areas);
+    const plan = buildLayoutReconcilePlan(existing, desired);
+
+    // 1. Create floors first, capturing the returned floor_id per key.
+    const keyToFloorId = new Map<string, string>();
+    for (const floor of plan.floorsToCreate) {
+      steps.push(
+        await runStep(`floor:create:${floor.name}`, deps.logger, async () => {
+          const result = await client.request<HaFloorRegistryEntry>({
+            type: 'config/floor_registry/create',
+            name: floor.name,
+            level: floor.level,
+          });
+          keyToFloorId.set(floor.key, result.floor_id);
+        }),
+      );
+    }
+
+    const resolveFloor = (ref: FloorRef): string | null =>
+      ref.kind === 'existing' ? ref.floorId : (keyToFloorId.get(ref.key) ?? null);
+
+    // 2. Rename floors.
+    for (const floor of plan.floorsToUpdate) {
+      steps.push(
+        await runStep(`floor:update:${floor.name}`, deps.logger, () =>
+          client.request({
+            type: 'config/floor_registry/update',
+            floor_id: floor.floorId,
+            name: floor.name,
+          }),
+        ),
+      );
+    }
+
+    // 3. Create areas under their (possibly just-created) floor.
+    for (const area of plan.areasToCreate) {
+      const floorId = resolveFloor(area.floor);
+      steps.push(
+        await runStep(`area:create:${area.name}`, deps.logger, () =>
+          client.request({
+            type: 'config/area_registry/create',
+            name: area.name,
+            ...(floorId !== null ? { floor_id: floorId } : {}),
+          }),
+        ),
+      );
+    }
+
+    // 4. Rename / reparent areas.
+    for (const area of plan.areasToUpdate) {
+      steps.push(
+        await runStep(`area:update:${area.areaId}`, deps.logger, () =>
+          client.request({
+            type: 'config/area_registry/update',
+            area_id: area.areaId,
+            ...(area.name !== undefined ? { name: area.name } : {}),
+            ...(area.floor !== undefined ? { floor_id: resolveFloor(area.floor) } : {}),
+          }),
+        ),
+      );
+    }
+
+    // 5. Delete removed areas, then 6. removed floors (areas first so a
+    // deleted floor never orphans an area).
+    for (const areaId of plan.areaIdsToDelete) {
+      steps.push(
+        await runStep(`area:delete:${areaId}`, deps.logger, () =>
+          client.request({ type: 'config/area_registry/delete', area_id: areaId }),
+        ),
+      );
+    }
+    for (const floorId of plan.floorIdsToDelete) {
+      steps.push(
+        await runStep(`floor:delete:${floorId}`, deps.logger, () =>
+          client.request({ type: 'config/floor_registry/delete', floor_id: floorId }),
+        ),
+      );
+    }
+  } finally {
+    await client.close().catch(() => {
+      /* ignore */
+    });
+  }
+
+  return { ok: steps.every((step) => step.ok), steps };
 }
 
 /**

--- a/apps/api/src/routes/setup.test.ts
+++ b/apps/api/src/routes/setup.test.ts
@@ -313,3 +313,88 @@ describe('setup — ha-config (#646)', () => {
     expect(await res.json()).toMatchObject({ error: 'ha-unreachable' });
   });
 });
+
+describe('setup — ha-layout reconcile (#652)', () => {
+  async function postLayout(
+    router: ReturnType<typeof createSetupRouter>,
+    body: unknown,
+  ): Promise<Response> {
+    return router.request('/ha-layout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const existingFloors = [{ floor_id: 'f-ground', name: 'Ground', level: 0 }];
+  const existingAreas = [
+    { area_id: 'a-living', name: 'Living', floor_id: 'f-ground' },
+    { area_id: 'a-garage', name: 'Garage', floor_id: null },
+  ];
+
+  it('responds 503 when HA Core is not configured', async () => {
+    const router = createSetupRouter({ config: baseConfig() });
+    const res = await postLayout(router, { floors: [{ id: 'f', name: 'F', rooms: [] }] });
+    expect(res.status).toBe(503);
+  });
+
+  it('responds 400 on a malformed body', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink }),
+    });
+    const res = await postLayout(router, { floors: [] }); // min(1) violated
+    expect(res.status).toBe(400);
+  });
+
+  it('creates a new floor + area and threads the created floor_id', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink, floors: [], areas: [] }),
+    });
+    const res = await postLayout(router, {
+      floors: [{ id: 'new-floor', name: 'Attic', rooms: [{ id: 'new-room', name: 'Studio' }] }],
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+    const floorCreate = sink.find((f) => f.type === 'config/floor_registry/create');
+    expect(floorCreate).toMatchObject({ name: 'Attic' });
+    const areaCreate = sink.find((f) => f.type === 'config/area_registry/create');
+    // fakeClient returns floor_id `floor_<name>` from the create.
+    expect(areaCreate).toMatchObject({ name: 'Studio', floor_id: 'floor_Attic' });
+  });
+
+  it('renames a floor + deletes a removed area, no stray creates (idempotent shape)', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink, floors: existingFloors, areas: existingAreas }),
+    });
+    const res = await postLayout(router, {
+      floors: [{ id: 'f-ground', name: 'Main', rooms: [{ id: 'a-living', name: 'Living' }] }],
+    });
+    expect(res.status).toBe(200);
+    expect(sink.find((f) => f.type === 'config/floor_registry/update')).toMatchObject({
+      floor_id: 'f-ground',
+      name: 'Main',
+    });
+    // a-garage (unassigned, dropped from desired) is deleted.
+    expect(sink.find((f) => f.type === 'config/area_registry/delete')).toMatchObject({
+      area_id: 'a-garage',
+    });
+    expect(sink.some((f) => f.type === 'config/floor_registry/create')).toBe(false);
+  });
+
+  it('responds 502 when the HA Core connection cannot be established', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink, connectError: new Error('ECONNREFUSED') }),
+    });
+    const res = await postLayout(router, { floors: [{ id: 'f', name: 'F', rooms: [] }] });
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -25,10 +25,11 @@ import {
   HaCoreUnreachableError,
   readHaConfig,
   readHaLayout,
+  reconcileHaLayout,
   type HaSetupClient,
 } from '../ha/ha-setup-service';
 import type { Logger } from '../observability/logger';
-import { ApplyHaRequestSchema } from '../schemas';
+import { ApplyHaRequestSchema, ReconcileLayoutRequestSchema } from '../schemas';
 
 interface SetupRouterDeps {
   readonly config: Config;
@@ -97,6 +98,35 @@ export function createSetupRouter(deps: SetupRouterDeps): Hono {
       }
       deps.logger?.error({
         event: 'setup.ha-config.failed',
+        message: err instanceof Error ? err.message : 'unknown',
+      });
+      return c.json({ error: 'internal' }, 500);
+    }
+  });
+
+  // Per-step Layout save (#652): reconcile the device's floor + area
+  // registries to the wizard's desired layout. Idempotent — safe to
+  // re-POST on back-navigation. Same auth posture + config-gating.
+  router.post('/ha-layout', async (c) => {
+    const raw: unknown = await c.req.json().catch(() => null);
+    const parsed = ReconcileLayoutRequestSchema.safeParse(raw);
+    if (!parsed.success) return c.json({ error: 'invalid-body' }, 400);
+
+    const factory = resolveFactory();
+    if (factory === undefined) return c.json(notConfigured, 503);
+    try {
+      const result = await reconcileHaLayout(parsed.data, {
+        clientFactory: factory,
+        ...(deps.logger !== undefined ? { logger: deps.logger } : {}),
+      });
+      return c.json(result, 200);
+    } catch (err) {
+      if (err instanceof HaCoreUnreachableError) {
+        deps.logger?.error({ event: 'setup.ha-layout-save.unreachable', message: err.message });
+        return c.json({ error: 'ha-unreachable' }, 502);
+      }
+      deps.logger?.error({
+        event: 'setup.ha-layout-save.failed',
         message: err instanceof Error ? err.message : 'unknown',
       });
       return c.json({ error: 'internal' }, 500);

--- a/apps/api/src/schemas.ts
+++ b/apps/api/src/schemas.ts
@@ -9,6 +9,7 @@
 
 export {
   ApplyHaRequestSchema,
+  ReconcileLayoutRequestSchema,
   AuthExchangeRequestSchema,
   AuthRefreshRequestSchema,
   HaPasswordGrantRequestSchema,

--- a/apps/web/src/features/setup/apply/apply-step.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.tsx
@@ -82,7 +82,9 @@ async function pushSettingsToHa(collected: DeviceConfigInput): Promise<HaApplyOu
   if (collected.timezone !== undefined) body.timezone = collected.timezone;
   if (collected.country !== undefined) body.country = collected.country;
   if (collected.locale !== undefined) body.locale = collected.locale;
-  if (collected.layout !== undefined) body.layout = collected.layout;
+  // `layout` is no longer sent here — the Layout step reconciles it to the
+  // device per-step via `POST /api/setup/ha-layout` (#652). Re-creating it
+  // through apply-ha would duplicate floors/rooms.
 
   // Nothing collected that maps to HA → no-op success.
   if (Object.keys(body).length === 0) return { kind: 'ok' };

--- a/apps/web/src/features/setup/layout/layout-api.ts
+++ b/apps/web/src/features/setup/layout/layout-api.ts
@@ -1,0 +1,50 @@
+// Layout step device I/O (#652). The per-step save (`POST /api/setup/
+// ha-layout`) reconciles the device's HA floor + area registries to the
+// editor's current layout — idempotent, so a back-navigation re-save
+// doesn't duplicate floors/rooms. Mirrors the home-overview save's
+// outcome mapping; raw `fetch` per the apps/web idiom.
+
+import type { Layout } from '@glaon/core/config';
+
+const HA_LAYOUT_URL = '/api/setup/ha-layout';
+
+/**
+ * Outcome of reconciling the layout to the device.
+ *   - `ok`       the reconcile landed (all steps succeeded).
+ *   - `skipped`  no HA Core configured (503) — expected in HA-less dev.
+ *   - `error`    couldn't reach apps/api / HA, or a step failed.
+ * Only `error` blocks advancement + surfaces a Toast.
+ */
+type SaveLayoutOutcome = 'ok' | 'skipped' | 'error';
+
+/**
+ * POST the editor's layout for reconcile. The body carries floor/room
+ * `id`s (HA registry ids for seeded entities, client UUIDs for new ones)
+ * so the server matches by id; room `type` is dropped server-side.
+ */
+export async function saveLayout(layout: Layout): Promise<SaveLayoutOutcome> {
+  const body = {
+    floors: layout.floors.map((floor) => ({
+      id: floor.id,
+      name: floor.name,
+      rooms: floor.rooms.map((room) => ({ id: room.id, name: room.name })),
+    })),
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(HA_LAYOUT_URL, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return 'error';
+  }
+  if (response.status === 503) return 'skipped';
+  if (!response.ok) return 'error';
+  const json = (await response.json().catch(() => null)) as { ok?: boolean } | null;
+  if (json === null) return 'error';
+  return json.ok === true ? 'ok' : 'error';
+}

--- a/apps/web/src/features/setup/layout/layout-step.test.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.test.tsx
@@ -25,13 +25,27 @@ function mockResponse(init: { ok?: boolean; status?: number; json?: unknown }): 
   } as unknown as Response;
 }
 
-beforeEach(() => {
-  // Default: HA Core not configured (503) → the step degrades silently to
-  // a blank default floor. Tests that exercise seeding override this.
+// URL/method-aware fetch: the GET seed (`ha-layout`) returns `seed` (or a
+// 503 when omitted → blank default floor); the per-step save (#652) POST
+// to `ha-layout` returns a successful reconcile so Next advances.
+function installFetch(seed?: unknown): void {
   vi.stubGlobal(
     'fetch',
-    vi.fn(() => Promise.resolve(mockResponse({ ok: false, status: 503, json: {} }))),
+    vi.fn((url: unknown, init?: { method?: string }) => {
+      const u = String(url);
+      if (u.includes('/api/setup/ha-layout') && init?.method === 'POST') {
+        return Promise.resolve(mockResponse({ json: { ok: true, steps: [] } }));
+      }
+      if (seed === undefined) {
+        return Promise.resolve(mockResponse({ ok: false, status: 503, json: {} }));
+      }
+      return Promise.resolve(mockResponse({ json: seed }));
+    }),
   );
+}
+
+beforeEach(() => {
+  installFetch();
 });
 
 afterEach(() => {
@@ -49,19 +63,10 @@ describe('LayoutStep', () => {
   });
 
   it('seeds floors + rooms from the device HA layout (#638)', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(() =>
-        Promise.resolve(
-          mockResponse({
-            json: {
-              floors: [{ id: 'f1', name: 'Garage Floor', rooms: [{ id: 'r1', name: 'Workshop' }] }],
-              unassigned: [{ id: 'r2', name: 'Patio' }],
-            },
-          }),
-        ),
-      ),
-    );
+    installFetch({
+      floors: [{ id: 'f1', name: 'Garage Floor', rooms: [{ id: 'r1', name: 'Workshop' }] }],
+      unassigned: [{ id: 'r2', name: 'Patio' }],
+    });
     const onNext = vi.fn();
     const { findByText, getByRole, getByDisplayValue } = render(
       wrap(<LayoutStep collected={{}} onNext={onNext} />),
@@ -69,9 +74,12 @@ describe('LayoutStep', () => {
     // The device floor pill + its room (in an input) render after the seed.
     expect(await findByText('Garage Floor')).toBeInTheDocument();
     expect(getByDisplayValue('Workshop')).toBeInTheDocument();
-    // Submitting carries both the device floor and the unassigned area
-    // (under the default-named floor).
+    // Submitting (per-step save → advance) carries both the device floor
+    // and the unassigned area (under the default-named floor).
     fireEvent.click(getByRole('button', { name: 'Next' }));
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
     const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
     expect(partial.layout?.floors.map((f) => f.name)).toEqual(['Garage Floor', 'Ground Floor']);
     expect(partial.layout?.floors[1]?.rooms.map((r) => r.name)).toEqual(['Patio']);
@@ -81,7 +89,9 @@ describe('LayoutStep', () => {
     const onNext = vi.fn();
     const { findByRole } = render(wrap(<LayoutStep collected={{}} onNext={onNext} />));
     fireEvent.click(await findByRole('button', { name: 'Next' }));
-    expect(onNext).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
     const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
     expect(partial.layout?.floors).toHaveLength(1);
     expect(partial.layout?.floors[0]?.name).toBe('Ground Floor');
@@ -93,6 +103,9 @@ describe('LayoutStep', () => {
     const { findByRole, getByRole } = render(wrap(<LayoutStep collected={{}} onNext={onNext} />));
     fireEvent.click(await findByRole('button', { name: /Add floor/i }));
     fireEvent.click(getByRole('button', { name: 'Next' }));
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
     const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
     expect(partial.layout?.floors).toHaveLength(2);
     expect(partial.layout?.floors[1]?.rooms).toEqual([]);
@@ -103,6 +116,9 @@ describe('LayoutStep', () => {
     const { findByRole, getByRole } = render(wrap(<LayoutStep collected={{}} onNext={onNext} />));
     fireEvent.click(await findByRole('button', { name: /Add your first room/i }));
     fireEvent.click(getByRole('button', { name: 'Next' }));
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
     const partial = onNext.mock.calls[0]?.[0] as { layout?: Layout };
     expect(partial.layout?.floors[0]?.rooms).toHaveLength(1);
     expect((partial.layout?.floors[0]?.rooms[0]?.name ?? '').length).toBeGreaterThan(0);

--- a/apps/web/src/features/setup/layout/layout-step.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.tsx
@@ -26,6 +26,7 @@ import type { DeviceConfigInput, Layout } from '@glaon/core/config';
 
 import { WizardBackButton } from '../wizard-back-button';
 import { FloorTabs } from './floor-tabs';
+import { saveLayout } from './layout-api';
 import { RoomGrid } from './room-grid';
 import { useLayoutState } from './use-layout-state';
 
@@ -154,6 +155,8 @@ interface LayoutEditorProps {
 
 function LayoutEditor({ initialLayout, onNext, onBack }: LayoutEditorProps): ReactNode {
   const { t } = useTranslation();
+  const toast = useToast();
+  const [isSaving, setIsSaving] = useState<boolean>(false);
 
   const { state, actions, toLayout } = useLayoutState({
     defaultFloorName: t('setup.layoutSetup.defaultFloorName'),
@@ -163,9 +166,25 @@ function LayoutEditor({ initialLayout, onNext, onBack }: LayoutEditorProps): Rea
   const activeFloor =
     state.floors.find((floor) => floor.id === state.activeFloorId) ?? state.floors[0];
 
-  const onSubmit = (event: SubmitEvent<HTMLFormElement>): void => {
+  // Per-step save (#652): reconcile the layout to the device before
+  // advancing. Idempotent, so a back-nav re-save doesn't duplicate. An
+  // `error` keeps the user here + surfaces a Toast; `ok`/`skipped` advance.
+  const onSubmit = async (event: SubmitEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
-    onNext({ layout: toLayout() });
+    if (isSaving) return;
+    const layout = toLayout();
+    setIsSaving(true);
+    const outcome = await saveLayout(layout);
+    if (outcome === 'error') {
+      setIsSaving(false);
+      toast.show({
+        intent: 'danger',
+        title: t('setup.layoutSetup.saveFailed.title'),
+        description: t('setup.layoutSetup.saveFailed.description'),
+      });
+      return;
+    }
+    onNext({ layout });
   };
 
   const onAddFloor = (): void => {
@@ -186,7 +205,13 @@ function LayoutEditor({ initialLayout, onNext, onBack }: LayoutEditorProps): Rea
     <div className="flex flex-col p-8 lg:p-12">
       <LayoutHeader />
 
-      <form onSubmit={onSubmit} noValidate className="flex flex-col gap-6">
+      <form
+        onSubmit={(event) => {
+          void onSubmit(event);
+        }}
+        noValidate
+        className="flex flex-col gap-6"
+      >
         <FloorTabs
           floors={state.floors}
           activeFloorId={state.activeFloorId}
@@ -218,10 +243,12 @@ function LayoutEditor({ initialLayout, onNext, onBack }: LayoutEditorProps): Rea
           {onBack !== undefined ? <WizardBackButton onBack={onBack} /> : <span />}
           <button
             type="submit"
-            className="inline-flex items-center gap-2 rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white shadow-xs-skeuomorphic hover:bg-brand-solid_hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+            disabled={isSaving}
+            aria-busy={isSaving}
+            className="inline-flex items-center gap-2 rounded-lg bg-brand-solid px-4 py-2 text-sm font-semibold text-white shadow-xs-skeuomorphic hover:bg-brand-solid_hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:cursor-not-allowed disabled:opacity-70"
           >
             <span>{t('setup.layoutSetup.actions.next')}</span>
-            <NextArrowIcon />
+            {isSaving ? <SavingSpinner /> : <NextArrowIcon />}
           </button>
         </div>
       </form>
@@ -243,6 +270,20 @@ function NextArrowIcon(): ReactNode {
       aria-hidden="true"
     >
       <path d="M4.167 10h11.666m0 0L10 4.167M15.833 10 10 15.833" />
+    </svg>
+  );
+}
+
+// Inline loading spinner shown on Next while the layout is saved (#652).
+function SavingSpinner(): ReactNode {
+  return (
+    <svg className="size-4 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4z"
+      />
     </svg>
   );
 }

--- a/apps/web/src/features/setup/setup-route.test.tsx
+++ b/apps/web/src/features/setup/setup-route.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { InMemoryConfigStore } from '@glaon/core/config';
@@ -30,7 +30,19 @@ beforeEach(() => {
   vi.stubEnv('VITE_APP_MODE', 'standalone');
   vi.stubGlobal(
     'fetch',
-    vi.fn(() => Promise.reject(new TypeError('network'))),
+    vi.fn((url: unknown, init?: { method?: string }) => {
+      // The Layout step's per-step save (#652) POSTs to ha-layout; resolve
+      // it so the Next path can advance. Everything else rejects (the GET
+      // seeds degrade to blank, which is what these routing tests want).
+      if (String(url).includes('/api/setup/ha-layout') && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ ok: true, steps: [] }),
+        } as Response);
+      }
+      return Promise.reject(new TypeError('network'));
+    }),
   );
 });
 afterEach(() => {
@@ -53,7 +65,10 @@ describe('SetupRoute', () => {
     // the blank editor; await its Next button before clicking.
     const { container, findByRole } = renderRoute('layout');
     fireEvent.click(await findByRole('button', { name: 'Next' }));
-    expect(container.querySelector('h1')?.textContent).toBe('Device Security');
+    // The layout save is async (#652) — wait for the advance.
+    await waitFor(() => {
+      expect(container.querySelector('h1')?.textContent).toBe('Device Security');
+    });
   });
 
   it('renders the Network step (after Security in the 5-step order)', () => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -144,6 +144,10 @@
       "loadFailed": {
         "title": "Couldn't load the current layout",
         "description": "Starting with a blank layout — add floors and rooms below."
+      },
+      "saveFailed": {
+        "title": "Couldn't save the layout",
+        "description": "Your floors and rooms weren't saved. Check the connection and try again."
       }
     },
     "wifi": {

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -144,6 +144,10 @@
       "loadFailed": {
         "title": "Mevcut yerleşim yüklenemedi",
         "description": "Boş bir yerleşimle başlıyoruz — aşağıdan kat ve oda ekleyebilirsin."
+      },
+      "saveFailed": {
+        "title": "Yerleşim kaydedilemedi",
+        "description": "Katların ve odaların kaydedilmedi. Bağlantını kontrol edip tekrar dene."
       }
     },
     "wifi": {

--- a/packages/core/src/api-client/index.ts
+++ b/packages/core/src/api-client/index.ts
@@ -54,9 +54,11 @@ export {
   ApplyHaStepResultSchema,
   HaLayoutResponseSchema,
   HaConfigResponseSchema,
+  ReconcileLayoutRequestSchema,
   type ApplyHaRequest,
   type ApplyHaResponse,
   type ApplyHaStepResult,
   type HaLayoutResponse,
   type HaConfigResponse,
+  type ReconcileLayoutRequest,
 } from './setup';

--- a/packages/core/src/api-client/setup.ts
+++ b/packages/core/src/api-client/setup.ts
@@ -97,6 +97,25 @@ export type HaLayoutResponse = z.infer<typeof HaLayoutResponseSchema>;
  * matches `HaConfigSeed` (ha/setup-commands.ts), the pure mapper apps/api
  * builds it from.
  */
+/**
+ * Request body for `POST /setup/ha-layout` (#652): the wizard's desired
+ * layout. Floor/room ids are either HA registry ids (seeded entities) or
+ * client UUIDs (newly added) — the server's reconcile matches by id.
+ * Structurally matches `ReconcileLayoutInput` (ha/setup-commands.ts). Room
+ * `type` is intentionally not accepted: it's app-local and never reaches
+ * the HA area registry.
+ */
+const ReconcileRoomSchema = z.object({ id: z.string().min(1), name: z.string().min(1).max(64) });
+const ReconcileFloorSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1).max(64),
+  rooms: z.array(ReconcileRoomSchema).max(50),
+});
+export const ReconcileLayoutRequestSchema = z.object({
+  floors: z.array(ReconcileFloorSchema).min(1).max(10),
+});
+export type ReconcileLayoutRequest = z.infer<typeof ReconcileLayoutRequestSchema>;
+
 export const HaConfigResponseSchema = z.object({
   latitude: z.number().optional(),
   longitude: z.number().optional(),

--- a/packages/core/src/ha/protocol/messages.ts
+++ b/packages/core/src/ha/protocol/messages.ts
@@ -192,6 +192,48 @@ export interface HaAreaRegistryEntry {
   readonly floor_id?: string | null;
 }
 
+/* ---------- Registry mutations for layout reconcile (#652) ---------- */
+
+/**
+ * `config/floor_registry/update` — rename an existing floor. Used by the
+ * wizard's per-step Layout reconcile to apply a renamed floor without
+ * recreating it (which would orphan its areas).
+ */
+export interface HaFloorRegistryUpdateFrame {
+  readonly id: number;
+  readonly type: 'config/floor_registry/update';
+  readonly floor_id: string;
+  readonly name?: string;
+  readonly level?: number;
+}
+
+/** `config/floor_registry/delete` — remove a floor the user dropped. */
+export interface HaFloorRegistryDeleteFrame {
+  readonly id: number;
+  readonly type: 'config/floor_registry/delete';
+  readonly floor_id: string;
+}
+
+/**
+ * `config/area_registry/update` — rename and/or reparent an area. The
+ * reconcile uses it to apply renames and to move a (previously floorless)
+ * area under its floor. `floor_id: null` clears the floor link.
+ */
+export interface HaAreaRegistryUpdateFrame {
+  readonly id: number;
+  readonly type: 'config/area_registry/update';
+  readonly area_id: string;
+  readonly name?: string;
+  readonly floor_id?: string | null;
+}
+
+/** `config/area_registry/delete` — remove an area the user dropped. */
+export interface HaAreaRegistryDeleteFrame {
+  readonly id: number;
+  readonly type: 'config/area_registry/delete';
+  readonly area_id: string;
+}
+
 /**
  * `get_config` — reads HA Core's current configuration (location, unit
  * system, time zone, currency, country, language). Used to seed the
@@ -254,5 +296,9 @@ export type HaOutboundFrame =
   | HaConfigCoreUpdateFrame
   | HaFloorRegistryCreateFrame
   | HaFloorRegistryListFrame
+  | HaFloorRegistryUpdateFrame
+  | HaFloorRegistryDeleteFrame
   | HaAreaRegistryCreateFrame
-  | HaAreaRegistryListFrame;
+  | HaAreaRegistryListFrame
+  | HaAreaRegistryUpdateFrame
+  | HaAreaRegistryDeleteFrame;

--- a/packages/core/src/ha/setup-commands.test.ts
+++ b/packages/core/src/ha/setup-commands.test.ts
@@ -4,6 +4,7 @@ import type { HaAreaRegistryEntry, HaFloorRegistryEntry } from './protocol/messa
 import {
   buildHaSetupPlan,
   buildLayoutFromRegistries,
+  buildLayoutReconcilePlan,
   mapHaConfigResult,
   type HaSetupInput,
 } from './setup-commands';
@@ -171,5 +172,105 @@ describe('mapHaConfigResult — get_config → Home Overview seed (#646)', () =>
     expect(mapHaConfigResult(null)).toEqual({});
     expect(mapHaConfigResult(undefined)).toEqual({});
     expect(mapHaConfigResult('x')).toEqual({});
+  });
+});
+
+describe('buildLayoutReconcilePlan — desired vs existing registries (#652)', () => {
+  const existing = {
+    floors: [
+      { id: 'f-ground', name: 'Ground', rooms: [{ id: 'a-living', name: 'Living' }] },
+      { id: 'f-up', name: 'Upstairs', rooms: [{ id: 'a-bed', name: 'Bedroom' }] },
+    ],
+    unassigned: [{ id: 'a-garage', name: 'Garage' }],
+  };
+
+  it('is a no-op when desired matches existing (idempotent re-save)', () => {
+    const plan = buildLayoutReconcilePlan(existing, {
+      floors: [
+        { id: 'f-ground', name: 'Ground', rooms: [{ id: 'a-living', name: 'Living' }] },
+        { id: 'f-up', name: 'Upstairs', rooms: [{ id: 'a-bed', name: 'Bedroom' }] },
+      ],
+    });
+    // a-garage is unassigned + absent from desired → it gets deleted; the
+    // rest is unchanged.
+    expect(plan.floorsToCreate).toEqual([]);
+    expect(plan.floorsToUpdate).toEqual([]);
+    expect(plan.floorIdsToDelete).toEqual([]);
+    expect(plan.areasToCreate).toEqual([]);
+    expect(plan.areasToUpdate).toEqual([]);
+    expect(plan.areaIdsToDelete).toEqual(['a-garage']);
+  });
+
+  it('renames a floor and a room in place (no recreate)', () => {
+    const plan = buildLayoutReconcilePlan(
+      { floors: existing.floors, unassigned: [] },
+      {
+        floors: [
+          { id: 'f-ground', name: 'Main', rooms: [{ id: 'a-living', name: 'Lounge' }] },
+          { id: 'f-up', name: 'Upstairs', rooms: [{ id: 'a-bed', name: 'Bedroom' }] },
+        ],
+      },
+    );
+    expect(plan.floorsToUpdate).toEqual([{ floorId: 'f-ground', name: 'Main' }]);
+    expect(plan.areasToUpdate).toEqual([{ areaId: 'a-living', name: 'Lounge' }]);
+    expect(plan.floorsToCreate).toEqual([]);
+    expect(plan.areaIdsToDelete).toEqual([]);
+  });
+
+  it('creates new floors/rooms (client-UUID ids) and threads the floor key', () => {
+    const plan = buildLayoutReconcilePlan(
+      { floors: [], unassigned: [] },
+      { floors: [{ id: 'new-floor', name: 'Attic', rooms: [{ id: 'new-room', name: 'Studio' }] }] },
+    );
+    expect(plan.floorsToCreate).toEqual([{ key: 'new-floor', name: 'Attic', level: 0 }]);
+    expect(plan.areasToCreate).toEqual([
+      { name: 'Studio', floor: { kind: 'new', key: 'new-floor' } },
+    ]);
+  });
+
+  it('deletes floors and rooms the user removed', () => {
+    const plan = buildLayoutReconcilePlan(existing, {
+      floors: [{ id: 'f-ground', name: 'Ground', rooms: [{ id: 'a-living', name: 'Living' }] }],
+    });
+    expect(plan.floorIdsToDelete).toEqual(['f-up']);
+    expect([...plan.areaIdsToDelete].sort()).toEqual(['a-bed', 'a-garage']);
+  });
+
+  it('reparents a formerly-unassigned area under a newly-created floor', () => {
+    const plan = buildLayoutReconcilePlan(existing, {
+      floors: [
+        { id: 'f-ground', name: 'Ground', rooms: [{ id: 'a-living', name: 'Living' }] },
+        { id: 'f-up', name: 'Upstairs', rooms: [{ id: 'a-bed', name: 'Bedroom' }] },
+        // Synthetic floor the UI created for the unassigned Garage.
+        { id: 'f-new', name: 'Ground Floor', rooms: [{ id: 'a-garage', name: 'Garage' }] },
+      ],
+    });
+    expect(plan.floorsToCreate).toEqual([{ key: 'f-new', name: 'Ground Floor', level: 2 }]);
+    expect(plan.areasToUpdate).toEqual([
+      { areaId: 'a-garage', floor: { kind: 'new', key: 'f-new' } },
+    ]);
+    expect(plan.areaIdsToDelete).toEqual([]);
+  });
+
+  it('reparents an area moved between two existing floors', () => {
+    const plan = buildLayoutReconcilePlan(
+      { floors: existing.floors, unassigned: [] },
+      {
+        floors: [
+          { id: 'f-ground', name: 'Ground', rooms: [] },
+          {
+            id: 'f-up',
+            name: 'Upstairs',
+            rooms: [
+              { id: 'a-bed', name: 'Bedroom' },
+              { id: 'a-living', name: 'Living' },
+            ],
+          },
+        ],
+      },
+    );
+    expect(plan.areasToUpdate).toEqual([
+      { areaId: 'a-living', floor: { kind: 'existing', floorId: 'f-up' } },
+    ]);
   });
 });

--- a/packages/core/src/ha/setup-commands.ts
+++ b/packages/core/src/ha/setup-commands.ts
@@ -265,6 +265,145 @@ export function buildLayoutFromRegistries(
   return { floors: mappedFloors, unassigned };
 }
 
+// ---- Layout reconcile: desired Layout vs existing HA registries (#652) ----
+
+/** Desired layout shape the reconcile reads (subset of config `Layout`). */
+export interface ReconcileLayoutInput {
+  readonly floors: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly rooms: readonly { readonly id: string; readonly name: string }[];
+  }[];
+}
+
+/** A floor reference an area's create/update points at. `new` floors are
+ *  created first; the service resolves `key` to the returned floor_id. */
+export type FloorRef =
+  | { readonly kind: 'existing'; readonly floorId: string }
+  | { readonly kind: 'new'; readonly key: string };
+
+export interface ReconcileFloorCreate {
+  /** The desired floor's client id — the thread key areas reference. */
+  readonly key: string;
+  readonly name: string;
+  readonly level: number;
+}
+export interface ReconcileFloorUpdate {
+  readonly floorId: string;
+  readonly name: string;
+}
+export interface ReconcileAreaCreate {
+  readonly name: string;
+  readonly floor: FloorRef;
+}
+export interface ReconcileAreaUpdate {
+  readonly areaId: string;
+  /** Present only when the name changed. */
+  readonly name?: string;
+  /** Present only when the floor changed (rename-only updates omit it). */
+  readonly floor?: FloorRef;
+}
+
+/**
+ * Idempotent reconcile plan: what to create / update / delete so HA's
+ * floor + area registries match the wizard's desired layout (#652). Pure —
+ * the service (`reconcileHaLayout`) executes it, threading created floor
+ * ids into the areas that point at them. Ordering for the executor:
+ * create floors → create/update areas → delete areas → delete floors
+ * (floors last so areas are moved off them before removal).
+ */
+export interface LayoutReconcilePlan {
+  readonly floorsToCreate: readonly ReconcileFloorCreate[];
+  readonly floorsToUpdate: readonly ReconcileFloorUpdate[];
+  readonly floorIdsToDelete: readonly string[];
+  readonly areasToCreate: readonly ReconcileAreaCreate[];
+  readonly areasToUpdate: readonly ReconcileAreaUpdate[];
+  readonly areaIdsToDelete: readonly string[];
+}
+
+/**
+ * Diff the device's current registries (`existing`, from
+ * `buildLayoutFromRegistries`) against the wizard's `desired` layout and
+ * produce a reconcile plan. Matching is by id: a desired floor/room whose
+ * id equals an existing registry id is the same entity (rename/reparent);
+ * an unmatched desired entity is new (create); an existing id absent from
+ * the desired layout is removed (delete). Pure + deterministic.
+ */
+export function buildLayoutReconcilePlan(
+  existing: HaLayoutResult,
+  desired: ReconcileLayoutInput,
+): LayoutReconcilePlan {
+  const existingFloorIds = new Set(existing.floors.map((f) => f.id));
+  const existingFloorNameById = new Map(existing.floors.map((f) => [f.id, f.name]));
+
+  // area_id → { name, floorId|null } across assigned + unassigned areas.
+  const existingAreas = new Map<string, { name: string; floorId: string | null }>();
+  for (const floor of existing.floors) {
+    for (const room of floor.rooms)
+      existingAreas.set(room.id, { name: room.name, floorId: floor.id });
+  }
+  for (const room of existing.unassigned) {
+    existingAreas.set(room.id, { name: room.name, floorId: null });
+  }
+
+  const floorsToCreate: ReconcileFloorCreate[] = [];
+  const floorsToUpdate: ReconcileFloorUpdate[] = [];
+  const areasToCreate: ReconcileAreaCreate[] = [];
+  const areasToUpdate: ReconcileAreaUpdate[] = [];
+
+  const desiredFloorIds = new Set<string>();
+  const desiredAreaIds = new Set<string>();
+
+  desired.floors.forEach((floor, index) => {
+    desiredFloorIds.add(floor.id);
+    const floorIsExisting = existingFloorIds.has(floor.id);
+    if (floorIsExisting) {
+      if (existingFloorNameById.get(floor.id) !== floor.name) {
+        floorsToUpdate.push({ floorId: floor.id, name: floor.name });
+      }
+    } else {
+      floorsToCreate.push({ key: floor.id, name: floor.name, level: index });
+    }
+    const floorRef: FloorRef = floorIsExisting
+      ? { kind: 'existing', floorId: floor.id }
+      : { kind: 'new', key: floor.id };
+
+    for (const room of floor.rooms) {
+      desiredAreaIds.add(room.id);
+      const prior = existingAreas.get(room.id);
+      if (prior === undefined) {
+        areasToCreate.push({ name: room.name, floor: floorRef });
+        continue;
+      }
+      const nameChanged = prior.name !== room.name;
+      // Floor changed when the target is a brand-new floor, or an existing
+      // floor id that differs from where the area currently sits.
+      const floorChanged = floorRef.kind === 'new' ? true : prior.floorId !== floorRef.floorId;
+      if (nameChanged || floorChanged) {
+        areasToUpdate.push({
+          areaId: room.id,
+          ...(nameChanged ? { name: room.name } : {}),
+          ...(floorChanged ? { floor: floorRef } : {}),
+        });
+      }
+    }
+  });
+
+  const floorIdsToDelete = existing.floors
+    .map((f) => f.id)
+    .filter((id) => !desiredFloorIds.has(id));
+  const areaIdsToDelete = [...existingAreas.keys()].filter((id) => !desiredAreaIds.has(id));
+
+  return {
+    floorsToCreate,
+    floorsToUpdate,
+    floorIdsToDelete,
+    areasToCreate,
+    areasToUpdate,
+    areaIdsToDelete,
+  };
+}
+
 /**
  * Glaon's `imperial` is HA's `us_customary`; `metric` is shared. Kept
  * as a function (not a record) so an unexpected value fails the type


### PR DESCRIPTION
## Summary

Sub-issue G′ of #645 (split from #646) — the final wizard piece. The **Layout step now saves to the device per-step** (on Next) instead of only at the terminal Apply step, via an **idempotent registry reconcile**:

- **`@glaon/core`:** new HA frames `config/{floor,area}_registry/{update,delete}` + a pure **`buildLayoutReconcilePlan(existing, desired)`** — diffs the desired layout against the device's current floors/areas, **matching by id** (HA registry id for seeded entities, client UUID for new ones): rename/reparent existing, create new, delete removed.
- **`apps/api`:** **`reconcileHaLayout`** executes the plan — create floors → create/update (rename + reparent) areas → delete areas → delete floors (floors last so areas aren't orphaned), threading created floor ids — behind **`POST /api/setup/ha-layout`**.
- **`apps/web`:** the Layout step POSTs the layout on Next (loading state, Toast on failure); a back-nav re-save is safe (idempotent). The **Apply step no longer pushes `layout`** (it would duplicate floors/rooms).

## Scope

**In:** core frames + reconcile planner (+ unit tests), api service + route (+ tests), `layout-api.ts` + layout-step per-step save, apply-step layout removal, i18n `setup.layoutSetup.saveFailed`.
**Out:** No UI restructure (existing button gains a spinner) — no new Figma frame.

## Test plan

- [x] core `buildLayoutReconcilePlan` — no-op/rename/create/delete/reparent (23 setup-commands tests).
- [x] api `POST /ha-layout` — create+thread floor_id, rename+delete, 400/503/502 (19 route tests).
- [x] web — layout-step per-step save + loading, setup-route advance; full setup suite (100).
- [x] type-check (11), lint, knip, i18n green.
- [ ] Playwright @smoke + Chromatic (CI).
- [ ] Manual: re-saving the layout (back-nav) produces no duplicate floors/rooms on the device.

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)