### PR TITLE
fix(ui): setup layout single scroll + full-height sidebar

### DIFF
--- a/apps/web-e2e/tests/setup-wizard.spec.ts
+++ b/apps/web-e2e/tests/setup-wizard.spec.ts
@@ -188,6 +188,33 @@ test.describe('setup wizard @smoke', () => {
     await expect(page.getByLabel('Home Name')).toHaveValue('Olivia');
   });
 
+  test('keeps a single content scroll — no window scrollbar at desktop (#665)', async ({
+    page,
+  }) => {
+    // A short, wide desktop viewport so the Home Overview form overflows
+    // vertically: at >=lg the SetupLayout pins the page to the viewport and
+    // only <main> scrolls. The regression (#665) was a second, window-level
+    // scrollbar caused by an absolutely-positioned visually-hidden input
+    // escaping <main>'s clip — guarded by anchoring it via `position:
+    // relative` on <main>.
+    await page.setViewportSize({ width: 1440, height: 640 });
+    await page.goto('/');
+    await expect(page.getByRole('heading', { level: 1, name: 'Home Overview' })).toBeVisible();
+
+    const scroll = await page.evaluate(() => {
+      const html = document.documentElement;
+      const main = document.querySelector('main');
+      return {
+        windowScrolls: html.scrollHeight > html.clientHeight + 1,
+        mainScrolls: main ? main.scrollHeight > main.clientHeight + 1 : false,
+      };
+    });
+    // The window must not scroll (single scrollbar); <main> carries the
+    // overflow instead.
+    expect(scroll.windowScrolls).toBe(false);
+    expect(scroll.mainScrolls).toBe(true);
+  });
+
   test('reload after completion never re-runs the wizard', async ({ page }) => {
     await walkToNetworkStep(page);
     await page.getByRole('button', { name: /PreviewGuest/i }).click();

--- a/packages/ui/src/components/SetupLayout/SetupLayout.tsx
+++ b/packages/ui/src/components/SetupLayout/SetupLayout.tsx
@@ -126,7 +126,17 @@ export function SetupLayout({
           )}
         </div>
       </aside>
-      <main className="flex flex-1 flex-col lg:min-w-[480px] lg:overflow-y-auto">{children}</main>
+      {/* `relative` makes <main> the containing block for its
+          absolutely-positioned descendants (#665). Step forms include
+          react-aria visually-hidden inputs (`position: absolute`); without
+          a positioning context here their containing block is <body>, so
+          they escape <main>'s `overflow-y-auto` clip and poke past the
+          viewport, producing a second, window-level scrollbar on top of
+          <main>'s own scroll. Anchoring them to <main> keeps a single
+          content scroll and the sidebar full-height. */}
+      <main className="relative flex flex-1 flex-col lg:min-w-[480px] lg:overflow-y-auto">
+        {children}
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the Setup Wizard's double-scrollbar + short-sidebar bug (#665, post-epic polish from #645 feedback).

**Root cause** (diagnosed live in the running app): the wizard step forms render react-aria visually-hidden inputs with `position: absolute`. `<main>` (the `overflow-y-auto` scroll region) was *not* a positioning context, so those inputs' containing block was `<body>`. They escaped `<main>`'s clip and extended ~32px past the viewport, producing a second **window-level** scrollbar on top of `<main>`'s intended content scroll — and because the page then scrolled at the window level, the sidebar (`lg:h-full`) appeared to fall short.

**Fix**: add `position: relative` to `<main>` in `SetupLayout`. The absolutely-positioned descendants are now anchored to (and clipped by) the scroll container, restoring a single content scroll and a full-height sidebar.

## How it was verified

Inspected the live wizard at desktop via DOM measurement:

| | before | after |
|---|---|---|
| `html.scrollHeight` vs `clientHeight` (900) | **932** (window scrolls) | **900** (no window scroll) |
| `<main>` scrolls | yes | yes (single content scroll) |
| sidebar reaches viewport bottom | no | yes |

At `<lg` the layout stacks and uses a single window scroll as before — unaffected by the change.

## Scope

In:
- `SetupLayout.tsx`: `relative` on `<main>` (+ explanatory comment).
- `setup-wizard.spec.ts`: a `@smoke` regression assertion — at a short desktop viewport, the window must not scroll while `<main>` does.

Out:
- The #666 picker polish (separate PR #667).

## Test plan

- [x] type-check + lint (`@glaon/ui`) — green.
- [x] Live verification in the running app (desktop 1440×900 and 1440×640; tablet 768): single scroll, sidebar full-height; `<lg` stacked single window scroll unchanged.
- [ ] CI: wizard `@smoke` regression test (`keeps a single content scroll …`) passes on all Playwright projects.
- [ ] Chromatic: SetupLayout story diff reviewed (no visual change expected — `relative` only affects descendant containing block).

Closes #665