### PR TITLE
feat(web): seed Home Overview from unified GET /api/setup (incl. radius)

### DIFF
--- a/apps/web/src/features/setup/home-overview/home-overview-api.ts
+++ b/apps/web/src/features/setup/home-overview/home-overview-api.ts
@@ -9,29 +9,30 @@
 // (HA-less dev) — reads degrade to "no seed" and saves degrade to a
 // no-op success so the wizard still walks in standalone dev.
 
-import { HaConfigResponseSchema, type HaConfigResponse } from '@glaon/core/api-client';
+import { SetupSeedResponseSchema, type SetupHomeOverview } from '@glaon/core/api-client';
 
-const HA_CONFIG_URL = '/api/setup/ha-config';
+const SETUP_SEED_URL = '/api/setup';
 const HA_APPLY_SETTINGS = '/api/setup/apply-ha';
 
 /**
- * Read the device's current HA Core config to seed the Home Overview
- * fields. Returns `null` when there is nothing to seed — no HA Core
- * configured (503), unreachable, or a malformed response — so the caller
- * just starts with blank/auto-detect defaults.
+ * Read the unified device seed (#678) and return its Home Overview section
+ * (HA Core `get_config` + the `zone.home` radius). Returns `null` when
+ * there is nothing to seed — no HA Core configured/reachable (the section
+ * comes back `null`), the request failed, or a malformed response — so the
+ * caller just starts with blank/auto-detect defaults. The wizard reads the
+ * whole seed from one endpoint; this helper hands back only the slice the
+ * Home Overview step needs.
  */
