### PR TITLE
refactor(web): per-step save for Network + Security, slim Apply commit

### DIFF
--- a/apps/web/src/features/setup/apply/apply-step.test.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.test.tsx
@@ -161,7 +161,7 @@ describe('ApplyStep — commit', () => {
     expect(findPost('/network/interface/')).toBeUndefined();
   });
 
-  it('pushes the hostname and a static IPv4 config, then reloads', async () => {
+  it('does NOT re-push hostname/IP at commit — they were saved per-step (#653)', async () => {
     const collected = {
       ...baseCollected,
       network: {
@@ -184,9 +184,10 @@ describe('ApplyStep — commit', () => {
     await waitFor(() => {
       expect(reloadSpy).toHaveBeenCalledTimes(1);
     });
-    expect(postBody(findPost('/host/options'))).toMatchObject({ hostname: 'glaon-wall' });
-    const ifaceBody = postBody(findPost('/network/interface/end0/update'));
-    expect(ifaceBody).toMatchObject({ ipv4: { method: 'static', address: ['192.168.1.50/24'] } });
+    // The Network step pushed these on its own Next; Apply (no Wi-Fi here)
+    // must not touch the Supervisor.
+    expect(findPost('/host/options')).toBeUndefined();
+    expect(findPost('/network/interface/end0/update')).toBeUndefined();
   });
 
   it('commits an unsecured Wi-Fi without opening the handoff modal', async () => {
@@ -246,28 +247,14 @@ describe('ApplyStep — commit', () => {
     expect(reloadSpy).not.toHaveBeenCalled();
   });
 
-  it('aborts before the network push and toasts when the HA-settings push fails', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((url: unknown) => {
-        const u = String(url);
-        if (u.includes('/api/setup/apply-ha')) {
-          return Promise.resolve(
-            mockFetchResponse({
-              json: { ok: false, steps: [{ step: 'core', ok: false, error: 'boom' }] },
-            }),
-          );
-        }
-        return Promise.resolve(mockFetchResponse({ json: { result: 'ok' } }));
-      }),
-    );
-    const collected = { ...baseCollected, wifi: { ssid: 'Guest', passwordCipher: '(unsecured)' } };
-    const { getByRole, findByRole } = render(wrap(<ApplyStep collected={collected} />));
+  it('does NOT push HA settings at commit — they were saved per-step (#646/#653)', async () => {
+    const { getByRole } = render(wrap(<ApplyStep collected={baseCollected} />));
     fireEvent.click(getByRole('button', { name: 'Save and switch network' }));
-    expect(await findByRole('status')).toBeInTheDocument();
-    expect(reloadSpy).not.toHaveBeenCalled();
-    // The destructive network push never fired.
-    expect(findPost('/network/interface/')).toBeUndefined();
+    await waitFor(() => {
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+    // The slimmed commit (#653) never re-pushes home settings to apply-ha.
+    expect(findPost('/api/setup/apply-ha')).toBeUndefined();
   });
 });
 

--- a/apps/web/src/features/setup/apply/apply-step.tsx
+++ b/apps/web/src/features/setup/apply/apply-step.tsx
@@ -22,7 +22,6 @@ import { Button, useToast } from '@glaon/ui';
 import { useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import type { ApplyHaResponse } from '@glaon/core/api-client';
 import type { DeviceConfigInput, InterfaceConfig, IpConfig, Layout } from '@glaon/core/config';
 
 import { useDeviceConfig } from '../../../config/config-provider';
@@ -30,9 +29,7 @@ import {
   DEFAULT_WIRELESS_INTERFACE,
   NETWORK_INFO_URL,
   findWirelessInterface,
-  pushHostname,
   pushInterfaceUpdate,
-  toSupervisorIpBlock,
 } from '../network/network-api';
 import { HandoffModal } from '../wifi/handoff-modal';
 import { HandoffOverlay } from '../wifi/handoff-overlay';
@@ -48,63 +45,12 @@ interface ApplyStepProps {
   readonly onBack?: () => void;
 }
 
-// #617 — apps/api endpoint that pushes the collected home settings into
-// HA Core (config/core/update + floor/area registry) over WebSocket.
-const HA_APPLY_SETTINGS = '/api/setup/apply-ha';
-
 // Hard-coded URL the QR code encodes. The mDNS responder advertises the
 // device under `glaon.local` on the home network (addon-side concern).
 const DEVICE_URL_AFTER_HANDOFF = 'http://glaon.local';
 
 function isSecuredCipher(cipher: string | undefined): boolean {
   return cipher !== undefined && cipher !== '' && cipher !== '(unsecured)';
-}
-
-/**
- * Outcome of pushing the collected home settings into HA Core (#617).
- *   - `ok`       every command landed.
- *   - `skipped`  apps/api has no HA Core configured (503) — expected in
- *                dev when HA_CORE_* is unset; not a user-facing error.
- *   - `partial`  some commands failed (HA reachable, rejected a step).
- *   - `error`    couldn't reach apps/api / HA, or a malformed response.
- */
-type HaApplyOutcome =
-  | { readonly kind: 'ok' }
-  | { readonly kind: 'skipped' }
-  | { readonly kind: 'partial' }
-  | { readonly kind: 'error' };
-
-async function pushSettingsToHa(collected: DeviceConfigInput): Promise<HaApplyOutcome> {
-  const body: Record<string, unknown> = {};
-  if (collected.latitude !== undefined) body.latitude = collected.latitude;
-  if (collected.longitude !== undefined) body.longitude = collected.longitude;
-  if (collected.unitSystem !== undefined) body.unitSystem = collected.unitSystem;
-  if (collected.timezone !== undefined) body.timezone = collected.timezone;
-  if (collected.country !== undefined) body.country = collected.country;
-  if (collected.locale !== undefined) body.locale = collected.locale;
-  // `layout` is no longer sent here — the Layout step reconciles it to the
-  // device per-step via `POST /api/setup/ha-layout` (#652). Re-creating it
-  // through apply-ha would duplicate floors/rooms.
-
-  // Nothing collected that maps to HA → no-op success.
-  if (Object.keys(body).length === 0) return { kind: 'ok' };
-
-  let response: Response;
-  try {
-    response = await fetch(HA_APPLY_SETTINGS, {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-  } catch {
-    return { kind: 'error' };
-  }
-  if (response.status === 503) return { kind: 'skipped' };
-  if (!response.ok) return { kind: 'error' };
-  const json = (await response.json().catch(() => null)) as ApplyHaResponse | null;
-  if (json === null) return { kind: 'error' };
-  return json.ok ? { kind: 'ok' } : { kind: 'partial' };
 }
 
 /** Discover the wireless interface so the Wi-Fi handoff targets the right
@@ -178,50 +124,23 @@ export function ApplyStep({ collected, onBack }: ApplyStepProps): ReactNode {
   async function runCommit(wifiPassword: string): Promise<void> {
     setHandoffPhase('committing');
 
-    // Push home settings to HA *before* touching the network — non-
-    // destructive, network still stable, so a failure aborts cleanly. A
-    // `skipped` outcome (no HA Core configured — dev 503) proceeds.
-    const haOutcome = await pushSettingsToHa(collected);
-    if (haOutcome.kind === 'error' || haOutcome.kind === 'partial') {
-      setHandoffPhase(wifiSecured ? 'confirming' : 'idle');
-      toast.show({
-        intent: 'danger',
-        title: t('setup.apply.haSettingsFailed.title'),
-        description: t('setup.apply.haSettingsFailed.description'),
-      });
-      return;
-    }
-
     try {
-      // Hostname first — cheap and non-destructive.
-      if (collected.network?.hostname !== undefined) {
-        await pushHostname(collected.network.hostname);
+      // Everything non-destructive is already on the device via per-step
+      // saves: HA settings (#646), layout (#652), hostname + IP config
+      // (#653), and the security config. All that's left here is the
+      // destructive Wi-Fi join — push the credentials to the wireless
+      // interface, which is the AP→home disconnect moment.
+      if (wifi !== undefined) {
+        const wirelessIface = await discoverWirelessInterface();
+        const wifiBody = wifiSecured
+          ? { mode: 'infrastructure', auth: 'wpa-psk', ssid: wifi.ssid, psk: wifiPassword }
+          : { mode: 'infrastructure', auth: 'open', ssid: wifi.ssid };
+        await pushInterfaceUpdate(wirelessIface, { wifi: wifiBody });
       }
 
-      // Per-interface IP config. The wireless interface's update folds in
-      // the Wi-Fi credentials so the home-network join is one request.
-      const wirelessIface = wifi !== undefined ? await discoverWirelessInterface() : undefined;
-      const interfaces = collected.network?.interfaces ?? [];
-      const wifiBody = wifiSecured
-        ? { mode: 'infrastructure', auth: 'wpa-psk', ssid: wifi.ssid, psk: wifiPassword }
-        : { mode: 'infrastructure', auth: 'open', ssid: wifi?.ssid };
-
-      for (const iface of interfaces) {
-        const body: Record<string, unknown> = {};
-        if (iface.ipv4 !== undefined) body.ipv4 = toSupervisorIpBlock(iface.ipv4);
-        if (iface.ipv6 !== undefined) body.ipv6 = toSupervisorIpBlock(iface.ipv6);
-        if (iface.name === wirelessIface && wifi !== undefined) body.wifi = wifiBody;
-        if (Object.keys(body).length > 0) await pushInterfaceUpdate(iface.name, body);
-      }
-
-      // Edge: Wi-Fi was chosen but the Network step never collected an
-      // interface list (it degraded to "unavailable") — push Wi-Fi on its
-      // own to the discovered wireless interface.
-      const wirelessInList = interfaces.some((i) => i.name === wirelessIface);
-      if (wifi !== undefined && !wirelessInList) {
-        await pushInterfaceUpdate(wirelessIface ?? DEFAULT_WIRELESS_INTERFACE, { wifi: wifiBody });
-      }
-
+      // Mirror the full collected blob into the ConfigStore + mark the
+      // wizard complete. (Most fields were already persisted per-step; this
+      // is the authoritative final write + the `completedAt` flip.)
       await setPartial(collected);
       await markComplete();
       // Wizard complete — drop the Wi-Fi wrap key so a future visit never

--- a/apps/web/src/features/setup/network/network-api.ts
+++ b/apps/web/src/features/setup/network/network-api.ts
@@ -5,7 +5,7 @@
 // (`supervisor-not-configured`) means this environment genuinely can't
 // reach a Supervisor (HA-less dev); callers degrade gracefully.
 
-import type { IpConfig, IpMethod } from '@glaon/core/config';
+import type { IpConfig, IpMethod, NetworkConfig } from '@glaon/core/config';
 
 export const NETWORK_INFO_URL = '/api/hassio/network/info';
 export const HOST_INFO_URL = '/api/hassio/host/info';
@@ -131,8 +131,9 @@ export function parseHostname(json: unknown): string | undefined {
   return typeof hostname === 'string' && hostname !== '' ? hostname : undefined;
 }
 
-/** Push the device hostname to the Supervisor host API. Throws on non-ok. */
-export async function pushHostname(hostname: string): Promise<void> {
+/** Push the device hostname to the Supervisor host API. Throws on non-ok.
+ *  Internal — only `saveNetworkConfig` calls it now (#653). */
+async function pushHostname(hostname: string): Promise<void> {
   const response = await fetch(HOST_OPTIONS_URL, {
     method: 'POST',
     credentials: 'include',
@@ -152,8 +153,9 @@ interface SupervisorIpBlock {
   readonly nameservers?: string[];
 }
 
-/** Map a collected `IpConfig` to the Supervisor update wire shape. */
-export function toSupervisorIpBlock(config: IpConfig): SupervisorIpBlock {
+/** Map a collected `IpConfig` to the Supervisor update wire shape.
+ *  Internal — only `saveNetworkConfig` calls it now (#653). */
+function toSupervisorIpBlock(config: IpConfig): SupervisorIpBlock {
   if (config.method !== 'static') return { method: config.method };
   return {
     method: 'static',
@@ -185,5 +187,28 @@ export async function pushInterfaceUpdate(
   });
   if (!response.ok) {
     throw new Error(`Supervisor interface update responded ${String(response.status)}`);
+  }
+}
+
+/**
+ * Per-step Network save (#653): push the hostname + each interface's
+ * IPv4/IPv6 config to the Supervisor on the wizard's Next, **without**
+ * Wi-Fi — the destructive network join stays in the terminal Apply step.
+ * Only called when the Supervisor is reachable (the step skips the save
+ * entirely when `/network/info` returned 503), so any throw is a real
+ * failure → `'error'`; the caller surfaces a Toast and stays on the step.
+ */
+export async function saveNetworkConfig(network: NetworkConfig): Promise<'ok' | 'error'> {
+  try {
+    if (network.hostname !== undefined) await pushHostname(network.hostname);
+    for (const iface of network.interfaces ?? []) {
+      const body: Record<string, unknown> = {};
+      if (iface.ipv4 !== undefined) body.ipv4 = toSupervisorIpBlock(iface.ipv4);
+      if (iface.ipv6 !== undefined) body.ipv6 = toSupervisorIpBlock(iface.ipv6);
+      if (Object.keys(body).length > 0) await pushInterfaceUpdate(iface.name, body);
+    }
+    return 'ok';
+  } catch {
+    return 'error';
   }
 }

--- a/apps/web/src/features/setup/network/network-step.test.tsx
+++ b/apps/web/src/features/setup/network/network-step.test.tsx
@@ -115,6 +115,42 @@ describe('NetworkStep — ready', () => {
     expect(end0?.ipv4?.address).toEqual(['192.168.1.50/24']);
   });
 
+  it('saves the hostname + interface config to the device on Next (#653)', async () => {
+    const { onNext, findByTestId, getByTestId } = renderStep();
+    await findByTestId('network-hostname');
+    fireEvent.click(getByTestId('network-next'));
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+    const fetchMock = global.fetch as unknown as { mock: { calls: unknown[][] } };
+    const posted = (substr: string): boolean =>
+      fetchMock.mock.calls.some(
+        ([u, init]) =>
+          String(u).includes(substr) &&
+          (init as { method?: string } | undefined)?.method === 'POST',
+      );
+    expect(posted('/host/options')).toBe(true);
+    expect(posted('/network/interface/end0/update')).toBe(true);
+  });
+
+  it('stays on the step and toasts when the per-step network save fails (#653)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: unknown, init?: { method?: string }) => {
+        const u = String(url);
+        if (init?.method === 'POST' && u.includes('/host/options')) {
+          return Promise.resolve(mockFetchResponse({ ok: false, status: 500 }));
+        }
+        return readyFetch(url);
+      }),
+    );
+    const { onNext, findByTestId, getByTestId, findByRole } = renderStep();
+    await findByTestId('network-hostname');
+    fireEvent.click(getByTestId('network-next'));
+    expect(await findByRole('status')).toBeInTheDocument();
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
   it('splits a seeded CIDR into an IP + dotted subnet mask on a static interface (#639)', async () => {
     const { findByRole, getByLabelText } = renderStep();
     // end0's IPv4 is static, so its panel auto-opens; the seeded

--- a/apps/web/src/features/setup/network/network-step.tsx
+++ b/apps/web/src/features/setup/network/network-step.tsx
@@ -41,6 +41,7 @@ import {
   parseAccessPoints,
   parseHostname,
   parseInterfaces,
+  saveNetworkConfig,
   type AccessPoint,
   type InterfaceInfo,
 } from './network-api';
@@ -371,10 +372,27 @@ export function NetworkStep({ collected, onNext, onBack }: NetworkStepProps): Re
       partial.network = network;
 
     if (selectedNetwork !== null) {
-      setIsSubmitting(true);
       const password = draftPassword.trim();
       const passwordCipher = password !== '' ? await wrapPassword(password) : '(unsecured)';
       partial.wifi = { ssid: selectedNetwork.ssid, passwordCipher };
+    }
+
+    // Per-step save (#653): push hostname + per-interface IP config to the
+    // device now (Wi-Fi join stays terminal — Apply). Only runs when the
+    // Supervisor is reachable (loadState === 'ready'), so a failure here is
+    // real → Toast + stay. The collected Wi-Fi still flows to Apply.
+    setIsSubmitting(true);
+    if (partial.network !== undefined) {
+      const outcome = await saveNetworkConfig(partial.network);
+      if (outcome === 'error') {
+        setIsSubmitting(false);
+        toast.show({
+          intent: 'danger',
+          title: t('setup.network.saveFailed.title'),
+          description: t('setup.network.saveFailed.description'),
+        });
+        return;
+      }
     }
 
     onNext(partial);
@@ -387,6 +405,8 @@ export function NetworkStep({ collected, onNext, onBack }: NetworkStepProps): Re
     loadState,
     onNext,
     selectedNetwork,
+    t,
+    toast,
   ]);
 
   return (

--- a/apps/web/src/features/setup/security/security-step.tsx
+++ b/apps/web/src/features/setup/security/security-step.tsx
@@ -70,7 +70,7 @@ function validatePasswords(
 export function SecurityStep({ collected, onNext, onBack }: SecurityStepProps): ReactNode {
   const { t } = useTranslation();
   const toast = useToast();
-  const { config } = useDeviceConfig();
+  const { config, setPartial } = useDeviceConfig();
   const usernameId = useId();
   const passwordId = useId();
   const confirmId = useId();
@@ -110,22 +110,20 @@ export function SecurityStep({ collected, onNext, onBack }: SecurityStepProps): 
     setSubmitted(true);
     if (!usernameValid || validation.kind !== 'ok') return;
 
-    // No new password entered + the device already has one → keep it.
-    // Emit only the username so the terminal commit's merge leaves the
-    // stored `securityPinHash` untouched (#651).
-    if (password === '') {
-      onNext({ adminUsername: usernameTrimmed });
-      return;
-    }
-
     setIsHashing(true);
     try {
-      const hash = await sha256Hex(password);
-      onNext({ adminUsername: usernameTrimmed, securityPinHash: hash });
+      // Build the slice: always the username; the hash only when a new
+      // password was entered (blank keeps the stored one — #651).
+      const partial: DeviceConfigInput = { adminUsername: usernameTrimmed };
+      if (password !== '') partial.securityPinHash = await sha256Hex(password);
+      // Per-step save (#653): persist to the device's ConfigStore now, then
+      // advance. A merge write, so omitting `securityPinHash` keeps the
+      // existing one.
+      await setPartial(partial);
+      onNext(partial);
     } catch {
-      // Web Crypto failure is extremely rare (older browsers without
-      // `crypto.subtle`). Surface via Toast per the API Error Toast
-      // Rule so the user has somewhere to read the failure.
+      // Web Crypto failure (no `crypto.subtle`) or a ConfigStore write
+      // error — surface via Toast per the API Error Toast Rule.
       toast.show({
         intent: 'danger',
         title: t('setup.security.hashFailed.title'),

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -207,6 +207,10 @@
       "subtitle": "Set this device's hostname and how each interface gets its address, then pick the Wi-Fi network it should join.",
       "loading": "Loading network configuration…",
       "loadFailed": "We couldn't load the current network configuration. The Home Assistant add-on may be restarting.",
+      "saveFailed": {
+        "title": "Couldn't save network settings",
+        "description": "The hostname or interface settings weren't applied. Check the connection and try again."
+      },
       "unavailable": "Network configuration isn't available in this environment, so we'll skip it. Your other settings will still be saved.",
       "hostname": {
         "label": "Hostname",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -207,6 +207,10 @@
       "subtitle": "Bu cihazın ana bilgisayar adını ve her arayüzün adresini nasıl alacağını ayarla, sonra bağlanacağı Wi-Fi ağını seç.",
       "loading": "Ağ yapılandırması yükleniyor…",
       "loadFailed": "Mevcut ağ yapılandırması yüklenemedi. Home Assistant add-on’u yeniden başlatılıyor olabilir.",
+      "saveFailed": {
+        "title": "Ağ ayarları kaydedilemedi",
+        "description": "Ana bilgisayar adı veya arayüz ayarları uygulanmadı. Bağlantını kontrol edip tekrar dene."
+      },
       "unavailable": "Bu ortamda ağ yapılandırması yapılamıyor, bu yüzden atlanacak. Diğer ayarların yine de kaydedilir.",
       "hostname": {
         "label": "Ana bilgisayar adı",


### PR DESCRIPTION
## Summary

Final piece of the per-step model (#653, split from #646). With this, **every non-destructive write happens on the step's Next**, and the terminal Apply commit is just the destructive Wi-Fi join:

- **Network step** — `saveNetworkConfig` pushes the **hostname + per-interface IPv4/IPv6** to the Supervisor on Next (loading state on the button, Toast on failure). Only runs when the Supervisor is reachable; the **Wi-Fi join stays deferred to Apply** (terminal/destructive).
- **Security step** — `setPartial`s the admin username (+ pin hash, when a new password was entered) to the ConfigStore on Next.
- **Apply step** — `runCommit` slims to the **Wi-Fi join + `setPartial(collected)` + `markComplete`**. It no longer re-pushes HA settings / hostname / IP config (those are per-step now and re-pushing would double-write). `pushHostname` + `toSupervisorIpBlock` become internal (only `saveNetworkConfig` uses them).

## Result

The wizard now matches the agreed model end-to-end: Home Overview (#646), Layout (#652), Network + Security (this) all save per-step; Apply = the one destructive Wi-Fi switch.

## Scope

**In:** `saveNetworkConfig` + network-step Next save, security-step `setPartial`, apply-step `runCommit` slim + dead-code removal, i18n `setup.network.saveFailed`.
**Out:** no UI restructure → no Figma frame.

## Test plan

- [x] network-step: per-step save POSTs hostname + interface; Toast + no-advance on failure; unavailable path still advances.
- [x] apply-step: commit no longer pushes HA settings / hostname / IP; Wi-Fi handoff (open + secured) unchanged.
- [x] security-step: setPartial on Next (seeding + optional-password from #651 intact).
- [x] full setup suite (102), type-check (11), lint, knip, i18n green.
- [ ] Playwright @smoke + Chromatic (CI).

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)