### PR TITLE
feat(api,web): serve wizard language list from the device seed

### DIFF
--- a/apps/api/src/routes/setup.test.ts
+++ b/apps/api/src/routes/setup.test.ts
@@ -360,4 +360,27 @@ describe('setup — unified seed GET / (#678)', () => {
     expect(body.network).toBeNull();
     expect(body.homeOverview?.country).toBe('TR');
   });
+
+  it('offers languages with the device language first (#683)', async () => {
+    const sink: RecordedFrame[] = [];
+    const router = createSetupRouter({
+      config: baseConfig(),
+      clientFactory: () => fakeClient({ sink, config: { language: 'tr' } }),
+    });
+    const res = await router.request('/');
+    const body = (await res.json()) as { languages: string[] };
+    expect(Array.isArray(body.languages)).toBe(true);
+    expect(body.languages[0]).toBe('tr'); // device language hoisted first
+    expect(body.languages).toContain('en'); // static HA set still present
+    expect(body.languages.filter((l) => l === 'tr')).toHaveLength(1); // deduped
+  });
+
+  it('falls back to the static language set when HA Core is unconfigured (#683)', async () => {
+    const router = createSetupRouter({ config: baseConfig() });
+    const res = await router.request('/');
+    const body = (await res.json()) as { languages: string[]; homeOverview: unknown };
+    expect(body.homeOverview).toBeNull();
+    expect(body.languages.length).toBeGreaterThan(10);
+    expect(body.languages).toContain('en');
+  });
 });

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -19,6 +19,7 @@
 import { Hono } from 'hono';
 
 import { SetupSeedResponseSchema, type SetupHomeOverview } from '@glaon/core/api-client';
+import { HA_LANGUAGES } from '@glaon/core/i18n';
 
 import type { Config } from '../config';
 import {
@@ -118,9 +119,20 @@ export function createSetupRouter(deps: SetupRouterDeps): Hono {
     });
 
     const [homeOverview, layout, network] = await Promise.all([homeOverviewP, layoutP, networkP]);
+
+    // Languages offered by the picker (#683): the HA-supported set with the
+    // device's current language guaranteed present (deduped, device-first so
+    // an unlisted-but-active language still surfaces). Always available — the
+    // static set stands in even when HA Core is unconfigured.
+    const deviceLanguage = homeOverview?.language;
+    const languages = [
+      ...(deviceLanguage !== undefined ? [deviceLanguage] : []),
+      ...HA_LANGUAGES.filter((code) => code !== deviceLanguage),
+    ];
+
     // Validate the assembled seed against the published contract before
     // returning — strips any stray keys + guarantees the nested shape.
-    return c.json(SetupSeedResponseSchema.parse({ homeOverview, layout, network }), 200);
+    return c.json(SetupSeedResponseSchema.parse({ homeOverview, layout, network, languages }), 200);
   });
 
   // The per-step GET seeds (`/ha-config` #646, `/ha-layout` #638) were

--- a/apps/web/src/features/setup/home-overview/home-overview-api.ts
+++ b/apps/web/src/features/setup/home-overview/home-overview-api.ts
@@ -15,24 +15,35 @@ const SETUP_SEED_URL = '/api/setup';
 const HA_APPLY_SETTINGS = '/api/setup/apply-ha';
 
 /**
- * Read the unified device seed (#678) and return its Home Overview section
- * (HA Core `get_config` + the `zone.home` radius). Returns `null` when
- * there is nothing to seed — no HA Core configured/reachable (the section
- * comes back `null`), the request failed, or a malformed response — so the
- * caller just starts with blank/auto-detect defaults. The wizard reads the
- * whole seed from one endpoint; this helper hands back only the slice the
- * Home Overview step needs.
+ * What the Home Overview step needs from the unified seed (#678/#683):
+ * the `homeOverview` section (`null` when HA Core is unconfigured/unreachable
+ * → blank/auto-detect defaults) and the device-sourced `languages` list for
+ * the language picker (empty on failure → the picker's built-in fallback).
  */
