### PR TITLE
fix(web): apply Home Overview device seed under StrictMode

### DIFF
--- a/apps/web/src/features/setup/home-overview/home-overview-step.test.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.test.tsx
@@ -45,7 +45,7 @@ HTMLCanvasElement.prototype.getContext = ((): CanvasRenderingContext2D =>
     arc: () => undefined,
   }) as unknown as CanvasRenderingContext2D) as unknown as typeof HTMLCanvasElement.prototype.getContext;
 
-import type { ReactNode } from 'react';
+import { StrictMode, type ReactNode } from 'react';
 
 import { ToastProvider } from '@glaon/ui';
 
@@ -222,6 +222,22 @@ describe('HomeOverviewStep', () => {
     installFetch({ haConfig: { locationName: 'Evim', country: 'TR' } });
     const { getByTestId } = render(
       wrap(<HomeOverviewStep collected={{}} onNext={() => undefined} />),
+    );
+    const homeNameInput = getByTestId('home-overview-home-name') as HTMLInputElement;
+    await waitFor(() => {
+      expect(homeNameInput.value).toBe('Evim');
+    });
+  });
+
+  it('applies the device seed under StrictMode — no seededRef drop (#676)', async () => {
+    // Regression guard: StrictMode double-invokes the seed effect (mount →
+    // unmount → remount). The old `seededRef` "run once" guard let the
+    // first (cancelled) fetch win and blocked the live remount fetch, so the
+    // form stayed blank in dev. Rendering inside <StrictMode> reproduces the
+    // double-invoke; the seed must still apply.
+    installFetch({ haConfig: { locationName: 'Evim' } });
+    const { getByTestId } = render(
+      <StrictMode>{wrap(<HomeOverviewStep collected={{}} onNext={() => undefined} />)}</StrictMode>,
     );
     const homeNameInput = getByTestId('home-overview-home-name') as HTMLInputElement;
     await waitFor(() => {

--- a/apps/web/src/features/setup/home-overview/home-overview-step.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.tsx
@@ -46,15 +46,7 @@ import {
   nominatimGeocode,
   useToast,
 } from '@glaon/ui';
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  type ReactNode,
-  type SubmitEvent,
-} from 'react';
+import { useCallback, useEffect, useId, useState, type ReactNode, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { HA_LANGUAGES, SUPPORTED_LOCALES } from '@glaon/core/i18n';
@@ -114,12 +106,16 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
   // Seed from the device (#646): on the first visit the wizard reads the
   // current HA Core config and pre-fills the fields the user hasn't
   // already set. Guarded by `collected.*` so a back-navigation keeps the
-  // user's entered values instead of re-seeding over them, and by a ref so
-  // it runs once. A missing/unreachable HA Core just leaves the defaults.
-  const seededRef = useRef(false);
+  // user's entered values instead of re-seeding over them. A
+  // missing/unreachable HA Core just leaves the defaults.
+  //
+  // No `seededRef` "run once" guard (#676): under React StrictMode the
+  // effect mounts → unmounts → remounts in dev, and a ref guard would let
+  // the first (now-cancelled) fetch win while blocking the second, live
+  // one — dropping the seed entirely so the form stayed blank in dev. The
+  // GET is idempotent, so we rely solely on the `cancelled` flag: the
+  // remount's fetch resolves with `cancelled === false` and seeds.
   useEffect(() => {
-    if (seededRef.current) return;
-    seededRef.current = true;
     let cancelled = false;
     void fetchHaConfig().then((seed) => {
       if (cancelled || seed === null) return;
@@ -164,7 +160,7 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
     return () => {
       cancelled = true;
     };
-    // Seed once on mount; `collected` is read for the initial guard only.
+    // Seed on mount; `collected` is read for the initial guard only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -333,13 +329,15 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
 
         {/* Country sits above Location (#648) so its selection can recenter
             the map. The picker has no built-in label — the FormRow's label
-            is associated via aria-labelledby. */}
+            is associated via aria-labelledby. Controlled on `country` (#676)
+            so the device seed (and country→map/timezone/currency sync) is
+            reflected in the trigger; auto-detect only when nothing is set. */}
         <FormRow label={t('setup.homeOverview.country.label')} labelId={countryLabelId}>
           <CountrySelect
             aria-labelledby={countryLabelId}
             placeholder={t('setup.homeOverview.country.placeholder')}
-            {...(collected.country !== undefined ? { defaultValue: collected.country } : {})}
-            autoDetect={collected.country === undefined}
+            {...(country !== '' ? { value: country } : {})}
+            autoDetect={collected.country === undefined && country === ''}
             onSelectionChange={onCountrySelect}
           />
         </FormRow>


### PR DESCRIPTION
## Summary

The Home Overview form stayed **blank** in dev even though `GET /api/setup/ha-config` returned valid data (verified live: `{latitude, longitude, unitSystem, timezone:"Europe/Istanbul", country:"TR", currency:"TRY", language:"tr", locationName:"Evim"}`).

**Root cause 1 — seed discarded under React StrictMode.** The seed `useEffect` used a `seededRef` "run once" guard alongside a `cancelled` flag. StrictMode (on in `main.tsx`) double-invokes effects in dev (mount → unmount → remount):
1. run #1 → `seededRef=true`, fetch starts, `cancelled1=false`
2. cleanup #1 → `cancelled1=true`
3. run #2 → `seededRef` already true → returns, **no second fetch**
4. the single fetch resolves → `cancelled1` true → **seed discarded**

Fix: drop the `seededRef` guard, rely on the `cancelled` flag alone (the GET is idempotent). The remount's fetch resolves with `cancelled===false` and seeds. (Prod has no double-invoke, which is why it seeded there and this slipped through.)

**Root cause 2 — Country picker uncontrolled.** `CountrySelect` only read `collected.country` as `defaultValue`, so even once seeding worked the device's country didn't show in the trigger (value was still saved). Fix: `value={country}` (controlled), like Timezone/Currency.

## Verification (live, against a real HA via apps/api)

Home Overview now pre-fills: Ev Adı **Evim**, Dil **Türkçe**, Ülke **Türkiye**, Saat dilimi **Istanbul (UTC+03:00)**, Para birimi **TRY**, Enlem/Boylam **39.658…/27.906…**. (Yarıçap shows the 100m default — `get_config` carries no radius; tracked separately.)

## Scope
- `home-overview-step.tsx`: remove `seededRef`; `CountrySelect value={country}`.
- `home-overview-step.test.tsx`: StrictMode regression test (seed must apply under double-invoke).

## Test plan
- [x] `@glaon/web` type-check + lint green.
- [x] `home-overview-step` tests (11) green, incl. new StrictMode guard.
- [x] Live: full form pre-fills from a real HA.
- [ ] CI green.

Closes #676