### PR TITLE
refactor(ui): use curated offset-grouped list in TimezoneSelect

### DIFF
--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.mdx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.mdx
@@ -79,31 +79,34 @@ Auto-detection is **skipped** when:
 />
 ```
 
-Options are **grouped by GMT offset**: each section carries a sticky
-`GMT±hh:mm` header and the rows under it show just the city (e.g.
-`Istanbul` under `GMT+3:00`) so the long list stays scannable instead
-of repeating the offset on every row. The selected trigger and the
-search index still use the full `(GMT±hh:mm) City` label. The offset is
-DST-aware (recomputed for the current date).
+Each row is one **GMT offset** with a multi-city label, e.g.
+`(GMT+3:00) Istanbul, Minsk, Moscow, St. Petersburg, Volgograd`. This is
+the curated, offset-grouped presentation (~79 rows) — deliberately
+compact rather than the full IANA list. The offset is DST-aware
+(recomputed for the current date).
 
 ## Dataset
 
-The labels come from `react-timezone-select`'s
-`useTimezoneSelect({ labelStyle: 'original', timezones })` hook, fed the
-**full** runtime IANA list (`Intl.supportedValuesOf('timeZone')`, via
-`buildTimezoneDict`) so every zone the wizard may seed/sync — e.g.
-`Europe/Istanbul` — is present; the library's curated `allTimezones` is
-used only as a fallback when `supportedValuesOf` is unavailable. We use
-the hook only, so `react-select` is **not** bundled (the `spacetime` /
-`timezone-soft` label engine is). The emitted value stays the raw IANA id.
+The list + labels come from `react-timezone-select`'s
+`useTimezoneSelect({ labelStyle: 'original', timezones: allTimezones })`
+hook — the library's curated set with offset-grouped, DST-aware labels.
+We use the hook only, so `react-select` is **not** bundled (the
+`spacetime` / `timezone-soft` label engine is).
+
+Each curated row's `value` is a representative IANA id (the GMT+3 row's
+id is `Europe/Moscow`). A seeded id that isn't a curated key — e.g.
+`Europe/Istanbul` from the country→timezone sync — is fuzzy-resolved by
+`parseTimezone` to its curated row **for display only**: the trigger
+shows the right label and the row highlights, but the held value stays
+the seeded id. It is only rewritten to the curated representative when
+the user actively picks a row.
 
 ## Search behaviour
 
 A search field sits at the top of the popover. The filter is
-**diacritic-insensitive** and runs against the full `(GMT±hh:mm) City`
-label — typing `istanbul` matches `Istanbul`, `reunion` matches
-`Réunion`, and `gmt+3` matches every GMT+3 zone — even though the rows
-display the city only.
+**diacritic-insensitive** and runs against the displayed label — typing
+`istanbul` matches the `(GMT+3:00) Istanbul, …` row, `reunion` matches
+`Réunion`.
 
 ## Error UX
 

--- a/packages/ui/src/components/TimezoneSelect/TimezoneSelect.tsx
+++ b/packages/ui/src/components/TimezoneSelect/TimezoneSelect.tsx
@@ -18,21 +18,7 @@ import { Clock } from '@untitledui/icons';
 import { allTimezones, useTimezoneSelect } from 'react-timezone-select';
 
 import { SearchSelect, SelectItem, type SelectItemType } from '../Select';
-import { buildTimezoneDict, detectBrowserTimezone, diacriticInsensitiveFilter } from './timezones';
-
-// react-timezone-select labels are `(GMT±hh:mm) City`. Many IANA zones share
-// an offset, so we group them under a `GMT±hh:mm` section header and show
-// just the city per row — the full label is kept as the trigger value and as
-// the search `textValue`, so typing "gmt+3" or "istanbul" both match.
-const GMT_PREFIX_RE = /^\(([^)]*)\)\s*/;
-
-function offsetGroup(item: SelectItemType): string {
-  return GMT_PREFIX_RE.exec(item.label ?? '')?.[1] ?? 'Other';
-}
-
-function cityLabel(label: string): string {
-  return label.replace(GMT_PREFIX_RE, '') || label;
-}
+import { detectBrowserTimezone, diacriticInsensitiveFilter } from './timezones';
 
 // Types stay un-exported per memory note `feedback_knip_props_interfaces.md`.
 type TimezoneSelectSize = 'sm' | 'md' | 'lg';
@@ -105,16 +91,15 @@ export function TimezoneSelect({
   className,
   popoverClassName,
 }: TimezoneSelectProps) {
-  // DST-aware timezone options from react-timezone-select, over the FULL
-  // runtime IANA list (so every zone the wizard may seed/sync — e.g.
-  // Europe/Istanbul — is present; the library's curated `allTimezones`
-  // omits many). Falls back to `allTimezones` if `supportedValuesOf` is
-  // unavailable. `value` is the IANA id; `label` is `(GMT±hh:mm) City`.
-  const timezoneDict = useMemo(() => {
-    const full = buildTimezoneDict();
-    return Object.keys(full).length > 0 ? full : allTimezones;
-  }, []);
-  const { options } = useTimezoneSelect({ labelStyle: 'original', timezones: timezoneDict });
+  // DST-aware timezone options from react-timezone-select's curated
+  // `allTimezones` set: one row per GMT offset with a multi-city label, e.g.
+  // `(GMT+3:00) Istanbul, Minsk, Moscow, St. Petersburg, Volgograd`. This is
+  // the deliberately compact, offset-grouped presentation (~79 rows) rather
+  // than the full IANA list. `value` is the curated representative IANA id.
+  const { options, parseTimezone } = useTimezoneSelect({
+    labelStyle: 'original',
+    timezones: allTimezones,
+  });
   const items = useMemo<SelectItemType[]>(
     () => options.map((o) => ({ id: o.value, label: o.label })),
     [options],
@@ -135,6 +120,24 @@ export function TimezoneSelect({
 
   const effectiveKey = isHostControlled ? value : internalKey;
 
+  // The curated list keys one row per offset (e.g. the GMT+3 row's id is
+  // `Europe/Moscow`), so a seeded id that isn't a curated key — like
+  // `Europe/Istanbul` from the country→timezone sync — wouldn't match any
+  // row and the trigger would render blank. `parseTimezone` fuzzy-resolves
+  // any IANA id to its curated row, so we resolve the *displayed* key only.
+  // The held value (`effectiveKey`) stays untouched: we never rewrite the
+  // seeded id to the curated representative — that only happens when the
+  // user actively picks a row (via `handleSelectionChange`).
+  const displayKey = useMemo<string | null>(() => {
+    if (effectiveKey == null) return null;
+    if (items.some((i) => i.id === effectiveKey)) return effectiveKey;
+    // react-timezone-select types `parseTimezone` as always returning an
+    // option, but at runtime it returns `false` for an unrecognised id that
+    // has no "/" — widen to the real contract so the guard is legitimate.
+    const resolved = parseTimezone(effectiveKey) as { value: string } | string | false;
+    return resolved && typeof resolved === 'object' ? resolved.value : effectiveKey;
+  }, [effectiveKey, items, parseTimezone]);
+
   const [suppressInvalid, setSuppressInvalid] = useState(false);
   useEffect(() => {
     setSuppressInvalid(false);
@@ -153,11 +156,10 @@ export function TimezoneSelect({
   const selectProps: Record<string, unknown> = {
     items,
     size,
-    selectedKey: effectiveKey ?? null,
+    selectedKey: displayKey,
     onSelectionChange: handleSelectionChange,
     filter: diacriticInsensitiveFilter,
     leadingIcon: Clock,
-    groupBy: offsetGroup,
   };
 
   if (label !== undefined) selectProps.label = label;
@@ -176,9 +178,7 @@ export function TimezoneSelect({
 
   return (
     <SearchSelect {...selectProps}>
-      {(item: SelectItemType) => (
-        <SelectItem id={item.id} label={cityLabel(item.label ?? '')} textValue={item.label ?? ''} />
-      )}
+      {(item: SelectItemType) => <SelectItem id={item.id} label={item.label ?? ''} />}
     </SearchSelect>
   );
 }

--- a/packages/ui/src/components/TimezoneSelect/timezones.ts
+++ b/packages/ui/src/components/TimezoneSelect/timezones.ts
@@ -1,40 +1,11 @@
 // TimezoneSelect data + helpers.
 //
-// The timezone *list + labels* now come from `react-timezone-select`'s
-// `useTimezoneSelect` hook (#690) — a curated set with DST-aware
-// `(GMT±hh:mm) City` labels — so the old `Intl.supportedValuesOf` +
-// offset-formatting helpers are gone. This module only keeps the two
-// pure helpers the wrapper still needs: browser detection + the
-// diacritic-insensitive search filter.
-
-/**
- * Build the `timezones` dict fed to `react-timezone-select`'s
- * `useTimezoneSelect` (#690). Its bundled `allTimezones` is a curated
- * ~78-zone set that omits many IANA ids the wizard relies on (e.g.
- * `Europe/Istanbul`, set by the country→timezone sync), which would leave
- * the trigger blank for those. So we feed the **full** runtime IANA list
- * (`Intl.supportedValuesOf('timeZone')`) mapped to a city display name; the
- * hook still computes the DST-aware `(GMT±hh:mm)` offset prefix. Returns an
- * empty object when the API is unavailable so the caller can fall back to
- * the library's `allTimezones`.
- */
-export function buildTimezoneDict(): Record<string, string> {
-  try {
-    const intlWithSupported = Intl as typeof Intl & {
-      supportedValuesOf?: (key: 'timeZone') => string[];
-    };
-    if (typeof intlWithSupported.supportedValuesOf !== 'function') return {};
-    const zones = intlWithSupported.supportedValuesOf('timeZone');
-    const dict: Record<string, string> = {};
-    for (const tz of zones) {
-      const city = (tz.split('/').pop() ?? tz).replace(/_/g, ' ');
-      dict[tz] = city;
-    }
-    return dict;
-  } catch {
-    return {};
-  }
-}
+// The timezone *list + labels* come from `react-timezone-select`'s
+// `useTimezoneSelect` hook (#690), fed the library's curated `allTimezones`
+// set — DST-aware, offset-grouped `(GMT±hh:mm) City1, City2…` labels — so
+// the old `Intl.supportedValuesOf` + offset-formatting helpers are gone.
+// This module only keeps the two pure helpers the wrapper still needs:
+// browser detection + the diacritic-insensitive search filter.
 
 /**
  * Detect the user's IANA timezone from the runtime's locale settings.

--- a/packages/ui/src/components/base/select/search-select.tsx
+++ b/packages/ui/src/components/base/select/search-select.tsx
@@ -18,13 +18,10 @@ import type { Key, Selection } from 'react-aria-components';
 import {
   Autocomplete as AriaAutocomplete,
   Button as AriaButton,
-  Collection as AriaCollection,
   Dialog as AriaDialog,
   DialogTrigger as AriaDialogTrigger,
-  Header as AriaHeader,
   Input as AriaInput,
   ListBox as AriaListBox,
-  ListBoxSection as AriaListBoxSection,
   Popover as AriaPopover,
   SearchField as AriaSearchField,
 } from 'react-aria-components';
@@ -57,11 +54,6 @@ interface SearchSelectProps extends CommonProps {
   leadingIcon?: FC | ReactNode;
   /** Diacritic-insensitive `(textValue, inputValue) => boolean` filter. */
   filter?: (textValue: string, inputValue: string) => boolean;
-  /** When set, options are grouped into sections keyed by the returned
-   *  string, each rendered under a sticky header (e.g. group timezones by
-   *  GMT offset). Items keep their source order, so the first time a key is
-   *  seen fixes that section's position. Omit for a flat list. */
-  groupBy?: (item: SelectItemType) => string;
   /** Placeholder inside the popover search field. */
   searchPlaceholder?: string;
   /** Text shown when the search matches no option. */
@@ -83,7 +75,6 @@ const SearchSelectRoot = ({
   onSelectionChange,
   leadingIcon,
   filter,
-  groupBy,
   searchPlaceholder = 'Search',
   noResultsLabel = 'No results found',
   isDisabled,
@@ -124,24 +115,6 @@ const SearchSelectRoot = ({
   const selectedItem = selectedKey != null ? items?.find((i) => i.id === selectedKey) : undefined;
   // Capitalized so JSX treats it as a component, not a literal DOM tag.
   const TriggerIcon = selectedItem?.icon ?? leadingIcon;
-
-  // Group the flat `items` into sections when `groupBy` is set, preserving
-  // first-seen order so callers control section ordering by item order.
-  const sections = groupBy
-    ? (() => {
-        const byKey = new Map<string, { id: string; items: SelectItemType[] }>();
-        for (const item of items ?? []) {
-          const key = groupBy(item);
-          let section = byKey.get(key);
-          if (!section) {
-            section = { id: key, items: [] };
-            byKey.set(key, section);
-          }
-          section.items.push(item);
-        }
-        return [...byKey.values()];
-      })()
-    : null;
 
   return (
     <SelectContext.Provider value={{ size }}>
@@ -251,7 +224,7 @@ const SearchSelectRoot = ({
 
                 <AriaListBox
                   aria-label={label || ariaLabel || 'Options'}
-                  items={sections ?? items}
+                  items={items}
                   selectionMode="single"
                   selectedKeys={selectedKey != null ? new Set([selectedKey]) : new Set()}
                   onSelectionChange={handleListSelectionChange}
@@ -260,16 +233,7 @@ const SearchSelectRoot = ({
                   )}
                   className={cx('overflow-y-auto py-1 outline-hidden', popoverMaxHeights[size])}
                 >
-                  {sections
-                    ? (section: { id: string; items: SelectItemType[] }) => (
-                        <AriaListBoxSection id={section.id}>
-                          <AriaHeader className="sticky top-0 z-10 truncate bg-primary px-3 pt-2 pb-1 text-xs font-semibold text-tertiary">
-                            {section.id}
-                          </AriaHeader>
-                          <AriaCollection items={section.items}>{children}</AriaCollection>
-                        </AriaListBoxSection>
-                      )
-                    : children}
+                  {children}
                 </AriaListBox>
               </AriaAutocomplete>
             </AriaDialog>


### PR DESCRIPTION
Follow-up to #691 (merged). Switches the Timezone picker from the full IANA list split into GMT-offset **sections** to `react-timezone-select`'s **curated `allTimezones`** flat list: one row per offset with a multi-city label, e.g. `(GMT+3:00) Istanbul, Minsk, Moscow, St. Petersburg, Volgograd` (~79 rows). This is the preferred compact presentation.

## Changes
- `TimezoneSelect`: feed `useTimezoneSelect` the curated `allTimezones` (not the full `Intl.supportedValuesOf` list); rows render the full multi-city label.
- **Seeded off-list ids** (e.g. `Europe/Istanbul`, whose offset row is keyed `Europe/Moscow`) are fuzzy-resolved by the hook's `parseTimezone` **for display only** — the held value stays the seeded id; it is rewritten to the curated representative only when the user actively picks a row.
- Remove the now-unused `groupBy` section machinery from `SearchSelect` (the leading-icon fix from #691 stays).
- Remove the dead `buildTimezoneDict` helper. Story/controls/mdx updated.

## Verified live (Storybook)
- Trigger shows `(GMT+3:00) Istanbul, Minsk, Mosc…` with the Clock leading icon for a `Europe/Istanbul` seed (display-only resolution).
- Dropdown is the curated multi-city flat list (`(GMT-11:00) Midway Island, Samoa`, `(GMT-10:00) Hawaii`, …).
- Search filters against the displayed label (`istanbul` → the GMT+3 row).

## Test plan
- [x] `@glaon/ui` type-check + lint + 171 unit; prettier; gitleaks.
- [x] Live: curated list + Istanbul display resolution + Clock icon.
- [ ] CI green (story-tests, lighthouse-mobile, visual regression).
- [ ] Chromatic + Figma node linked.

Closes #692