### PR TITLE
feat(web): seed Layout step from unified GET /api/setup

### DIFF
--- a/apps/web/src/features/setup/layout/layout-api.ts
+++ b/apps/web/src/features/setup/layout/layout-api.ts
@@ -4,9 +4,43 @@
 // doesn't duplicate floors/rooms. Mirrors the home-overview save's
 // outcome mapping; raw `fetch` per the apps/web idiom.
 
+import { SetupSeedResponseSchema, type HaLayoutResponse } from '@glaon/core/api-client';
 import type { Layout } from '@glaon/core/config';
 
 const HA_LAYOUT_URL = '/api/setup/ha-layout';
+const SETUP_SEED_URL = '/api/setup';
+
+/**
+ * Outcome of reading the Layout seed from the unified `GET /api/setup`
+ * (#678). `ok` separates "nothing to seed" (a `null` layout section, or a
+ * 503 in HA-less / backend-down dev) — which the step handles silently —
+ * from a real fetch failure that should surface a Toast.
+ */
+export type LayoutSeedResult =
+  | { readonly ok: true; readonly layout: HaLayoutResponse | null }
+  | { readonly ok: false };
+
+/**
+ * Read the unified device seed and return its Layout section (#678 phase
+ * 2b). A `null` section (HA Core unconfigured/unreachable) and a 503
+ * (apps/api down, per the dev proxy #674) both resolve to
+ * `{ ok: true, layout: null }` — expected in dev, seed silently skipped.
+ * A thrown request or any other non-OK is `{ ok: false }` so the step can
+ * surface a load-failed Toast.
+ */
+export async function fetchLayoutSeed(): Promise<LayoutSeedResult> {
+  let response: Response;
+  try {
+    response = await fetch(SETUP_SEED_URL, { credentials: 'include' });
+  } catch {
+    return { ok: false };
+  }
+  if (response.status === 503) return { ok: true, layout: null };
+  if (!response.ok) return { ok: false };
+  const parsed = SetupSeedResponseSchema.safeParse(await response.json().catch(() => null));
+  if (!parsed.success) return { ok: false };
+  return { ok: true, layout: parsed.data.layout };
+}
 
 /**
  * Outcome of reconciling the layout to the device.

--- a/apps/web/src/features/setup/layout/layout-api.ts
+++ b/apps/web/src/features/setup/layout/layout-api.ts
@@ -16,7 +16,10 @@ const SETUP_SEED_URL = '/api/setup';
  * 503 in HA-less / backend-down dev) — which the step handles silently —
  * from a real fetch failure that should surface a Toast.
  */
-export type LayoutSeedResult =
+// Not exported: only `fetchLayoutSeed` (this module) references it, and
+// the step consumes the result structurally (memory: knip blocks PRs on
+// exports without an external consumer).
+type LayoutSeedResult =
   | { readonly ok: true; readonly layout: HaLayoutResponse | null }
   | { readonly ok: false };
 

--- a/apps/web/src/features/setup/layout/layout-step.test.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.test.tsx
@@ -25,9 +25,10 @@ function mockResponse(init: { ok?: boolean; status?: number; json?: unknown }): 
   } as unknown as Response;
 }
 
-// URL/method-aware fetch: the GET seed (`ha-layout`) returns `seed` (or a
-// 503 when omitted → blank default floor); the per-step save (#652) POST
-// to `ha-layout` returns a successful reconcile so Next advances.
+// URL/method-aware fetch: the GET seed now hits the unified `GET /api/setup`
+// (#678) and reads its `layout` section (`seed`, or a 503 when omitted →
+// blank default floor); the per-step save (#652) POST to `ha-layout`
+// returns a successful reconcile so Next advances.
 function installFetch(seed?: unknown): void {
   vi.stubGlobal(
     'fetch',
@@ -36,10 +37,15 @@ function installFetch(seed?: unknown): void {
       if (u.includes('/api/setup/ha-layout') && init?.method === 'POST') {
         return Promise.resolve(mockResponse({ json: { ok: true, steps: [] } }));
       }
-      if (seed === undefined) {
-        return Promise.resolve(mockResponse({ ok: false, status: 503, json: {} }));
+      if (u.endsWith('/api/setup')) {
+        if (seed === undefined) {
+          return Promise.resolve(mockResponse({ ok: false, status: 503, json: {} }));
+        }
+        return Promise.resolve(
+          mockResponse({ json: { homeOverview: null, layout: seed, network: null } }),
+        );
       }
-      return Promise.resolve(mockResponse({ json: seed }));
+      return Promise.resolve(mockResponse({ json: {} }));
     }),
   );
 }