-export async function fetchHomeOverviewSeed(): Promise<SetupHomeOverview | null> {
+// Not exported: only `fetchHomeOverviewSeed`'s signature references it; the
+// step consumes the result structurally (knip blocks unused exports).
+interface HomeOverviewSeed {
+  readonly overview: SetupHomeOverview | null;
+  readonly languages: readonly string[];
+}
+
+/**
+ * Read the unified device seed (#678) and return the Home Overview slice.
+ * The wizard reads the whole seed from one endpoint; this helper hands back
+ * the `homeOverview` section + the offered `languages` (#683). A failed /
+ * malformed response degrades to `{ overview: null, languages: [] }`.
+ */
+export async function fetchHomeOverviewSeed(): Promise<HomeOverviewSeed> {
   let response: Response;
   try {
     response = await fetch(SETUP_SEED_URL, { credentials: 'include' });
   } catch {
-    return null;
+    return { overview: null, languages: [] };
   }
-  if (!response.ok) return null;
+  if (!response.ok) return { overview: null, languages: [] };
   const parsed = SetupSeedResponseSchema.safeParse(await response.json().catch(() => null));
-  return parsed.success ? (parsed.data.homeOverview ?? null) : null;
+  if (!parsed.success) return { overview: null, languages: [] };
+  return { overview: parsed.data.homeOverview, languages: parsed.data.languages };
 }
 
 /**

--- a/apps/web/src/features/setup/home-overview/home-overview-step.test.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.test.tsx
@@ -77,7 +77,12 @@ function installFetch(overrides: FetchOverrides = {}): void {
       const u = String(url);
       if (u.endsWith('/api/setup')) {
         return Promise.resolve(
-          mockResponse({ homeOverview: overrides.haConfig ?? {}, layout: null, network: null }),
+          mockResponse({
+            homeOverview: overrides.haConfig ?? {},
+            layout: null,
+            network: null,
+            languages: ['en', 'tr'],
+          }),
         );
       }
       if (u.includes('/api/setup/apply-ha') && init?.method === 'POST') {

--- a/apps/web/src/features/setup/home-overview/home-overview-step.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.tsx
@@ -5,11 +5,12 @@
 // Header: title/subtitle on the left, an independent **language switcher
 // pinned top-right** (#670) — outside the <form> so it reads as page
 // chrome, not a form field. It changes the wizard UI language (i18n) and
-// seeds the HA `language` value the form saves on Next. The full HA
-// language set is offered (HA_LANGUAGES) since the value maps to HA Core's
-// `language` (the device language), not only Glaon's own UI bundle —
-// picking a non-Glaon-UI language saves to the device without re-skinning
-// the wizard (only SUPPORTED_LOCALES drive `i18n.changeLanguage`).
+// seeds the HA `language` value the form saves on Next. The offered
+// languages come from the device seed (#683: `GET /api/setup` `languages`),
+// since the value maps to HA Core's `language` (the device language), not
+// only Glaon's own UI bundle — picking a non-Glaon-UI language saves to the
+// device without re-skinning the wizard (only SUPPORTED_LOCALES drive
+// `i18n.changeLanguage`).
 //
 // Form fields (per Figma, top to bottom):
 // - Home Name (required text input)
@@ -49,7 +50,7 @@ import {
 import { useCallback, useEffect, useId, useState, type ReactNode, type SubmitEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { HA_LANGUAGES, SUPPORTED_LOCALES } from '@glaon/core/i18n';
+import { SUPPORTED_LOCALES } from '@glaon/core/i18n';
 import type { DeviceConfigInput } from '@glaon/core/config';
 
 import {
@@ -100,6 +101,10 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
   // Locale is a free BCP-47 string (#666): it maps to HA Core `language`,
   // which spans the full HA language set — not only Glaon's UI locales.
   const [locale, setLocale] = useState<string>(collected.locale ?? 'en');
+  // Languages offered by the picker — sourced from the device seed (#683).
+  // Empty until the seed lands; LanguageSelect falls back to a built-in set
+  // for that sub-second window (and if the backend is unreachable).
+  const [languages, setLanguages] = useState<readonly string[]>([]);
   const [showHomeNameError, setShowHomeNameError] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
 
@@ -117,8 +122,11 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
   // remount's fetch resolves with `cancelled === false` and seeds.
   useEffect(() => {
     let cancelled = false;
-    void fetchHomeOverviewSeed().then((seed) => {
-      if (cancelled || seed === null) return;
+    void fetchHomeOverviewSeed().then((result) => {
+      if (cancelled) return;
+      setLanguages(result.languages);
+      const seed = result.overview;
+      if (seed === null) return;
       if (collected.homeName === undefined && seed.locationName !== undefined) {
         setHomeName((prev) => (prev === '' ? (seed.locationName ?? prev) : prev));
       }
@@ -280,8 +288,9 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
           language switcher pinned top-right (#670). The switcher lives
           *outside* the <form> so it reads as page chrome, not a form field
           — it changes the wizard UI language (i18n) and seeds the HA
-          `language` value the form saves on Next. Full HA_LANGUAGES set is
-          offered; only Glaon UI locales (SUPPORTED_LOCALES) re-skin the UI. */}
+          `language` value the form saves on Next. The offered languages come
+          from the device seed (#683); only Glaon UI locales
+          (SUPPORTED_LOCALES) re-skin the UI. */}
       <header className="flex items-start justify-between gap-6 pb-6">
         <div className="flex flex-col gap-1">
           <h1 className="text-display-xs font-semibold text-primary">
