### PR TITLE
perf(ui): defer LocationPicker map mount until browser idle

### DIFF
--- a/packages/ui/src/components/LocationPicker/LocationPicker.tsx
+++ b/packages/ui/src/components/LocationPicker/LocationPicker.tsx
@@ -314,6 +314,30 @@ export function LocationPicker({
     };
   }, []);
 
+  // Defer the heavy MapLibre mount until the browser is idle, i.e. after the
+  // first paint / LCP (#686). The wizard renders LocationPicker on `/` (the
+  // page Lighthouse measures), and MapLibre's WebGL/style init is the
+  // dominant LCP+TBT cost. Until then the numeric fields stay fully usable
+  // and a neutral placeholder fills the map area, so the form paints fast.
+  const [mapReady, setMapReady] = useState<boolean>(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const ready = () => {
+      setMapReady(true);
+    };
+    const ric = window.requestIdleCallback;
+    if (typeof ric === 'function') {
+      const id = ric(ready, { timeout: 2000 });
+      return () => {
+        window.cancelIdleCallback(id);
+      };
+    }
+    const t = window.setTimeout(ready, 200);
+    return () => {
+      window.clearTimeout(t);
+    };
+  }, []);
+
   // --- Map fly-to on external center change (geocode pick / field edit) ---
   const mapRef = useRef<MapRef>(null);
   const lastFlownTo = useRef<string | null>(null);
@@ -442,7 +466,7 @@ export function LocationPicker({
         className="overflow-hidden rounded-lg ring-1 ring-primary"
         style={{ height: mapHeight }}
       >
-        {isOnline ? (
+        {isOnline && mapReady ? (
           <Map
             ref={mapRef}
             initialViewState={initialView}
@@ -483,8 +507,13 @@ export function LocationPicker({
             )}
           </Map>
         ) : (
-          <div className="flex size-full items-center justify-center bg-secondary p-4 text-center text-sm text-tertiary">
-            {offlineLabel}
+          <div
+            aria-hidden={isOnline ? 'true' : undefined}
+            className="flex size-full items-center justify-center bg-secondary p-4 text-center text-sm text-tertiary"
+          >
+            {/* Offline → explain; online-but-not-yet-mounted → neutral
+                placeholder for the brief pre-idle window (#686). */}
+            {isOnline ? null : offlineLabel}
           </div>
         )}
       </div>


### PR DESCRIPTION
Reduce mobile Lighthouse LCP/TBT on the wizard (which is `/` for unconfigured devices, the page Lighthouse measures). LCP was riding the 5200ms ceiling (5208ms observed).

## Change
`LocationPicker` mounted MapLibre eagerly — its WebGL/style init is the dominant LCP+TBT cost on the measured page. Now the `<Map>` is gated behind a `mapReady` flag flipped from `requestIdleCallback` (200ms `setTimeout` fallback), so it mounts **after first paint**. The numeric lat/lng/radius fields stay fully usable and a neutral placeholder fills the map area until then (the offline label only shows when actually offline — #647 offline mode preserved).

MapLibre is already its own ~273KB-gzip chunk, so deferring the mount keeps its WebGL init off the LCP path; the form/title becomes the LCP element and paints fast.

## Verified
- `pnpm --filter @glaon/web build` — succeeds; maplibre stays a separate chunk.
- `@glaon/ui` type-check + lint + 171 unit tests; `@glaon/web` home-overview (22) green.

## Test plan
- [ ] CI green.
- [ ] Wizard: fields + placeholder paint immediately; map appears shortly after; offline still shows the offline notice; drag/geocode/fly-to still work once mounted.
- [ ] Chromatic: LocationPicker story still captures the map (idle fires within the capture window) — review the diff.
- [ ] Lighthouse mobile LCP/TBT drop with headroom (non-required signal).

Closes #686
Refs #500