### PR TITLE
refactor(ui): make CountrySelect a button-trigger searchable select

### DIFF
--- a/apps/web/src/features/setup/home-overview/home-overview-step.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.tsx
@@ -354,6 +354,8 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
           <CountrySelect
             aria-labelledby={countryLabelId}
             placeholder={t('setup.homeOverview.country.placeholder')}
+            searchPlaceholder={t('setup.homeOverview.country.searchPlaceholder')}
+            noResultsLabel={t('setup.homeOverview.country.noResults')}
             {...(country !== '' ? { value: country } : {})}
             autoDetect={collected.country === undefined && country === ''}
             onSelectionChange={onCountrySelect}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -72,7 +72,9 @@
       },
       "country": {
         "label": "Country",
-        "placeholder": "Select your country"
+        "placeholder": "Select your country",
+        "searchPlaceholder": "Search countries",
+        "noResults": "No results found"
       },
       "timezone": {
         "label": "Timezone",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -72,7 +72,9 @@
       },
       "country": {
         "label": "Ülke",
-        "placeholder": "Ülkeni seç"
+        "placeholder": "Ülkeni seç",
+        "searchPlaceholder": "Ülke ara",
+        "noResults": "Sonuç bulunamadı"
       },
       "timezone": {
         "label": "Saat Dilimi",

--- a/packages/ui/src/components/CountrySelect/CountrySelect.controls.ts
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.controls.ts
@@ -21,7 +21,19 @@ export const countrySelectControls = {
     type: 'text',
     default: 'Select a country',
     description:
-      'Hint text shown when no option is selected. Never use placeholder as a substitute for the label.',
+      'Hint text shown in the closed trigger when no country is selected. Never use placeholder as a substitute for the label.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  searchPlaceholder: {
+    type: 'text',
+    default: 'Search',
+    description: 'Placeholder inside the in-popover search field.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  noResultsLabel: {
+    type: 'text',
+    default: 'No results found',
+    description: 'Text shown in the popover when the search matches no country.',
     category: 'Content',
   } satisfies ControlSpec<string>,
   hint: {

--- a/packages/ui/src/components/CountrySelect/CountrySelect.mdx
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.mdx
@@ -6,14 +6,16 @@ import * as CountrySelectStories from './CountrySelect.stories';
 
 # CountrySelect
 
-App-primitive country picker. Thin wrap over the kit
-[`<ComboBox>`](?path=/docs/web-primitives-select--docs#withsearch) that
-adds the ISO 3166-1 alpha-2 list, runtime localization through
-`Intl.DisplayNames`, diacritic-insensitive search, and optional
-one-shot browser locale auto-detection.
+App-primitive country picker. Thin wrap over the kit `SearchSelect`
+(#688) — a **button trigger** (flag + country name + chevron) that opens
+a popover with a **search field inside it**, not an editable input. Adds
+the ISO 3166-1 alpha-2 list, runtime localization through
+`Intl.DisplayNames`, diacritic-insensitive search, and optional one-shot
+browser locale auto-detection.
 
-The wrap layer is what you import. The visual + popover positioning +
-RAC plumbing all come from the kit ComboBox.
+The wrap layer is what you import. The trigger + popover + in-popover
+search + RAC plumbing all come from the kit `SearchSelect` (itself the
+kit `MultiSelect` button-and-search pattern, as single-select).
 
 ## When to use
 
@@ -77,8 +79,9 @@ Auto-detection is **skipped** when:
 />
 ```
 
-The trigger renders the localized country name once a selection is
-made; the input becomes a search field while the popover is open.
+The trigger is a button showing the selected country's flag + localized
+name (a Globe glyph + placeholder until one is picked). Opening it shows
+a search field at the top of the popover; picking a country closes it.
 
 ## Localization
 
@@ -105,10 +108,9 @@ browser supports — no shipped translation tables, no extra dependency.
 - Pass a visible `label`, **or** — when the host renders its own label
   (e.g. a form row) — associate it via `aria-labelledby` (id of the
   external label) or supply an `aria-label`. One of the three must be
-  present so the ComboBox always has an accessible name.
-- The popover is keyboard-navigable (Arrow up/down, Enter to select,
-  Esc to dismiss) and the search input is a real `<input>` element
-  with `aria-autocomplete="list"`.
+  present so the trigger button always has an accessible name.
+- Keyboard: open with Enter/Space, type in the popover search field to
+  filter, Arrow up/down through results, Enter to select, Esc to dismiss.
 - Pair `isInvalid` with a descriptive `hint` ("Country is required.")
   — the kit wires `aria-invalid` + `aria-describedby` automatically.
 - `isRequired` adds a visual `*` and forwards `aria-required`. Use

--- a/packages/ui/src/components/CountrySelect/CountrySelect.stories.tsx
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.stories.tsx
@@ -80,8 +80,8 @@ export const GermanLocale: Story = {
 
 /**
  * Arabic locale — exercises the RTL render path. The decorator wraps
- * the field in `dir="rtl"` so the popover, input alignment, and
- * indicator placement mirror correctly.
+ * the field in `dir="rtl"` so the trigger, popover, and search-field
+ * alignment mirror correctly.
  */
 export const ArabicRtl: Story = {
   args: { locale: 'ar-SA', autoDetect: false, defaultValue: 'SA', label: 'الدولة' },

--- a/packages/ui/src/components/CountrySelect/CountrySelect.tsx
+++ b/packages/ui/src/components/CountrySelect/CountrySelect.tsx
@@ -25,20 +25,11 @@
 // this wrapper's contribution is the prop API + the static country
 // list + locale detection. No network call lives here.
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type FC,
-  type FocusEvent,
-  type ReactNode,
-} from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Globe01 } from '@untitledui/icons';
-import type { Key } from 'react-aria-components';
 
 import { Flag } from '../../icons/flag';
-import { ComboBox, SelectItem, type SelectItemType } from '../Select';
+import { SearchSelect, SelectItem, type SelectItemType } from '../Select';
 import { buildCountryItems, detectBrowserCountry, diacriticInsensitiveFilter } from './countries';
 
 // Types stay un-exported per memory note `feedback_knip_props_interfaces.md`
@@ -93,8 +84,12 @@ interface CountrySelectProps {
    * (e.g. a form row) instead of the built-in `label`.
    */
   'aria-labelledby'?: string;
-  /** Placeholder text shown when no option is selected. */
+  /** Placeholder text shown in the (closed) trigger when nothing is selected. */
   placeholder?: string;
+  /** Placeholder inside the in-popover search field. @default 'Search' */
+  searchPlaceholder?: string;
+  /** Text shown when the search matches no country. @default 'No results found' */
+  noResultsLabel?: string;
   /** Helper text shown under the trigger; doubles as the error
    *  message when `isInvalid` is true. */
   hint?: ReactNode;
@@ -136,6 +131,8 @@ export function CountrySelect({
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
   placeholder,
+  searchPlaceholder,
+  noResultsLabel,
   hint,
   isDisabled,
   isInvalid,
@@ -146,7 +143,16 @@ export function CountrySelect({
   popoverClassName,
 }: CountrySelectProps) {
   const resolvedLocale = useResolvedLocale(locale);
-  const items = useMemo(() => buildCountryItems(resolvedLocale), [resolvedLocale]);
+  // Each item carries its flag as `icon` so the SearchSelect trigger shows
+  // the selected country's flag and every popover row shows its flag.
+  const items = useMemo(
+    () =>
+      buildCountryItems(resolvedLocale).map((item) => ({
+        ...item,
+        icon: renderListItemFlag(String(item.id)),
+      })),
+    [resolvedLocale],
+  );
 
   const isHostControlled = value !== undefined;
 
@@ -177,73 +183,48 @@ export function CountrySelect({
     setSuppressInvalid(false);
   }, [isInvalid]);
 
-  const handleSelectionChange = (key: Key | null) => {
-    const next = key === null ? null : String(key);
+  const handleSelectionChange = (next: string | null) => {
     if (!isHostControlled) setInternalKey(next);
     setSuppressInvalid(true);
     onSelectionChange?.(next);
   };
 
-  // Select-all-on-focus inside the inner search input so the next
-  // keystroke replaces the previous label cleanly. RAC's ComboBox
-  // doesn't forward `onFocus` to the input, so we capture at the
-  // wrapper and act on any input descendant. `requestAnimationFrame`
-  // defers the `.select()` until RAC's own focus handling settles.
-  const handleFocusCapture = useCallback((event: FocusEvent<HTMLDivElement>) => {
-    const target = event.target;
-    if (!(target instanceof HTMLInputElement)) return;
-    if (target.disabled || target.readOnly) return;
-    requestAnimationFrame(() => {
-      try {
-        target.select();
-      } catch {
-        // Input may have unmounted (e.g. dropdown closed) between
-        // the focus event and the rAF tick — the failed `.select()`
-        // is harmless and we don't need to surface it.
-      }
-    });
-  }, []);
-
   const effectiveInvalid = isInvalid === true && !suppressInvalid;
-  const triggerIcon = renderTriggerIcon(effectiveKey);
 
-  // Build the ComboBox props bag conditionally — the @glaon/ui package
-  // compiles with `exactOptionalPropertyTypes: true`, so passing
-  // explicit `undefined` to an optional prop fails type-check.
-  const comboProps: Record<string, unknown> = {
+  // Build the SearchSelect props bag conditionally — the @glaon/ui package
+  // compiles with `exactOptionalPropertyTypes: true`, so passing explicit
+  // `undefined` to an optional prop fails type-check.
+  const selectProps: Record<string, unknown> = {
     items,
     size,
     selectedKey: effectiveKey ?? null,
     onSelectionChange: handleSelectionChange,
-    defaultFilter: diacriticInsensitiveFilter,
-    shortcut: false,
-    icon: triggerIcon,
+    filter: diacriticInsensitiveFilter,
+    // Globe placeholder glyph until a country is picked; once selected the
+    // SearchSelect trigger shows that country's flag (the item's `icon`).
+    leadingIcon: Globe01,
   };
 
-  if (label !== undefined) comboProps.label = label;
-  if (ariaLabel !== undefined) comboProps['aria-label'] = ariaLabel;
-  if (ariaLabelledby !== undefined) comboProps['aria-labelledby'] = ariaLabelledby;
-  if (placeholder !== undefined) comboProps.placeholder = placeholder;
-  if (hint !== undefined) comboProps.hint = hint;
-  if (isDisabled === true) comboProps.isDisabled = true;
-  if (effectiveInvalid) comboProps.isInvalid = true;
-  if (isRequired === true) comboProps.isRequired = true;
-  if (hideRequiredIndicator === true) comboProps.hideRequiredIndicator = true;
-  if (className !== undefined) comboProps.className = className;
-  if (popoverClassName !== undefined) comboProps.popoverClassName = popoverClassName;
+  if (label !== undefined) selectProps.label = label;
+  if (ariaLabel !== undefined) selectProps['aria-label'] = ariaLabel;
+  if (ariaLabelledby !== undefined) selectProps['aria-labelledby'] = ariaLabelledby;
+  if (placeholder !== undefined) selectProps.placeholder = placeholder;
+  if (searchPlaceholder !== undefined) selectProps.searchPlaceholder = searchPlaceholder;
+  if (noResultsLabel !== undefined) selectProps.noResultsLabel = noResultsLabel;
+  if (hint !== undefined) selectProps.hint = hint;
+  if (isDisabled === true) selectProps.isDisabled = true;
+  if (effectiveInvalid) selectProps.isInvalid = true;
+  if (isRequired === true) selectProps.isRequired = true;
+  if (hideRequiredIndicator === true) selectProps.hideRequiredIndicator = true;
+  if (className !== undefined) selectProps.className = className;
+  if (popoverClassName !== undefined) selectProps.popoverClassName = popoverClassName;
 
   return (
-    <div onFocusCapture={handleFocusCapture}>
-      <ComboBox {...comboProps}>
-        {(item: SelectItemType) => (
-          <SelectItem
-            id={item.id}
-            label={item.label ?? ''}
-            icon={renderListItemFlag(String(item.id))}
-          />
-        )}
-      </ComboBox>
-    </div>
+    <SearchSelect {...selectProps}>
+      {(item: SelectItemType) => (
+        <SelectItem id={item.id} label={item.label ?? ''} icon={item.icon} />
+      )}
+    </SearchSelect>
   );
 }
 
@@ -264,26 +245,9 @@ function useResolvedLocale(locale: string | undefined): string {
 }
 
 /**
- * Trigger leading icon. Returns the `Globe01` component (so the kit
- * applies the standard `*:data-icon:size-5` styling) until the user
- * picks a country; once a country is selected, returns a pre-tagged
- * `<span data-icon>` wrapping the country's flag so the kit's
- * `isValidElement` branch renders it verbatim — `data-icon` is what
- * pulls the sizing + colour utilities through.
- */
-function renderTriggerIcon(code: string | null | undefined): FC | ReactNode {
-  if (!code) return Globe01;
-  return (
-    <span data-icon className="flex shrink-0 items-center" aria-hidden="true">
-      <Flag country={code} shape="square" />
-    </span>
-  );
-}
-
-/**
- * Per-row flag for each country in the popover. Same `data-icon` trick
- * as the trigger icon — the kit's `*:data-icon:size-5` selector on
- * the row container picks it up.
+ * Per-row flag for each country (popover rows + the selected trigger).
+ * Pre-tagged `<span data-icon>` so the kit's `*:data-icon:size-5` selector
+ * on the container pulls the sizing + colour utilities through.
  */
 function renderListItemFlag(code: string): ReactNode {
   return (

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -23,6 +23,7 @@
 export { Select, type SelectProps } from '../base/select/select';
 export { ComboBox } from '../base/select/combobox';
 export { MultiSelect } from '../base/select/multi-select';
+export { SearchSelect } from '../base/select/search-select';
 export { TagSelect, TagSelectBase, TagSelectTagsValue } from '../base/select/tag-select';
 export { NativeSelect } from '../base/select/select-native';
 export { SelectItem } from '../base/select/select-item';

--- a/packages/ui/src/components/Select/index.ts
+++ b/packages/ui/src/components/Select/index.ts
@@ -2,6 +2,7 @@ export {
   ComboBox,
   MultiSelect,
   NativeSelect,
+  SearchSelect,
   Select,
   SelectContext,
   SelectItem,

--- a/packages/ui/src/components/base/select/search-select.tsx
+++ b/packages/ui/src/components/base/select/search-select.tsx
@@ -1,0 +1,255 @@
+// @ts-nocheck
+// Kit-derived single-select with search-in-popover (#688). The Untitled
+// UI free kit ships a searchable *input-trigger* select (`ComboBox`) and a
+// *multi*-select popover (`MultiSelect`), but no single-select **button
+// trigger + in-popover search** variant. This composes that pattern from
+// the exact same react-aria-components building blocks the kit's
+// `multi-select.tsx` uses (`DialogTrigger` + `Button` + `Popover` +
+// `Autocomplete` + `SearchField` + `ListBox`), as single-select: a button
+// trigger (leading icon + selected label + chevron) that opens a popover
+// with a search field, and closes on pick. `@ts-nocheck` matches the kit
+// files so an `untitledui upgrade` of the siblings stays a clean replace.
+'use client';
+
+import type { FC, ReactNode } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { ChevronDown, SearchLg } from '@untitledui/icons';
+import type { Key, Selection } from 'react-aria-components';
+import {
+  Autocomplete as AriaAutocomplete,
+  Button as AriaButton,
+  Dialog as AriaDialog,
+  DialogTrigger as AriaDialogTrigger,
+  Input as AriaInput,
+  ListBox as AriaListBox,
+  Popover as AriaPopover,
+  SearchField as AriaSearchField,
+} from 'react-aria-components';
+import { HintText } from '@/components/base/input/hint-text';
+import { Label } from '@/components/base/input/label';
+import { isReactComponent } from '@/utils/is-react-component';
+import { cx } from '@/utils/cx';
+import { SelectItem } from './select-item';
+import { type CommonProps, SelectContext, type SelectItemType, sizes } from './select-shared';
+
+const searchSizes = {
+  sm: { wrapper: 'py-1', root: 'px-3 py-2 gap-2 *:data-icon:size-4 *:data-icon:stroke-[2.25px]', text: 'text-sm' },
+  md: { wrapper: 'py-0.5', root: 'px-3 py-2 gap-2 *:data-icon:size-5', text: 'text-md' },
+  lg: { wrapper: 'py-0.5', root: 'px-3.5 py-2.5 gap-2 *:data-icon:size-5', text: 'text-md' },
+};
+
+const popoverMaxHeights = { sm: 'max-h-68', md: 'max-h-76', lg: 'max-h-92' };
+
+interface SearchSelectProps extends CommonProps {
+  /** Options to render in the listbox. */
+  items?: SelectItemType[];
+  /** Row renderer (defaults to `<SelectItem>`). */
+  children: ReactNode | ((item: SelectItemType) => ReactNode);
+  /** Controlled selection — the selected item's key, or `null`. */
+  selectedKey?: string | null;
+  /** Fires with the picked key (or `null` when cleared). */
+  onSelectionChange?: (key: string | null) => void;
+  /** Leading icon shown in the trigger when nothing is selected. The
+   *  selected item's own `icon` (e.g. a flag) takes over once picked. */
+  leadingIcon?: FC | ReactNode;
+  /** Diacritic-insensitive `(textValue, inputValue) => boolean` filter. */
+  filter?: (textValue: string, inputValue: string) => boolean;
+  /** Placeholder inside the popover search field. */
+  searchPlaceholder?: string;
+  /** Text shown when the search matches no option. */
+  noResultsLabel?: string;
+  isDisabled?: boolean;
+  isRequired?: boolean;
+  isInvalid?: boolean;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  className?: string;
+  popoverClassName?: string;
+}
+
+const SearchSelectRoot = ({
+  items,
+  children,
+  size = 'md',
+  selectedKey = null,
+  onSelectionChange,
+  leadingIcon,
+  filter,
+  searchPlaceholder = 'Search',
+  noResultsLabel = 'No results found',
+  isDisabled,
+  isRequired,
+  isInvalid,
+  placeholder = 'Select',
+  label,
+  hint,
+  tooltip,
+  hideRequiredIndicator,
+  className,
+  popoverClassName,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+}: SearchSelectProps) => {
+  const [searchValue, setSearchValue] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [popoverWidth, setPopoverWidth] = useState('');
+
+  const onResize = useCallback(() => {
+    if (!triggerRef.current) return;
+    setPopoverWidth(triggerRef.current.getBoundingClientRect().width + 'px');
+  }, []);
+
+  const onOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (!open) setSearchValue('');
+  };
+
+  const handleListSelectionChange = (keys: Selection) => {
+    const next = keys === 'all' ? null : ([...keys][0] as Key | undefined);
+    onSelectionChange?.(next === undefined || next === null ? null : String(next));
+    setIsOpen(false);
+    setSearchValue('');
+  };
+
+  const selectedItem = selectedKey != null ? items?.find((i) => i.id === selectedKey) : undefined;
+  const triggerIcon = selectedItem?.icon ?? leadingIcon;
+
+  return (
+    <SelectContext.Provider value={{ size }}>
+      <div className={cx('flex flex-col gap-1.5', className)}>
+        {label && (
+          <Label
+            isRequired={hideRequiredIndicator ? false : isRequired}
+            isInvalid={isInvalid}
+            tooltip={tooltip}
+          >
+            {label}
+          </Label>
+        )}
+
+        <AriaDialogTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
+          <AriaButton
+            ref={triggerRef}
+            isDisabled={isDisabled}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
+            onPress={onResize}
+            className={(state) =>
+              cx(
+                'relative flex w-full cursor-pointer items-center rounded-lg bg-primary shadow-xs ring-1 outline-hidden transition duration-100 ease-linear ring-inset',
+                isInvalid ? 'ring-error' : 'ring-primary',
+                (state.isFocusVisible || state.isPressed || isOpen) && 'ring-2 ring-brand',
+                state.isDisabled && 'cursor-not-allowed opacity-50',
+              )
+            }
+          >
+            <span
+              className={cx(
+                'flex w-full items-center truncate text-left',
+                sizes[size].root,
+                '*:data-icon:shrink-0 *:data-icon:text-fg-quaternary',
+              )}
+            >
+              {isReactComponent(triggerIcon) ? (
+                <triggerIcon data-icon aria-hidden="true" />
+              ) : (
+                (triggerIcon ?? null)
+              )}
+
+              <span className={cx('flex flex-1 truncate', sizes[size].textContainer)}>
+                {selectedItem ? (
+                  <span className={cx('truncate font-medium text-primary', sizes[size].text)}>
+                    {selectedItem.label}
+                  </span>
+                ) : (
+                  <span className={cx('truncate text-placeholder', sizes[size].text)}>
+                    {placeholder}
+                  </span>
+                )}
+              </span>
+
+              <ChevronDown
+                aria-hidden="true"
+                className={cx(
+                  'ml-auto shrink-0 text-fg-quaternary',
+                  size === 'lg' ? 'size-5' : 'size-4 stroke-[2.25px]',
+                )}
+              />
+            </span>
+          </AriaButton>
+
+          <AriaPopover
+            placement="bottom"
+            offset={4}
+            containerPadding={0}
+            style={{ width: popoverWidth || undefined }}
+            className={(state) =>
+              cx(
+                'w-(--trigger-width) origin-(--trigger-anchor-point) overflow-hidden rounded-lg bg-primary shadow-lg ring-1 ring-secondary_alt outline-hidden will-change-transform',
+                state.isEntering &&
+                  'duration-150 ease-out animate-in fade-in placement-bottom:slide-in-from-top-0.5',
+                state.isExiting &&
+                  'duration-100 ease-in animate-out fade-out placement-bottom:slide-out-to-top-0.5',
+                popoverClassName,
+              )
+            }
+          >
+            <AriaDialog className="outline-hidden">
+              <AriaAutocomplete
+                filter={filter}
+                inputValue={searchValue}
+                onInputChange={setSearchValue}
+              >
+                <div className={cx('border-b border-secondary', searchSizes[size].wrapper)}>
+                  <AriaSearchField
+                    aria-label="Search"
+                    value={searchValue}
+                    onChange={setSearchValue}
+                    autoFocus
+                  >
+                    <div className={cx('flex items-center', searchSizes[size].root)}>
+                      <SearchLg data-icon aria-hidden="true" className="shrink-0 text-fg-quaternary" />
+                      <AriaInput
+                        placeholder={searchPlaceholder}
+                        className={cx(
+                          'w-full appearance-none bg-transparent text-primary caret-alpha-black/90 outline-hidden placeholder:text-placeholder',
+                          searchSizes[size].text,
+                        )}
+                      />
+                    </div>
+                  </AriaSearchField>
+                </div>
+
+                <AriaListBox
+                  aria-label={label || ariaLabel || 'Options'}
+                  items={items}
+                  selectionMode="single"
+                  selectedKeys={selectedKey != null ? new Set([selectedKey]) : new Set()}
+                  onSelectionChange={handleListSelectionChange}
+                  renderEmptyState={() => (
+                    <div className="px-4 py-3 text-center text-sm text-tertiary">{noResultsLabel}</div>
+                  )}
+                  className={cx('overflow-y-auto py-1 outline-hidden', popoverMaxHeights[size])}
+                >
+                  {children}
+                </AriaListBox>
+              </AriaAutocomplete>
+            </AriaDialog>
+          </AriaPopover>
+        </AriaDialogTrigger>
+
+        {hint && (
+          <HintText isInvalid={isInvalid} className={cx(size === 'sm' && 'text-xs')}>
+            {hint}
+          </HintText>
+        )}
+      </div>
+    </SelectContext.Provider>
+  );
+};
+
+const SearchSelect = SearchSelectRoot as typeof SearchSelectRoot & { Item: typeof SelectItem };
+SearchSelect.Item = SelectItem;
+
+export { SearchSelect };

--- a/tools/figma-plugin/scripts/11-countryselect-search-select.js
+++ b/tools/figma-plugin/scripts/11-countryselect-search-select.js
@@ -1,0 +1,160 @@
+// Glaon — 11 CountrySelect → SearchSelect (button + popover search) (#688)
+//
+// Updates the "App Primitives/CountrySelect" COMPONENT in the Design
+// System Figma file to match PR #688: the country picker is no longer an
+// editable input (ComboBox) — it's a **button trigger** (leading flag +
+// selected country name + chevron) that opens a popover with a **search
+// field** inside it (kit SearchSelect, the MultiSelect button-and-search
+// pattern as single-select). The component keeps its `storybook-id:
+// app-primitives-country-select` description (Chromatic Figma-diff
+// contract; see docs/figma.md).
+//
+// The frame shows the closed trigger (flag + "Türkiye" + chevron). The
+// search-in-popover is the open state, documented in Storybook.
+//
+// Usage:
+//   1. Copy this file's contents into tools/figma-plugin/code.js.
+//   2. Open the Design System Figma file (Inter installed; else fallback).
+//   3. Run plugin (Plugins → Development → Glaon) → review dry-run.
+//   4. Flip CONFIRM = true → re-run → report the node id for the PR body.
+//   5. git restore tools/figma-plugin/code.js
+//
+// Idempotent: rebuilds the trigger's children in place.
+
+const CONFIRM = false;
+
+const COMPONENT_NAME = 'App Primitives/CountrySelect';
+const STORYBOOK_ID = 'app-primitives-country-select';
+const FRAME_WIDTH = 360;
+const SAMPLE_LABEL = 'Türkiye'; // selected country (autonymless — localized name)
+const SAMPLE_FLAG = '🇹🇷'; // stand-in glyph for the flag-icons sprite
+
+const TOKENS = {
+  surface: { var: 'surface/default', hex: '#FFFFFF' },
+  border: { var: 'border/subtle', hex: '#E4E7EC' },
+  textPrimary: { var: 'text/primary', hex: '#181D27' },
+  textMuted: { var: 'text/muted', hex: '#717680' },
+};
+
+function hexToRgb(hex) {
+  const h = hex.replace('#', '');
+  return {
+    r: parseInt(h.slice(0, 2), 16) / 255,
+    g: parseInt(h.slice(2, 4), 16) / 255,
+    b: parseInt(h.slice(4, 6), 16) / 255,
+  };
+}
+
+(async () => {
+  try {
+    const existing = (await figma.root.findAllWithCriteria({ types: ['COMPONENT'] })).find(
+      (n) => n.name === COMPONENT_NAME,
+    );
+
+    if (!CONFIRM) {
+      figma.notify(
+        existing
+          ? `🔍 DRY-RUN — would rebuild "${COMPONENT_NAME}" [${existing.id}] as a button trigger ` +
+              `(flag + "${SAMPLE_LABEL}" + chevron; search lives in the popover). Flip CONFIRM to apply.`
+          : `🔍 DRY-RUN — "${COMPONENT_NAME}" not found; would create it. Flip CONFIRM.`,
+        { timeout: 13000 },
+      );
+      figma.closePlugin();
+      return;
+    }
+
+    const vars = await figma.variables.getLocalVariablesAsync();
+    const byName = new Map(vars.map((v) => [v.name, v]));
+    const fill = (key) => {
+      const t = TOKENS[key];
+      const paint = { type: 'SOLID', color: hexToRgb(t.hex) };
+      const v = byName.get(t.var);
+      return v ? figma.variables.setBoundVariableForPaint(paint, 'color', v) : paint;
+    };
+
+    const FAMILY = 'Inter';
+    let fontReg = { family: FAMILY, style: 'Regular' };
+    let fontMed = { family: FAMILY, style: 'Medium' };
+    try {
+      await figma.loadFontAsync(fontReg);
+      await figma.loadFontAsync(fontMed);
+    } catch {
+      const fb = { family: 'Roboto', style: 'Regular' };
+      await figma.loadFontAsync(fb);
+      fontReg = fb;
+      fontMed = fb;
+    }
+    const text = (chars, font, size, colorKey) => {
+      const t = figma.createText();
+      t.fontName = font;
+      t.fontSize = size;
+      t.characters = chars;
+      t.fills = [fill(colorKey)];
+      return t;
+    };
+
+    const buildTrigger = () => {
+      const trigger = figma.createFrame();
+      trigger.name = 'trigger';
+      trigger.layoutMode = 'HORIZONTAL';
+      trigger.itemSpacing = 8;
+      trigger.counterAxisAlignItems = 'CENTER';
+      trigger.paddingLeft = 12;
+      trigger.paddingRight = 12;
+      trigger.paddingTop = 10;
+      trigger.paddingBottom = 10;
+      trigger.cornerRadius = 8;
+      trigger.fills = [fill('surface')];
+      trigger.strokes = [fill('border')];
+      trigger.strokeWeight = 1;
+      trigger.layoutAlign = 'STRETCH';
+      trigger.primaryAxisSizingMode = 'FIXED';
+      trigger.counterAxisSizingMode = 'AUTO';
+
+      trigger.appendChild(text(SAMPLE_FLAG, fontReg, 16, 'textPrimary')); // flag stand-in
+      const value = text(SAMPLE_LABEL, fontMed, 16, 'textPrimary');
+      value.layoutGrow = 1;
+      trigger.appendChild(value);
+      trigger.appendChild(text('⌄', fontReg, 14, 'textMuted')); // chevron
+      return trigger;
+    };
+
+    let root = existing;
+    const apply = (node) => {
+      node.layoutMode = 'VERTICAL';
+      node.itemSpacing = 6;
+      node.fills = [];
+      node.resize(FRAME_WIDTH, 10);
+      node.primaryAxisSizingMode = 'AUTO';
+      node.counterAxisSizingMode = 'FIXED';
+      node.appendChild(text('Country', fontMed, 14, 'textPrimary'));
+      node.appendChild(buildTrigger());
+    };
+
+    if (root) {
+      for (const child of [...root.children]) child.remove();
+      apply(root);
+      if (!root.description.includes(`storybook-id: ${STORYBOOK_ID}`)) {
+        root.description =
+          (root.description ? root.description + '\n' : '') + `storybook-id: ${STORYBOOK_ID}`;
+      }
+    } else {
+      root = figma.createComponent();
+      root.name = COMPONENT_NAME;
+      root.description = `Glaon country picker — kit SearchSelect (button trigger + in-popover search) (#688).\nstorybook-id: ${STORYBOOK_ID}`;
+      apply(root);
+      root.x = Math.round(figma.viewport.center.x - FRAME_WIDTH / 2);
+      root.y = Math.round(figma.viewport.center.y - 40);
+      figma.currentPage.appendChild(root);
+    }
+
+    figma.viewport.scrollAndZoomIntoView([root]);
+    figma.notify(`✅ Updated "${COMPONENT_NAME}" — node id: ${root.id}`, { timeout: 15000 });
+    console.log('[Glaon 11 CountrySelect] node id:', root.id);
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();


### PR DESCRIPTION
Change the wizard's Country picker from the input-trigger ComboBox to a **button trigger + search-in-popover** select (UUI Select #search shape — "not a bare input"). (#688)

## What changes
- **New kit-derived `SearchSelect`** (`base/select/search-select.tsx`): a single-select **button trigger** (leading icon + selected label + chevron) that opens a popover with a **search field inside it**, closing on pick. Composed from the exact RAC primitives the kit `MultiSelect` uses (`DialogTrigger` + `Button` + `Popover` + `Autocomplete` + `SearchField` + `ListBox`) — the free kit ships no single-select-search variant, so this mirrors the kit's own pattern as single-select. `@ts-nocheck` like the sibling kit files.
- **CountrySelect** now wraps `SearchSelect`: each item carries its flag as `icon` (trigger shows the selected country's flag; Globe placeholder until set), diacritic-insensitive filter, prop contract + autoDetect + invalid-clear preserved. New `searchPlaceholder` / `noResultsLabel` props, i18n-wired in Home Overview (en + tr).
- Story / controls / mdx updated for the button + popover-search behavior.

## Verified live (dev wizard)
Trigger is a `<button>` ("Türkiye" + flag + chevron), not an input. Click → popover with a "Ülke ara" search field + flagged country list. Typing `alman` filters to `Almanya` (diacritic-insensitive). Selecting closes + updates the trigger.

## Test plan
- [x] `@glaon/ui` type-check + lint + 171 unit (incl. F6 prop-coverage for the 2 new props); `@glaon/web` type-check + 22 home-overview; i18n-check; knip — all green.
- [x] Live: button trigger + in-popover search + filter + select.
- [ ] CI green.
- [ ] Chromatic: CountrySelect story (closed trigger; open-state popover) — review diff.
- [ ] Figma: run `tools/figma-plugin/scripts/11-countryselect-search-select.js`, link the node ID (Design-System Fidelity).

Closes #688