### PR TITLE
refactor(ui): source TimezoneSelect options from react-timezone-select

### DIFF
--- a/apps/web/src/features/setup/home-overview/home-overview-step.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.tsx
@@ -409,6 +409,8 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
           <TimezoneSelect
             aria-labelledby={timezoneLabelId}
             placeholder={t('setup.homeOverview.timezone.placeholder')}
+            searchPlaceholder={t('setup.homeOverview.timezone.searchPlaceholder')}
+            noResultsLabel={t('setup.homeOverview.timezone.noResults')}
             {...(timezone !== '' ? { value: timezone } : {})}
             autoDetect={collected.timezone === undefined && timezone === ''}
             onSelectionChange={(tz) => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -79,6 +79,8 @@
       "timezone": {
         "label": "Timezone",
         "placeholder": "Select timezone",
+        "searchPlaceholder": "Search timezones",
+        "noResults": "No results found",
         "tooltip": "Used by HA-time displays and automations."
       },
       "currency": {

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -79,6 +79,8 @@
       "timezone": {
         "label": "Saat Dilimi",
         "placeholder": "Saat dilimini seç",
+        "searchPlaceholder": "Saat dilimi ara",
+        "noResults": "Sonuç bulunamadı",
         "tooltip": "HA saat görüntülemeleri ve otomasyonları için kullanılır."
       },
       "currency": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -78,6 +78,7 @@
     "react-aria": "^3.48.0",
     "react-aria-components": "^1.17.0",
     "react-map-gl": "^8.1.1",
-    "react-stately": "^3.46.0"
+    "react-stately": "^3.46.0",
+    "react-timezone-select": "^3.3.3"
   }
 }

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.controls.ts
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.controls.ts
@@ -7,7 +7,6 @@ import type { ControlSpec } from '../_internal/controls';
 import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
 
 const sizeOptions = ['sm', 'md', 'lg'] as const;
