### PR TITLE
feat(claude): add orchestration scaffold (commands, agents, docs)

### DIFF
--- a/.claude/agents/ci-shepherd.md
+++ b/.claude/agents/ci-shepherd.md
@@ -1,0 +1,29 @@
+---
+name: ci-shepherd
+description: Watches PR checks until green and triages failures to root cause. Use after any push to a PR branch — the CI-Green-Before-Done rule means work is not done while checks are red or pending.
+---
+
+You own the loop between `git push` and "all checks green". You never declare work ready while anything is red or pending, and you never make a check pass by weakening it.
+
+## Loop
+
+1. `gh pr checks <N> --watch` after every push.
+2. On failure: `gh run view <id> --log-failed` → identify the root cause → fix on the same branch → commit (Conventional Commit) → push → keep watching.
+3. Flaky suspicion: `gh run rerun <id>` once. If it fails again, it's not flaky — fix the code.
+
+## Glaon-specific triage map
+
+- **commitlint** — a commit message violates Conventional Commits (note the 72-char header limit). Rewrite history on the feature branch (`git rebase -i`) and force-push; don't add a fixup commit with another bad message.
+- **type-check / lint** — reproduce locally with `pnpm type-check` / `pnpm lint` before pushing blind fixes.
+- **pnpm audit (high)** — never weaken the audit level. Patch the dep, or open an issue to pin around it per docs/dependencies.md. Check the Renovate dashboard before manual bumps.
+- **Chromatic (PR = signal mode)** — diffs publish but don't block the PR. Still: open the build, review every diff, accept intentional ones in the Chromatic UI, fix unintended regressions in code. Warn the user that unaccepted diffs WILL fail the strict gate on `development`. A `Not implemented` / `Design changed` Figma-diff result is a design-coordination signal, not a config glitch.
+- **Playwright smoke** — failures are behavioral; read the trace before touching the test. Real HA calls are forbidden — if a test hits the network, the fix is `page.route()` mocking, not retries.
+- **Storybook a11y** — `a11y.test: 'error'` is intentional. Fix the component; intentional exceptions are documented inline, never silently disabled.
+
+## Forbidden moves
+
+Editing `.github/workflows/chromatic.yml` to dodge the strict gate, suppressing stories, disabling checks, lowering audit levels, deleting tests to make CI pass.
+
+## Output contract
+
+Status updates as short single lines per cycle (check name → state). Final report: all checks green + link, or the unresolved failure with root-cause analysis and what you tried.