@@ -292,7 +301,7 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
         <div className="w-44 shrink-0">
           <LanguageSelect
             aria-label={t('setup.homeOverview.language.label')}
-            options={HA_LANGUAGES}
+            options={languages}
             value={locale}
             placeholder={t('setup.homeOverview.language.placeholder')}
             autoDetect={false}

--- a/apps/web/src/features/setup/layout/layout-step.test.tsx
+++ b/apps/web/src/features/setup/layout/layout-step.test.tsx
@@ -42,7 +42,9 @@ function installFetch(seed?: unknown): void {
           return Promise.resolve(mockResponse({ ok: false, status: 503, json: {} }));
         }
         return Promise.resolve(
-          mockResponse({ json: { homeOverview: null, layout: seed, network: null } }),
+          mockResponse({
+            json: { homeOverview: null, layout: seed, network: null, languages: [] },
+          }),
         );
       }
       return Promise.resolve(mockResponse({ json: {} }));

--- a/packages/core/src/api-client/setup.ts
+++ b/packages/core/src/api-client/setup.ts
@@ -164,5 +164,12 @@ export const SetupSeedResponseSchema = z.object({
   homeOverview: SetupHomeOverviewSchema.nullable(),
   layout: HaLayoutResponseSchema.nullable(),
   network: SetupNetworkSchema.nullable(),
+  /**
+   * Languages offered by the Home Overview language picker (#683), sourced
+   * by the server: the HA-supported set (`HA_LANGUAGES`) with the device's
+   * current `get_config.language` guaranteed present. Always non-null — even
+   * when HA Core is unconfigured the static set is available. BCP-47 codes.
+   */
+  languages: z.array(z.string()),
 });
 export type SetupSeedResponse = z.infer<typeof SetupSeedResponseSchema>;


### PR DESCRIPTION
**Phase A of #683.** The Home Overview language picker's options now come from the unified `GET /api/setup` seed instead of importing the static `HA_LANGUAGES` in the frontend. (Phase B rewrites the `LanguageSelect` component to UUI `Select` with native+localized labels.)

## What changes
- **core/api**: add a top-level `languages: string[]` to the setup seed, built server-side as the HA-supported set (`HA_LANGUAGES`) with the device's current `get_config.language` **hoisted first** (deduped). **Always present** — the static set stands in even when HA Core is unconfigured (HA exposes no WS command listing its languages; see #666).
- **web**: `fetchHomeOverviewSeed` now returns `{ overview, languages }`; the Home Overview step feeds `LanguageSelect options` from `languages` (empty pre-seed → the picker's built-in fallback list for that sub-second window / backend-down). The `HA_LANGUAGES` frontend import is dropped from the step.

## Out of scope (Phase B)
- `LanguageSelect` → UUI `Select` (icon-leading, no search) + `Deutsch — Almanca` labels + Figma frame.

## Test plan
- [x] core build + api/web type-check + lint green.
- [x] api setup tests (16): `languages` device-first + deduped; static fallback when HA unconfigured.
- [x] web home-overview (22) + layout (21): seed mocks updated to the `languages`-bearing shape.
- [ ] CI green.

Refs #683