-const localeOptions = ['', 'tr-TR', 'en-US', 'de-DE', 'fr-FR', 'ar-SA'] as const;
 
 export const timezoneSelectControls = {
   label: {
@@ -21,7 +20,19 @@ export const timezoneSelectControls = {
     type: 'text',
     default: 'Select a timezone',
     description:
-      'Hint text shown when no option is selected. Never use placeholder as a substitute for the label.',
+      'Hint text shown in the closed trigger when no zone is selected. Never use placeholder as a substitute for the label.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  searchPlaceholder: {
+    type: 'text',
+    default: 'Search',
+    description: 'Placeholder inside the in-popover search field.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  noResultsLabel: {
+    type: 'text',
+    default: 'No results found',
+    description: 'Text shown in the popover when the search matches no zone.',
     category: 'Content',
   } satisfies ControlSpec<string>,
   hint: {
@@ -37,14 +48,6 @@ export const timezoneSelectControls = {
       'When true (default), pre-select the timezone returned by `Intl.DateTimeFormat().resolvedOptions().timeZone` on mount. Ignored when `value` or `defaultValue` is set. Detection is one-shot — re-mount to re-detect.',
     category: 'Behavior',
   } satisfies ControlSpec<boolean>,
-  locale: {
-    type: 'select',
-    options: localeOptions,
-    default: '',
-    description:
-      'BCP-47 locale used for collation when sorting city labels. Leave empty to use the browser default (`navigator.language`). The labels themselves stay in English — only the sort order follows the locale.',
-    category: 'Content',
-  } satisfies ControlSpec<(typeof localeOptions)[number]>,
   defaultValue: {
     type: 'text',
     description:
@@ -56,7 +59,7 @@ export const timezoneSelectControls = {
     options: sizeOptions,
     default: 'md',
     description:
-      'Visual scale forwarded to the underlying ComboBox. `sm` for compact toolbars, `md` (default) for forms, `lg` for hero affordances.',
+      'Visual scale forwarded to the underlying SearchSelect. `sm` for compact toolbars, `md` (default) for forms, `lg` for hero affordances.',
     category: 'Style',
   } satisfies ControlSpec<(typeof sizeOptions)[number]>,
   isDisabled: {

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.mdx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.mdx
@@ -6,18 +6,19 @@ import * as TimezoneSelectStories from './TimezoneSelect.stories';
 
 # TimezoneSelect
 
-App-primitive IANA timezone picker. Thin wrap over the kit
-[`<ComboBox>`](?path=/docs/web-primitives-select--docs#withsearch)
-that adds the built-in timezone list, locale-aware sorting,
-diacritic-insensitive search, and optional one-shot browser
-autodetection.
+App-primitive timezone picker. The option list + labels come from
+[`react-timezone-select`](https://github.com/ndom91/react-timezone-select)'s
+`useTimezoneSelect` hook (#690) — a curated set with DST-aware
+`(GMT±hh:mm) City` labels — rendered through our UUI `SearchSelect`
+(button trigger + in-popover search). No `react-select` (hook-only).
 
 Sister primitive to
-[CountrySelect](?path=/docs/app-primitives-countryselect--docs) —
-same prop contract, same state machine, same polish (auto-clear-error,
-select-all-on-focus). The differences come from the dataset (IANA
-zones, no flag glyphs) and the detection source
-(`Intl.DateTimeFormat().resolvedOptions().timeZone`).
+[CountrySelect](?path=/docs/app-primitives-countryselect--docs) — same
+`SearchSelect` shape + state machine (auto-clear-error, diacritic-
+insensitive search, one-shot browser autodetection). The differences
+come from the dataset (IANA zones, no flag glyphs) and the detection
+source (`Intl.DateTimeFormat().resolvedOptions().timeZone`). The emitted
+value is the IANA id (`Europe/Istanbul`).
 
 ## When to use
 
@@ -78,27 +79,24 @@ Auto-detection is **skipped** when:
 />
 ```
 
-Each row renders the city (last segment of the IANA id with
-underscores prettied) and the current UTC offset, e.g.
-`Istanbul — (UTC+03:00)`. The UTC zone itself shows as `UTC — (UTC)`.
+Each row renders the GMT offset + city, e.g. `(GMT+03:00) Istanbul`,
+from `react-timezone-select`'s labels. The offset is DST-aware
+(recomputed for the current date).
 
-## Dataset and localization
+## Dataset
 
-The list comes from `Intl.supportedValuesOf('timeZone')` — the
-runtime-built-in IANA database (~430 zones on a modern engine, no
-shipped table). The `locale` prop drives `Intl.Collator` for
-locale-aware sort order; labels themselves stay in English because
-the IANA database is English-only. If your design needs localized
-city names, that's a follow-up that needs a translation table.
+The list + labels come from `react-timezone-select`'s
+`useTimezoneSelect({ labelStyle: 'original', timezones: allTimezones })`
+hook — a curated set of common zones with offset-grouped ordering and
+DST-aware labels. We use the hook only, so `react-select` is **not**
+bundled (the `spacetime` / `timezone-soft` label engine is). The emitted
+value stays the raw IANA id.
 
 ## Search behaviour
 
-The filter is **diacritic-insensitive** — typing `istanbul` matches
-`Istanbul`, `reunion` matches `Réunion`. Search is by the displayed
-label only (city + offset string).
-
-The input **selects-all on focus**, so the next keystroke replaces
-the current label cleanly. Tab in, type, pick — no manual clear.
+A search field sits at the top of the popover. The filter is
+**diacritic-insensitive** — typing `istanbul` matches `Istanbul`,
+`reunion` matches `Réunion` — matching the displayed label.
 
 ## Error UX
 
@@ -120,11 +118,10 @@ picker re-arms its suppression every time the prop transitions.
 
 - Pass a visible `label`, **or** associate a host-rendered label via
   `aria-labelledby` (id of the external label), **or** supply an
-  `aria-label`. One of the three must be present so the ComboBox always
-  has an accessible name.
-- The popover is keyboard-navigable (Arrow up/down, Enter to select,
-  Esc to dismiss) and the search input is a real `<input>` with
-  `aria-autocomplete="list"`.
+  `aria-label`. One of the three must be present so the trigger button
+  always has an accessible name.
+- Keyboard: open with Enter/Space, type in the popover search field to
+  filter, Arrow up/down through results, Enter to select, Esc to dismiss.
 - Pair `isInvalid` with a descriptive `hint` ("Timezone is
   required.") — the kit wires `aria-invalid` + `aria-describedby`
   automatically.

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.mdx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.mdx
@@ -79,24 +79,31 @@ Auto-detection is **skipped** when:
 />
 ```
 
-Each row renders the GMT offset + city, e.g. `(GMT+03:00) Istanbul`,
-from `react-timezone-select`'s labels. The offset is DST-aware
-(recomputed for the current date).
+Options are **grouped by GMT offset**: each section carries a sticky
+`GMT±hh:mm` header and the rows under it show just the city (e.g.
+`Istanbul` under `GMT+3:00`) so the long list stays scannable instead
+of repeating the offset on every row. The selected trigger and the
+search index still use the full `(GMT±hh:mm) City` label. The offset is
+DST-aware (recomputed for the current date).
 
 ## Dataset
 
-The list + labels come from `react-timezone-select`'s
-`useTimezoneSelect({ labelStyle: 'original', timezones: allTimezones })`
-hook — a curated set of common zones with offset-grouped ordering and
-DST-aware labels. We use the hook only, so `react-select` is **not**
-bundled (the `spacetime` / `timezone-soft` label engine is). The emitted
-value stays the raw IANA id.
+The labels come from `react-timezone-select`'s
+`useTimezoneSelect({ labelStyle: 'original', timezones })` hook, fed the
+**full** runtime IANA list (`Intl.supportedValuesOf('timeZone')`, via
+`buildTimezoneDict`) so every zone the wizard may seed/sync — e.g.
+`Europe/Istanbul` — is present; the library's curated `allTimezones` is
+used only as a fallback when `supportedValuesOf` is unavailable. We use
+the hook only, so `react-select` is **not** bundled (the `spacetime` /
+`timezone-soft` label engine is). The emitted value stays the raw IANA id.
 
 ## Search behaviour
 
 A search field sits at the top of the popover. The filter is
-**diacritic-insensitive** — typing `istanbul` matches `Istanbul`,
-`reunion` matches `Réunion` — matching the displayed label.
+**diacritic-insensitive** and runs against the full `(GMT±hh:mm) City`
+label — typing `istanbul` matches `Istanbul`, `reunion` matches
+`Réunion`, and `gmt+3` matches every GMT+3 zone — even though the rows
+display the city only.
 
 ## Error UX
 

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.stories.tsx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.stories.tsx
@@ -79,14 +79,9 @@ export const Utc: Story = {
   args: { defaultValue: 'UTC', autoDetect: false },
 };
 
-/**
- * Turkish locale — same dataset, Turkish collation order. Labels
- * stay in English (the IANA database is English-only) but sort
- * behaviour follows the locale's `Intl.Collator` rules.
- */
+/** A seeded selection — the trigger shows the `(GMT±hh:mm) City` label. */
 export const TurkishLocale: Story = {
   args: {
-    locale: 'tr-TR',
     autoDetect: false,
     defaultValue: 'Europe/Istanbul',
     label: 'Saat dilimi',
@@ -94,13 +89,11 @@ export const TurkishLocale: Story = {
 };
 
 /**
- * Arabic locale — exercises the RTL render path. The decorator wraps
- * the field in `dir="rtl"` so the popover, input alignment, and
- * indicator placement mirror correctly.
+ * RTL render path — the decorator wraps the field in `dir="rtl"` so the
+ * trigger, popover, and search-field alignment mirror correctly.
  */
 export const ArabicRtl: Story = {
   args: {
-    locale: 'ar-SA',
     autoDetect: false,
     defaultValue: 'Asia/Riyadh',
     label: 'المنطقة الزمنية',

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.tsx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.tsx
@@ -1,109 +1,69 @@
-// Glaon TimezoneSelect — searchable IANA timezone picker that wraps
-// the kit `<ComboBox>` (`packages/ui/src/components/base/select/combobox.tsx`).
+// Glaon TimezoneSelect — timezone picker. The option list + labels come
+// from `react-timezone-select`'s `useTimezoneSelect` hook (#690): a curated
+// set with DST-aware `(GMT±hh:mm) City` labels. The UI is our UUI
+// `SearchSelect` (button trigger + in-popover search, #688) — same look as
+// CountrySelect, no `react-select` (hook-only).
 //
-// Sister primitive to `CountrySelect` — same wrap pattern, same
-// state machine, same polish features (auto-clear-error,
-// select-all-on-focus, diacritic-insensitive filter):
+// Sister primitive to `CountrySelect`: same wrap pattern + state machine
+// (auto-clear-error, diacritic-insensitive filter, one-shot browser
+// auto-detection). The emitted value is the IANA id (`Europe/Istanbul`).
 //
-//   - Built-in IANA list from `Intl.supportedValuesOf('timeZone')`,
-//     no shipped database, no extra dependency.
-//   - Display labels combine city (last segment of the IANA id, with
-//     underscores prettied) and current UTC offset
-//     (`(UTC+03:00)` etc.) so users can disambiguate at a glance.
-//   - Optional one-shot browser autodetection — when on, the picker
-//     preselects the zone returned by
-//     `Intl.DateTimeFormat().resolvedOptions().timeZone`.
-//   - `Clock` glyph (`@untitledui/icons`) as the trigger leading
-//     icon. Unlike CountrySelect we don't swap the icon per-zone;
-//     timezones don't have a comparable visual identity.
-//
-// Per CLAUDE.md's UUI Source Rule and Component Data-Fetching Boundary:
-// the visual + popover positioning + RAC plumbing come from the kit;
-// this wrapper contributes the prop API + the dataset + detection.
-// No network call lives here.
+// Per CLAUDE.md's UUI Source Rule + Component Data-Fetching Boundary: the
+// trigger + popover + search come from the kit `SearchSelect`; this wrapper
+// contributes the prop API + the hook-sourced dataset + detection. No
+// network call here.
 
-import { useCallback, useEffect, useMemo, useState, type FocusEvent, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Clock } from '@untitledui/icons';
-import type { Key } from 'react-aria-components';
+import { allTimezones, useTimezoneSelect } from 'react-timezone-select';
 
-import { ComboBox, SelectItem, type SelectItemType } from '../Select';
-import { buildTimezoneItems, detectBrowserTimezone, diacriticInsensitiveFilter } from './timezones';
+import { SearchSelect, SelectItem, type SelectItemType } from '../Select';
+import { buildTimezoneDict, detectBrowserTimezone, diacriticInsensitiveFilter } from './timezones';
 
-// Types stay un-exported per memory note `feedback_knip_props_interfaces.md`
-// — `react-docgen-typescript` still resolves the prop names for the
-// F6 prop-coverage gate without a top-level `export`. Promote to
-// `index.ts` once an external consumer needs them.
+// Types stay un-exported per memory note `feedback_knip_props_interfaces.md`.
 type TimezoneSelectSize = 'sm' | 'md' | 'lg';
 
 interface TimezoneSelectProps {
   /**
    * Controlled selection — IANA timezone identifier (e.g.
-   * `'Europe/Istanbul'`, `'America/New_York'`). Pair with
-   * `onSelectionChange` to manage state outside. When set,
+   * `'Europe/Istanbul'`). Pair with `onSelectionChange`. When set,
    * `defaultValue` and `autoDetect` are ignored.
    */
   value?: string;
-  /**
-   * Uncontrolled initial selection — IANA timezone identifier to
-   * start with. When set, `autoDetect` is ignored.
-   */
+  /** Uncontrolled initial selection — IANA id. Ignores `autoDetect`. */
   defaultValue?: string;
-  /**
-   * Fires when the user (or the auto-detect path) changes the
-   * selection. Receives the IANA identifier, or `null` when the
-   * selection is cleared.
-   */
+  /** Fires on selection change. Receives the IANA id, or `null`. */
   onSelectionChange?: (timezone: string | null) => void;
   /**
    * When `true` (default), pre-select the timezone returned by
-   * `Intl.DateTimeFormat().resolvedOptions().timeZone` on mount.
-   * Ignored when `value` or `defaultValue` is set. Detection is
-   * one-shot — re-mount to re-detect.
-   * @default true
+   * `Intl.DateTimeFormat().resolvedOptions().timeZone` on mount. Ignored
+   * when `value` / `defaultValue` is set. One-shot. @default true
    */
   autoDetect?: boolean;
-  /**
-   * BCP-47 locale tag used to sort city labels. Defaults to
-   * `navigator.language` in the browser, `'en'` on a runtime without
-   * `navigator` (e.g. SSR). The city labels themselves stay in
-   * English (the IANA database is English); only the sort order
-   * follows the locale's collation rules.
-   */
-  locale?: string;
   /** Field label rendered above the trigger. */
   label?: string;
-  /** Accessible name when no visible `label` is rendered. Forwarded to
-   *  the underlying ComboBox. */
+  /** Accessible name when no visible `label` is rendered. */
   'aria-label'?: string;
-  /** Id of an external visible label; forwarded as `aria-labelledby` to
-   *  associate a host-rendered label instead of the built-in `label`. */
+  /** Id of an external visible label; forwarded as `aria-labelledby`. */
   'aria-labelledby'?: string;
-  /** Placeholder text shown when no option is selected. */
+  /** Placeholder shown in the (closed) trigger when nothing is selected. */
   placeholder?: string;
-  /** Helper text shown under the trigger; doubles as the error
-   *  message when `isInvalid` is true. */
+  /** Placeholder inside the in-popover search field. @default 'Search' */
+  searchPlaceholder?: string;
+  /** Text shown when the search matches no zone. @default 'No results found' */
+  noResultsLabel?: string;
+  /** Helper text under the trigger; doubles as the error message when
+   *  `isInvalid` is true. */
   hint?: ReactNode;
   /** Block all interaction and dim the trigger. */
   isDisabled?: boolean;
-  /**
-   * Surface validation error styling. Pair with `hint` to describe
-   * the error; the kit wires `aria-invalid` + `aria-describedby`.
-   *
-   * The picker auto-clears this styling once the user makes a
-   * selection — the host can re-assert it by toggling `isInvalid`
-   * from `false` → `true` after re-validation.
-   */
+  /** Surface validation error styling. Auto-clears on selection. */
   isInvalid?: boolean;
-  /** Mark the field as required (renders an indicator next to the
-   *  label and forwards `aria-required`). */
+  /** Mark the field as required. */
   isRequired?: boolean;
-  /** Hide the visual `*` next to the label even when `isRequired`
-   *  is true. Keeps the a11y contract. */
+  /** Hide the visual `*` even when `isRequired` is true. */
   hideRequiredIndicator?: boolean;
-  /**
-   * Visual scale of the underlying ComboBox.
-   * @default 'md'
-   */
+  /** Visual scale of the underlying SearchSelect. @default 'md' */
   size?: TimezoneSelectSize;
   /** Tailwind override hook for the outer wrapper. */
   className?: string;
@@ -116,11 +76,12 @@ export function TimezoneSelect({
   defaultValue,
   onSelectionChange,
   autoDetect = true,
-  locale,
   label,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
   placeholder,
+  searchPlaceholder,
+  noResultsLabel,
   hint,
   isDisabled,
   isInvalid,
@@ -130,15 +91,22 @@ export function TimezoneSelect({
   className,
   popoverClassName,
 }: TimezoneSelectProps) {
-  const resolvedLocale = useResolvedLocale(locale);
-  const items = useMemo(() => buildTimezoneItems(resolvedLocale), [resolvedLocale]);
+  // DST-aware timezone options from react-timezone-select, over the FULL
+  // runtime IANA list (so every zone the wizard may seed/sync — e.g.
+  // Europe/Istanbul — is present; the library's curated `allTimezones`
+  // omits many). Falls back to `allTimezones` if `supportedValuesOf` is
+  // unavailable. `value` is the IANA id; `label` is `(GMT±hh:mm) City`.
+  const timezoneDict = useMemo(() => {
+    const full = buildTimezoneDict();
+    return Object.keys(full).length > 0 ? full : allTimezones;
+  }, []);
+  const { options } = useTimezoneSelect({ labelStyle: 'original', timezones: timezoneDict });
+  const items = useMemo<SelectItemType[]>(
+    () => options.map((o) => ({ id: o.value, label: o.label })),
+    [options],
+  );
 
   const isHostControlled = value !== undefined;
-
-  // Unified selection state — seeded from `defaultValue`; auto-detect
-  // promotes the seed when neither `value` nor `defaultValue` is set.
-  // Same shape as CountrySelect so the wrap pattern stays consistent
-  // across the sister pair.
   const [internalKey, setInternalKey] = useState<string | null>(defaultValue ?? null);
 
   useEffect(() => {
@@ -153,88 +121,47 @@ export function TimezoneSelect({
 
   const effectiveKey = isHostControlled ? value : internalKey;
 
-  // Suppress the invalid styling once the user picks something. The
-  // host can re-assert `isInvalid` by toggling it false → true (the
-  // effect below resets the suppression when the prop transitions).
   const [suppressInvalid, setSuppressInvalid] = useState(false);
   useEffect(() => {
     setSuppressInvalid(false);
   }, [isInvalid]);
 
-  const handleSelectionChange = (key: Key | null) => {
-    const next = key === null ? null : String(key);
+  const handleSelectionChange = (next: string | null) => {
     if (!isHostControlled) setInternalKey(next);
     setSuppressInvalid(true);
     onSelectionChange?.(next);
   };
 
-  // Select-all-on-focus inside the inner search input so the next
-  // keystroke replaces the previous label cleanly. RAC's ComboBox
-  // doesn't forward `onFocus` to the input, so we capture at the
-  // wrapper and act on any input descendant. `requestAnimationFrame`
-  // defers the `.select()` until RAC's own focus handling settles.
-  const handleFocusCapture = useCallback((event: FocusEvent<HTMLDivElement>) => {
-    const target = event.target;
-    if (!(target instanceof HTMLInputElement)) return;
-    if (target.disabled || target.readOnly) return;
-    requestAnimationFrame(() => {
-      try {
-        target.select();
-      } catch {
-        // Input may have unmounted between the focus event and the
-        // rAF tick — the failed `.select()` is harmless.
-      }
-    });
-  }, []);
-
   const effectiveInvalid = isInvalid === true && !suppressInvalid;
 
-  // Build the ComboBox props bag conditionally — the @glaon/ui package
-  // compiles with `exactOptionalPropertyTypes: true`, so passing
-  // explicit `undefined` to an optional prop fails type-check.
-  const comboProps: Record<string, unknown> = {
+  // Build the SearchSelect props bag conditionally — @glaon/ui compiles with
+  // `exactOptionalPropertyTypes: true`, so explicit `undefined` fails.
+  const selectProps: Record<string, unknown> = {
     items,
     size,
     selectedKey: effectiveKey ?? null,
     onSelectionChange: handleSelectionChange,
-    defaultFilter: diacriticInsensitiveFilter,
-    shortcut: false,
-    icon: Clock,
+    filter: diacriticInsensitiveFilter,
+    leadingIcon: Clock,
   };
 
-  if (label !== undefined) comboProps.label = label;
-  if (ariaLabel !== undefined) comboProps['aria-label'] = ariaLabel;
-  if (ariaLabelledby !== undefined) comboProps['aria-labelledby'] = ariaLabelledby;
-  if (placeholder !== undefined) comboProps.placeholder = placeholder;
-  if (hint !== undefined) comboProps.hint = hint;
-  if (isDisabled === true) comboProps.isDisabled = true;
-  if (effectiveInvalid) comboProps.isInvalid = true;
-  if (isRequired === true) comboProps.isRequired = true;
-  if (hideRequiredIndicator === true) comboProps.hideRequiredIndicator = true;
-  if (className !== undefined) comboProps.className = className;
-  if (popoverClassName !== undefined) comboProps.popoverClassName = popoverClassName;
+  if (label !== undefined) selectProps.label = label;
+  if (ariaLabel !== undefined) selectProps['aria-label'] = ariaLabel;
+  if (ariaLabelledby !== undefined) selectProps['aria-labelledby'] = ariaLabelledby;
+  if (placeholder !== undefined) selectProps.placeholder = placeholder;
+  if (searchPlaceholder !== undefined) selectProps.searchPlaceholder = searchPlaceholder;
+  if (noResultsLabel !== undefined) selectProps.noResultsLabel = noResultsLabel;
+  if (hint !== undefined) selectProps.hint = hint;
+  if (isDisabled === true) selectProps.isDisabled = true;
+  if (effectiveInvalid) selectProps.isInvalid = true;
+  if (isRequired === true) selectProps.isRequired = true;
+  if (hideRequiredIndicator === true) selectProps.hideRequiredIndicator = true;
+  if (className !== undefined) selectProps.className = className;
+  if (popoverClassName !== undefined) selectProps.popoverClassName = popoverClassName;
 
   return (
-    <div onFocusCapture={handleFocusCapture}>
-      <ComboBox {...comboProps}>
-        {(item: SelectItemType) => <SelectItem id={item.id} label={item.label ?? ''} />}
-      </ComboBox>
-    </div>
+    <SearchSelect {...selectProps}>
+      {(item: SelectItemType) => <SelectItem id={item.id} label={item.label ?? ''} />}
+    </SearchSelect>
   );
-}
-
-/**
- * Resolve the locale to use for the timezone collator. Reads
- * `navigator.language` lazily so SSR builds don't crash on a missing
- * `navigator`. Falls back to `'en'` when neither prop nor navigator
- * is available.
- */
-function useResolvedLocale(locale: string | undefined): string {
-  return useMemo(() => {
-    if (locale !== undefined && locale.length > 0) return locale;
-    if (typeof navigator !== 'undefined' && navigator.language) {
-      return navigator.language;
-    }
-    return 'en';
-  }, [locale]);
 }

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.tsx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.tsx
@@ -20,6 +20,20 @@ import { allTimezones, useTimezoneSelect } from 'react-timezone-select';
 import { SearchSelect, SelectItem, type SelectItemType } from '../Select';
 import { buildTimezoneDict, detectBrowserTimezone, diacriticInsensitiveFilter } from './timezones';
 
+// react-timezone-select labels are `(GMT±hh:mm) City`. Many IANA zones share
+// an offset, so we group them under a `GMT±hh:mm` section header and show
+// just the city per row — the full label is kept as the trigger value and as
+// the search `textValue`, so typing "gmt+3" or "istanbul" both match.
+const GMT_PREFIX_RE = /^\(([^)]*)\)\s*/;
+
+function offsetGroup(item: SelectItemType): string {
+  return GMT_PREFIX_RE.exec(item.label ?? '')?.[1] ?? 'Other';
+}
+
+function cityLabel(label: string): string {
+  return label.replace(GMT_PREFIX_RE, '') || label;
+}
+
 // Types stay un-exported per memory note `feedback_knip_props_interfaces.md`.
 type TimezoneSelectSize = 'sm' | 'md' | 'lg';
 
@@ -143,6 +157,7 @@ export function TimezoneSelect({
     onSelectionChange: handleSelectionChange,
     filter: diacriticInsensitiveFilter,
     leadingIcon: Clock,
+    groupBy: offsetGroup,
   };
 
   if (label !== undefined) selectProps.label = label;
@@ -161,7 +176,9 @@ export function TimezoneSelect({
 
   return (
     <SearchSelect {...selectProps}>
-      {(item: SelectItemType) => <SelectItem id={item.id} label={item.label ?? ''} />}
+      {(item: SelectItemType) => (
+        <SelectItem id={item.id} label={cityLabel(item.label ?? '')} textValue={item.label ?? ''} />
+      )}
     </SearchSelect>
   );
 }

--- a/packages/ui/src/components/TimezoneSelect/timezones.ts
+++ b/packages/ui/src/components/TimezoneSelect/timezones.ts
@@ -1,102 +1,39 @@
 // TimezoneSelect data + helpers.
 //
-// The IANA timezone list comes from `Intl.supportedValuesOf('timeZone')`
-// — supported across modern engines (Chrome 99+, Firefox 93+,
-// Safari 15.4+). On a runtime without the API we fall back to `[UTC]`
-// so the picker at least surfaces *something* rather than erroring;
-// the fallback is intentionally minimal because every supported
-// browser meets the threshold.
-//
-// Display labels combine the city (last segment of the IANA id, with
-// underscores prettied) and the current UTC offset
-// (`Intl.DateTimeFormat` with `timeZoneName: 'longOffset'`). The
-// offset is a snapshot at module-load time — we don't track DST
-// transitions live; consumers that need that should observe the
-// underlying value and re-mount when the wall clock changes day.
-
-import type { SelectItemType } from '../base/select/select-shared';
-
-const FALLBACK_TIMEZONES = ['UTC'] as const;
+// The timezone *list + labels* now come from `react-timezone-select`'s
+// `useTimezoneSelect` hook (#690) — a curated set with DST-aware
+// `(GMT±hh:mm) City` labels — so the old `Intl.supportedValuesOf` +
+// offset-formatting helpers are gone. This module only keeps the two
+// pure helpers the wrapper still needs: browser detection + the
+// diacritic-insensitive search filter.
 
 /**
- * Resolve the list of IANA timezone identifiers exposed by the
- * runtime. Built-in via `Intl.supportedValuesOf` on modern engines;
- * falls back to a single-entry list on engines that predate the API.
- *
- * Internal — un-exported per memory note `feedback_knip_props_interfaces.md`
- * (knip blocks PRs on unused exports). Promote when an external
- * consumer needs the raw list.
+ * Build the `timezones` dict fed to `react-timezone-select`'s
+ * `useTimezoneSelect` (#690). Its bundled `allTimezones` is a curated
+ * ~78-zone set that omits many IANA ids the wizard relies on (e.g.
+ * `Europe/Istanbul`, set by the country→timezone sync), which would leave
+ * the trigger blank for those. So we feed the **full** runtime IANA list
+ * (`Intl.supportedValuesOf('timeZone')`) mapped to a city display name; the
+ * hook still computes the DST-aware `(GMT±hh:mm)` offset prefix. Returns an
+ * empty object when the API is unavailable so the caller can fall back to
+ * the library's `allTimezones`.
  */
-function getTimezoneList(): readonly string[] {
+export function buildTimezoneDict(): Record<string, string> {
   try {
     const intlWithSupported = Intl as typeof Intl & {
       supportedValuesOf?: (key: 'timeZone') => string[];
     };
-    if (typeof intlWithSupported.supportedValuesOf === 'function') {
-      const zones = intlWithSupported.supportedValuesOf('timeZone');
-      if (zones.length > 0) return zones;
+    if (typeof intlWithSupported.supportedValuesOf !== 'function') return {};
+    const zones = intlWithSupported.supportedValuesOf('timeZone');
+    const dict: Record<string, string> = {};
+    for (const tz of zones) {
+      const city = (tz.split('/').pop() ?? tz).replace(/_/g, ' ');
+      dict[tz] = city;
     }
+    return dict;
   } catch {
-    // Fall through to the static fallback.
+    return {};
   }
-  return FALLBACK_TIMEZONES;
-}
-
-/**
- * Compute the `(UTC±HH:MM)` offset suffix for a given IANA timezone
- * at the current moment. Returns the string suitable for direct
- * concatenation into a display label, e.g. `'(UTC+03:00)'` for
- * `'Europe/Istanbul'`. Falls back to `'(UTC)'` for the UTC zone or
- * any zone the runtime cannot format.
- */
-function formatUtcOffset(timeZone: string): string {
-  try {
-    const dtf = new Intl.DateTimeFormat('en-US', {
-      timeZone,
-      timeZoneName: 'longOffset',
-    });
-    const parts = dtf.formatToParts(new Date());
-    const tzPart = parts.find((p) => p.type === 'timeZoneName');
-    const raw = tzPart?.value ?? '';
-    // `longOffset` yields strings like `'GMT+03:00'`, `'GMT-05:30'`,
-    // or `'GMT'` for UTC. Normalize to the Glaon convention
-    // (`UTC` rather than `GMT`, explicit `±00:00` for the zero
-    // offset so the column visually aligns).
-    if (raw === 'GMT' || raw === '') return '(UTC)';
-    return `(${raw.replace('GMT', 'UTC')})`;
-  } catch {
-    return '(UTC)';
-  }
-}
-
-/**
- * Derive a human-readable city label from an IANA timezone id:
- * - `'Europe/Istanbul'` → `'Istanbul'`
- * - `'America/New_York'` → `'New York'`
- * - `'Pacific/Port_Moresby'` → `'Port Moresby'`
- * - `'UTC'` → `'UTC'`
- */
-function cityFromTimezone(timeZone: string): string {
-  const segments = timeZone.split('/');
-  const last = segments[segments.length - 1] ?? timeZone;
-  return last.replace(/_/g, ' ');
-}
-
-/**
- * Build a `{ id, label }` list of timezones sorted by the localized
- * city label using `Intl.Collator` so locale-aware collation kicks in
- * (e.g. Turkish ordering for Turkish callers).
- */
-export function buildTimezoneItems(locale: string): SelectItemType[] {
-  const zones = getTimezoneList();
-  const collator = new Intl.Collator(locale, { sensitivity: 'base' });
-  return zones
-    .map((tz) => {
-      const city = cityFromTimezone(tz);
-      const offset = formatUtcOffset(tz);
-      return { id: tz, label: `${city} — ${offset}` };
-    })
-    .sort((a, b) => collator.compare(a.label, b.label));
 }
 
 /**
@@ -119,12 +56,11 @@ export function detectBrowserTimezone(): string | null {
 }
 
 /**
- * Diacritic-insensitive substring filter for the ComboBox's
- * `defaultFilter` prop — mirrors the helper inside
- * `CountrySelect/countries.ts`. Duplicated rather than extracted to a
- * shared util to keep this PR scoped to TimezoneSelect; a follow-up
- * can pull both copies into a shared `_internal` module when there's
- * a third caller.
+ * Diacritic-insensitive substring filter for the SearchSelect's
+ * `filter` prop — mirrors the helper inside `CountrySelect/countries.ts`.
+ * Duplicated rather than extracted to a shared util to keep this PR
+ * scoped; a follow-up can pull the copies into a shared `_internal`
+ * module when there's a third caller.
  */
 export function diacriticInsensitiveFilter(textValue: string, inputValue: string): boolean {
   if (!inputValue) return true;

--- a/packages/ui/src/components/base/select/search-select.tsx
+++ b/packages/ui/src/components/base/select/search-select.tsx
@@ -18,10 +18,13 @@ import type { Key, Selection } from 'react-aria-components';
 import {
   Autocomplete as AriaAutocomplete,
   Button as AriaButton,
+  Collection as AriaCollection,
   Dialog as AriaDialog,
   DialogTrigger as AriaDialogTrigger,
+  Header as AriaHeader,
   Input as AriaInput,
   ListBox as AriaListBox,
+  ListBoxSection as AriaListBoxSection,
   Popover as AriaPopover,
   SearchField as AriaSearchField,
 } from 'react-aria-components';
@@ -54,6 +57,11 @@ interface SearchSelectProps extends CommonProps {
   leadingIcon?: FC | ReactNode;
   /** Diacritic-insensitive `(textValue, inputValue) => boolean` filter. */
   filter?: (textValue: string, inputValue: string) => boolean;
+  /** When set, options are grouped into sections keyed by the returned
+   *  string, each rendered under a sticky header (e.g. group timezones by
+   *  GMT offset). Items keep their source order, so the first time a key is
+   *  seen fixes that section's position. Omit for a flat list. */
+  groupBy?: (item: SelectItemType) => string;
   /** Placeholder inside the popover search field. */
   searchPlaceholder?: string;
   /** Text shown when the search matches no option. */
@@ -75,6 +83,7 @@ const SearchSelectRoot = ({
   onSelectionChange,
   leadingIcon,
   filter,
+  groupBy,
   searchPlaceholder = 'Search',
   noResultsLabel = 'No results found',
   isDisabled,
@@ -113,7 +122,26 @@ const SearchSelectRoot = ({
   };
 
   const selectedItem = selectedKey != null ? items?.find((i) => i.id === selectedKey) : undefined;
-  const triggerIcon = selectedItem?.icon ?? leadingIcon;
+  // Capitalized so JSX treats it as a component, not a literal DOM tag.
+  const TriggerIcon = selectedItem?.icon ?? leadingIcon;
+
+  // Group the flat `items` into sections when `groupBy` is set, preserving
+  // first-seen order so callers control section ordering by item order.
+  const sections = groupBy
+    ? (() => {
+        const byKey = new Map<string, { id: string; items: SelectItemType[] }>();
+        for (const item of items ?? []) {
+          const key = groupBy(item);
+          let section = byKey.get(key);
+          if (!section) {
+            section = { id: key, items: [] };
+            byKey.set(key, section);
+          }
+          section.items.push(item);
+        }
+        return [...byKey.values()];
+      })()
+    : null;
 
   return (
     <SelectContext.Provider value={{ size }}>
@@ -151,10 +179,10 @@ const SearchSelectRoot = ({
                 '*:data-icon:shrink-0 *:data-icon:text-fg-quaternary',
               )}
             >
-              {isReactComponent(triggerIcon) ? (
-                <triggerIcon data-icon aria-hidden="true" />
+              {isReactComponent(TriggerIcon) ? (
+                <TriggerIcon data-icon aria-hidden="true" />
               ) : (
-                (triggerIcon ?? null)
+                (TriggerIcon ?? null)
               )}
 
               <span className={cx('flex flex-1 truncate', sizes[size].textContainer)}>
@@ -223,7 +251,7 @@ const SearchSelectRoot = ({
 
                 <AriaListBox
                   aria-label={label || ariaLabel || 'Options'}
-                  items={items}
+                  items={sections ?? items}
                   selectionMode="single"
                   selectedKeys={selectedKey != null ? new Set([selectedKey]) : new Set()}
                   onSelectionChange={handleListSelectionChange}
@@ -232,7 +260,16 @@ const SearchSelectRoot = ({
                   )}
                   className={cx('overflow-y-auto py-1 outline-hidden', popoverMaxHeights[size])}
                 >
-                  {children}
+                  {sections
+                    ? (section: { id: string; items: SelectItemType[] }) => (
+                        <AriaListBoxSection id={section.id}>
+                          <AriaHeader className="sticky top-0 z-10 truncate bg-primary px-3 pt-2 pb-1 text-xs font-semibold text-tertiary">
+                            {section.id}
+                          </AriaHeader>
+                          <AriaCollection items={section.items}>{children}</AriaCollection>
+                        </AriaListBoxSection>
+                      )
+                    : children}
                 </AriaListBox>
               </AriaAutocomplete>
             </AriaDialog>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,7 @@ importers:
     dependencies:
       '@clerk/clerk-expo':
         specifier: ^2.19.36
-        version: 2.19.36(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(expo-auth-session@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3))(expo-crypto@55.0.14(expo@55.0.15))(expo-secure-store@55.0.13(expo@55.0.15))(expo-web-browser@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)))(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.3.6)
+        version: 2.19.36(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(expo-auth-session@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3))(expo-crypto@55.0.14(expo@55.0.15))(expo-secure-store@55.0.13(expo@55.0.15))(expo-web-browser@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.3.6)
       '@glaon/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -179,7 +179,7 @@ importers:
         version: 8.8.0(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo:
         specifier: ~55.0.0
-        version: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+        version: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       expo-auth-session:
         specifier: ~55.0.0
         version: 55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)
@@ -215,7 +215,7 @@ importers:
         version: 19.2.6
       react-i18next:
         specifier: ^15.3.0
-        version: 15.7.4(i18next@23.16.8)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)
+        version: 15.7.4(i18next@23.16.8)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)
       react-native:
         specifier: 0.85.2
         version: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
@@ -408,6 +408,9 @@ importers:
       react-stately:
         specifier: ^3.46.0
         version: 3.46.0(react@19.2.5)
+      react-timezone-select:
+        specifier: ^3.3.3
+        version: 3.3.3(react-dom@19.2.5(react@19.2.5))(react-select@5.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
     devDependencies:
       '@glaon/config':
         specifier: workspace:*
@@ -3414,6 +3417,11 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
+  '@types/react-transition-group@4.4.12':
+    resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
@@ -4554,6 +4562,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -6841,10 +6852,29 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-select@5.10.2:
+    resolution: {integrity: sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-stately@3.46.0:
     resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-timezone-select@3.3.3:
+    resolution: {integrity: sha512-wcKk5jTR7FWhdQI43k9sHQw/97xJ80z7ambdiisKzJ++7SthxeMC1QrTOq3jINz4c5EjDkYVC324yMo2No/mtA==}
+    peerDependencies:
+      react: ^16 || ^17.0.1 || ^18 || ^19
+      react-dom: ^16 || ^17.0.1 || ^18 || ^19
+      react-select: ^5.9.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
@@ -7196,6 +7226,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  spacetime@7.12.1:
+    resolution: {integrity: sha512-lX2rBX39xevG6Yh+6TDWjjC5DTTt4+QuIqhUyWVxHAOGLFDtsnUJt1gF7BMNTZOLudlTdu/iut+1m33pDnsDLA==}
+
   sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
@@ -7523,6 +7556,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  timezone-soft@1.5.2:
+    resolution: {integrity: sha512-BUr+CfBfeWXJwFAuEzPO9uF+v6sy3pL5SKLkDg4vdEhsyXgbBnpFoBCW8oEKSNTqNq9YHbVOjNb31xE7WyGmrA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -7794,6 +7830,15 @@ packages:
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
     engines: {node: '>= 0.4'}
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -8886,17 +8931,16 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  '@clerk/clerk-expo@2.19.36(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(expo-auth-session@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3))(expo-crypto@55.0.14(expo@55.0.15))(expo-secure-store@55.0.13(expo@55.0.15))(expo-web-browser@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)))(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.3.6)':
+  '@clerk/clerk-expo@2.19.36(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(expo-auth-session@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3))(expo-crypto@55.0.14(expo@55.0.15))(expo-secure-store@55.0.13(expo@55.0.15))(expo-web-browser@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.3.6)':
     dependencies:
-      '@clerk/clerk-js': 5.125.10(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.3.6)
-      '@clerk/clerk-react': 5.61.6(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
-      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
-      '@clerk/types': 4.101.23(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@clerk/clerk-js': 5.125.10(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.3.6)
+      '@clerk/clerk-react': 5.61.6(react@19.2.6)
+      '@clerk/shared': 3.47.5(react@19.2.6)
+      '@clerk/types': 4.101.23(react@19.2.6)
       base-64: 1.0.0
       expo-auth-session: 55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)
       expo-web-browser: 55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       react-native-url-polyfill: 2.0.0(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))
       tslib: 2.8.1
@@ -8916,16 +8960,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@clerk/clerk-js@5.125.10(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.3.6)':
+  '@clerk/clerk-js@5.125.10(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.3.6)':
     dependencies:
       '@base-org/account': 2.0.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(typescript@5.7.3)(use-sync-external-store@1.6.0(react@19.2.6))(utf-8-validate@6.0.6)(zod@4.3.6)
-      '@clerk/localizations': 3.37.5(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
-      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@clerk/localizations': 3.37.5(react@19.2.6)
+      '@clerk/shared': 3.47.5(react@19.2.6)
       '@coinbase/wallet-sdk': 4.3.0
       '@emotion/cache': 11.11.0
       '@emotion/react': 11.11.1(@types/react@19.2.14)(react@19.2.6)
-      '@floating-ui/react': 0.27.12(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@floating-ui/react': 0.27.12(react@19.2.6)
+      '@floating-ui/react-dom': 2.1.8(react@19.2.6)
       '@formkit/auto-animate': 0.8.4
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))
       '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.7.3)(utf-8-validate@6.0.6))(bs58@6.0.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)
@@ -8942,10 +8986,9 @@ snapshots:
       core-js: 3.41.0
       crypto-js: 4.2.0
       dequal: 2.0.3
-      input-otp: 1.4.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      input-otp: 1.4.2(react@19.2.6)
       qrcode.react: 4.2.0(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
       regenerator-runtime: 0.14.1
     transitivePeerDependencies:
       - '@solana/web3.js'
@@ -8968,16 +9011,15 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       tslib: 2.8.1
 
-  '@clerk/clerk-react@5.61.6(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@clerk/clerk-react@5.61.6(react@19.2.6)':
     dependencies:
-      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@clerk/shared': 3.47.5(react@19.2.6)
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
       tslib: 2.8.1
 
-  '@clerk/localizations@3.37.5(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@clerk/localizations@3.37.5(react@19.2.6)':
     dependencies:
-      '@clerk/types': 4.101.23(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@clerk/types': 4.101.23(react@19.2.6)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -8994,7 +9036,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@clerk/shared@3.47.5(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@clerk/shared@3.47.5(react@19.2.6)':
     dependencies:
       csstype: 3.1.3
       dequal: 2.0.3
@@ -9004,11 +9046,10 @@ snapshots:
       swr: 2.3.4(react@19.2.6)
     optionalDependencies:
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
 
-  '@clerk/types@4.101.23(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@clerk/types@4.101.23(react@19.2.6)':
     dependencies:
-      '@clerk/shared': 3.47.5(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@clerk/shared': 3.47.5(react@19.2.6)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -9129,6 +9170,22 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
+  '@emotion/react@11.11.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.11.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.5)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.3.1
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - supports-color
+
   '@emotion/react@11.11.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -9156,6 +9213,10 @@ snapshots:
   '@emotion/sheet@1.4.0': {}
 
   '@emotion/unitless@0.10.0': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
 
   '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.6)':
     dependencies:
@@ -9289,7 +9350,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@expo/cli@55.0.24(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(expo-constants@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3))(expo-font@55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo@55.0.15)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)':
+  '@expo/cli@55.0.24(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(expo-constants@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3))(expo-font@55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 55.0.15(typescript@5.7.3)
@@ -9306,7 +9367,7 @@ snapshots:
       '@expo/plist': 0.5.2
       '@expo/prebuild-config': 55.0.15(expo@55.0.15)(typescript@5.7.3)
       '@expo/require-utils': 55.0.4(typescript@5.7.3)
-      '@expo/router-server': 55.0.14(expo-constants@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3))(expo-font@55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo-server@55.0.7)(expo@55.0.15)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@expo/router-server': 55.0.14(expo-constants@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3))(expo-font@55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo-server@55.0.7)(expo@55.0.15)(react@19.2.6)
       '@expo/schema-utils': 55.0.3
       '@expo/spawn-async': 1.7.2
       '@expo/ws-tunnel': 1.0.6
@@ -9323,7 +9384,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.4
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       expo-server: 55.0.7
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -9420,7 +9481,7 @@ snapshots:
 
   '@expo/dom-webview@55.0.5(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)':
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       react: 19.2.6
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
@@ -9478,7 +9539,7 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 55.0.5(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       react: 19.2.6
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       stacktrace-parser: 0.1.11
@@ -9505,7 +9566,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9561,7 +9622,7 @@ snapshots:
       '@expo/json-file': 10.0.13
       '@react-native/normalize-colors': 0.83.4
       debug: 4.4.3
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       resolve-from: 5.0.0
       semver: 7.7.4
       xml2js: 0.6.0
@@ -9579,16 +9640,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/router-server@55.0.14(expo-constants@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3))(expo-font@55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo-server@55.0.7)(expo@55.0.15)(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@expo/router-server@55.0.14(expo-constants@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3))(expo-font@55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo-server@55.0.7)(expo@55.0.15)(react@19.2.6)':
     dependencies:
       debug: 4.4.3
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       expo-constants: 55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3)
       expo-font: 55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       expo-server: 55.0.7
       react: 19.2.6
-    optionalDependencies:
-      react-dom: 19.2.5(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -9635,18 +9694,16 @@ snapshots:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
-  '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@floating-ui/react-dom@2.1.8(react@19.2.6)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
 
-  '@floating-ui/react@0.27.12(react-dom@19.2.5(react@19.2.6))(react@19.2.6)':
+  '@floating-ui/react@0.27.12(react@19.2.6)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.6))(react@19.2.6)
+      '@floating-ui/react-dom': 2.1.8(react@19.2.6)
       '@floating-ui/utils': 0.2.11
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
@@ -10411,7 +10468,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.84.3(bufferutil@4.1.0)
-      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.3(bufferutil@4.1.0)
       metro-core: 0.84.3
       semver: 7.7.4
     transitivePeerDependencies:
@@ -10425,7 +10482,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.3(bufferutil@4.1.0)
       metro-core: 0.84.3
       semver: 7.7.4
     transitivePeerDependencies:
@@ -10870,7 +10927,7 @@ snapshots:
       react: 19.2.6
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     optionalDependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
 
   '@sentry/react@10.48.0(react@19.2.6)':
     dependencies:
@@ -11511,7 +11568,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 22.19.17
 
   '@types/deep-eql@4.0.2': {}
 
@@ -11556,6 +11613,10 @@ snapshots:
     dependencies:
       '@types/react': 19.2.14
 
+  '@types/react-transition-group@4.4.12(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
@@ -11576,7 +11637,7 @@ snapshots:
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 22.19.17
 
   '@types/ws@8.18.1':
     dependencies:
@@ -11832,9 +11893,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.17)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.0.13(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.8(@types/node@25.6.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1(bufferutil@4.1.0))(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vite@8.0.13(@types/node@22.19.17)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
+      '@vitest/browser': 4.1.8(bufferutil@4.1.0)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.8)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -12234,7 +12295,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -12840,6 +12901,11 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      csstype: 3.2.3
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -13180,12 +13246,12 @@ snapshots:
 
   expo-application@55.0.14(expo@55.0.15):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
 
   expo-asset@55.0.15(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3):
     dependencies:
       '@expo/image-utils': 0.8.13(typescript@5.7.3)
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       expo-constants: 55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3)
       react: 19.2.6
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
@@ -13210,7 +13276,7 @@ snapshots:
 
   expo-clipboard@55.0.13(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       react: 19.2.6
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
@@ -13218,7 +13284,7 @@ snapshots:
     dependencies:
       '@expo/config': 55.0.15(typescript@5.7.3)
       '@expo/env': 2.1.1
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - supports-color
@@ -13226,23 +13292,23 @@ snapshots:
 
   expo-crypto@55.0.14(expo@55.0.15):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
 
   expo-file-system@55.0.16(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   expo-font@55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       fontfaceobserver: 2.3.0
       react: 19.2.6
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
   expo-keep-awake@55.0.6(expo@55.0.15)(react@19.2.6):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       react: 19.2.6
 
   expo-linking@55.0.13(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3):
@@ -13258,7 +13324,7 @@ snapshots:
 
   expo-localization@55.0.13(expo@55.0.15)(react@19.2.6):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       react: 19.2.6
       rtl-detect: 1.1.2
 
@@ -13280,7 +13346,7 @@ snapshots:
 
   expo-secure-store@55.0.13(expo@55.0.15):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
 
   expo-server@55.0.7: {}
 
@@ -13292,13 +13358,13 @@ snapshots:
 
   expo-web-browser@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)):
     dependencies:
-      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
 
-  expo@55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6):
+  expo@55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.24(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(expo-constants@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3))(expo-font@55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo@55.0.15)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
+      '@expo/cli': 55.0.24(@expo/dom-webview@55.0.5)(bufferutil@4.1.0)(expo-constants@55.0.14(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(typescript@5.7.3))(expo-font@55.0.6(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6))(expo@55.0.15)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3)(utf-8-validate@6.0.6)
       '@expo/config': 55.0.15(typescript@5.7.3)
       '@expo/config-plugins': 55.0.8
       '@expo/devtools': 55.0.2(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
@@ -13838,10 +13904,9 @@ snapshots:
     dependencies:
       css-in-js-utils: 3.1.0
 
-  input-otp@1.4.2(react-dom@19.2.5(react@19.2.6))(react@19.2.6):
+  input-otp@1.4.2(react@19.2.6):
     dependencies:
       react: 19.2.6
-      react-dom: 19.2.5(react@19.2.6)
 
   inquirer@6.5.2:
     dependencies:
@@ -14615,12 +14680,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+  metro-config@0.84.3(bufferutil@4.1.0):
     dependencies:
       connect: 3.7.0
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro: 0.84.3(bufferutil@4.1.0)
       metro-cache: 0.84.3
       metro-core: 0.84.3
       metro-runtime: 0.84.3
@@ -14903,7 +14968,7 @@ snapshots:
       metro-babel-transformer: 0.84.3
       metro-cache: 0.84.3
       metro-cache-key: 0.84.3
-      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.3(bufferutil@4.1.0)
       metro-core: 0.84.3
       metro-file-map: 0.84.3
       metro-resolver: 0.84.3
@@ -14950,7 +15015,7 @@ snapshots:
       metro-babel-transformer: 0.84.3
       metro-cache: 0.84.3
       metro-cache-key: 0.84.3
-      metro-config: 0.84.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.84.3(bufferutil@4.1.0)
       metro-core: 0.84.3
       metro-file-map: 0.84.3
       metro-resolver: 0.84.3
@@ -15681,14 +15746,13 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       typescript: 5.7.3
 
-  react-i18next@15.7.4(i18next@23.16.8)(react-dom@19.2.5(react@19.2.6))(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3):
+  react-i18next@15.7.4(i18next@23.16.8)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)(typescript@5.7.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
       i18next: 23.16.8
       react: 19.2.6
     optionalDependencies:
-      react-dom: 19.2.5(react@19.2.6)
       react-native: 0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
       typescript: 5.7.3
 
@@ -15826,6 +15890,23 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-select@5.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/cache': 11.11.0
+      '@emotion/react': 11.11.1(@types/react@19.2.14)(react@19.2.5)
+      '@floating-ui/dom': 1.7.6
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.14)
+      memoize-one: 6.0.0
+      prop-types: 15.8.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-transition-group: 4.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
   react-stately@3.46.0(react@19.2.5):
     dependencies:
       '@internationalized/date': 3.12.1
@@ -15835,6 +15916,23 @@ snapshots:
       '@swc/helpers': 0.5.21
       react: 19.2.5
       use-sync-external-store: 1.6.0(react@19.2.5)
+
+  react-timezone-select@3.3.3(react-dom@19.2.5(react@19.2.5))(react-select@5.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-select: 5.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      spacetime: 7.12.1
+      timezone-soft: 1.5.2
+
+  react-transition-group@4.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   react@19.2.5: {}
 
@@ -16295,6 +16393,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  spacetime@7.12.1: {}
+
   sparse-bitfield@3.0.3:
     dependencies:
       memory-pager: 1.5.0
@@ -16680,6 +16780,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  timezone-soft@1.5.2: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -16935,6 +17037,12 @@ snapshots:
     dependencies:
       punycode: 1.4.1
       qs: 6.14.2
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:

--- a/tools/figma-plugin/scripts/12-timezoneselect-search-select.js
+++ b/tools/figma-plugin/scripts/12-timezoneselect-search-select.js
@@ -1,0 +1,155 @@
+// Glaon — 12 TimezoneSelect → SearchSelect (button + popover search) (#690)
+//
+// Updates the "App Primitives/TimezoneSelect" COMPONENT in the Design
+// System Figma file to match PR #690: the timezone picker is no longer an
+// editable input (ComboBox) — it's a **button trigger** (leading clock
+// glyph + selected `(GMT±hh:mm) City` label + chevron) that opens a popover
+// with a **search field** inside it (kit SearchSelect). Options come from
+// react-timezone-select; the value is the IANA id. Keeps `storybook-id:
+// app-primitives-timezone-select` (Chromatic Figma-diff contract).
+//
+// The frame shows the closed trigger; search-in-popover is the open state.
+//
+// Usage:
+//   1. Copy this file's contents into tools/figma-plugin/code.js.
+//   2. Open the Design System Figma file.
+//   3. Run plugin (Plugins → Development → Glaon) → review dry-run.
+//   4. Flip CONFIRM = true → re-run → report the node id for the PR body.
+//   5. git restore tools/figma-plugin/code.js
+
+const CONFIRM = false;
+
+const COMPONENT_NAME = 'App Primitives/TimezoneSelect';
+const STORYBOOK_ID = 'app-primitives-timezone-select';
+const FRAME_WIDTH = 360;
+const SAMPLE_LABEL = '(GMT+03:00) Istanbul';
+
+const TOKENS = {
+  surface: { var: 'surface/default', hex: '#FFFFFF' },
+  border: { var: 'border/subtle', hex: '#E4E7EC' },
+  textPrimary: { var: 'text/primary', hex: '#181D27' },
+  textMuted: { var: 'text/muted', hex: '#717680' },
+};
+
+function hexToRgb(hex) {
+  const h = hex.replace('#', '');
+  return {
+    r: parseInt(h.slice(0, 2), 16) / 255,
+    g: parseInt(h.slice(2, 4), 16) / 255,
+    b: parseInt(h.slice(4, 6), 16) / 255,
+  };
+}
+
+(async () => {
+  try {
+    const existing = (await figma.root.findAllWithCriteria({ types: ['COMPONENT'] })).find(
+      (n) => n.name === COMPONENT_NAME,
+    );
+
+    if (!CONFIRM) {
+      figma.notify(
+        existing
+          ? `🔍 DRY-RUN — would rebuild "${COMPONENT_NAME}" [${existing.id}] as a button trigger ` +
+              `(clock + "${SAMPLE_LABEL}" + chevron; search in popover). Flip CONFIRM to apply.`
+          : `🔍 DRY-RUN — "${COMPONENT_NAME}" not found; would create it. Flip CONFIRM.`,
+        { timeout: 13000 },
+      );
+      figma.closePlugin();
+      return;
+    }
+
+    const vars = await figma.variables.getLocalVariablesAsync();
+    const byName = new Map(vars.map((v) => [v.name, v]));
+    const fill = (key) => {
+      const t = TOKENS[key];
+      const paint = { type: 'SOLID', color: hexToRgb(t.hex) };
+      const v = byName.get(t.var);
+      return v ? figma.variables.setBoundVariableForPaint(paint, 'color', v) : paint;
+    };
+
+    const FAMILY = 'Inter';
+    let fontReg = { family: FAMILY, style: 'Regular' };
+    let fontMed = { family: FAMILY, style: 'Medium' };
+    try {
+      await figma.loadFontAsync(fontReg);
+      await figma.loadFontAsync(fontMed);
+    } catch {
+      const fb = { family: 'Roboto', style: 'Regular' };
+      await figma.loadFontAsync(fb);
+      fontReg = fb;
+      fontMed = fb;
+    }
+    const text = (chars, font, size, colorKey) => {
+      const t = figma.createText();
+      t.fontName = font;
+      t.fontSize = size;
+      t.characters = chars;
+      t.fills = [fill(colorKey)];
+      return t;
+    };
+
+    const buildTrigger = () => {
+      const trigger = figma.createFrame();
+      trigger.name = 'trigger';
+      trigger.layoutMode = 'HORIZONTAL';
+      trigger.itemSpacing = 8;
+      trigger.counterAxisAlignItems = 'CENTER';
+      trigger.paddingLeft = 12;
+      trigger.paddingRight = 12;
+      trigger.paddingTop = 10;
+      trigger.paddingBottom = 10;
+      trigger.cornerRadius = 8;
+      trigger.fills = [fill('surface')];
+      trigger.strokes = [fill('border')];
+      trigger.strokeWeight = 1;
+      trigger.layoutAlign = 'STRETCH';
+      trigger.primaryAxisSizingMode = 'FIXED';
+      trigger.counterAxisSizingMode = 'AUTO';
+
+      trigger.appendChild(text('🕐', fontReg, 16, 'textMuted')); // clock glyph stand-in
+      const value = text(SAMPLE_LABEL, fontMed, 16, 'textPrimary');
+      value.layoutGrow = 1;
+      trigger.appendChild(value);
+      trigger.appendChild(text('⌄', fontReg, 14, 'textMuted')); // chevron
+      return trigger;
+    };
+
+    const apply = (node) => {
+      node.layoutMode = 'VERTICAL';
+      node.itemSpacing = 6;
+      node.fills = [];
+      node.resize(FRAME_WIDTH, 10);
+      node.primaryAxisSizingMode = 'AUTO';
+      node.counterAxisSizingMode = 'FIXED';
+      node.appendChild(text('Timezone', fontMed, 14, 'textPrimary'));
+      node.appendChild(buildTrigger());
+    };
+
+    let root = existing;
+    if (root) {
+      for (const child of [...root.children]) child.remove();
+      apply(root);
+      if (!root.description.includes(`storybook-id: ${STORYBOOK_ID}`)) {
+        root.description =
+          (root.description ? root.description + '\n' : '') + `storybook-id: ${STORYBOOK_ID}`;
+      }
+    } else {
+      root = figma.createComponent();
+      root.name = COMPONENT_NAME;
+      root.description = `Glaon timezone picker — kit SearchSelect (button + in-popover search), options from react-timezone-select (#690).\nstorybook-id: ${STORYBOOK_ID}`;
+      apply(root);
+      root.x = Math.round(figma.viewport.center.x - FRAME_WIDTH / 2);
+      root.y = Math.round(figma.viewport.center.y - 40);
+      figma.currentPage.appendChild(root);
+    }
+
+    figma.viewport.scrollAndZoomIntoView([root]);
+    figma.notify(`✅ Updated "${COMPONENT_NAME}" — node id: ${root.id}`, { timeout: 15000 });
+    console.log('[Glaon 12 TimezoneSelect] node id:', root.id);
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();


### PR DESCRIPTION
Refactor the wizard's Timezone picker (#690) to use **`react-timezone-select`** for its option list + DST-aware `(GMT±hh:mm) City` labels, rendered through our UUI **`SearchSelect`** (button trigger + in-popover search, #688). Consistent with CountrySelect; **no `react-select`**.

## Approach (hook-only)
`react-timezone-select`'s default component pulls in `react-select`; the library supports a **hook-only** path. We use `useTimezoneSelect` for the data and keep our UUI UI. Build-verified: **react-select is tree-shaken out** (no emotion / react-select tokens in the bundle); only `spacetime`/`timezone-soft` (the label engine) land in the already-lazy wizard chunk.

## Full-coverage fix
The library's bundled `allTimezones` is a curated **~78-zone** set that **omits `Europe/Istanbul`** (and others the country→timezone sync emits) — that would leave the trigger blank. So we feed the hook the **full** runtime IANA list (`Intl.supportedValuesOf('timeZone')` → city names) and let it format the offset labels; falls back to `allTimezones` if the API is missing.

## Follow-up polish (user feedback on the shipped trigger)
- **Leading icon was blank.** `SearchSelect` rendered its icon variable lowercase (`<triggerIcon>`), so JSX treated it as a literal `<triggericon>` DOM tag and the Clock never showed (same latent bug hid CountrySelect's Globe placeholder). Capitalized the variable → the Clock renders.
- **List was crowded.** The full IANA list repeats one offset across many zones. Added an optional **`groupBy`** to `SearchSelect` that buckets options into RAC sections with sticky `GMT±hh:mm` headers; `TimezoneSelect` groups by offset and shows **city-only rows** (e.g. `Istanbul` under `GMT+3:00`) while keeping the full `(GMT±hh:mm) City` label for the trigger value + search index — so `gmt+3` and `istanbul` both still match.

## Changes
- Add `react-timezone-select` to `@glaon/ui` (hook-only).
- `TimezoneSelect` wraps `SearchSelect` (Clock glyph, diacritic filter, `groupBy` GMT offset); drops the now-meaningless `locale`/collation prop (offset-ordered). New `searchPlaceholder`/`noResultsLabel`, i18n-wired (en+tr).
- `SearchSelect`: fix lowercase icon-component render; add optional `groupBy` → RAC sectioned listbox with sticky headers.
- `timezones.ts` trimmed to `buildTimezoneDict` + detect/filter helpers. Story/controls/mdx updated. Figma script 12.

## Verified live
- Trigger is a button showing `(GMT+3:00) Istanbul` with the **Clock leading icon** (Turkey seed/sync resolves correctly now).
- Popover groups options under sticky `GMT±hh:mm` headers with city-only rows; search filters by city (`istanbul` → 1 row) **and** offset (`gmt+3` → all 35 GMT+3 zones); emits the IANA id.

## Test plan
- [x] `@glaon/ui` type-check + lint + 171 unit (F6 prop-coverage); `@glaon/web` type-check + 22 home-overview; i18n-check; knip; `pnpm audit` (no high/critical) — all green.
- [x] Build: react-select NOT bundled.
- [x] Live (Storybook): Clock icon in trigger; GMT-offset section headers + city-only rows; city + offset search both match; Turkey sync.
- [ ] CI green (incl. lighthouse-mobile — wizard map still deferred from #687).
- [ ] Chromatic + Figma node linked.

## Note
Adds a runtime dep (`react-timezone-select`) per the explicit request.

Closes #690
