### PR TITLE
refactor(ui): CurrencySelect → button-trigger select, flag + code only

### DIFF
--- a/apps/web/src/features/setup/home-overview/home-overview-step.tsx
+++ b/apps/web/src/features/setup/home-overview/home-overview-step.tsx
@@ -426,6 +426,8 @@ export function HomeOverviewStep({ collected, onNext }: HomeOverviewStepProps): 
           <CurrencySelect
             aria-labelledby={currencyLabelId}
             placeholder={t('setup.homeOverview.currency.placeholder')}
+            searchPlaceholder={t('setup.homeOverview.currency.searchPlaceholder')}
+            noResultsLabel={t('setup.homeOverview.currency.noResults')}
             {...(currency !== '' ? { value: currency } : {})}
             autoDetect={collected.currency === undefined && currency === ''}
             onSelectionChange={(code) => {

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -85,7 +85,9 @@
       },
       "currency": {
         "label": "Currency",
-        "placeholder": "Select currency"
+        "placeholder": "Select currency",
+        "searchPlaceholder": "Search currencies",
+        "noResults": "No results found"
       },
       "language": {
         "label": "Language",

--- a/apps/web/src/i18n/locales/tr.json
+++ b/apps/web/src/i18n/locales/tr.json
@@ -85,7 +85,9 @@
       },
       "currency": {
         "label": "Para Birimi",
-        "placeholder": "Para birimi seç"
+        "placeholder": "Para birimi seç",
+        "searchPlaceholder": "Para birimi ara",
+        "noResults": "Sonuç bulunamadı"
       },
       "language": {
         "label": "Dil",

--- a/packages/ui/src/components/CurrencySelect/CurrencySelect.controls.ts
+++ b/packages/ui/src/components/CurrencySelect/CurrencySelect.controls.ts
@@ -7,7 +7,6 @@ import type { ControlSpec } from '../_internal/controls';
 import { excludeFromArgs as defineExcludeFromArgs } from '../_internal/controls';
 
 const sizeOptions = ['sm', 'md', 'lg'] as const;
-const localeOptions = ['', 'tr-TR', 'en-US', 'de-DE', 'fr-FR', 'ar-SA'] as const;
 
 export const currencySelectControls = {
   label: {
@@ -21,7 +20,19 @@ export const currencySelectControls = {
     type: 'text',
     default: 'Select a currency',
     description:
-      'Hint text shown when no option is selected. Never use placeholder as a substitute for the label.',
+      'Hint text shown in the closed trigger when no option is selected. Never use placeholder as a substitute for the label.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  searchPlaceholder: {
+    type: 'text',
+    default: 'Search',
+    description: 'Placeholder inside the in-popover search field.',
+    category: 'Content',
+  } satisfies ControlSpec<string>,
+  noResultsLabel: {
+    type: 'text',
+    default: 'No results found',
+    description: 'Text shown when the search matches no currency.',
     category: 'Content',
   } satisfies ControlSpec<string>,
   hint: {
@@ -37,14 +48,6 @@ export const currencySelectControls = {
       "When true (default), preselect the currency of the browser locale's region on mount (Intl Locale Info `getCurrencies`). Ignored when `value` or `defaultValue` is set. One-shot — re-mount to re-detect.",
     category: 'Behavior',
   } satisfies ControlSpec<boolean>,
-  locale: {
-    type: 'select',
-    options: localeOptions,
-    default: '',
-    description:
-      'BCP-47 locale used for the localized currency names + label collation. Leave empty to use the browser default (`navigator.language`).',
-    category: 'Content',
-  } satisfies ControlSpec<(typeof localeOptions)[number]>,
   defaultValue: {
     type: 'text',
     description:
@@ -55,7 +58,7 @@ export const currencySelectControls = {
     type: 'inline-radio',
     options: sizeOptions,
     default: 'md',
-    description: 'Visual scale forwarded to the underlying ComboBox.',
+    description: 'Visual scale forwarded to the underlying SearchSelect.',
     category: 'Style',
   } satisfies ControlSpec<(typeof sizeOptions)[number]>,
   isDisabled: {

--- a/packages/ui/src/components/CurrencySelect/CurrencySelect.mdx
+++ b/packages/ui/src/components/CurrencySelect/CurrencySelect.mdx
@@ -7,16 +7,20 @@ import * as CurrencySelectStories from './CurrencySelect.stories';
 # CurrencySelect
 
 App-primitive ISO 4217 currency picker. Thin wrap over the kit
-[`<ComboBox>`](?path=/docs/web-primitives-select--docs#withsearch) that
-adds the built-in currency list, locale-aware sorting + names,
+`<SearchSelect>` (button trigger + in-popover search) — the same
+primitive [CountrySelect](?path=/docs/app-primitives-countryselect--docs)
+uses — that adds the built-in currency list, currency flags,
 diacritic-insensitive search, and optional one-shot autodetection.
 
-Sister primitive to
-[CountrySelect](?path=/docs/app-primitives-countryselect--docs) and
+Sister primitive to CountrySelect and
 [TimezoneSelect](?path=/docs/app-primitives-timezoneselect--docs) — same
-prop contract, same state machine, same polish (auto-clear-error,
-select-all-on-focus). The differences come from the dataset (ISO 4217
-codes) and the detection source (the browser locale's region currency).
+prop contract, same state machine, same polish (auto-clear-error). The
+differences come from the dataset (ISO 4217 codes) and the detection
+source (the browser locale's region currency).
+
+Rows + trigger show the **flag + code only** (🇹🇷 `TRY`). The localized
+currency *name* is intentionally dropped: it is locale-dependent and
+reads as noise in a multi-language wizard.
 
 ## When to use
 
@@ -66,22 +70,22 @@ Intl Locale Info API the picker simply starts empty.
 />
 ```
 
-Each row renders the ISO 4217 code + the localized currency name, e.g.
-`TRY — Turkish Lira`. The emitted value is the bare code (`'TRY'`).
+Each row renders the currency's **flag + ISO 4217 code**, e.g. 🇹🇷 `TRY`.
+The emitted value is the bare code (`'TRY'`).
 
-## Dataset and localization
+## Dataset and flags
 
 The list comes from `Intl.supportedValuesOf('currency')` — the
-runtime-built-in ISO 4217 set, no shipped table. The `locale` prop drives
-both the localized currency **names** (`Intl.DisplayNames`) and the sort
-order (`Intl.Collator`), so the same list renders correctly in any locale
-the browser supports.
+runtime-built-in ISO 4217 set, no shipped table — sorted alphabetically
+by code. Each row's flag maps the currency code to a country: `EUR` → the
+EU flag, otherwise the first two letters (`USD` → `us`, `TRY` → `tr`).
+Supranational / metal codes (`XAF`, `XAU`, …) have no flag asset, so the
+flag box renders empty while the code still identifies the row.
 
 ## Search behaviour
 
-The filter is **diacritic-insensitive** and matches the displayed label
-(code + name). The input **selects-all on focus** so the next keystroke
-replaces the current label cleanly.
+A search field sits at the top of the popover. The filter is
+**diacritic-insensitive** and matches the currency code.
 
 ## Error UX
 
@@ -101,8 +105,8 @@ it back on.
 
 - Pass a visible `label`, **or** associate a host-rendered label via
   `aria-labelledby` (id of the external label), **or** supply an
-  `aria-label`. One of the three must be present so the ComboBox always
-  has an accessible name.
+  `aria-label`. One of the three must be present so the trigger button
+  always has an accessible name.
 - The popover is keyboard-navigable (Arrow up/down, Enter to select, Esc
   to dismiss) and the search input is a real `<input>` with
   `aria-autocomplete="list"`.

--- a/packages/ui/src/components/CurrencySelect/CurrencySelect.stories.tsx
+++ b/packages/ui/src/components/CurrencySelect/CurrencySelect.stories.tsx
@@ -66,12 +66,11 @@ export const UsDollar: Story = {
 };
 
 /**
- * Turkish locale — same dataset, Turkish collation order and localized
- * currency names (`TRY — Türk Lirası`).
+ * Localized field label — the rows still show the code + flag only
+ * (`TRY` 🇹🇷); only the field's own `label` is translated by the host.
  */
 export const TurkishLocale: Story = {
   args: {
-    locale: 'tr-TR',
     autoDetect: false,
     defaultValue: 'TRY',
     label: 'Para birimi',
@@ -79,12 +78,11 @@ export const TurkishLocale: Story = {
 };
 
 /**
- * Arabic locale — exercises the RTL render path; the decorator wraps the
- * field in `dir="rtl"` so the popover + alignment mirror correctly.
+ * RTL render path — the decorator wraps the field in `dir="rtl"` so the
+ * popover + alignment mirror correctly. Rows stay code + flag.
  */
 export const ArabicRtl: Story = {
   args: {
-    locale: 'ar-SA',
     autoDetect: false,
     defaultValue: 'SAR',
     label: 'العملة',

--- a/packages/ui/src/components/CurrencySelect/CurrencySelect.tsx
+++ b/packages/ui/src/components/CurrencySelect/CurrencySelect.tsx
@@ -1,29 +1,33 @@
 // Glaon CurrencySelect — searchable ISO 4217 currency picker that wraps
-// the kit `<ComboBox>` (`packages/ui/src/components/base/select/combobox.tsx`).
+// the kit `<SearchSelect>` (button trigger + in-popover search), the same
+// primitive CountrySelect uses (#688).
 //
 // Sister primitive to `CountrySelect` / `TimezoneSelect` — same wrap
 // pattern, same state machine, same polish (auto-clear-error,
-// select-all-on-focus, diacritic-insensitive filter):
+// diacritic-insensitive filter):
 //
 //   - Built-in list from `Intl.supportedValuesOf('currency')`, no shipped
 //     database, no extra dependency.
-//   - Labels combine the code + localized currency name
-//     (`'TRY — Turkish Lira'`) via `Intl.DisplayNames`.
+//   - Rows + trigger show the **flag + ISO 4217 code only** (e.g. 🇹🇷 TRY).
+//     The localized currency *name* is dropped on purpose — it's
+//     locale-dependent and reads as noise in a multi-language wizard.
 //   - Optional one-shot autodetection from the browser locale's region
 //     (`Intl.Locale.getCurrencies()`).
-//   - `Coins01` glyph (`@untitledui/icons`) as the trigger leading icon.
+//   - `Coins01` glyph (`@untitledui/icons`) as the placeholder trigger icon
+//     until a currency is picked.
 //
 // Per CLAUDE.md's UUI Source Rule + Component Data-Fetching Boundary: the
 // visual + popover + RAC plumbing come from the kit; this wrapper adds the
 // prop API + dataset + detection. No network call here.
 
-import { useCallback, useEffect, useMemo, useState, type FocusEvent, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Coins01 } from '@untitledui/icons';
-import type { Key } from 'react-aria-components';
 
-import { ComboBox, SelectItem, type SelectItemType } from '../Select';
+import { Flag } from '../../icons/flag';
+import { SearchSelect, SelectItem, type SelectItemType } from '../Select';
 import {
   buildCurrencyItems,
+  currencyFlagCode,
   detectBrowserCurrency,
   diacriticInsensitiveFilter,
 } from './currencies';
@@ -48,17 +52,19 @@ interface CurrencySelectProps {
    * One-shot — re-mount to re-detect. @default true
    */
   autoDetect?: boolean;
-  /** BCP-47 locale used for currency names + label collation. */
-  locale?: string;
   /** Field label rendered above the trigger. */
   label?: string;
   /** Accessible name when no visible `label` is rendered; forwarded to
-   *  the ComboBox. */
+   *  the SearchSelect. */
   'aria-label'?: string;
   /** Id of an external visible label; forwarded as `aria-labelledby`. */
   'aria-labelledby'?: string;
-  /** Placeholder text shown when no option is selected. */
+  /** Placeholder shown in the (closed) trigger when nothing is selected. */
   placeholder?: string;
+  /** Placeholder inside the in-popover search field. @default 'Search' */
+  searchPlaceholder?: string;
+  /** Text shown when the search matches no currency. @default 'No results found' */
+  noResultsLabel?: string;
   /** Helper text under the trigger; doubles as the error message when
    *  `isInvalid` is true. */
   hint?: ReactNode;
@@ -83,11 +89,12 @@ export function CurrencySelect({
   defaultValue,
   onSelectionChange,
   autoDetect = true,
-  locale,
   label,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
   placeholder,
+  searchPlaceholder,
+  noResultsLabel,
   hint,
   isDisabled,
   isInvalid,
@@ -97,8 +104,16 @@ export function CurrencySelect({
   className,
   popoverClassName,
 }: CurrencySelectProps) {
-  const resolvedLocale = useResolvedLocale(locale);
-  const items = useMemo(() => buildCurrencyItems(resolvedLocale), [resolvedLocale]);
+  // Each item carries its flag as `icon` so the SearchSelect trigger shows
+  // the selected currency's flag and every popover row shows its flag.
+  const items = useMemo(
+    () =>
+      buildCurrencyItems().map((item) => ({
+        ...item,
+        icon: renderListItemFlag(currencyFlagCode(String(item.id))),
+      })),
+    [],
+  );
 
   const isHostControlled = value !== undefined;
   const [internalKey, setInternalKey] = useState<string | null>(defaultValue ?? null);
@@ -120,70 +135,60 @@ export function CurrencySelect({
     setSuppressInvalid(false);
   }, [isInvalid]);
 
-  const handleSelectionChange = (key: Key | null) => {
-    const next = key === null ? null : String(key);
+  const handleSelectionChange = (next: string | null) => {
     if (!isHostControlled) setInternalKey(next);
     setSuppressInvalid(true);
     onSelectionChange?.(next);
   };
 
-  const handleFocusCapture = useCallback((event: FocusEvent<HTMLDivElement>) => {
-    const target = event.target;
-    if (!(target instanceof HTMLInputElement)) return;
-    if (target.disabled || target.readOnly) return;
-    requestAnimationFrame(() => {
-      try {
-        target.select();
-      } catch {
-        // Input may have unmounted between the focus event and the rAF tick.
-      }
-    });
-  }, []);
-
   const effectiveInvalid = isInvalid === true && !suppressInvalid;
 
-  const comboProps: Record<string, unknown> = {
+  // Build the SearchSelect props bag conditionally — @glaon/ui compiles with
+  // `exactOptionalPropertyTypes: true`, so explicit `undefined` fails.
+  const selectProps: Record<string, unknown> = {
     items,
     size,
     selectedKey: effectiveKey ?? null,
     onSelectionChange: handleSelectionChange,
-    defaultFilter: diacriticInsensitiveFilter,
-    shortcut: false,
-    icon: Coins01,
+    filter: diacriticInsensitiveFilter,
+    // Coins placeholder glyph until a currency is picked; once selected the
+    // SearchSelect trigger shows that currency's flag (the item's `icon`).
+    leadingIcon: Coins01,
   };
 
-  if (label !== undefined) comboProps.label = label;
-  if (ariaLabel !== undefined) comboProps['aria-label'] = ariaLabel;
-  if (ariaLabelledby !== undefined) comboProps['aria-labelledby'] = ariaLabelledby;
-  if (placeholder !== undefined) comboProps.placeholder = placeholder;
-  if (hint !== undefined) comboProps.hint = hint;
-  if (isDisabled === true) comboProps.isDisabled = true;
-  if (effectiveInvalid) comboProps.isInvalid = true;
-  if (isRequired === true) comboProps.isRequired = true;
-  if (hideRequiredIndicator === true) comboProps.hideRequiredIndicator = true;
-  if (className !== undefined) comboProps.className = className;
-  if (popoverClassName !== undefined) comboProps.popoverClassName = popoverClassName;
+  if (label !== undefined) selectProps.label = label;
+  if (ariaLabel !== undefined) selectProps['aria-label'] = ariaLabel;
+  if (ariaLabelledby !== undefined) selectProps['aria-labelledby'] = ariaLabelledby;
+  if (placeholder !== undefined) selectProps.placeholder = placeholder;
+  if (searchPlaceholder !== undefined) selectProps.searchPlaceholder = searchPlaceholder;
+  if (noResultsLabel !== undefined) selectProps.noResultsLabel = noResultsLabel;
+  if (hint !== undefined) selectProps.hint = hint;
+  if (isDisabled === true) selectProps.isDisabled = true;
+  if (effectiveInvalid) selectProps.isInvalid = true;
+  if (isRequired === true) selectProps.isRequired = true;
+  if (hideRequiredIndicator === true) selectProps.hideRequiredIndicator = true;
+  if (className !== undefined) selectProps.className = className;
+  if (popoverClassName !== undefined) selectProps.popoverClassName = popoverClassName;
 
   return (
-    <div onFocusCapture={handleFocusCapture}>
-      <ComboBox {...comboProps}>
-        {(item: SelectItemType) => <SelectItem id={item.id} label={item.label ?? ''} />}
-      </ComboBox>
-    </div>
+    <SearchSelect {...selectProps}>
+      {(item: SelectItemType) => (
+        <SelectItem id={item.id} label={item.label ?? ''} icon={item.icon} />
+      )}
+    </SearchSelect>
   );
 }
 
 /**
- * Resolve the locale for currency names + collation. Reads
- * `navigator.language` lazily so SSR builds don't crash on a missing
- * `navigator`. Falls back to `'en'`.
+ * Per-row flag for each currency (popover rows + the selected trigger).
+ * Pre-tagged `<span data-icon>` so the kit's `*:data-icon:size-5` selector
+ * on the container pulls the sizing + colour utilities through. Mirrors
+ * CountrySelect's `renderListItemFlag`.
  */
-function useResolvedLocale(locale: string | undefined): string {
-  return useMemo(() => {
-    if (locale !== undefined && locale.length > 0) return locale;
-    if (typeof navigator !== 'undefined' && navigator.language) {
-      return navigator.language;
-    }
-    return 'en';
-  }, [locale]);
+function renderListItemFlag(code: string): ReactNode {
+  return (
+    <span data-icon className="flex shrink-0 items-center" aria-hidden="true">
+      <Flag country={code} shape="square" />
+    </span>
+  );
 }

--- a/packages/ui/src/components/CurrencySelect/currencies.ts
+++ b/packages/ui/src/components/CurrencySelect/currencies.ts
@@ -5,10 +5,9 @@
 // fall back to a small common set so the picker surfaces something rather
 // than erroring — every supported browser meets the threshold.
 //
-// Display labels combine the code and the localized currency name via
-// `Intl.DisplayNames(locale, { type: 'currency' })`, e.g.
-// `'TRY — Turkish Lira'`. No shipped translation tables, no extra
-// dependency — same runtime-locale approach as CountrySelect/TimezoneSelect.
+// Rows show the **code only** (e.g. `'TRY'`) plus the currency's flag (added
+// by the component). The localized currency *name* is deliberately dropped:
+// it is locale-dependent and reads as noise in a multi-language wizard.
 
 import type { SelectItemType } from '../base/select/select-shared';
 
@@ -34,28 +33,29 @@ function getCurrencyList(): readonly string[] {
   return FALLBACK_CURRENCIES;
 }
 
-/** Localized currency name for a code, e.g. `'TRY'` → `'Turkish Lira'`. */
-function currencyName(code: string, locale: string): string {
-  try {
-    const dn = new Intl.DisplayNames([locale], { type: 'currency' });
-    const name = dn.of(code);
-    return name ?? code;
-  } catch {
-    return code;
-  }
+/**
+ * Build a `{ id, label }` list of currencies sorted alphabetically by code.
+ * `id` and `label` are both the ISO 4217 code (e.g. `'TRY'`) — the canonical
+ * value persisted to HA Core's `currency`. The component layers the flag on
+ * top as the row/trigger `icon`. No locale needed (code-only display).
+ */
+export function buildCurrencyItems(): SelectItemType[] {
+  return [...getCurrencyList()]
+    .sort((a, b) => a.localeCompare(b))
+    .map((code) => ({ id: code, label: code }));
 }
 
 /**
- * Build a `{ id, label }` list of currencies sorted by the localized
- * label using `Intl.Collator`. `id` is the ISO 4217 code (e.g. `'TRY'`),
- * the canonical value persisted to HA Core's `currency`.
+ * Map an ISO 4217 currency code to the ISO 3166-1 alpha-2 country code for
+ * its flag. The currency code's first two letters are the country code for
+ * almost every national currency (`USD`→`us`, `TRY`→`tr`, `GBP`→`gb`);
+ * `EUR` maps to the EU flag. Supranational/metal codes (`XAF`, `XAU`, …)
+ * yield an `x…` code that `flag-icons` has no asset for, so the flag box
+ * renders empty — the code text still identifies the row.
  */
-export function buildCurrencyItems(locale: string): SelectItemType[] {
-  const codes = getCurrencyList();
-  const collator = new Intl.Collator(locale, { sensitivity: 'base' });
-  return codes
-    .map((code) => ({ id: code, label: `${code} — ${currencyName(code, locale)}` }))
-    .sort((a, b) => collator.compare(a.label, b.label));
+export function currencyFlagCode(code: string): string {
+  if (code === 'EUR') return 'eu';
+  return code.slice(0, 2).toLowerCase();
 }
 
 /**

--- a/tools/figma-plugin/scripts/13-currencyselect-search-select.js
+++ b/tools/figma-plugin/scripts/13-currencyselect-search-select.js
@@ -1,0 +1,160 @@
+// Glaon — 13 CurrencySelect → SearchSelect, flag + code only (#694)
+//
+// Updates the "App Primitives/CurrencySelect" COMPONENT in the Design
+// System Figma file to match PR #694: the currency picker is no longer an
+// editable input (ComboBox) — it's a **button trigger** (leading flag +
+// ISO 4217 code + chevron) that opens a popover with a **search field**
+// inside it (kit SearchSelect, the same pattern as CountrySelect #688).
+// The localized currency NAME is dropped — rows show flag + code only.
+// Keeps `storybook-id: app-primitives-currency-select` (Chromatic
+// Figma-diff contract; see docs/figma.md).
+//
+// The frame shows the closed trigger (flag + "TRY" + chevron). The
+// search-in-popover is the open state, documented in Storybook.
+//
+// Usage:
+//   1. Copy this file's contents into tools/figma-plugin/code.js.
+//   2. Open the Design System Figma file (Inter installed; else fallback).
+//   3. Run plugin (Plugins → Development → Glaon) → review dry-run.
+//   4. Flip CONFIRM = true → re-run → report the node id for the PR body.
+//   5. git restore tools/figma-plugin/code.js
+//
+// Idempotent: rebuilds the trigger's children in place.
+
+const CONFIRM = false;
+
+const COMPONENT_NAME = 'App Primitives/CurrencySelect';
+const STORYBOOK_ID = 'app-primitives-currency-select';
+const FRAME_WIDTH = 360;
+const SAMPLE_CODE = 'TRY'; // selected ISO 4217 code (no localized name)
+const SAMPLE_FLAG = '🇹🇷'; // stand-in glyph for the flag-icons sprite
+
+const TOKENS = {
+  surface: { var: 'surface/default', hex: '#FFFFFF' },
+  border: { var: 'border/subtle', hex: '#E4E7EC' },
+  textPrimary: { var: 'text/primary', hex: '#181D27' },
+  textMuted: { var: 'text/muted', hex: '#717680' },
+};
+
+function hexToRgb(hex) {
+  const h = hex.replace('#', '');
+  return {
+    r: parseInt(h.slice(0, 2), 16) / 255,
+    g: parseInt(h.slice(2, 4), 16) / 255,
+    b: parseInt(h.slice(4, 6), 16) / 255,
+  };
+}
+
+(async () => {
+  try {
+    const existing = (await figma.root.findAllWithCriteria({ types: ['COMPONENT'] })).find(
+      (n) => n.name === COMPONENT_NAME,
+    );
+
+    if (!CONFIRM) {
+      figma.notify(
+        existing
+          ? `🔍 DRY-RUN — would rebuild "${COMPONENT_NAME}" [${existing.id}] as a button trigger ` +
+              `(flag + "${SAMPLE_CODE}" + chevron; search lives in the popover, code only — no name). Flip CONFIRM to apply.`
+          : `🔍 DRY-RUN — "${COMPONENT_NAME}" not found; would create it. Flip CONFIRM.`,
+        { timeout: 13000 },
+      );
+      figma.closePlugin();
+      return;
+    }
+
+    const vars = await figma.variables.getLocalVariablesAsync();
+    const byName = new Map(vars.map((v) => [v.name, v]));
+    const fill = (key) => {
+      const t = TOKENS[key];
+      const paint = { type: 'SOLID', color: hexToRgb(t.hex) };
+      const v = byName.get(t.var);
+      return v ? figma.variables.setBoundVariableForPaint(paint, 'color', v) : paint;
+    };
+
+    const FAMILY = 'Inter';
+    let fontReg = { family: FAMILY, style: 'Regular' };
+    let fontMed = { family: FAMILY, style: 'Medium' };
+    try {
+      await figma.loadFontAsync(fontReg);
+      await figma.loadFontAsync(fontMed);
+    } catch {
+      const fb = { family: 'Roboto', style: 'Regular' };
+      await figma.loadFontAsync(fb);
+      fontReg = fb;
+      fontMed = fb;
+    }
+    const text = (chars, font, size, colorKey) => {
+      const t = figma.createText();
+      t.fontName = font;
+      t.fontSize = size;
+      t.characters = chars;
+      t.fills = [fill(colorKey)];
+      return t;
+    };
+
+    const buildTrigger = () => {
+      const trigger = figma.createFrame();
+      trigger.name = 'trigger';
+      trigger.layoutMode = 'HORIZONTAL';
+      trigger.itemSpacing = 8;
+      trigger.counterAxisAlignItems = 'CENTER';
+      trigger.paddingLeft = 12;
+      trigger.paddingRight = 12;
+      trigger.paddingTop = 10;
+      trigger.paddingBottom = 10;
+      trigger.cornerRadius = 8;
+      trigger.fills = [fill('surface')];
+      trigger.strokes = [fill('border')];
+      trigger.strokeWeight = 1;
+      trigger.layoutAlign = 'STRETCH';
+      trigger.primaryAxisSizingMode = 'FIXED';
+      trigger.counterAxisSizingMode = 'AUTO';
+
+      trigger.appendChild(text(SAMPLE_FLAG, fontReg, 16, 'textPrimary')); // flag stand-in
+      const value = text(SAMPLE_CODE, fontMed, 16, 'textPrimary');
+      value.layoutGrow = 1;
+      trigger.appendChild(value);
+      trigger.appendChild(text('⌄', fontReg, 14, 'textMuted')); // chevron
+      return trigger;
+    };
+
+    let root = existing;
+    const apply = (node) => {
+      node.layoutMode = 'VERTICAL';
+      node.itemSpacing = 6;
+      node.fills = [];
+      node.resize(FRAME_WIDTH, 10);
+      node.primaryAxisSizingMode = 'AUTO';
+      node.counterAxisSizingMode = 'FIXED';
+      node.appendChild(text('Currency', fontMed, 14, 'textPrimary'));
+      node.appendChild(buildTrigger());
+    };
+
+    if (root) {
+      for (const child of [...root.children]) child.remove();
+      apply(root);
+      if (!root.description.includes(`storybook-id: ${STORYBOOK_ID}`)) {
+        root.description =
+          (root.description ? root.description + '\n' : '') + `storybook-id: ${STORYBOOK_ID}`;
+      }
+    } else {
+      root = figma.createComponent();
+      root.name = COMPONENT_NAME;
+      root.description = `Glaon currency picker — kit SearchSelect (button trigger + in-popover search); flag + ISO 4217 code only, no localized name (#694).\nstorybook-id: ${STORYBOOK_ID}`;
+      apply(root);
+      root.x = Math.round(figma.viewport.center.x - FRAME_WIDTH / 2);
+      root.y = Math.round(figma.viewport.center.y - 40);
+      figma.currentPage.appendChild(root);
+    }
+
+    figma.viewport.scrollAndZoomIntoView([root]);
+    figma.notify(`✅ Updated "${COMPONENT_NAME}" — node id: ${root.id}`, { timeout: 15000 });
+    console.log('[Glaon 13 CurrencySelect] node id:', root.id);
+  } catch (err) {
+    figma.notify(`Glaon plugin error: ${err.message}`, { error: true });
+    throw err;
+  } finally {
+    figma.closePlugin();
+  }
+})();


### PR DESCRIPTION
Aligns `CurrencySelect` with the `CountrySelect` pattern (#688) and drops the localized currency **name**.

## Changes
- `CurrencySelect`: input-trigger `ComboBox` → button-trigger `SearchSelect` (in-popover search), mirroring CountrySelect.
- Rows + trigger show the **flag + ISO 4217 code only** (e.g. 🇹🇷 `TRY`). The localized name (`Intl.DisplayNames`) is dropped — it's locale-dependent and reads as noise in a multi-language wizard.
- Flag maps currency → country: `EUR`→`eu`, otherwise the first two letters (`USD`→`us`, `TRY`→`tr`); supranational/metal codes (`XAF`, `XAU`, …) have no flag asset → empty box, code still identifies the row. `Coins01` placeholder until a pick.
- Drop the `locale` prop + `Intl.DisplayNames`/`Collator` name lookup (sort by code). Add `searchPlaceholder`/`noResultsLabel`, i18n-wired in Home Overview (en+tr).
- Value contract (ISO 4217 code) + `autoDetect` + auto-clear-error unchanged. Story/controls/mdx updated; Figma frame script 13.

## Verified live (Storybook)
- Trigger renders flag + code, no name: 🇹🇷 `TRY`, 🇺🇸 `USD`.
- No runtime/console errors.
- (Open popover rows + EUR→EU flag covered by the Chromatic story snapshot.)

## Test plan
- [x] `@glaon/ui` type-check + lint + 171 unit (F6: new props in controls); `@glaon/web` type-check; i18n-check; prettier; gitleaks.
- [x] Live: trigger flag + code for TRY/USD.
- [ ] CI green (story-tests, visual regression, lighthouse-mobile).
- [ ] Chromatic review + Figma node linked (run script 13).

## Design
Figma frame updated via `tools/figma-plugin/scripts/13-currencyselect-search-select.js` — node id to be appended after the user runs it.

Closes #694