### PR TITLE
refactor(ui,web): wizard pickers select-box feel + country/lang sync

### DIFF
--- a/apps/web/src/features/setup/home-overview/home-overview-api.test.ts
+++ b/apps/web/src/features/setup/home-overview/home-overview-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { countryTimeZones, lookupCountryCenter } from './home-overview-api';
+import { countryCurrency, countryTimeZones, lookupCountryCenter } from './home-overview-api';
 
 describe('lookupCountryCenter (#648)', () => {
   it("geocodes the country's localized display name and returns the first center", async () => {
@@ -52,5 +52,25 @@ describe('countryTimeZones (#648)', () => {
 
   it('uppercases the region code', () => {
     expect(countryTimeZones('tr')).toEqual(countryTimeZones('TR'));
+  });
+});
+
+describe('countryCurrency (#666)', () => {
+  it('returns the ISO 4217 code for a country', () => {
+    const ccy = countryCurrency('TR');
+    // Runtimes with Intl Locale Info return 'TRY'; older ones return
+    // undefined (the caller then skips the currency sync).
+    if (ccy !== undefined) {
+      expect(ccy).toBe('TRY');
+    }
+  });
+
+  it('uppercases the region code', () => {
+    expect(countryCurrency('jp')).toBe(countryCurrency('JP'));
+  });
+
+  it('returns undefined and never throws for odd input', () => {
+    expect(() => countryCurrency('ZZ')).not.toThrow();
+    expect(() => countryCurrency('')).not.toThrow();
   });
 });

--- a/apps/web/src/features/setup/home-overview/home-overview-api.ts
+++ b/apps/web/src/features/setup/home-overview/home-overview-api.ts
@@ -151,3 +151,24 @@ export function countryTimeZones(iso: string): string[] {
     return [];
   }
 }
+
+/**
+ * Country → currency sync (#666). Returns the ISO 4217 currency code for an
+ * ISO 3166-1 alpha-2 region via `Intl.Locale.getCurrencies()` (Intl Locale
+ * Info). `undefined` when the runtime lacks the API or the code is unknown,
+ * so the caller skips the currency sync rather than guessing. Multi-currency
+ * regions return the first (legal-tender) entry, which the user can change.
+ */
+export function countryCurrency(iso: string): string | undefined {
+  try {
+    const loc = new Intl.Locale('und', { region: iso.toUpperCase() }) as unknown as {
+      getCurrencies?: () => string[];
+      currencies?: string[];
+    };
+    const currencies =
+      typeof loc.getCurrencies === 'function' ? loc.getCurrencies() : loc.currencies;
+    return Array.isArray(currencies) ? currencies[0] : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/web/src/features/setup/home-overview/home-overview-step.test.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.test.tsx
@@ -121,6 +121,18 @@ describe('HomeOverviewStep', () => {
     ).toBeTruthy();
   });
 
+  it('renders Language first, above the home name (#666 reorder)', () => {
+    const { getByText, getByTestId } = render(
+      wrap(<HomeOverviewStep collected={{}} onNext={() => undefined} />),
+    );
+    const language = getByText('Language');
+    const homeName = getByTestId('home-overview-home-name');
+    // Language's row precedes the home name field in document order.
+    expect(
+      language.compareDocumentPosition(homeName) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it('blocks submission when home name is empty and shows an inline error', () => {
     const onNext = vi.fn();
     const { getByRole, queryByRole } = render(

--- a/apps/web/src/features/setup/home-overview/home-overview-step.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.tsx
@@ -3,12 +3,20 @@
 // 1277:791 right column. Replaces the placeholder from #539.
 //
 // Form fields (per Figma, top to bottom):
+// - Language (LanguageSelect; the HA-supported language set from @glaon/core)
 // - Home Name (required text input)
+// - Country (CountrySelect — auto-detect on first visit)
 // - Location (LocationPicker — autocomplete + map + draggable marker)
 // - Unit System (radio: metric / imperial)
-// - Country (CountrySelect — auto-detect on first visit)
 // - Timezone (TimezoneSelect — auto-detect on first visit)
-// - Language (Select; SUPPORTED_LOCALES from @glaon/core)
+// - Currency (CurrencySelect — follows the country selection)
+//
+// Language sits first (#666): it switches the wizard UI language, so the
+// user picks it before reading the rest of the form. The full HA language
+// set is offered (HA_LANGUAGES) since the value maps to HA Core's
+// `language` (the device language), not only Glaon's own UI bundle —
+// picking a non-Glaon-UI language saves to the device without re-skinning
+// the wizard (only SUPPORTED_LOCALES drive `i18n.changeLanguage`).
 //
 // Layout follows the UUI horizontal-form pattern: a label column on
 // the left, the control on the right, horizontal divider between
@@ -37,13 +45,22 @@ import {
   nominatimGeocode,
   useToast,
 } from '@glaon/ui';
-import { useEffect, useId, useRef, useState, type ReactNode, type SubmitEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+  type SubmitEvent,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { SUPPORTED_LOCALES, type SupportedLocale } from '@glaon/core/i18n';
+import { HA_LANGUAGES, SUPPORTED_LOCALES } from '@glaon/core/i18n';
 import type { DeviceConfigInput } from '@glaon/core/config';
 
 import {
+  countryCurrency,
   countryTimeZones,
   fetchHaConfig,
   lookupCountryCenter,
@@ -88,9 +105,9 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
   const [country, setCountry] = useState<string>(collected.country ?? '');
   const [timezone, setTimezone] = useState<string>(collected.timezone ?? '');
   const [currency, setCurrency] = useState<string>(collected.currency ?? '');
-  const [locale, setLocale] = useState<SupportedLocale>(
-    (collected.locale as SupportedLocale | undefined) ?? 'en',
-  );
+  // Locale is a free BCP-47 string (#666): it maps to HA Core `language`,
+  // which spans the full HA language set — not only Glaon's UI locales.
+  const [locale, setLocale] = useState<string>(collected.locale ?? 'en');
   const [showHomeNameError, setShowHomeNameError] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
 
@@ -133,12 +150,15 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
       if (collected.currency === undefined && seed.currency !== undefined) {
         setCurrency((prev) => (prev === '' ? (seed.currency ?? prev) : prev));
       }
-      if (
-        collected.locale === undefined &&
-        seed.language !== undefined &&
-        (SUPPORTED_LOCALES as readonly string[]).includes(seed.language)
-      ) {
-        setLocale(seed.language as SupportedLocale);
+      // Seed the language from any device language (#666), not just Glaon's
+      // UI locales — the field maps to HA Core `language`. Only flip the
+      // wizard UI when the seeded language is one Glaon actually ships.
+      if (collected.locale === undefined && seed.language !== undefined) {
+        const lang = seed.language;
+        setLocale(lang);
+        if ((SUPPORTED_LOCALES as readonly string[]).includes(lang)) {
+          void i18n.changeLanguage(lang);
+        }
       }
     });
     return () => {
@@ -165,18 +185,22 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
         }
       : undefined;
 
-  // Country → map + timezone sync (#648). Every country selection drives
-  // both: the timezone snaps to the country's primary IANA zone, and the
-  // map recenters to the country's centre (geocoded best-effort, online
-  // only). Country is the authoritative high-level choice, so each change
-  // re-syncs (the first pick and every subsequent one). Radius is kept;
-  // the address is cleared (a country centre isn't a precise address).
+  // Country → map + timezone + currency sync (#648, #666). Every country
+  // selection drives all three: the timezone snaps to the country's primary
+  // IANA zone, the currency snaps to its ISO 4217 code, and the map recenters
+  // to the country's centre (geocoded best-effort, online only). Country is
+  // the authoritative high-level choice, so each change re-syncs (the first
+  // pick and every subsequent one). Radius is kept; the address is cleared
+  // (a country centre isn't a precise address).
   const onCountrySelect = (iso: string | null): void => {
     setCountry(iso ?? '');
     if (iso === null || iso === '') return;
 
     const zones = countryTimeZones(iso);
     if (zones[0] !== undefined) setTimezone(zones[0]);
+
+    const ccy = countryCurrency(iso);
+    if (ccy !== undefined) setCurrency(ccy);
 
     const online = typeof navigator === 'undefined' || navigator.onLine;
     if (!online) return;
@@ -190,6 +214,16 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
       }));
     });
   };
+
+  // Country-scoped address search (#666). Once a country is picked, the
+  // LocationPicker's geocoder is bound to that country (`countrycodes`) so
+  // address lookups stay in-country and resolve faster. Re-created when the
+  // country changes so the picker re-queries with the new scope.
+  const scopedGeocode = useCallback(
+    (query: string, signal?: AbortSignal, geoLocale?: string) =>
+      nominatimGeocode(query, signal, geoLocale, country !== '' ? country : undefined),
+    [country],
+  );
 
   const onSubmit = async (event: SubmitEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
@@ -251,6 +285,28 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
         noValidate
         className="flex flex-col"
       >
+        {/* Language sits first (#666) — it switches the wizard UI, so the
+            user chooses it before reading the rest. The full HA language set
+            (HA_LANGUAGES) is offered since the value maps to HA Core
+            `language`; only Glaon's own UI locales (SUPPORTED_LOCALES)
+            actually re-skin the wizard via i18n.changeLanguage. */}
+        <FormRow label={t('setup.homeOverview.language.label')} labelId={languageLabelId}>
+          <LanguageSelect
+            aria-labelledby={languageLabelId}
+            options={HA_LANGUAGES}
+            value={locale}
+            placeholder={t('setup.homeOverview.language.placeholder')}
+            autoDetect={false}
+            onSelectionChange={(code) => {
+              if (code === null) return;
+              setLocale(code);
+              if ((SUPPORTED_LOCALES as readonly string[]).includes(code)) {
+                void i18n.changeLanguage(code);
+              }
+            }}
+          />
+        </FormRow>
+
         <FormRow label={t('setup.homeOverview.homeName.label')} labelId={homeNameLabelId} required>
           <TextField
             value={homeName}
@@ -293,7 +349,7 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
             radiusLabel={t('setup.homeOverview.location.radius')}
             radiusUnit={t('setup.homeOverview.location.radiusUnit')}
             placeholder={t('setup.homeOverview.location.placeholder')}
-            geocode={nominatimGeocode}
+            geocode={scopedGeocode}
             {...(locationValue !== undefined ? { value: locationValue } : {})}
             onChange={(value) => {
               setLocation({
@@ -340,35 +396,17 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
           />
         </FormRow>
 
-        {/* Currency sits under Timezone (#649). Label-less picker — the
-            form-row label is associated via aria-labelledby. */}
+        {/* Currency sits under Timezone (#649). Controlled (#666) so a
+            country change can drive it (country → currency sync). Label-less
+            picker — the form-row label is associated via aria-labelledby. */}
         <FormRow label={t('setup.homeOverview.currency.label')} labelId={currencyLabelId}>
           <CurrencySelect
             aria-labelledby={currencyLabelId}
             placeholder={t('setup.homeOverview.currency.placeholder')}
-            {...(collected.currency !== undefined ? { defaultValue: collected.currency } : {})}
-            autoDetect={collected.currency === undefined}
+            {...(currency !== '' ? { value: currency } : {})}
+            autoDetect={collected.currency === undefined && currency === ''}
             onSelectionChange={(code) => {
               setCurrency(code ?? '');
-            }}
-          />
-        </FormRow>
-
-        {/* Single language control (#650) — the sidebar switcher was
-            removed. Selecting a language live-switches the wizard UI
-            (i18n.changeLanguage) and is saved to HA core `language`. */}
-        <FormRow label={t('setup.homeOverview.language.label')} labelId={languageLabelId}>
-          <LanguageSelect
-            aria-labelledby={languageLabelId}
-            options={SUPPORTED_LOCALES}
-            value={locale}
-            placeholder={t('setup.homeOverview.language.placeholder')}
-            autoDetect={false}
-            onSelectionChange={(code) => {
-              if (code !== null && (SUPPORTED_LOCALES as readonly string[]).includes(code)) {
-                setLocale(code as SupportedLocale);
-                void i18n.changeLanguage(code);
-              }
             }}
           />
         </FormRow>

--- a/packages/core/src/i18n/ha-languages.ts
+++ b/packages/core/src/i18n/ha-languages.ts
@@ -1,0 +1,79 @@
+// HA-supported language codes (#666). This is the *Home Assistant* set of
+// translation languages — distinct from Glaon's own UI `SUPPORTED_LOCALES`
+// (currently en/tr). The wizard's Home Overview language picker offers
+// this full set because the chosen value maps to HA Core's `language`
+// (the device's language), not only the Glaon UI bundle.
+//
+// HA exposes no clean pre-auth endpoint that lists its supported
+// languages (the list lives in the frontend build), so we ship a static
+// snapshot of HA's translation set. BCP-47 codes; the picker localizes
+// each via `Intl.DisplayNames`. Region/script variants (en-GB, pt-BR,
+// zh-Hans, …) are kept verbatim so they round-trip to HA unchanged.
+//
+// Maintenance: refresh against HA frontend's `translationMetadata` when a
+// new HA language ships. The wizard always merges in the device's current
+// `get_config.language` even if it's not in this snapshot, so an
+// unlisted-but-active language is never dropped.
+
+export const HA_LANGUAGES = [
+  'af',
+  'ar',
+  'bg',
+  'bn',
+  'ca',
+  'cs',
+  'cy',
+  'da',
+  'de',
+  'el',
+  'en',
+  'en-GB',
+  'eo',
+  'es',
+  'es-419',
+  'et',
+  'eu',
+  'fa',
+  'fi',
+  'fr',
+  'fy',
+  'gl',
+  'gsw',
+  'he',
+  'hi',
+  'hr',
+  'hu',
+  'hy',
+  'id',
+  'is',
+  'it',
+  'ja',
+  'ka',
+  'ko',
+  'lb',
+  'lt',
+  'lv',
+  'ml',
+  'nb',
+  'nl',
+  'nn',
+  'pl',
+  'pt',
+  'pt-BR',
+  'ro',
+  'ru',
+  'sk',
+  'sl',
+  'sr',
+  'sr-Latn',
+  'sv',
+  'ta',
+  'te',
+  'th',
+  'tr',
+  'uk',
+  'ur',
+  'vi',
+  'zh-Hans',
+  'zh-Hant',
+] as const;

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -12,6 +12,7 @@ export {
   type LocaleNegotiationInput,
   type SupportedLocale,
 } from './locale-negotiator';
+export { HA_LANGUAGES } from './ha-languages';
 export type { I18nNamespaces, I18nResource, I18nResources, LocaleChoice } from './types';
 export {
   clearHaTranslationsCache,

--- a/packages/ui/src/components/CountrySelect/CountrySelect.tsx
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.tsx
@@ -275,7 +275,7 @@ function renderTriggerIcon(code: string | null | undefined): FC | ReactNode {
   if (!code) return Globe01;
   return (
     <span data-icon className="flex shrink-0 items-center" aria-hidden="true">
-      <Flag country={code} shape="circle" />
+      <Flag country={code} shape="square" />
     </span>
   );
 }
@@ -288,7 +288,7 @@ function renderTriggerIcon(code: string | null | undefined): FC | ReactNode {
 function renderListItemFlag(code: string): ReactNode {
   return (
     <span data-icon className="flex shrink-0 items-center" aria-hidden="true">
-      <Flag country={code} shape="circle" />
+      <Flag country={code} shape="square" />
     </span>
   );
 }

--- a/packages/ui/src/components/LocationPicker/geocoding.test.ts
+++ b/packages/ui/src/components/LocationPicker/geocoding.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { nominatimGeocode } from './geocoding';
+
+function mockFetchOnce(json: unknown, ok = true): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() =>
+      Promise.resolve({
+        ok,
+        status: ok ? 200 : 500,
+        json: () => Promise.resolve(json),
+      } as Response),
+    ),
+  );
+}
+
+function lastRequestUrl(): URL {
+  const fetchMock = global.fetch as unknown as { mock: { calls: unknown[][] } };
+  return new URL(String(fetchMock.mock.calls[0]?.[0]));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('nominatimGeocode', () => {
+  it('resolves blank queries to an empty list without fetching', async () => {
+    mockFetchOnce([]);
+    expect(await nominatimGeocode('   ')).toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('maps Nominatim rows to suggestions and drops non-finite coordinates', async () => {
+    mockFetchOnce([
+      { place_id: 1, display_name: 'Istanbul', lat: '41.0082', lon: '28.9784' },
+      { place_id: 2, display_name: 'Bad', lat: 'x', lon: 'y' },
+    ]);
+    const out = await nominatimGeocode('istanbul');
+    expect(out).toEqual([{ id: '1', label: 'Istanbul', lat: 41.0082, lng: 28.9784 }]);
+  });
+
+  it('scopes the search to the country via countrycodes (#666)', async () => {
+    mockFetchOnce([]);
+    await nominatimGeocode('main st', undefined, 'en', 'TR');
+    expect(lastRequestUrl().searchParams.get('countrycodes')).toBe('tr');
+  });
+
+  it('omits countrycodes when no/invalid country code is given (#666)', async () => {
+    mockFetchOnce([]);
+    await nominatimGeocode('main st', undefined, 'en', 'TRX');
+    expect(lastRequestUrl().searchParams.has('countrycodes')).toBe(false);
+  });
+
+  it('forwards the locale as accept-language', async () => {
+    mockFetchOnce([]);
+    await nominatimGeocode('paris', undefined, 'fr');
+    expect(lastRequestUrl().searchParams.get('accept-language')).toBe('fr');
+  });
+
+  it('throws on a non-ok response', async () => {
+    mockFetchOnce(null, false);
+    await expect(nominatimGeocode('boom')).rejects.toThrow(/Nominatim/);
+  });
+});

--- a/packages/ui/src/components/LocationPicker/geocoding.ts
+++ b/packages/ui/src/components/LocationPicker/geocoding.ts
@@ -44,11 +44,15 @@ const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
  * @param locale Optional BCP-47 tag — passed to Nominatim's
  *               `accept-language` query so labels come back in the
  *               user's language when available.
+ * @param countryCode Optional ISO 3166-1 alpha-2 — scopes the search to
+ *               that country (`countrycodes`), so address lookups after a
+ *               country pick are faster and in-country only (#666).
  */
 export async function nominatimGeocode(
   query: string,
   signal?: AbortSignal,
   locale?: string,
+  countryCode?: string,
 ): Promise<GeocodeSuggestion[]> {
   const trimmed = query.trim();
   if (trimmed.length === 0) return [];
@@ -61,6 +65,9 @@ export async function nominatimGeocode(
   });
   if (locale !== undefined && locale.length > 0) {
     params.set('accept-language', locale);
+  }
+  if (countryCode !== undefined && /^[A-Za-z]{2}$/.test(countryCode)) {
+    params.set('countrycodes', countryCode.toLowerCase());
   }
 
   const url = `${NOMINATIM_BASE}/search?${params.toString()}`;

--- a/packages/ui/src/components/base/select/combobox.tsx
+++ b/packages/ui/src/components/base/select/combobox.tsx
@@ -81,6 +81,17 @@ const ComboBoxValue = ({ size, shortcut, placeholder, shortcutClassName, icon: I
 
                 <AriaInput
                     placeholder={placeholder}
+                    // GLAON PATCH (re-apply on upgrade): the kit leaves the
+                    // combobox input open to browser autofill/autocomplete,
+                    // which pops a stray native suggestion list over our own
+                    // option popover (the "select box, not a text input"
+                    // review note). Disable browser autocomplete/correct; the
+                    // RAC `aria-autocomplete` listbox is the only suggestion
+                    // surface.
+                    autoComplete="off"
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    spellCheck={false}
                     className={cx(
                         "z-10 w-full appearance-none bg-transparent text-transparent caret-alpha-black/90 placeholder:text-placeholder focus:outline-hidden disabled:cursor-not-allowed",
                         sizes[size].text,


### PR DESCRIPTION
## Summary

Post-epic polish pass on the Setup Wizard's Home Overview pickers (#666), from user feedback on the merged epic #645.

- **Select-box feel** — the kit `ComboBox` input now disables browser `autocomplete`/`autocorrect`/`autocapitalize`/`spellcheck`, so the only suggestion surface is the RAC listbox (no stray native autofill popover over our options). Applies to every picker + the LocationPicker search.
- **Language to the top + full HA set** — Language is now the first field; it offers the full HA-supported language set (`HA_LANGUAGES`, new in `@glaon/core/i18n`) instead of only Glaon's UI locales, because the value maps to HA Core `language` (the device language). Only `SUPPORTED_LOCALES` drive `i18n.changeLanguage`, so picking a non-Glaon-UI language saves to the device without re-skinning the wizard.
- **Square flags** — `CountrySelect` renders flags with `shape="square"` (no corner radius) in both the trigger and the list rows.
- **Country-scoped geocode** — `nominatimGeocode` takes an optional ISO country code and scopes the Nominatim query via `countrycodes`; the Home Overview LocationPicker is given a geocoder bound to the selected country for faster, in-country address lookups.
- **Country → currency sync** — selecting a country now also snaps the currency (`Intl.Locale.getCurrencies`), alongside the existing timezone + map-centre sync. `CurrencySelect` is now controlled so the sync reflects in the UI.

### HA language source caveat

The user asked to fetch HA's language list at runtime and fall back to a static set. HA exposes **no clean pre-auth endpoint** that lists its supported languages (the list lives in the frontend build), so the deliverable is the static ~60-language snapshot **plus** the device's current `get_config.language`, which is always seeded into the field even if it's not in the snapshot. Maintenance notes are in `packages/core/src/i18n/ha-languages.ts`.

## Scope

In:
- `combobox.tsx` autocomplete-off patch (re-apply on kit upgrade — noted inline).
- `CountrySelect` square flags.
- `nominatimGeocode` country scoping + new `geocoding.test.ts`.
- `HA_LANGUAGES` dataset + barrel export.
- Home Overview: language-to-top, HA_LANGUAGES wiring, locale → free BCP-47 string, country→currency sync, controlled `CurrencySelect`, country-bound geocoder.

Out:
- Wizard layout double-scroll / sidebar full-height — tracked separately in #665.
- New Figma frames for the reordered Home Overview — design follow-up (node ID to be linked before merge).

## Test plan

- [x] `pnpm type-check` — green.
- [x] `pnpm lint` — green.
- [x] `pnpm --filter @glaon/web test` (home-overview step + api) — language-first reorder, country→currency (`countryCurrency`) unit coverage.
- [x] `pnpm --filter @glaon/ui test` (geocoding `countrycodes` scoping, full unit project 171 passing).
- [ ] Chromatic: review the `CountrySelect` flag diff (circle → square) — intentional.
- [ ] Figma side-by-side at Desktop 1440 / Mobile 375 for the reordered Home Overview (frame refresh pending).
- [ ] Manual `/run` against dev HA: language switches UI for en/tr only, full list selectable; country pick syncs timezone + currency + map; address search scoped to country.

Closes #666