--- a/apps/web/src/features/setup/layout/layout-step.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.tsx
@@ -2,9 +2,10 @@
 // (epic #533, ADR 0028). Multi-floor + rooms editor (#592).
 //
 // On entry the step seeds its editor from the device's existing HA
-// floors + areas (#638): `GET /api/setup/ha-layout` returns the current
-// registries normalized into floors-with-rooms (+ floorless areas under
-// `unassigned`), which we map into the editor's initial state. The user
+// floors + areas (#638), read from the unified `GET /api/setup` (#678)
+// `layout` section: the current registries normalized into
+// floors-with-rooms (+ floorless areas under `unassigned`), which we map
+// into the editor's initial state. The user
 // then adds / edits on top. When the wizard already collected a layout
 // (re-entry / back-navigation), that takes precedence and the device
 // read is skipped. A 503 (HA Core not configured — HA-less dev) is
@@ -21,12 +22,12 @@ import { useToast } from '@glaon/ui';
 import { useCallback, useEffect, useState, type ReactNode, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { HaLayoutResponseSchema, type HaLayoutResponse } from '@glaon/core/api-client';
+import type { HaLayoutResponse } from '@glaon/core/api-client';
 import type { DeviceConfigInput, Layout } from '@glaon/core/config';
 
 import { WizardBackButton } from '../wizard-back-button';
 import { FloorTabs } from './floor-tabs';
-import { saveLayout } from './layout-api';
+import { fetchLayoutSeed, saveLayout } from './layout-api';
 import { RoomGrid } from './room-grid';
 import { useLayoutState } from './use-layout-state';
 
@@ -41,7 +42,6 @@ interface LayoutStepProps {
 
 const MAX_FLOORS = 10;
 const MAX_ROOMS_PER_FLOOR = 50;
-const HA_LAYOUT_URL = '/api/setup/ha-layout';
 
 /**
  * Map the device's HA floors/areas into the editor's seed `Layout`.
@@ -97,23 +97,16 @@ export function LayoutStep({ collected, onNext, onBack }: LayoutStepProps): Reac
     // stable while on the step), and a setState after unmount is a no-op
     // in React 19.
     void (async () => {
-      try {
-        const res = await fetch(HA_LAYOUT_URL, { credentials: 'include' });
-        if (res.ok) {
-          const parsed = HaLayoutResponseSchema.safeParse(await res.json().catch(() => null));
-          if (parsed.success) {
-            setSeed(mapHaLayoutToSeed(parsed.data, defaultFloorName));
-          }
-        } else if (res.status !== 503) {
-          // 503 = HA Core not configured (HA-less dev): expected, silent.
-          // Any other non-ok is a real failure worth surfacing.
-          showLoadError();
-        }
-      } catch {
+      // Seed the Layout section from the unified `GET /api/setup` (#678).
+      // A null section (HA Core unconfigured) / 503 (backend down) is a
+      // silent no-seed; only a real fetch failure surfaces a Toast.
+      const result = await fetchLayoutSeed();
+      if (!result.ok) {
         showLoadError();
-      } finally {
-        setPhase('ready');
+      } else if (result.layout !== null) {
+        setSeed(mapHaLayoutToSeed(result.layout, defaultFloorName));
       }
+      setPhase('ready');
     })();
   }, [collected.layout, defaultFloorName, showLoadError]);
 


### PR DESCRIPTION
**Phase 2b of #678** (builds on #679/#680). Migrates the Layout step to seed from the unified `GET /api/setup` endpoint's `layout` section instead of the legacy `GET /api/setup/ha-layout`.

## What changes
- New **`fetchLayoutSeed`** in `layout-api.ts`: GETs `/api/setup`, validates against `SetupSeedResponseSchema`, returns a `LayoutSeedResult`:
  - `{ ok: true, layout }` — the `layout` section (or `null` when HA Core is unconfigured/unreachable, or a **503** when apps/api is down per #674) → **silent no-seed → blank default floor**.
  - `{ ok: false }` — a thrown request or other non-OK → **load-failed Toast** (preserves the existing API Error Toast behavior).
- The step's seed effect uses it; the inline `fetch('/api/setup/ha-layout')` + local schema parse are gone.
- The per-step reconcile **save** still POSTs to `/api/setup/ha-layout` (unchanged).

## Out of scope (next sub-phases)
- Network step migration (Phase 2c).
- Removing the deprecated `GET /api/setup/ha-config` + `/ha-layout` aliases (final sub-phase).

## Test plan
- [x] `@glaon/web` type-check + lint green.
- [x] `layout` tests (21) — seed-applied, 503→blank-default, and collected-skip paths now exercise `GET /api/setup` (nested mock).
- [ ] CI green.

Refs #678