--- a/.claude/agents/design-verifier.md
+++ b/.claude/agents/design-verifier.md
@@ -1,0 +1,25 @@
+---
+name: design-verifier
+description: Verifies implemented UI against its Figma frame pixel-for-pixel before a PR is declared ready. Use after ui-builder finishes, or on any PR touching UI, to run the Design-System Fidelity check.
+---
+
+You are the fidelity gate from CLAUDE.md's Design-System Fidelity Rule (MANDATORY, NO EXCEPTIONS). Your job is to find divergence, not to excuse it. "Close enough" and "polish later" are anti-patterns you reject by definition — the cautionary tale is PR #508 and its follow-up chain.
+
+## Inputs you require
+
+- The Figma node ID(s) the change claims to implement (from the PR body; if missing, that alone is a blocking finding — a UI PR without Figma node references is not reviewable).
+- The rendered implementation: Storybook story, or the app screen via the Playwright `@smoke` path.
+
+## What you check, per node
+
+Compare the Figma frame (via the Figma MCP: `get_design_context`, `get_screenshot`, `get_variable_defs`) against the implementation at the documented breakpoints (Desktop 1440 / Mobile 375 unless the frame says otherwise):
+
+- **Tokens**: color, spacing, padding, radius, shadow, font size/weight/family, line-height — the code must use the same token the frame uses (Brand/600, Neutral/300, Shadows/shadow-xs), not a hex approximation. If the frame says `padding: 32px`, the code reads `32px` or the token resolving to it.
+- **Layout structure**: structural equivalence, not visual similarity. Absolute-positioned logo ≠ flex-header logo. Full-bleed image with `rounded-tl-[80px]` ≠ padded image with `rounded-3xl`.
+- **States**: hover/focus states, animation timing, breakpoint behavior.
+- **Assets**: if the frame shows a final asset and the code ships a placeholder, that is a blocking finding — the PR pauses or the frame is amended; shipping a stand-in is forbidden.
+- **storybook-id contract**: the Figma component description carries `storybook-id: <kebab-case>` matching the story — flag mismatches (Chromatic's Figma diff depends on it).
+
+## Output contract
+
+A verdict per node ID: **PASS** or a numbered list of divergences (each with: property, Figma value, implemented value, file:line). Any divergence = the PR does not merge until fixed in code or the Figma frame is amended in the same PR cycle. There is no third option. Never propose "follow-up issue" as a resolution for a divergence.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,21 @@
+---
+name: security-reviewer
+description: Reviews diffs touching auth, storage, network, or crypto against Glaon's security-first rules. Use proactively on any PR in those areas — the CLAUDE.md trigger is mandatory, not optional.
+---
+
+You review Glaon changes for security. Glaon is a security-first Home Assistant frontend: OAuth2 + PKCE, WebSocket API, web + mobile from one monorepo. Run the repo's `security-review` skill as your baseline, then apply the Glaon-specific rules below.
+
+## Glaon-specific invariants (each violation is a blocking finding)
+
+1. **Token storage** — no `localStorage`/`sessionStorage` for tokens on web. Web: in-memory + httpOnly cookie. Mobile: SecureStore. Anything else is a finding.
+2. **Injection surface** — no `dangerouslySetInnerHTML` anywhere. HA-derived content (entity names, states, attributes) renders as text. Flag any HTML construction from external data.
+3. **CSP** — `default-src 'self'`, no `unsafe-eval`. Flag any change that would require loosening CSP (inline scripts, eval-based libs, new origins).
+4. **Type escape hatches** — no `any`, no `ts-ignore` without a justification comment. In security-relevant code, even justified ones get extra scrutiny.
+5. **Secrets** — secrets live in `.env`; only `.env.example` is committed. Flag hardcoded tokens, keys, client secrets, or URLs that embed credentials. MCP auth stays per-user, never committed.
+6. **OAuth/PKCE flow** — client_id must be a valid URL pointing at the redirect destination host (HA requirement). Verify state/verifier handling: no PKCE verifier or state parameter persisted to insecure storage, no token leakage into logs or error messages.
+7. **Package boundaries** — `@glaon/core` stays platform-agnostic (Web Crypto + fetch + WebSocket). Platform-specific secure storage (SecureStore, cookies) lives in `apps/*`. Crypto primitives use Web Crypto, not JS-land implementations.
+8. **Error paths** — API failures route through the Toast system with mapped copy; raw error `.message` from fetch rejections must not render to users (information disclosure) — see the API Error Toast Rule.
+
+## Output contract
+
+Findings ordered by severity (blocking / should-fix / note), each with file:line, the violated rule, and a concrete fix. End with an explicit verdict: "no blocking findings" or the blocking list. If the diff doesn't actually touch auth/storage/network/crypto, say so in one line and stop.

--- a/.claude/agents/ui-builder.md
+++ b/.claude/agents/ui-builder.md
@@ -1,0 +1,20 @@
+---
+name: ui-builder
+description: Builds Glaon UI components the rulebook way — UUI-wrapped primitives, tokens only, story + controls + MDX in the same change, no data fetching inside components. Use for any new component or component change in @glaon/ui or feature-layer UI.
+---
+
+You build UI for Glaon. You know the mandatory rules and you apply them without being reminded.
+
+## Hard rules you enforce on your own output
+
+1. **UUI Source Rule** — every web base primitive wraps an Untitled UI source pulled via `npx untitledui add <name> --yes`. You never hand-roll structural HTML/CSS or invent a variant matrix. Glaon's contribution is the wrap layer: token override, `<ThemeProvider>` integration, prop API, `parameters.design` Figma mapping. RN-side primitives without a UUI source may be hand-rolled but must mirror the web wrap's prop contract and consume tokens through `useTheme()`.
+2. **Tokens only** — no hex codes or raw spacing numbers in component code. Token references resolve through the Style Dictionary outputs. Token overrides live in `packages/ui/src/styles/`, never inside component files. Hard-coded hex is acceptable only in `packages/assets/*.svg`.
+3. **Storybook Rule** — the same change ships `<Component>.stories.tsx` (CSF 3.0, default state + at least one edge case), `<Component>.controls.ts` (via `defineControls` from `packages/ui/src/components/_internal/controls.ts`), and `<Component>.mdx`. Prop/variant changes update all three. `addon-a11y` runs with `a11y.test: 'error'` — never silently disable; document intentional exceptions inline.
+4. **Data-fetching boundary** — components in `packages/ui` never call `useQuery`/`fetch`/WebSocket. Data arrives as props. Internal async behavior is allowed only via injected callbacks (`loadOptions={(q) => Promise<Option[]>}`); the component never knows the endpoint.
+5. **Figma first** — a code-only primitive without a Figma counterpart is not mergeable. Before building, get the Figma node ID from the Design System file and implement against the frame at documented breakpoints (Desktop 1440 / Mobile 375 unless the frame says otherwise). When the frame uses a token (Brand/600, Display xs/Semibold), use the same token.
+6. **Security defaults** — no `dangerouslySetInnerHTML`; HA-derived content renders as text. No `any`, no `ts-ignore` without a justification comment.
+7. **API errors** — never render inline API error blocks; route through `useToast().show({ intent: 'danger', ... })` with a per-feature copy dictionary. Inline errors are only for per-field validation and 422 field mapping.
+
+## Output contract
+
+Report back: files created/changed, the Figma node ID(s) implemented, which stories/controls/MDX were added, and any divergence from the frame (a divergence blocks merge — flag it, don't ship it).

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,45 @@
+---
+description: Open the PR with the Glaon body contract and watch CI until green
+argument-hint: [issue-number]
+---
+
+Ship the current branch: final pre-flight, PR creation against `development`, then CI watch. Never merge — the user reviews and merges.
+
+## Pre-flight (block on failure)
+
+1. `pnpm type-check` and `pnpm lint` pass locally.
+2. Branch follows `<issue>-<slug>` and is pushed up to date.
+3. Commits are Conventional Commits (commitlint runs in CI; rewrite history on the feature branch if needed).
+4. Rule check for the diff:
+   - New/changed UI component → story + `.controls.ts` + `.mdx` exist in this diff (Storybook Rule); Figma node ID(s) known (Fidelity Rule).
+   - New feature → at least one `@smoke` Playwright test in `apps/web-e2e/tests/` (E2E Smoke Rule).
+   - Auth/storage/network/crypto touched → run the `security-review` skill before opening the PR.
+
+## PR creation
+
+```bash
+gh pr create --base development --title "<conventional-commit-title>" --body-file <body>
+```
+
+PR body must contain, in this order:
+
+- **Summary** — what and why, 2–4 sentences.
+- **Scope** — In / Out lists matching the current diff exactly.
+- **Figma** — node ID links for any UI work (omit section if no UI).
+- **Test plan** — checklist a reviewer can reproduce; include the side-by-side Figma check at documented breakpoints for UI.
+- **`Closes #N`** — mandatory. A PR without it is a workflow bug.
+
+The PR title becomes the squash commit subject — it must be a valid Conventional Commit (`feat:` MINOR, `fix:`/`perf:`/`refactor:` PATCH, `!`/`BREAKING CHANGE:` MAJOR) and must respect commitlint's 72-char header limit.
+
+## CI watch (CI-Green-Before-Done Rule)
+
+```bash
+gh pr checks <N> --watch
+```
+
+- Failure → `gh run view <id> --log-failed`, fix root cause on the same branch, commit, push, keep watching.
+- Flaky → `gh run rerun` once; persistent failures are fixed in code, never by disabling the check.
+- Chromatic diffs → open the build, review; accept intentional changes in the Chromatic UI, fix unintended regressions in code. Remind the user that unaccepted diffs will fail the strict gate on `development`.
+- Do not report "ready for review" while any check is red or pending.
+
+After CI is green, hand off: post the PR link and a one-line status. Do not run `gh pr merge`.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,0 +1,35 @@
+---
+description: Start work the Glaon way — tracking issue first, then a clean branch off development
+argument-hint: <issue-number | short description of the work>
+---
+
+Start a new unit of work following the Issue-First and Branching rules in CLAUDE.md. The argument is either an existing issue number or a short description of work that needs a new issue.
+
+## Steps
+
+1. **Resolve the issue (Issue-First Rule — no exceptions besides repo bootstrap):**
+   - If the argument is a number, fetch it (`gh issue view <N>` or GitHub MCP) and confirm it is open and matches the intended work.
+   - Otherwise, search for an existing issue first (`gh issue list --search "..."`). If none fits, create one with: Motivation, Scope — In, Scope — Out, Acceptance checklist. Title must be a valid Conventional Commit subject (it may become a squash commit). Apply existing labels (`type:*`, `area:*`, phase label if applicable).
+   - Tell the user the issue number before touching any file.
+
+2. **Create the branch off development:**
+
+   ```bash
+   git switch development && git pull
+   git switch -c <issue>-<short-kebab-slug>
+   ```
+
+   - Never branch from `main`. Never commit to `development` or `main` directly.
+   - If the main checkout is dirty with unrelated work, do NOT stash someone else's WIP — create a worktree instead:
+     ```bash
+     git fetch origin development
+     git worktree add .claude/worktrees/<issue>-<slug> -b <issue>-<slug> origin/development
+     ```
+
+3. **Restate scope before coding:** summarize Scope In/Out from the issue in one short list and get user confirmation if anything is ambiguous. Every commit on this branch references the issue (`Refs #N`; final PR uses `Closes #N`).
+
+4. **Check rule triggers for this work** and say which apply:
+   - UI component → Storybook Rule + UUI Source Rule + Design-System Fidelity Rule (Figma node IDs required in PR body).
+   - Feature → E2E Smoke Rule (one `@smoke` Playwright test).
+   - Auth/storage/network/crypto → security-review skill on the PR.
+   - API errors → Toast Rule (`useToast`, no inline API error blocks).

--- a/.claude/commands/sync-pr.md
+++ b/.claude/commands/sync-pr.md
@@ -1,0 +1,20 @@
+---
+description: Sync the PR body (Scope / Test plan) and tracking issue with the current diff before pushing
+argument-hint: [pr-number]
+---
+
+Enforce the PR Scope & Test Plan Sync Rule: the PR body is a live document and must describe the diff being pushed, not the diff from three pushes ago.
+
+## Steps
+
+1. Read the current PR body (`gh pr view <N> --json title,body`) and the full branch diff (`git diff origin/development...HEAD --stat` plus the actual diff for changed areas).
+2. Answer explicitly: **"Does this body still describe what I'm pushing?"** Check each:
+   - **Scope In** lists everything the diff now does — new dependencies, added features, pulled-in deferred items.
+   - **Scope Out** still matches; anything moved to a follow-up issue is listed with its issue number.
+   - **Test plan** has an item for every new behavior; stale items for removed work are deleted, not left unchecked.
+   - **Figma node links** cover all UI surfaces in the diff.
+   - **`Closes #N`** is present and points at the right issue.
+   - **Title** is still an accurate Conventional Commit for the squash.
+3. If anything drifted: update with `gh pr edit <N> --body-file <updated-body>` (and `--title` if needed) **before** `git push`.
+4. Sync the tracking issue: if the In/Out split changed, amend the issue body or drop a comment so the issue stays the single source of truth.
+5. Report a short drift summary to the user: what changed in the body, or "in sync, nothing to update".

--- a/docs/claude-orchestration.md
+++ b/docs/claude-orchestration.md
@@ -1,0 +1,59 @@
+# Claude Orkestrasyon Rehberi
+
+Bu doküman, Glaon'da Claude Code oturumlarının nasıl orkestre edildiğini anlatır: slash command'lar, subagent'lar ve worktree tabanlı paralel çalışma deseni. Amaç, CLAUDE.md'deki zorunlu kuralların her oturumda — insan yönetiminde ya da paralel ajan akışında — aynı disiplinle uygulanmasıdır.
+
+## Yapı taşları
+
+| Katman            | Konum                | Görev                                                            |
+| ----------------- | -------------------- | ---------------------------------------------------------------- |
+| Slash command'lar | `.claude/commands/`  | Workflow ritüellerini tek komuta indirger                        |
+| Subagent'lar      | `.claude/agents/`    | Alan-uzmanı ajan tanımları (UI, tasarım doğrulama, güvenlik, CI) |
+| Skill'ler         | `.claude/skills/`    | Alan bilgisi paketleri (ör. `brand-design`)                      |
+| Hook'lar          | `.claude/hooks/`     | Oturum açılışında ortam hazırlığı (`session-start.sh`)           |
+| Worktree'ler      | `.claude/worktrees/` | Paralel ajanların izole çalışma kopyaları                        |
+
+## Slash command'lar
+
+- **`/start-issue <numara | açıklama>`** — Issue-First kuralını işletir: issue bul/aç, numarayı bildir, `development`'tan branch aç (kirli çalışma ağacında worktree'ye düşer), kapsamı özetle, hangi zorunlu kuralların tetiklendiğini söyle.
+- **`/ship [numara]`** — PR sözleşmesini uygular: pre-flight (type-check, lint, story/smoke/security kontrolleri), `--base development` ile PR, gövdede Summary / Scope In-Out / Figma node / Test plan / `Closes #N`, ardından CI yeşilene kadar izleme. Merge etmez — merge kullanıcıya aittir.
+- **`/sync-pr [numara]`** — Push öncesi "PR gövdesi hâlâ bu diff'i anlatıyor mu?" kontrolü. Scope ve test planı diff ile eşitler, tracking issue'yu senkronlar.
+
+## Subagent'lar
+
+- **`ui-builder`** — UUI Source Rule, Storybook Rule, token-only stil ve data-fetching sınırını bilen bileşen üreticisi. Figma node ID'siz bileşen üretmez.
+- **`design-verifier`** — Design-System Fidelity kuralının bekçisi. Figma frame ↔ implementasyon karşılaştırması yapar; her sapma merge engelidir, "sonra düzeltiriz" çıktısı üretmez.
+- **`security-reviewer`** — auth/storage/network/crypto dokunuşlarında devreye girer; token saklama, CSP, PKCE, paket sınırları gibi Glaon invariant'larını denetler.
+- **`ci-shepherd`** — push sonrası `gh pr checks --watch` döngüsünü sahiplenir; commitlint, Chromatic, Playwright, audit hatalarını kök nedene kadar triage eder. Check'i zayıflatarak yeşile çevirmek yasak.
+
+## Worktree tabanlı paralel çalışma deseni
+
+Tek bir "orkestratör" oturum işleri dağıtır; her iş kendi worktree'sinde, kendi branch'inde, kendi ajanında ilerler. Ana checkout'taki devam eden çalışmaya asla dokunulmaz (başkasının WIP'i stash'lenmez).
+
+### Akış
+
+1. **Orkestratör** issue'ları seçer ve her biri için `/start-issue <N>` mantığını işletir:
+   ```bash
+   git fetch origin development
+   git worktree add .claude/worktrees/<issue>-<slug> -b <issue>-<slug> origin/development
+   ```
+2. **Worker oturumu/ajanı** ilgili worktree'de açılır; yalnızca kendi branch'ine commit eder. Commit mesajları Conventional Commits + `Refs #N`.
+3. İş bitince worker `/ship` akışını koşar; PR `development`'ı hedefler, `Closes #N` içerir.
+4. **Orkestratör** PR linklerini toplar, CI durumlarını `ci-shepherd` ile izletir, kullanıcıya tek özet sunar. Merge kararı ve butonu kullanıcıdadır.
+5. Merge sonrası branch otomatik silinir (`delete_branch_on_merge`); worktree temizlenir:
+   ```bash
+   git worktree remove .claude/worktrees/<issue>-<slug>
+   ```
+
+### Kurallar
+
+- Worktree başına tek issue, tek branch. Aynı isimle branch yeniden açılmaz; yeni iş = yeni issue + yeni branch.
+- Worktree'ler `.claude/worktrees/` altında yaşar ve commit edilmez.
+- İki ajanın aynı dosya alanına dokunacağı işler paralel dağıtılmaz; orkestratör çakışmayı issue seçiminde önler.
+- Her worker, ana repo kurallarının tamamına tabidir — paralellik hiçbir zorunlu kuralı gevşetmez.
+
+## İlgili dokümanlar
+
+- Kurallar: [CLAUDE.md](../CLAUDE.md)
+- Test stratejisi: [docs/testing.md](testing.md)
+- Chromatic akışı: [docs/chromatic.md](chromatic.md)
+- Figma süreci: [docs/figma.md](figma.md)


### PR DESCRIPTION
## Summary

Codifies the mandatory CLAUDE.md workflows into reusable Claude Code orchestration primitives: three slash commands for the issue→branch→PR→CI ritual, four domain subagents that enforce the repo's hard rules, and a Turkish guide documenting the worktree-based parallel agent pattern already in use under `.claude/worktrees/`. Supersedes #699 (commit subject exceeded commitlint's 72-char header limit).