-export async function fetchHaConfig(): Promise<HaConfigResponse | null> {
+export async function fetchHomeOverviewSeed(): Promise<SetupHomeOverview | null> {
   let response: Response;
   try {
-    response = await fetch(HA_CONFIG_URL, { credentials: 'include' });
+    response = await fetch(SETUP_SEED_URL, { credentials: 'include' });
   } catch {
     return null;
   }
   if (!response.ok) return null;
-  // Validate the (camelCase) seed apps/api returns; pass the parsed JSON
-  // straight into Zod rather than binding it to an `any` local.
-  const parsed = HaConfigResponseSchema.safeParse(await response.json().catch(() => null));
-  return parsed.success ? parsed.data : null;
+  const parsed = SetupSeedResponseSchema.safeParse(await response.json().catch(() => null));
+  return parsed.success ? (parsed.data.homeOverview ?? null) : null;
 }
 
 /**

--- a/apps/web/src/features/setup/home-overview/home-overview-step.test.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.test.tsx
@@ -51,9 +51,11 @@ import { ToastProvider } from '@glaon/ui';
 
 import { HomeOverviewStep } from './home-overview-step';
 
-// The step now reads the device's HA config on mount (#646) and saves
-// the slice on Next. Mock fetch URL-aware: GET /ha-config returns the
-// `haConfig` seed; POST /apply-ha returns the `apply` result.
+// The step reads the device on mount (#646) from the unified seed
+// (#678 phase 2) and saves the slice on Next. Mock fetch URL-aware:
+// GET /api/setup returns the nested seed (its `homeOverview` section is
+// the `haConfig` override); POST /api/setup/apply-ha returns the `apply`
+// result.
 interface FetchOverrides {
   readonly haConfig?: unknown;
   readonly apply?: { ok?: boolean };
@@ -73,8 +75,10 @@ function installFetch(overrides: FetchOverrides = {}): void {
     'fetch',
     vi.fn((url: unknown, init?: { method?: string }) => {
       const u = String(url);
-      if (u.includes('/api/setup/ha-config')) {
-        return Promise.resolve(mockResponse(overrides.haConfig ?? {}));
+      if (u.endsWith('/api/setup')) {
+        return Promise.resolve(
+          mockResponse({ homeOverview: overrides.haConfig ?? {}, layout: null, network: null }),
+        );
       }
       if (u.includes('/api/setup/apply-ha') && init?.method === 'POST') {
         return Promise.resolve(
@@ -226,6 +230,19 @@ describe('HomeOverviewStep', () => {
     const homeNameInput = getByTestId('home-overview-home-name') as HTMLInputElement;
     await waitFor(() => {
       expect(homeNameInput.value).toBe('Evim');
+    });
+  });
+
+  it('seeds the home-zone radius from the unified seed (#678)', async () => {
+    installFetch({ haConfig: { latitude: 41, longitude: 29, radius: 250 } });
+    const { container } = render(
+      wrap(<HomeOverviewStep collected={{}} onNext={() => undefined} />),
+    );
+    // The radius (250) flows into the LocationPicker's numeric radius field;
+    // lat/lng are 41/29, so a `250` value uniquely identifies the radius input.
+    await waitFor(() => {
+      const values = Array.from(container.querySelectorAll('input')).map((i) => i.value);
+      expect(values).toContain('250');
     });
   });
 

--- a/apps/web/src/features/setup/home-overview/home-overview-step.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.tsx
@@ -55,7 +55,7 @@ import type { DeviceConfigInput } from '@glaon/core/config';
 import {
   countryCurrency,
   countryTimeZones,
-  fetchHaConfig,
+  fetchHomeOverviewSeed,
   lookupCountryCenter,
   saveHomeSettings,
 } from './home-overview-api';
@@ -117,7 +117,7 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
   // remount's fetch resolves with `cancelled === false` and seeds.
   useEffect(() => {
     let cancelled = false;
-    void fetchHaConfig().then((seed) => {
+    void fetchHomeOverviewSeed().then((seed) => {
       if (cancelled || seed === null) return;
       if (collected.homeName === undefined && seed.locationName !== undefined) {
         setHomeName((prev) => (prev === '' ? (seed.locationName ?? prev) : prev));
@@ -130,7 +130,16 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
       ) {
         setLocation((prev) =>
           prev.latitude === undefined && prev.longitude === undefined
-            ? { ...prev, latitude: seed.latitude, longitude: seed.longitude }
+            ? {
+                ...prev,
+                latitude: seed.latitude,
+                longitude: seed.longitude,
+                // Seed the home-zone radius too (#678) — it travels with the
+                // device's location. Only when the user hasn't set one yet.
+                ...(prev.radius === undefined && seed.radius !== undefined
+                  ? { radius: seed.radius }
+                  : {}),
+              }
             : prev,
         );
       }


### PR DESCRIPTION
**Phase 2a of #678** (builds on the merged #679 endpoint). Migrates the Home Overview step to seed from the unified `GET /api/setup` endpoint, and finally pre-fills the **home-zone radius** from the device.

## What changes
- `fetchHaConfig` → **`fetchHomeOverviewSeed`**: fetches `GET /api/setup`, validates against `SetupSeedResponseSchema`, returns the `homeOverview` section (HA Core `get_config` + `zone.home` radius). Returns `null` when that section is null (HA Core unconfigured/unreachable) so the step still degrades to blank/auto-detect defaults.
- The seed effect now also applies `radius` → the LocationPicker's radius field pre-fills from `zone.home` instead of always defaulting to 100 m. (Other fields unchanged; the StrictMode-safe seed from #676 is preserved.)

## Out of scope (next sub-phases)
- Layout + Network steps still use their existing reads; migrating them to the unified seed is Phase 2b/2c.
- Removing the deprecated `GET /api/setup/ha-config` + `/ha-layout` aliases is the final sub-phase (once no frontend caller remains).

## Test plan
- [x] `@glaon/web` type-check + lint green.
- [x] `home-overview` tests (12) — existing seed tests now exercise `GET /api/setup` (nested mock); new test asserts the radius (250) seeds into the picker; StrictMode regression preserved.
- [ ] CI green.
- [ ] Live (real HA, apps/api on #679): Home Overview pre-fills incl. the device's actual `zone.home` radius.

Refs #678