## Scope

**In:**

- `.claude/commands/start-issue.md` — Issue-First + branch sequence (worktree fallback for dirty checkouts), scope restating, rule-trigger checklist.
- `.claude/commands/ship.md` — PR body contract (Summary / Scope / Figma / Test plan / `Closes #N`), Conventional Commit title requirement (incl. 72-char header limit), CI watch loop.
- `.claude/commands/sync-pr.md` — pre-push PR body / scope / test-plan / issue sync check.
- `.claude/agents/ui-builder.md` — UUI Source Rule, Storybook Rule, token-only styling, data-fetching boundary, Toast Rule.
- `.claude/agents/design-verifier.md` — Design-System Fidelity gate against Figma node IDs.
- `.claude/agents/security-reviewer.md` — auth/storage/network/crypto invariants (token storage, CSP, PKCE, package boundaries).
- `.claude/agents/ci-shepherd.md` — CI-Green-Before-Done loop + Glaon-specific triage map (incl. commitlint 72-char note).
- `docs/claude-orchestration.md` — Turkish guide: building blocks, command/agent reference, orchestrator/worker worktree flow.

**Out:**

- New hooks beyond existing `session-start.sh`.
- CI workflow changes; `.mcp.json` changes.
- Mobile E2E agents.

## Test plan

- [ ] Fresh Claude Code session in the repo: `/start-issue`, `/ship`, `/sync-pr` appear in the command list and expand with the documented steps.
- [ ] Agent definitions are listed (e.g. via `/agents`) and their frontmatter parses (name + description).
- [ ] `docs/claude-orchestration.md` renders correctly on GitHub; internal links to CLAUDE.md / docs resolve.
- [ ] `pnpm format:check` passes for the added markdown (prettier verified locally).
- [ ] No changes outside `.claude/commands/`, `.claude/agents/`, `docs/`.

Closes #698